### PR TITLE
:lipstick: [#1021] make entire card clickable

### DIFF
--- a/src/open_inwoner/components/templates/components/Card/RenderCard.html
+++ b/src/open_inwoner/components/templates/components/Card/RenderCard.html
@@ -2,22 +2,25 @@
 
 {# Utilizes same template as Card. #}
 <div class="card{% if compact %} card--compact{% endif %}{% if inline %} card--inline{% endif %}{% if stretch %} card--stretch{% endif %}{% if tinted %} card--tinted{% endif %}{% if type %} card--type-{{ type }}{% endif %}">
-    {% if src %}
-        <a class="card__header" href="{{ href }}" title="{{ title }}" aria-describedby="{{ title }}">
-            <img class="card__img{% if image_object_fit %} card__img--{{ image_object_fit }}{% endif %}" src="{{ src }}" alt="{{ alt }}"/>
-        </a>
-    {% endif %}
+    <a class="card__link" href="{{ href }}" title="{{ title }}" aria-describedby="{{ title }}">
 
-    <div class="card__body{% if direction %} card__body--direction-{{ direction }}{% endif %}{% if grid %} card__body--grid{% endif %}">
-        {% if title %}
-            <p class="{% if compact %}h4{% else %}h3{% endif %}">
-                {% if href %}
-                    {% link href=href text=title %}
-                {% else %}
-                    {{ title }}
-                {% endif %}
-            </p>
+        {% if src %}
+            <a class="card__header" href="{{ href }}" title="{{ title }}" aria-describedby="{{ title }}">
+                <img class="card__img{% if image_object_fit %} card__img--{{ image_object_fit }}{% endif %}" src="{{ src }}" alt="{{ alt }}"/>
+            </a>
         {% endif %}
-        {{ contents }}
-    </div>
+
+        <div class="card__body{% if direction %} card__body--direction-{{ direction }}{% endif %}{% if grid %} card__body--grid{% endif %}">
+            {% if title %}
+                <p class="{% if compact %}h4{% else %}h3{% endif %}">
+                    {% if href %}
+                        {% link href=href text=title %}
+                    {% else %}
+                        {{ title }}
+                    {% endif %}
+                </p>
+            {% endif %}
+            {{ contents }}
+        </div>
+    </a>
 </div>


### PR DESCRIPTION
"As a visitor, I want to navigate through the entire product tile so that I can easily go to other pages.
Now only the image and title are clickable. Can the white part also be made clickable?"