### PR TITLE
Feature/895 pagination

### DIFF
--- a/src/open_inwoner/accounts/views/cases.py
+++ b/src/open_inwoner/accounts/views/cases.py
@@ -89,7 +89,6 @@ class CaseAccessMixin(AccessMixin):
 
 class CaseListMixin(PaginationMixin):
     paginate_by = 9
-    max_cases = 50
     template_name = "pages/cases/list.html"
 
     def get_cases(self):
@@ -142,9 +141,6 @@ class CaseListMixin(PaginationMixin):
         context = super().get_context_data(**kwargs)
 
         raw_cases = self.get_cases()
-        # Limit amount of total cases
-        if self.max_cases:
-            raw_cases = raw_cases[: self.max_cases]
         paginator_dict = self.paginate_with_context(raw_cases)
         cases = self.process_cases(paginator_dict["object_list"])
 

--- a/src/open_inwoner/accounts/views/cases.py
+++ b/src/open_inwoner/accounts/views/cases.py
@@ -37,6 +37,7 @@ from open_inwoner.openzaak.utils import (
     is_info_object_visible,
     is_zaak_visible,
 )
+from open_inwoner.utils.mixins import PaginationMixin
 
 
 class CaseAccessMixin(AccessMixin):
@@ -86,7 +87,9 @@ class CaseAccessMixin(AccessMixin):
         return fetch_single_case(case_uuid)
 
 
-class CaseListMixin:
+class CaseListMixin(PaginationMixin):
+    paginate_by = 9
+    max_cases = 50
     template_name = "pages/cases/list.html"
 
     def get_cases(self):
@@ -139,8 +142,14 @@ class CaseListMixin:
         context = super().get_context_data(**kwargs)
 
         raw_cases = self.get_cases()
-        cases = self.process_cases(raw_cases)
+        # Limit amount of total cases
+        if self.max_cases:
+            raw_cases = raw_cases[: self.max_cases]
+        paginator_dict = self.paginate_with_context(raw_cases)
+        cases = self.process_cases(paginator_dict["object_list"])
+
         context["cases"] = cases
+        context.update(paginator_dict)
 
         context["anchors"] = self.get_anchors()
         context["title"] = self.get_title()

