### PR TITLE
[#1057] Removed thumbnailer from header and footer logo

### DIFF
--- a/src/open_inwoner/components/templates/components/Footer/Footer.html
+++ b/src/open_inwoner/components/templates/components/Footer/Footer.html
@@ -4,13 +4,13 @@
 
 <footer class='footer'>
     {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
-    
+
     <div class="footer__logo-text">
         <p class="p">{{ config.footer_logo_title|linebreaksbr }}</p>
     </div>
 
     <div class="footer__logo">
-        {% logo src=config.footer_logo.file|thumbnail_url:'logo' alt=logo_alt_text href=config.footer_logo_url %}
+        {% logo src=config.footer_logo.file.url alt=logo_alt_text href=config.footer_logo_url %}
     </div>
 
     <div class="footer__visitor">

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -6,7 +6,7 @@
 <header class="header" aria-label="Navigatie header">
     <div class="header__container">
         {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
-        {% logo src=config.logo.file|thumbnail_url:'logo' alt=logo_alt_text %}
+        {% logo src=config.logo.file.url alt=logo_alt_text %}
 
         <div class="header__menu">
             <button class="header__button">

--- a/src/open_inwoner/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/open_inwoner/conf/locale/nl/LC_MESSAGES/django.po
@@ -1843,8 +1843,8 @@ msgid "Logo"
 msgstr "Logo"
 
 #: configurations/models.py:65
-msgid "Logo of the municipality"
-msgstr "Logo van de gemeente"
+msgid "Logo of the municipality - For best presentation keep images in square or landscape mode and with a maximum file size of 1 MB"
+msgstr "Logo van de gemeente - Houd afbeeldingen in vierkant of landschapsformaat en met een maximale bestandsgrootte van 1 MB"
 
 #: configurations/models.py:68
 msgid "Hero image login"
@@ -2885,8 +2885,8 @@ msgid "Slug of the organization"
 msgstr "Slug van de organisatie"
 
 #: pdc/models/organization.py:27
-msgid "Logo of the orgaization"
-msgstr "Logo van de organisatie"
+msgid "Logo of the organization - For best presentation keep images in square or landscape mode and with a maximum file size of 2 MB"
+msgstr "Logo van de organisatie - Houd afbeeldingen in vierkant of landschapsformaat en met een maximale bestandsgrootte van 2 MB"
 
 #: pdc/models/organization.py:34 pdc/models/organization.py:71
 #: pdc/models/organization.py:75

--- a/src/open_inwoner/scss/components/Footer/Footer.scss
+++ b/src/open_inwoner/scss/components/Footer/Footer.scss
@@ -33,6 +33,11 @@
 
   &__logo {
     grid-area: lg;
+
+    img {
+      width: auto;
+      max-height: 60px;
+    }
   }
 
   &__logo-text {

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -68,6 +68,10 @@ $vm: var(--spacing-large);
     @media (max-width: 767px) {
       padding: 8px;
     }
+
+    img {
+      max-height: 75px;
+    }
   }
 
   &__menu {


### PR DESCRIPTION
This is a draft because I hijacked @jiromaykin's ticket for the code change but there are some CSS considerations.