### PR TITLE
Fixed fixture discovery and added post-migrate admin-index fixture reloading

### DIFF
--- a/bin/generate_admin_index_fixture.sh
+++ b/bin/generate_admin_index_fixture.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Dump the current (local database) admin layout to a JSON fixture. This
+# overwrites the existing one.
+#
+# You can load this fixture with:
+# $ src/manage.py loaddata django-admin-index
+#
+# Run this script from the root of the repository
+
+src/manage.py dumpdata --indent=4 --natural-foreign --natural-primary admin_index.AppGroup admin_index.AppLink > src/open_inwoner/conf/fixtures/django-admin-index.json

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -416,7 +416,7 @@ X_FRAME_OPTIONS = "DENY"
 # FIXTURES
 #
 
-FIXTURE_DIRS = (os.path.join(DJANGO_PROJECT_DIR, "fixtures"),)
+FIXTURE_DIRS = (os.path.join(DJANGO_PROJECT_DIR, "conf", "fixtures"),)
 
 #
 # Custom settings


### PR DESCRIPTION
The first part fixes the discovery of fixtures, so you no longer need full path or extension.

The second part is a script `bin/generate_admin_index_fixture.sh` to manually run after we changed the admin-index, like after adding new models or links.

The third part adds a post-migrate signal handler so whenever `manage.py migrate` is run it will synchronize the admin-index so we're all looking at the same menu.

There is another level after this I didn't add for now, where we'd add a task to the CI workflow that fails if there are new models that aren't explicitly added or excluded from admin-index, but it can wait.