### PR TITLE
:lipstick: [#1082] Word/letter wrapping

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -87,7 +87,8 @@ development machine.
    .. code-block:: bash
 
        $ npm install
-       $ npm ci --legacy-peer-deps
+       or as an alternative: npm ci --legacy-peer-deps
+       $ npm run build
 
 6. Create the statics and database:
 
@@ -144,7 +145,8 @@ When updating an existing installation:
        $ git pull
        $ pip install -r requirements/dev.txt
        $ npm install
-       $ npm ci --legacy-peer-deps
+       or as an alternative: npm ci --legacy-peer-deps
+       $ npm run build
 
 3. Update the statics and database:
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -87,7 +87,7 @@ development machine.
    .. code-block:: bash
 
        $ npm install
-       $ npm run build
+       $ npm ci --legacy-peer-deps
 
 6. Create the statics and database:
 
@@ -144,7 +144,7 @@ When updating an existing installation:
        $ git pull
        $ pip install -r requirements/dev.txt
        $ npm install
-       $ npm run build
+       $ npm ci --legacy-peer-deps
 
 3. Update the statics and database:
 

--- a/src/open_inwoner/scss/components/Typography/H3.scss
+++ b/src/open_inwoner/scss/components/Typography/H3.scss
@@ -9,7 +9,8 @@
   margin: 0;
 
   @include mobile-only {
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
   }
 }
 

--- a/src/open_inwoner/scss/components/Typography/H4.scss
+++ b/src/open_inwoner/scss/components/Typography/H4.scss
@@ -9,6 +9,7 @@
   margin: 0;
 
   @include mobile-only {
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
Issue: on mobile view for locations, names/words break on all letters, instead of words.
(Both inside the headers of card-containers, as well in headers of leaflet map titles)
Note: "_While word-break: break-word is deprecated, it has the same effect, when specified, as word-break: normal and overflow-wrap: anywhere — regardless of the actual value of the [overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) property._"

![wordbreakall](https://user-images.githubusercontent.com/118177951/216649100-bcf5c418-91a8-4383-8bb7-acdcb636f435.png)
