### PR TITLE
Added setting to silence house-keeping signals that clutter tests

### DIFF
--- a/src/open_inwoner/accounts/apps.py
+++ b/src/open_inwoner/accounts/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class AccountsConfig(AppConfig):
@@ -6,3 +7,17 @@ class AccountsConfig(AppConfig):
 
     def ready(self):
         from .signals import log_user_login, log_user_logout  # register the signals
+
+        use_signals = getattr(settings, "ENABLE_USER_SIGNALS", True)
+        if not use_signals:
+            from django.contrib.auth.models import update_last_login
+            from django.contrib.auth.signals import user_logged_in, user_logged_out
+            from django.db.models.signals import pre_save
+
+            from open_inwoner.accounts.models import User
+            from open_inwoner.haalcentraal.signals import on_bsn_change
+
+            user_logged_in.disconnect(update_last_login)
+            user_logged_in.disconnect(log_user_login)
+            user_logged_out.disconnect(log_user_logout)
+            pre_save.disconnect(on_bsn_change, sender=User)

--- a/src/open_inwoner/conf/ci.py
+++ b/src/open_inwoner/conf/ci.py
@@ -28,3 +28,6 @@ CACHES = {
 }
 
 ELASTIC_APM["DEBUG"] = True
+
+# option to supress noisy signals during testing
+ENABLE_USER_SIGNALS = False

--- a/src/open_inwoner/conf/dev.py
+++ b/src/open_inwoner/conf/dev.py
@@ -137,6 +137,9 @@ TWO_FACTOR_PATCH_ADMIN = False
 # django-selenium-login needs an arbitrary and fast page to grab cookies
 SELENIUM_LOGIN_START_PAGE = "/admin/password_reset/"
 
+# option to supress noisy signals during testing
+ENABLE_USER_SIGNALS = False
+
 # Override settings with local settings.
 try:
     from .local import *  # noqa

--- a/src/open_inwoner/conf/local_example.py
+++ b/src/open_inwoner/conf/local_example.py
@@ -12,3 +12,7 @@ DATABASES = {
         "PORT": "",  # Set to empty string for default.
     }
 }
+
+
+# option to supress noisy signals during testing
+# ENABLE_USER_SIGNALS = False


### PR DESCRIPTION
The haalcentraal signal isn't very useful on CI, neither is the User 'last_login' type of logging functionality. But they create a log of noise that makes the CI/dev logs less usable.