### PR TITLE
#950 bump zgw-consumers to 0.23.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ brotli==1.0.9
     # via fonttools
 certifi==2022.9.24
     # via
+    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   requests
@@ -34,8 +35,9 @@ commonmark==0.9.1
     # via rich
 confusable-homoglyphs==3.2.0
     # via django-registration
-cryptography==35.0.0
+cryptography==38.0.4
     # via
+    #   django-simple-certmanager
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -76,6 +78,7 @@ django==3.2.15
     #   django-rich
     #   django-rosetta
     #   django-sendfile2
+    #   django-simple-certmanager
     #   django-sniplates
     #   django-timeline-logger
     #   django-treebeard
@@ -104,6 +107,7 @@ django-choices==1.7.2
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
+    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -157,7 +161,7 @@ django-polymorphic==3.0.0
 django-privates==1.2.2
     # via
     #   -r requirements/base.in
-    #   zgw-consumers
+    #   django-simple-certmanager
 django-redis==5.0.0
     # via -r requirements/base.in
 django-registration==3.2
@@ -174,6 +178,8 @@ django-sessionprofile==1.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
+django-simple-certmanager==1.1.2
+    # via zgw-consumers
 django-sniplates==0.7.0
     # via -r requirements/base.in
 django-solo==1.2.0
@@ -289,9 +295,10 @@ pygments==2.12.0
     # via rich
 pyjwt==2.3.0
     # via gemma-zds-client
-pyopenssl==21.0.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/base.in
+    #   django-simple-certmanager
     #   josepy
     #   maykin-python3-saml
     #   zgw-consumers
@@ -349,7 +356,6 @@ six==1.16.0
     #   html5lib
     #   isodate
     #   orderedmultidict
-    #   pyopenssl
     #   python-dateutil
     #   qrcode
     #   requests-mock
@@ -390,7 +396,7 @@ xlwt==1.3.0
     # via tablib
 xmlsec==1.3.12
     # via maykin-python3-saml
-zgw-consumers==0.18.0
+zgw-consumers==0.23.2
     # via -r requirements/base.in
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -43,6 +43,7 @@ certifi==2022.9.24
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   requests
@@ -71,10 +72,11 @@ confusable-homoglyphs==3.2.0
     #   django-registration
 coverage==4.5.4
     # via -r requirements/test-tools.in
-cryptography==35.0.0
+cryptography==38.0.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-simple-certmanager
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -126,6 +128,7 @@ django==3.2.15
     #   django-rich
     #   django-rosetta
     #   django-sendfile2
+    #   django-simple-certmanager
     #   django-sniplates
     #   django-timeline-logger
     #   django-treebeard
@@ -165,6 +168,7 @@ django-choices==1.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
+    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -269,7 +273,7 @@ django-privates==1.2.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   zgw-consumers
+    #   django-simple-certmanager
 django-redis==5.0.0
     # via
     #   -c requirements/base.txt
@@ -301,6 +305,11 @@ django-sessionprofile==1.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
+django-simple-certmanager==1.1.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   zgw-consumers
 django-sniplates==0.7.0
     # via
     #   -c requirements/base.txt
@@ -562,11 +571,12 @@ pyjwt==2.3.0
     #   gemma-zds-client
 pylint==2.11.1
     # via -r requirements/test-tools.in
-pyopenssl==21.0.0
+pyopenssl==22.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   -r requirements/test-tools.in
+    #   django-simple-certmanager
     #   josepy
     #   maykin-python3-saml
     #   zgw-consumers
@@ -670,7 +680,6 @@ six==1.16.0
     #   html5lib
     #   isodate
     #   orderedmultidict
-    #   pyopenssl
     #   python-dateutil
     #   qrcode
     #   requests-mock
@@ -777,7 +786,7 @@ xmlsec==1.3.12
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-python3-saml
-zgw-consumers==0.18.0
+zgw-consumers==0.23.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,6 +58,7 @@ certifi==2022.9.24
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   requests
@@ -92,10 +93,11 @@ coverage==4.5.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-cryptography==35.0.0
+cryptography==38.0.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-simple-certmanager
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
@@ -155,6 +157,7 @@ django==3.2.15
     #   django-rich
     #   django-rosetta
     #   django-sendfile2
+    #   django-simple-certmanager
     #   django-sniplates
     #   django-timeline-logger
     #   django-treebeard
@@ -194,6 +197,7 @@ django-choices==1.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
+    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -302,7 +306,7 @@ django-privates==1.2.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   zgw-consumers
+    #   django-simple-certmanager
 django-redis==5.0.0
     # via
     #   -c requirements/ci.txt
@@ -334,6 +338,11 @@ django-sessionprofile==1.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
+django-simple-certmanager==1.1.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   zgw-consumers
 django-sniplates==0.7.0
     # via
     #   -c requirements/ci.txt
@@ -664,10 +673,11 @@ pylint==2.11.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-pyopenssl==21.0.0
+pyopenssl==22.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-simple-certmanager
     #   josepy
     #   maykin-python3-saml
     #   zgw-consumers
@@ -786,7 +796,6 @@ six==1.16.0
     #   html5lib
     #   isodate
     #   orderedmultidict
-    #   pyopenssl
     #   python-dateutil
     #   qrcode
     #   requests-mock
@@ -959,7 +968,7 @@ xmlsec==1.3.12
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-python3-saml
-zgw-consumers==0.18.0
+zgw-consumers==0.23.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -144,6 +144,7 @@ INSTALLED_APPS = [
     "colorfield",
     "view_breadcrumbs",
     "django_better_admin_arrayfield",
+    "simple_certmanager",
     "zgw_consumers",
     "mail_editor",
     "ckeditor",

--- a/src/open_inwoner/openzaak/tests/factories.py
+++ b/src/open_inwoner/openzaak/tests/factories.py
@@ -1,5 +1,5 @@
 import factory
-from zgw_consumers.constants import CertificateTypes
+from simple_certmanager.constants import CertificateTypes
 from zgw_consumers.models import Certificate, Service
 
 

--- a/src/open_inwoner/openzaak/tests/factories.py
+++ b/src/open_inwoner/openzaak/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 from simple_certmanager.constants import CertificateTypes
-from zgw_consumers.models import Certificate, Service
+from simple_certmanager.models import Certificate
+from zgw_consumers.models import Service
 
 
 class ServiceFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
`zgw_consumers` 0.23.2 includes bugfix of `get_paginated_results` function, which should help with duplicated results (PR - https://github.com/maykinmedia/zgw-consumers/pull/58)


**NOTE!** 
`zgw_consumers` 0.21.0 has a breaking change - moving `Certificate` model into the separate library (https://github.com/maykinmedia/zgw-consumers/blob/main/CHANGELOG.rst#0210-2022-08-31)
After this PR is merged and deployed into staging the Open Zaak certificate configuration should be checked:
* requesting cases should work
* download documents should also work