### PR TITLE
:lipstick: set max-height for ck-editor

### DIFF
--- a/src/open_inwoner/scss/admin/_ck_editor.scss
+++ b/src/open_inwoner/scss/admin/_ck_editor.scss
@@ -12,6 +12,7 @@ $color-gray: silver;
 
 .ck-content {
   min-height: 200px;
+  max-height: 600px;
 }
 
 .aligned .ck-editor {


### PR DESCRIPTION
task - https://taiga.maykinmedia.nl/project/open-inwoner/task/614 

The toolbar is sticky by default, we just have to setup max height

CKEditor5 doesn't support AutoGrow plugin, so the easiest way to do it is with CSS. 