### PR TITLE
[#956] Fix/remove tables' additional line

### DIFF
--- a/src/open_inwoner/components/templates/components/table/table_cell.html
+++ b/src/open_inwoner/components/templates/components/table/table_cell.html
@@ -1,1 +1,1 @@
-<td class="table__item">{{ contents }}</td>
+<td class="table__item table__item--status">{{ contents }}</td>

--- a/src/open_inwoner/scss/components/Table/Table.scss
+++ b/src/open_inwoner/scss/components/Table/Table.scss
@@ -75,7 +75,7 @@
     border-bottom: 1px solid;
     border-bottom-color: var(--color-gray-light);
 
-    &:first-of-type {
+    &--status:first-of-type {
       border-top: 1px solid;
       border-top-color: var(--color-gray-light);
     }


### PR DESCRIPTION
After the styling of cases and statuses we added template tags for rendering tables in status. I saw that these template tags are being used only there that's why I changed only this part. @svenvandescheur  can provide his feedback about this.