### PR TITLE
[#911] Added 'indicatieInternOfExtern' access check, also refactored cases-views tests

### DIFF
--- a/src/open_inwoner/accounts/tests/factories.py
+++ b/src/open_inwoner/accounts/tests/factories.py
@@ -3,11 +3,13 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db.models.signals import post_save, pre_save
 
 import factory
 import factory.fuzzy
 
 
+@factory.django.mute_signals(pre_save, post_save)
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "accounts.User"

--- a/src/open_inwoner/openzaak/api_models.py
+++ b/src/open_inwoner/openzaak/api_models.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Optional
+from typing import Optional, Union
 
 from zgw_consumers.api_models.base import ZGWModel
+from zgw_consumers.api_models.catalogi import (
+    InformatieObjectType,
+    ResultaatType,
+    RolType,
+    StatusType,
+)
 from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
 
 """
@@ -18,14 +24,14 @@ class Zaak(ZGWModel):
     bronorganisatie: str
     omschrijving: str
     #    toelichting: str
-    zaaktype: str
+    zaaktype: Union[str, "ZaakType"]
     registratiedatum: date
     startdatum: date
-    einddatum_gepland: Optional[date]
-    uiterlijke_einddatum_afdoening: Optional[date]
-    #    publicatiedatum: Optional[date]
     vertrouwelijkheidaanduiding: str
-    status: str
+    status: Optional[Union[str, "Status"]]
+    einddatum_gepland: Optional[date] = None
+    uiterlijke_einddatum_afdoening: Optional[date] = None
+    #    publicatiedatum: Optional[date]
     einddatum: Optional[date] = None
     resultaat: Optional[str] = None
     #    relevante_andere_zaken: list
@@ -65,8 +71,8 @@ class ZaakType(ZGWModel):
 @dataclass
 class ZaakInformatieObject(ZGWModel):
     url: str
-    informatieobject: str
-    zaak: str
+    informatieobject: Union[str, "InformatieObject"]
+    zaak: Union[str, Zaak]
     # aard_relatie_weergave: str
     titel: str
     # beschrijving: str
@@ -91,7 +97,7 @@ class InformatieObject(ZGWModel):
     inhoud: str
     bestandsomvang: int
     # indicatieGebruiksrecht: str
-    informatieobjecttype: str
+    informatieobjecttype: Union[str, InformatieObjectType]
     locked: bool
     # bestandsdelen: List[str]
     beschrijving: Optional[str] = ""
@@ -107,7 +113,7 @@ class Rol(ZGWModel):
     url: str
     zaak: str
     betrokkene_type: str
-    roltype: str
+    roltype: Union[str, RolType]
     omschrijving: str
     omschrijving_generiek: str
     roltoelichting: str
@@ -126,15 +132,15 @@ class Rol(ZGWModel):
 @dataclass
 class Resultaat(ZGWModel):
     url: str
-    zaak: str
-    resultaattype: str
+    zaak: Union[str, Zaak]
+    resultaattype: Union[str, ResultaatType]
     toelichting: Optional[str] = ""
 
 
 @dataclass
 class Status(ZGWModel):
     url: str
-    zaak: str
-    statustype: str
+    zaak: Union[str, Zaak]
+    statustype: Union[str, StatusType]
     datum_status_gezet: Optional[datetime] = None
     statustoelichting: Optional[str] = ""

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -21,7 +21,7 @@ from zgw_consumers.test import generate_oas_component, mock_service_oas_get
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.accounts.views.cases import SimpleFile
-from open_inwoner.utils.test import paginated_response
+from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 from ..api_models import Status
 from ..models import OpenZaakConfig
@@ -33,51 +33,42 @@ DOCUMENTEN_ROOT = "https://documenten.nl/api/v1/"
 
 
 @requests_mock.Mocker()
-class TestCaseDetailView(WebTest):
-    def setUp(self):
-        super().setUp()
-        self.maxDiff = None
-        cache.clear()
-
-    def tearDown(self):
-        super().tearDown()
-        cache.clear()
-
+class TestCaseDetailView(ClearCachesMixin, WebTest):
     @classmethod
-    def setUpTestData(self):
+    def setUpTestData(cls):
         super().setUpTestData()
 
-        self.user = UserFactory(
+        cls.user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="johm@smith.nl"
         )
         # services
-        self.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
-        self.catalogi_service = ServiceFactory(
+        cls.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
+        cls.catalogi_service = ServiceFactory(
             api_root=CATALOGI_ROOT, api_type=APITypes.ztc
         )
-        self.document_service = ServiceFactory(
+        cls.document_service = ServiceFactory(
             api_root=DOCUMENTEN_ROOT, api_type=APITypes.drc
         )
         # openzaak config
-        self.config = OpenZaakConfig.get_solo()
-        self.config.zaak_service = self.zaak_service
-        self.config.catalogi_service = self.catalogi_service
-        self.config.document_service = self.document_service
-        self.config.document_max_confidentiality = (
+        cls.config = OpenZaakConfig.get_solo()
+        cls.config.zaak_service = cls.zaak_service
+        cls.config.catalogi_service = cls.catalogi_service
+        cls.config.document_service = cls.document_service
+        cls.config.document_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
-        self.config.zaak_max_confidentiality = (
+        cls.config.zaak_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
-        self.config.save()
+        cls.config.save()
 
-        self.case_detail_url = reverse(
+        cls.case_detail_url = reverse(
             "accounts:case_status",
             kwargs={"object_id": "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"},
         )
 
         # openzaak resources
-        self.zaak = generate_oas_component(
+        cls.zaak = generate_oas_component(
             "zrc",
             "schemas/Zaak",
             uuid="d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
@@ -93,78 +84,78 @@ class TestCaseDetailView(WebTest):
             resultaat=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.zaak_invisible = generate_oas_component(
+        cls.zaak_invisible = generate_oas_component(
             "zrc",
             "schemas/Zaak",
             uuid="213b0a04-fcbc-4fee-8d11-cf950a0a0bbb",
             url=f"{ZAKEN_ROOT}zaken/213b0a04-fcbc-4fee-8d11-cf950a0a0bbb",
-            zaaktype=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
+            zaaktype=cls.zaak["zaaktype"],
             identificatie="ZAAK-2022-invisible",
             omschrijving="Zaak invisible",
             startdatum="2022-01-02",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.geheim,
         )
-        self.zaaktype = generate_oas_component(
+        cls.zaaktype = generate_oas_component(
             "ztc",
             "schemas/ZaakType",
-            url=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
+            url=cls.zaak["zaaktype"],
             omschrijving="Coffee zaaktype",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
-            vertrouwelijkheidaanduiding="openbaar",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             doel="Ask for coffee",
             aanleiding="Coffee is essential",
-            indicatie_intern_of_extern="intern",
-            handeling_initiator="Request",
+            indicatieInternOfExtern="extern",
+            handelingInitiator="Request",
             onderwerp="Coffee",
-            handeling_behandelaar="Behandelen",
-            opschorting_en_aanhouding_mogelijk=False,
-            verlenging_mogelijk=False,
-            publicatie_indicatie=False,
+            handelingBehandelaar="Behandelen",
+            opschortingEnAanhoudingMogelijk=False,
+            verlengingMogelijk=False,
+            publicatieIndicatie=False,
             besluittypen=[],
-            begin_geldigheid="2020-09-25",
+            beginGeldigheid="2020-09-25",
             versiedatum="2020-09-25",
         )
-        self.status_new = generate_oas_component(
+        cls.status_new = generate_oas_component(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
-            zaak=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
+            zaak=cls.zaak["url"],
             statustype=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-777yu878km09",
-            datum_status_gezet="2021-01-12",
+            datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
-        self.status_finish = generate_oas_component(
+        cls.status_finish = generate_oas_component(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
-            zaak=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
+            zaak=cls.zaak["url"],
             statustype=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-744516671fe4",
-            datum_status_gezet="2021-03-12",
+            datumStatusGezet="2021-03-12",
             statustoelichting="",
         )
-        self.status_type_new = generate_oas_component(
+        cls.status_type_new = generate_oas_component(
             "ztc",
             "schemas/StatusType",
-            url=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-777yu878km09",
-            zaaktype=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
+            url=cls.status_new["statustype"],
+            zaaktype=cls.zaaktype["url"],
             omschrijving="Initial request",
-            omschrijving_generiek="some content",
+            omschrijvingGeneriek="some content",
             statustekst="",
             volgnummer=1,
-            is_eindstatus=False,
+            isEindstatus=False,
         )
-        self.status_type_finish = generate_oas_component(
+        cls.status_type_finish = generate_oas_component(
             "ztc",
             "schemas/StatusType",
-            url=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-744516671fe4",
-            zaaktype=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
+            url=cls.status_finish["statustype"],
+            zaaktype=cls.zaaktype["url"],
             omschrijving="Finish",
-            omschrijving_generiek="some content",
+            omschrijvingGeneriek="some content",
             statustekst="",
             volgnummer=2,
-            is_eindstatus=False,
+            isEindstatus=False,
         )
-        self.user_role = generate_oas_component(
+        cls.user_role = generate_oas_component(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/f33153aa-ad2c-4a07-ae75-15add5891",
@@ -177,7 +168,7 @@ class TestCaseDetailView(WebTest):
                 "geslachtsnaam": "Bazz",
             },
         )
-        self.not_initiator_role = generate_oas_component(
+        cls.not_initiator_role = generate_oas_component(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aa353aa-ad2c-4a07-ae75-15add5822",
@@ -189,88 +180,98 @@ class TestCaseDetailView(WebTest):
                 "geslachtsnaam": "Else",
             },
         )
-        self.result = generate_oas_component(
+        cls.result = generate_oas_component(
             "zrc",
             "schemas/Resultaat",
             uuid="a44153aa-ad2c-6a07-be75-15add5113",
-            url=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
+            url=cls.zaak["resultaat"],
             resultaattype=f"{CATALOGI_ROOT}resultaattypen/b1a268dd-4322-47bb-a930-b83066b4a32c",
-            zaak=self.zaak["url"],
+            zaak=cls.zaak["url"],
             toelichting="resultaat toelichting",
         )
-        self.zaak_informatie_object = generate_oas_component(
+        cls.zaak_informatie_object = generate_oas_component(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812",
-            zaak=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            aard_relatie_weergave="some content",
+            zaak=cls.zaak["url"],
+            aardRelatieWeergave="some content",
             titel="",
             beschrijving="",
             registratiedatum="2021-01-12",
         )
-        self.informatie_object_type = generate_oas_component(
+        cls.informatie_object_type = generate_oas_component(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
         )
-        self.informatie_object = generate_oas_component(
+        cls.informatie_object = generate_oas_component(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="014c38fe-b010-4412-881c-3000032fb812",
-            url=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812",
+            url=cls.zaak_informatie_object["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812/download",
-            informatieobjecttype=f"{CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
+            informatieobjecttype=cls.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="document.txt",
             bestandsomvang=123,
         )
 
-        self.zaak_informatie_object_invisible = generate_oas_component(
+        cls.zaak_informatie_object_invisible = generate_oas_component(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/fa5153aa-ad2c-4a07-ae75-15add57ee",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123",
-            zaak=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            aard_relatie_weergave="some invisible content",
+            zaak=cls.zaak_invisible["url"],
+            aardRelatieWeergave="some invisible content",
             titel="",
             beschrijving="",
             registratiedatum="2021-01-12",
         )
-        self.informatie_object_invisible = generate_oas_component(
+        cls.informatie_object_invisible = generate_oas_component(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="994c38fe-b010-4412-881c-3000032fb123",
-            url=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123",
+            url=cls.zaak_informatie_object_invisible["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123/download",
-            informatieobjecttype=f"{CATALOGI_ROOT}informatieobjecttype/994c38fe-b010-4412-881c-3000032fb123",
+            informatieobjecttype=cls.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.geheim,
             bestandsnaam="geheim-document.txt",
             bestandsomvang=123,
         )
 
-        self.informatie_object_file = SimpleFile(
+        cls.informatie_object_file = SimpleFile(
             name="document.txt",
             size=123,
             url=reverse(
                 "accounts:case_document_download",
                 kwargs={
-                    "object_id": self.zaak["uuid"],
-                    "info_id": self.informatie_object["uuid"],
+                    "object_id": cls.zaak["uuid"],
+                    "info_id": cls.informatie_object["uuid"],
                 },
             ),
         )
 
-    def _setUpMocks(self, m):
+    def _setUpOASMocks(self, m):
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
         mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
         mock_service_oas_get(m, DOCUMENTEN_ROOT, "drc")
-        m.get(
-            f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            json=self.zaak,
-        )
+
+    def _setUpMocks(self, m):
+        self._setUpOASMocks(m)
+
+        for resource in [
+            self.zaak,
+            self.result,
+            self.zaaktype,
+            self.informatie_object_type,
+            self.informatie_object,
+            self.informatie_object_invisible,
+        ]:
+            m.get(resource["url"], json=resource)
+
         m.get(
             f"{ZAKEN_ROOT}zaakinformatieobjecten?zaak={self.zaak['url']}",
             json=[self.zaak_informatie_object, self.zaak_informatie_object_invisible],
@@ -291,25 +292,8 @@ class TestCaseDetailView(WebTest):
             json=paginated_response([self.user_role, self.not_initiator_role]),
         )
         m.get(
-            f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
-            json=self.result,
-        )
-        m.get(f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f", json=self.zaaktype)
-        m.get(
             f"{CATALOGI_ROOT}statustypen?zaaktype={self.zaaktype['url']}",
             json=paginated_response([self.status_type_new, self.status_type_finish]),
-        )
-        m.get(
-            f"{CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
-            json=self.informatie_object_type,
-        )
-        m.get(
-            f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812",
-            json=self.informatie_object,
-        )
-        m.get(
-            f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123",
-            json=self.informatie_object_invisible,
         )
         m.get(
             f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812/download",
@@ -375,9 +359,7 @@ class TestCaseDetailView(WebTest):
         current_status = response.context.get("case", {}).get("current_status")
         self.assertEquals(current_status, "Finish")
 
-    def test_case_information_objects_are_retrieved_when_user_logged_in_via_digid(
-        self, m
-    ):
+    def test_case_io_objects_are_retrieved_when_user_logged_in_via_digid(self, m):
         self._setUpMocks(m)
 
         response = self.app.get(self.case_detail_url, user=self.user)
@@ -412,37 +394,48 @@ class TestCaseDetailView(WebTest):
         )
 
     def test_no_access_when_no_roles_are_found_for_user_bsn(self, m):
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_service_oas_get(m, DOCUMENTEN_ROOT, "drc")
-        m.get(
-            f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            json=self.zaak,
-        )
-        m.get(
-            f"{ZAKEN_ROOT}zaakinformatieobjecten?zaak={self.zaak['url']}",
-            json=[self.zaak_informatie_object, self.zaak_informatie_object_invisible],
-        )
-        m.get(
-            f"{ZAKEN_ROOT}statussen?zaak={self.zaak['url']}",
-            json=paginated_response([self.status_finish, self.status_new]),
-        )
+        self._setUpOASMocks(m)
+
+        m.get(self.zaak["url"], json=self.zaak)
+        m.get(self.zaaktype["url"], json=self.zaaktype)
         m.get(
             f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
             # no roles for our user found
             json=paginated_response([self.not_initiator_role]),
         )
+        # m.get(
+        #     f"{ZAKEN_ROOT}zaakinformatieobjecten?zaak={self.zaak['url']}",
+        #     json=[self.zaak_informatie_object, self.zaak_informatie_object_invisible],
+        # )
+        # m.get(
+        #     f"{ZAKEN_ROOT}statussen?zaak={self.zaak['url']}",
+        #     json=paginated_response([self.status_finish, self.status_new]),
+        # )
         response = self.app.get(self.case_detail_url, user=self.user)
         self.assertRedirects(response, reverse("root"))
 
-    def test_no_data_is_retrieved_when_http_404(self, m):
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_service_oas_get(m, DOCUMENTEN_ROOT, "drc")
+    def test_no_data_is_retrieved_when_zaaktype_is_internal(self, m):
+        self._setUpOASMocks(m)
+
+        m.get(self.zaak["url"], json=self.zaak)
         m.get(
-            f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            status_code=404,
+            f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+            # no roles for our user found
+            json=paginated_response([self.user_role]),
         )
+        zaaktype_intern = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=self.zaak["zaaktype"],
+            indicatieInternOfExtern="intern",
+        )
+        m.get(self.zaaktype["url"], json=zaaktype_intern)
+        self.app.get(self.informatie_object_file.url, user=self.user, status=403)
+
+    def test_no_data_is_retrieved_when_http_404(self, m):
+        self._setUpOASMocks(m)
+
+        m.get(self.zaak["url"], status_code=404)
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
@@ -450,13 +443,9 @@ class TestCaseDetailView(WebTest):
         self.assertContains(response, _("There is no available data at the moment."))
 
     def test_no_data_is_retrieved_when_http_500(self, m):
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_service_oas_get(m, DOCUMENTEN_ROOT, "drc")
-        m.get(
-            f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            status_code=500,
-        )
+        self._setUpOASMocks(m)
+
+        m.get(self.zaak["url"], status_code=500)
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
@@ -464,9 +453,10 @@ class TestCaseDetailView(WebTest):
         self.assertContains(response, _("There is no available data at the moment."))
 
     def test_no_access_when_case_is_confidential(self, m):
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        self._setUpOASMocks(m)
+
         m.get(self.zaak_invisible["url"], json=self.zaak_invisible)
+        m.get(self.zaaktype["url"], json=self.zaaktype)
         m.get(
             f"{ZAKEN_ROOT}rollen?zaak={self.zaak_invisible['url']}",
             json=paginated_response([self.user_role, self.not_initiator_role]),

--- a/src/open_inwoner/openzaak/tests/test_case_request.py
+++ b/src/open_inwoner/openzaak/tests/test_case_request.py
@@ -7,6 +7,7 @@ from zgw_consumers.test import generate_oas_component, mock_service_oas_get
 
 from open_inwoner.openzaak.cases import fetch_single_case
 
+from ...utils.test import ClearCachesMixin
 from ..models import OpenZaakConfig
 from .factories import ServiceFactory
 
@@ -15,7 +16,7 @@ CATALOGI_ROOT = "https://catalogi.nl/api/v1/"
 
 
 @requests_mock.Mocker()
-class TestFetchSpecificCase(TestCase):
+class TestFetchSpecificCase(ClearCachesMixin, TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
@@ -23,9 +24,7 @@ class TestFetchSpecificCase(TestCase):
         cls.config.zaak_service = cls.zaak_service
         cls.config.save()
 
-    def setUp(self):
-        super().setUp()
-        self.zaak = generate_oas_component(
+        cls.zaak = generate_oas_component(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
@@ -34,11 +33,6 @@ class TestFetchSpecificCase(TestCase):
             startdatum="2022-01-02",
             einddatum=None,
         )
-        cache.clear()
-
-    def tearDown(self):
-        super().tearDown()
-        cache.clear()
 
     def test_case_is_retrieved(self, m):
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -53,7 +53,8 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             url=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
             omschrijving="Coffee zaaktype",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
-            vertrouwelijkheidaanduiding="openbaar",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+            indicatieInternOfExtern="extern",
         )
         cls.status_type1 = generate_oas_component(
             "ztc",
@@ -62,7 +63,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             zaaktype=cls.zaaktype["url"],
             omschrijving="Initial request",
             volgnummer=1,
-            is_eindstatus=False,
+            isEindstatus=False,
         )
         cls.status_type2 = generate_oas_component(
             "ztc",
@@ -71,7 +72,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             zaaktype=cls.zaaktype["url"],
             omschrijving="Finish",
             volgnummer=2,
-            is_eindstatus=True,
+            isEindstatus=True,
         )
         cls.zaak1 = generate_oas_component(
             "zrc",
@@ -91,7 +92,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
             zaak=cls.zaak1["url"],
             statustype=cls.status_type1["url"],
-            datum_status_gezet="2021-01-12",
+            datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
         cls.zaak2 = generate_oas_component(
@@ -112,7 +113,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
             zaak=cls.zaak2["url"],
             statustype=cls.status_type2["url"],
-            datum_status_gezet="2021-03-12",
+            datumStatusGezet="2021-03-12",
             statustoelichting="",
         )
 
@@ -123,7 +124,8 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             url=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f-98ui7y87i876",
             omschrijving="Tea zaaktype",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
-            vertrouwelijkheidaanduiding="openbaar",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+            indicatieInternOfExtern="extern",
         )
         cls.new_status_type = generate_oas_component(
             "ztc",
@@ -132,7 +134,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             zaaktype=cls.new_zaaktype["url"],
             omschrijving="Process",
             volgnummer=1,
-            is_eindstatus=False,
+            isEindstatus=False,
         )
         cls.new_zaak = generate_oas_component(
             "zrc",
@@ -144,6 +146,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             startdatum="2022-01-02",
             einddatum=None,
             status=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-oie8u899923g",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
         cls.new_status = generate_oas_component(
             "zrc",
@@ -151,7 +154,7 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-oie8u899923g",
             zaak=cls.new_zaak["url"],
             statustype=cls.new_status_type["url"],
-            datum_status_gezet="2021-01-12",
+            datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
 

--- a/src/open_inwoner/openzaak/utils.py
+++ b/src/open_inwoner/openzaak/utils.py
@@ -49,6 +49,12 @@ def is_info_object_visible(
 def is_zaak_visible(zaak: Zaak) -> bool:
     """Check if zaak is visible for users"""
     config = OpenZaakConfig.get_solo()
+    if isinstance(zaak.zaaktype, str):
+        raise ValueError("expected zaak.zaaktype to be resolved from url to model")
+
+    if zaak.zaaktype.indicatie_intern_of_extern != "extern":
+        return False
+
     return is_object_visible(zaak, config.zaak_max_confidentiality)
 
 


### PR DESCRIPTION
Note: the important change was to `is_zaak_visible()`

Then I found this wasn't applied to the list-views at all, and that required a refactor because we needed the filtering before the pagination which required to move the zaaktype retrieval code around.

But then I found the issue with the property casing in the mocks, and some other test noise like the cache-reset mixin and test data setup.

As a bonus: less noisy UserFactory, and improved ZGW api_model dataclass annotations that support swapping link URI's to objects because that is how it was used.
