### PR TITLE
:bug: [#1121] focus-trap in Header and Search

### DIFF
--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -25,9 +25,16 @@ class Header extends Component {
    * Callbacks should trigger `setState` which in turn triggers `render`.
    */
   bindEvents() {
-    this.node.addEventListener('click', () =>
-      this.setState({ open: !this.state.open })
-    )
+    this.node.addEventListener('keyup', this.onKeyUp.bind(this))
+    this.node.addEventListener('click', (e) => {
+      console.log('click in bindEvents')
+      if (
+        e.target.matches('.header__button') ||
+        e.target.matches('.header__button *')
+      ) {
+        this.setState({ open: !this.state.open })
+      }
+    })
   }
 
   /**
@@ -35,6 +42,7 @@ class Header extends Component {
    * @returns {HTMLButtonElement}
    */
   getButton() {
+    console.log('getButton')
     return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_BUTTON)
   }
   /**
@@ -42,7 +50,18 @@ class Header extends Component {
    * @returns {HTMLDialogElement}
    */
   getSubMenu() {
+    console.log('getSubMenu')
     return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_SUBMENU)
+  }
+  /**
+   * Gets called when a key is released.
+   * If key is escape key, explicitly close the mobile menu.
+   * @param {KeyboardEvent} event
+   */
+  onKeyUp(event) {
+    if (event.key === 'Escape') {
+      this.setState({ open: false })
+    }
   }
 
   /**
@@ -51,10 +70,14 @@ class Header extends Component {
    * @param {Object} state State to render.
    */
   render(state) {
+    console.log('render', state)
     document.body.classList.add('body')
     BEM.toggleModifier(document.body, MODIFIER_OPEN, state.open)
     BEM.toggleModifier(this.getButton(), MODIFIER_OPEN, state.open)
-    state.open ? this.getSubMenu().showModal() : this.getSubMenu().close()
+
+    if (matchMedia('(max-width: 767px)').matches) {
+      state.open ? this.getSubMenu().show() : this.getSubMenu().close()
+    }
 
     if (state.open) {
       window.scrollTo({ x: 0, y: 0 })

--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -27,7 +27,6 @@ class Header extends Component {
   bindEvents() {
     this.node.addEventListener('keyup', this.onKeyUp.bind(this))
     this.node.addEventListener('click', (e) => {
-      console.log('click in bindEvents')
       if (
         e.target.matches('.header__button') ||
         e.target.matches('.header__button *')
@@ -42,7 +41,6 @@ class Header extends Component {
    * @returns {HTMLButtonElement}
    */
   getButton() {
-    console.log('getButton')
     return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_BUTTON)
   }
   /**
@@ -50,7 +48,6 @@ class Header extends Component {
    * @returns {HTMLDialogElement}
    */
   getSubMenu() {
-    console.log('getSubMenu')
     return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_SUBMENU)
   }
   /**
@@ -70,7 +67,6 @@ class Header extends Component {
    * @param {Object} state State to render.
    */
   render(state) {
-    console.log('render', state)
     document.body.classList.add('body')
     BEM.toggleModifier(document.body, MODIFIER_OPEN, state.open)
     BEM.toggleModifier(this.getButton(), MODIFIER_OPEN, state.open)

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -121,7 +121,7 @@ $vm: var(--spacing-large);
     z-index: 2;
 
     @media (min-width: 768px) {
-      display: block;
+      display: none;
     }
   }
   &__submenu::backdrop {


### PR DESCRIPTION
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/1121
Problem: propagation (bubbling) of events from the mobile menu into the dialog element that catches focus away from everything else.

**Notes for learning:**

Ways to inspect the constructor in file "_open_inwoner/js/components/abstract/component.js_":

`  constructor(node, initialState = {}) {
    console.log('Component constructor', node, initialState) [.....]`

and

`  setState(changes) {
    console.log('setState', changes) [.....]`

Ways to inspect the clickEvents in inspector: by using '[matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)' in these 5 **console-logs** in file "_open_inwoner/js/components/header/header.js_":

1.

`  bindEvents() {
    this.node.addEventListener('keyup', this.onKeyUp.bind(this))
    this.node.addEventListener('click', (e) => {
      console.log('click in bindEvents')
      if (
        e.target.matches('.header__button') ||
        e.target.matches('.header__button *')
      ) {
        this.setState({ open: !this.state.open })
      }
    })
  }`

2 & 3.

` getButton() {
    console.log('getButton')
    return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_BUTTON)
  }
  getSubMenu() {
    console.log('getSubMenu')
    return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_SUBMENU)
  }`

4. 

`render(state) {
    console.log('render', state)
    document.body.classList.add('body')
    BEM.toggleModifier(document.body, MODIFIER_OPEN, state.open)
    BEM.toggleModifier(this.getButton(), MODIFIER_OPEN, state.open)
    if (matchMedia('(max-width: 767px)').matches) {
      state.open ? this.getSubMenu().show() : this.getSubMenu().close()
    }
    if (state.open) {
      window.scrollTo({ x: 0, y: 0 })
    }
  }`

