### PR TITLE
[#899] Reselect template and contact on Plan-create validation error

### DIFF
--- a/src/open_inwoner/plans/forms.py
+++ b/src/open_inwoner/plans/forms.py
@@ -29,8 +29,13 @@ class PlanForm(forms.ModelForm):
         self.user = user
         user_contacts = self.user.get_active_contacts()
         self.fields["plan_contacts"].queryset = user_contacts
+
+        # NOTE we have to convert the ID value of the choice to string to make components recognize checked (taiga 899)
         self.fields["plan_contacts"].choices = [
-            [c.id, c.get_full_name()] for c in user_contacts
+            [str(c.id), c.get_full_name()] for c in user_contacts
+        ]
+        self.fields["template"].choices = [
+            (str(t.id), t) for t in self.fields["template"].queryset
         ]
 
         if self.instance.pk:

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -303,15 +303,18 @@ class PlanViewTests(WebTest):
     def test_plan_create_plan_validation_error_reselects_template_and_contact(self):
         plan_template = PlanTemplateFactory(file=None)
         ActionTemplateFactory(plan_template=plan_template)
+        # make sure we have only one plan
         self.assertEqual(Plan.objects.count(), 1)
+
         response = self.app.get(self.create_url, user=self.user)
         form = response.forms["plan-form"]
         form["title"] = "Plan"
         form["end_date"] = ""  # empty end_date so validation fails
-        form["contacts"] = [self.contact.pk]
-        form["template"] = plan_template.pk
+        form["plan_contacts"] = [str(self.contact.pk)]
+        form["template"] = str(plan_template.pk)
         response = form.submit()
         self.assertEqual(response.status_code, 200)
+
         # nothing was created
         self.assertEqual(Plan.objects.count(), 1)
 
@@ -320,7 +323,7 @@ class PlanViewTests(WebTest):
         self.assertEqual(elem.attrib.get("checked"), "checked")
 
         # NOTE: custom widget ID hardcoded on index of choice
-        elem = response.pyquery(f"#id_contacts_1")[0]
+        elem = response.pyquery(f"#id_plan_contacts_1")[0]
         self.assertEqual(elem.attrib.get("checked"), "checked")
 
     def test_plan_edit_login_required(self):

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -24,16 +24,17 @@
                 </div>
                 <label class="plan-template__row radio">
                     <div>
-                        <input class="radio__input" type="radio" name="template" value="" id="id_template_0">
+                        <input class="radio__input" type="radio" name="template" value="" id="id_template_0" {% if not form.data.template %}checked{% endif %}>
                         <label class="radio__label" for="id_template_0">Geen template</label>
                     </div>
                     <div></div>
                     <div></div>
                 </label>
-                {% for plan_template in form.template.field.queryset %}
+                {% for tpl_id, plan_template in form.template.field.choices %}
                     <label class="plan-template__row radio">
                         <div>
-                            <input class="radio__input" type="radio" name="template" value="{{ plan_template.id }}" id="id_template_{{ plan_template.id }}">
+                            <input class="radio__input" type="radio" name="template" value="{{ plan_template.id }}" id="id_template_{{ plan_template.id }}"
+                                   {% if tpl_id == form.data.template %}checked{% endif %}>
                             <label class="radio__label" for="id_template_{{ plan_template.id }}">{{ plan_template.name }}</label>
                         </div>
                         <div>


### PR DESCRIPTION
This was caused by custom widget template code doing an `in` operator, but the primary key of an object is an integer while the querydict has strings so it would never find the value.