### PR TITLE
:wheelchair: #1084 Check borders after accessibility changes

### DIFF
--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -1,7 +1,7 @@
 .card {
   --card-color-background: white;
   --card-color-border: var(--color-gray);
-  --card-size-border: 1px;
+  --card-size-border: var(--border-width-thin);
   --card-size-dog-ear: var(--gutter-width);
   --card-spacing: var(--spacing-large);
 

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -1,7 +1,7 @@
 .card {
   --card-color-background: white;
   --card-color-border: var(--color-mute-deco);
-  --card-size-border: var(--border-width);
+  --card-size-border: 1px;
   --card-size-dog-ear: var(--gutter-width);
   --card-spacing: var(--spacing-large);
 

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -1,6 +1,6 @@
 .card {
   --card-color-background: white;
-  --card-color-border: var(--color-mute);
+  --card-color-border: var(--color-mute-deco);
   --card-size-border: var(--border-width);
   --card-size-dog-ear: var(--gutter-width);
   --card-spacing: var(--spacing-large);

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -1,6 +1,6 @@
 .card {
   --card-color-background: white;
-  --card-color-border: var(--color-mute-deco);
+  --card-color-border: var(--color-gray);
   --card-size-border: 1px;
   --card-size-dog-ear: var(--gutter-width);
   --card-spacing: var(--spacing-large);

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -14,7 +14,7 @@
   }
 
   &__list-item {
-    border: var(--border-width) solid var(--color-mute);
+    border: var(--border-width) solid var(--color-mute-deco);
     padding: var(--spacing-large);
   }
 

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -14,7 +14,7 @@
   }
 
   &__list-item {
-    border: 1px solid var(--color-mute-deco);
+    border: 1px solid var(--color-gray);
     border-radius: var(--border-radius);
     padding: var(--spacing-large);
   }

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -14,7 +14,8 @@
   }
 
   &__list-item {
-    border: var(--border-width) solid var(--color-mute-deco);
+    border: 1px solid var(--color-mute-deco);
+    border-radius: var(--border-radius);
     padding: var(--spacing-large);
   }
 

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -14,7 +14,7 @@
   }
 
   &__list-item {
-    border: 1px solid var(--color-gray);
+    border: var(--border-width-thin) solid var(--color-gray);
     border-radius: var(--border-radius);
     padding: var(--spacing-large);
   }

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -1,7 +1,7 @@
 .file {
   &__file {
     align-items: center;
-    border: 1px solid var(--color-mute);
+    border: 1px solid var(--color-mute-deco);
     border-radius: var(--border-radius);
     box-sizing: border-box;
     display: flex;

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -1,7 +1,7 @@
 .file {
   &__file {
     align-items: center;
-    border: 1px solid var(--color-gray);
+    border: var(--border-width-thin) solid var(--color-gray);
     border-radius: var(--border-radius);
     box-sizing: border-box;
     display: flex;

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -1,7 +1,7 @@
 .file {
   &__file {
     align-items: center;
-    border: 1px solid var(--color-mute-deco);
+    border: 1px solid var(--color-gray);
     border-radius: var(--border-radius);
     box-sizing: border-box;
     display: flex;

--- a/src/open_inwoner/scss/components/Form/ButtonRadio.scss
+++ b/src/open_inwoner/scss/components/Form/ButtonRadio.scss
@@ -27,7 +27,7 @@
   }
 
   &__button {
-    border: 1px solid var(--color-gray-light);
+    border: var(--border-width-thin) solid var(--color-gray-light);
     border-left: 0;
     background-color: var(--color-gray-lightest);
     color: var(--color-gray-lighter);

--- a/src/open_inwoner/scss/components/Form/ButtonRadio.scss
+++ b/src/open_inwoner/scss/components/Form/ButtonRadio.scss
@@ -12,16 +12,38 @@
       color: var(--color-primary);
       cursor: default;
     }
+    &#negative {
+      &:checked ~ .button-radio__button {
+        color: #cf1c08;
+        cursor: default;
+      }
+    }
+    &#positive {
+      &:checked ~ .button-radio__button {
+        color: var(--color-green-dark);
+        cursor: default;
+      }
+    }
   }
 
   &__button {
-    border: 1px solid #d2d2d2;
+    border: 1px solid var(--color-gray-light);
     border-left: 0;
     background-color: var(--color-gray-lightest);
     color: var(--color-gray-lighter);
     display: inline-block;
     padding: 12px;
     cursor: pointer;
+
+    &[for='negative'] {
+      border-top-right-radius: var(--border-radius);
+      border-bottom-right-radius: var(--border-radius);
+    }
+
+    &[for='positive'] {
+      border-top-left-radius: var(--border-radius);
+      border-bottom-left-radius: var(--border-radius);
+    }
   }
 
   &:first-child {

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -34,7 +34,7 @@
     }
 
     &__list-item:nth-child(2) {
-      border-top: var(--border-width) solid var(--color-mute-deco);
+      border-top: var(--border-width) solid var(--color-gray);
     }
 
     &__list-item {

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -13,12 +13,12 @@
   }
 
   &__list-item {
-    border-bottom: var(--border-width) solid var(--color-mute);
+    border-bottom: var(--border-width) solid var(--color-mute-deco);
     padding: var(--spacing-large) var(--spacing-medium);
   }
 
   &__list-item:nth-child(1) {
-    border-top: var(--border-width) solid var(--color-mute);
+    border-top: var(--border-width) solid var(--color-mute-deco);
   }
 
   h2 {
@@ -34,7 +34,7 @@
     }
 
     &__list-item:nth-child(2) {
-      border-top: var(--border-width) solid var(--color-mute);
+      border-top: var(--border-width) solid var(--color-mute-deco);
     }
 
     &__list-item {

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -13,12 +13,12 @@
   }
 
   &__list-item {
-    border-bottom: var(--border-width) solid var(--color-gray);
+    border-bottom: var(--border-width-thin) solid var(--color-gray);
     padding: var(--spacing-large) var(--spacing-medium);
   }
 
   &__list-item:nth-child(1) {
-    border-top: var(--border-width) solid var(--color-gray);
+    border-top: var(--border-width-thin) solid var(--color-gray);
   }
 
   h2 {

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -13,12 +13,12 @@
   }
 
   &__list-item {
-    border-bottom: var(--border-width) solid var(--color-mute-deco);
+    border-bottom: var(--border-width) solid var(--color-gray);
     padding: var(--spacing-large) var(--spacing-medium);
   }
 
   &__list-item:nth-child(1) {
-    border-top: var(--border-width) solid var(--color-mute-deco);
+    border-top: var(--border-width) solid var(--color-gray);
   }
 
   h2 {

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -34,7 +34,7 @@
     }
 
     &__list-item:nth-child(2) {
-      border-top: var(--border-width) solid var(--color-gray);
+      border-top: var(--border-width-thin) solid var(--color-gray);
     }
 
     &__list-item {

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -151,7 +151,7 @@
   // changed to #949494 to get the required 3:1 contrast ratio
   --color-mute: #949494;
   // decorative, non-meaningful elements do not have contrast requirements
-  --color-mute-deco: #D2D2D2;
+  --color-mute-deco: #d2d2d2;
 
   /// Font.
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -148,10 +148,8 @@
   --color-font-accent: var(--color-gray-dark);
 
   --color-body: var(--color-gray-dark);
-  // changed to #949494 to get the required 3:1 contrast ratio
+  // changed to #949494 to get the required 3:1 contrast ratio - in case of decorative border use var(--color-gray).
   --color-mute: #949494;
-  // decorative, non-meaningful elements do not have contrast requirements
-  --color-mute-deco: var(--color-gray);
 
   /// Font.
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -12,7 +12,7 @@
     var(--color-accent-darker),
     var(--color-accent-lighter)
   );
-  --border-width: 2px;
+  --border-width: 1px;
   --border-radius: 3px;
 
   // Color.
@@ -150,6 +150,8 @@
   --color-body: var(--color-gray-dark);
   // changed to #949494 to get the required 3:1 contrast ratio
   --color-mute: #949494;
+  // decorative, non-meaningful elements do not have contrast requirements
+  --color-mute-deco: #D2D2D2;
 
   /// Font.
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -12,7 +12,7 @@
     var(--color-accent-darker),
     var(--color-accent-lighter)
   );
-  --border-width: 1px;
+  --border-width: 2px;
   --border-radius: 3px;
 
   // Color.

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -151,7 +151,7 @@
   // changed to #949494 to get the required 3:1 contrast ratio
   --color-mute: #949494;
   // decorative, non-meaningful elements do not have contrast requirements
-  --color-mute-deco: #d2d2d2;
+  --color-mute-deco: var(--color-gray);
 
   /// Font.
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -13,6 +13,7 @@
     var(--color-accent-lighter)
   );
   --border-width: 2px;
+  --border-width-thin: 1px;
   --border-radius: 3px;
 
   // Color.


### PR DESCRIPTION
Some borders need to be reverted to original design, because: The 'Toegankelijkheidsaudit' does not explicitly ask for borders around these areas + This Level AA requirement reads: "...Incidental: Text[...]that are part of an inactive user interface component, that are pure decoration,[...], have no contrast requirement..."
"pure decoration" in the definition of WCAG = "serving only an aesthetic purpose, providing no information, and having no functionality"

https://taiga.maykinmedia.nl/project/open-inwoner/task/1084

Answer to my question on Stack Overflow: https://stackoverflow.com/questions/75379770/do-borders-that-visually-group-related-content-have-a-contrast-requirement

“... WCAG does not require you to have a border around the grouped elements. […] there aren't any WCAG requirements for the contrast. [1.4.11 Non-text Contrast](https://www.w3.org/TR/WCAG21/#non-text-contrast) comes close but that requirement is for "Interface Components" and "Graphical Objects". Your tile might contain "Interface Components" (such as a link) but the tile itself is not an "Interface Component" so 1.4.11 does not apply. That doesn't mean you shouldn't try to have better contrast, but it's not required by WCAG.”