### PR TITLE
Added Github workflow "Check for model changes not present in the migrations"

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,6 +49,47 @@ jobs:
       - name: Run black
         run: |
           black --check --diff src
+
+  migrations:
+    name: Check for model changes not present in the migrations
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        # Needed because the postgres container does not provide a healthcheck
+        options:
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install system packages
+        run: |
+          sudo apt-get update \
+          && sudo apt-get install -y --no-install-recommends \
+            libgdal-dev \
+            gdal-bin
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          pip install -r requirements/dev.txt
+      - name: Run manage.py makemigrations --check --dry-run
+        run: |
+          src/manage.py makemigrations --check --dry-run
+        env:
+          DJANGO_SETTINGS_MODULE: open_inwoner.conf.dev
+          SECRET_KEY: dummy
+          DB_USER: postgres
+          DB_PASSWORD: ''
+
   prettier:
     name: Check code formatting with prettier
     runs-on: ubuntu-latest


### PR DESCRIPTION
This runs `manage.py makemigrations --check --dry-run` as part of the build, which will fail if there are changes in the model code that aren't part of the migrations up to this point.

So when you run makemigrations we won't have mystery migrations show up for code you didn't touch and have to decide if it was something important or just a label or choices change.

This also means a label change requires a migration.