--- a/src/open_inwoner/openzaak/cases.py
+++ b/src/open_inwoner/openzaak/cases.py
@@ -35,7 +35,7 @@ def fetch_cases(user_bsn: str, max_cases: Optional[int] = 100) -> List[Zaak]:
         response = get_paginated_results(
             client,
             "zaak",
-            minumum=max_cases,
+            minimum=max_cases,
             request_kwargs={
                 "params": {
                     "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": user_bsn,

--- a/src/open_inwoner/openzaak/cases.py
+++ b/src/open_inwoner/openzaak/cases.py
@@ -15,9 +15,14 @@ from .utils import cache as cache_result
 logger = logging.getLogger(__name__)
 
 
-def fetch_cases(user_bsn: str) -> List[Zaak]:
+# cache for 3 minutes to quickly switch between open and closed cases
+@cache_result("cases:{user_bsn}:{max_cases}", timeout=60 * 3)
+def fetch_cases(user_bsn: str, max_cases: Optional[int] = 100) -> List[Zaak]:
     """
     retrieve cases for particular user with allowed confidentiality level
+
+    :param:max_cases - used to limit the number of requests to list_zaken resource. The default
+    value = 100, which means only one 1 request
     """
     client = build_client("zaak")
 
@@ -30,6 +35,7 @@ def fetch_cases(user_bsn: str) -> List[Zaak]:
         response = get_paginated_results(
             client,
             "zaak",
+            minumum=max_cases,
             request_kwargs={
                 "params": {
                     "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": user_bsn,

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -220,21 +220,24 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
     def test_cached_case_types_in_combination_with_new_ones(self, m):
         self._setUpMocks(m)
 
-        # First attempt
-        self.assertIsNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+        with freeze_time("2022-01-01 12:00") as frozen_time:
+            # First attempt
+            self.assertIsNone(cache.get(f"case_type:{self.zaaktype['url']}"))
 
-        self.app.get(self.url, user=self.user)
+            self.app.get(self.url, user=self.user)
 
-        self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+            self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
 
-        # Second attempt with new case and case type
-        self.assertIsNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
-        self._setUpNewMock(m)
+            # Second attempt with new case and case type
+            self._setUpNewMock(m)
+            # Wait 3 minutes for the list cases cache to expire
+            frozen_time.tick(delta=datetime.timedelta(minutes=3))
+            self.assertIsNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
 
-        self.app.get(self.url, user=self.user)
+            self.app.get(self.url, user=self.user)
 
-        self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
-        self.assertIsNotNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
+            self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+            self.assertIsNotNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
 
     def test_status_types_are_cached(self, m):
         self._setUpMocks(m)
@@ -275,41 +278,43 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
     def test_cached_status_types_in_combination_with_new_ones(self, m):
         self._setUpMocks(m)
 
-        # First attempt
-        self.assertIsNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
-        self.assertIsNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
+        with freeze_time("2022-01-01 12:00") as frozen_time:
+            # First attempt
+            self.assertIsNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
+            self.assertIsNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
 
-        self.app.get(self.url, user=self.user)
+            self.app.get(self.url, user=self.user)
 
-        self.assertIsNotNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
-        self.assertIsNotNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
+            self.assertIsNotNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
 
-        # Second attempt with new case and status type
-        self._setUpNewMock(m)
+            # Second attempt with new case and status type
+            self._setUpNewMock(m)
+            # Wait 3 minutes for the list cases cache to expire
+            frozen_time.tick(delta=datetime.timedelta(minutes=3))
+            self.assertIsNone(
+                cache.get(f"status_types_for_case_type:{self.new_zaaktype['url']}")
+            )
 
-        self.assertIsNone(
-            cache.get(f"status_types_for_case_type:{self.new_zaaktype['url']}")
-        )
+            self.app.get(self.url, user=self.user)
 
-        self.app.get(self.url, user=self.user)
-
-        self.assertIsNotNone(
-            cache.get(f"status_types_for_case_type:{self.new_zaaktype['url']}")
-        )
-        self.assertIsNotNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
-        self.assertIsNotNone(
-            cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
-        )
+            self.assertIsNotNone(
+                cache.get(f"status_types_for_case_type:{self.new_zaaktype['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+            )
 
     def test_statuses_are_cached(self, m):
         self._setUpMocks(m)
@@ -338,25 +343,27 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
     def test_cached_statuses_in_combination_with_new_ones(self, m):
         self._setUpMocks(m)
 
-        # First attempt
-        self.assertIsNone(cache.get(f"status:{self.status1['url']}"))
-        self.assertIsNone(cache.get(f"status:{self.status2['url']}"))
+        with freeze_time("2022-01-01 12:00") as frozen_time:
+            # First attempt
+            self.assertIsNone(cache.get(f"status:{self.status1['url']}"))
+            self.assertIsNone(cache.get(f"status:{self.status2['url']}"))
 
-        self.app.get(self.url, user=self.user)
+            self.app.get(self.url, user=self.user)
 
-        self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
-        self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
+            self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
 
-        # Second attempt with new case and status type
-        self._setUpNewMock(m)
+            # Second attempt with new case and status type
+            self._setUpNewMock(m)
+            # Wait 3 minutes for the list cases cache to expire
+            frozen_time.tick(delta=datetime.timedelta(minutes=3))
+            self.assertIsNone(cache.get(f"status:{self.new_status['url']}"))
 
-        self.assertIsNone(cache.get(f"status:{self.new_status['url']}"))
+            self.app.get(self.url, user=self.user)
 
-        self.app.get(self.url, user=self.user)
-
-        self.assertIsNotNone(cache.get(f"status:{self.new_status['url']}"))
-        self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
-        self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNotNone(cache.get(f"status:{self.new_status['url']}"))
+            self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
+            self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
 
 
 class ClosedCaseListCacheTests(OpenCaseListCacheTests):

--- a/src/open_inwoner/templates/pages/cases/list.html
+++ b/src/open_inwoner/templates/pages/cases/list.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n anchor_menu_tags card_tags grid_tags icon_tags link_tags list_tags utils %}
+{% load i18n anchor_menu_tags card_tags grid_tags icon_tags link_tags list_tags pagination_tags utils %}
 
 {% block sidebar_content %}
     {% anchor_menu anchors=anchors desktop=True %}
@@ -9,7 +9,7 @@
     <h1 class="h1" id="title">{% trans "Mijn aanvragen" %}</h1>
 
     <div class="cases">
-        <h2 class="h2" id="cases">{{ title }} ({{ cases|length }})</h2>
+        <h2 class="h2" id="cases">{{ title }} ({{ paginator.count }})</h2>
         {% render_grid %}
             {% for case in cases %}
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
@@ -25,6 +25,8 @@
                 {% endrender_column %}
             {% endfor %}
         {% endrender_grid %}
+
+        {% pagination page_obj=page_obj paginator=paginator request=request %}
     </div>
 
 {% endblock content %}


### PR DESCRIPTION
Since we have to filter cases on client side (separate open cases from closed) we can't use `page` query param to Zaken API for pagination and we have to implement it also on the client side. 

There were **3 options** considered to implement pagination:
1. Each time request all cases, filter them and then paginate
  \+ We show client all the data
  \- Performance-heavy, especially on staging environment, where we have thousands cases for 1 person
2. Use `ordering` query param when requesting cases from Zaken API. 
  \+ It would be an optimal solution: we could order cases on the end date and limit the request to only open ones or closed ones.
  \- Too bas this query param doesn't work in eSuite
3. Set the maximum amount of requests we do to cases resource in Zaken API
  \+ Improve performance
  \- We don't show all cases
  \- We limit requests, not the amount of cases, and then we separate open and closed ones, it means it is possible to show the user 3 closed cases and hide 30 older ones. But for regular user in production it is very unusual situation

@alextreme and I decided to stick to the 3rd option for now, because it won't affect users in production much, since it's rare for a user to have hundreds of cases, but it will improve our performance on staging env

* only 100 cases can be retrieved and processed, e-Suite returns 20 cases per page, so no more than 5 requests to cases could be done
* these 100 cases are then separated on the open and closed ones, ~~each of them we limit to 50 cases. Not sure if this step is necessary, I'd like to hear your opinion~~ **Upd. removed thanks to** @alextreme 
* these open or closed cases are paginated. We request related resources (statuses, documents. etc) only for the cases shown on the page 
