### PR TITLE
[#1125] Fix/sort allowed file extensions in case document upload file

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -441,7 +441,7 @@ class CaseUploadForm(forms.Form):
 
         config = OpenZaakConfig.get_solo()
         max_allowed_size = 1024**2 * config.max_upload_size
-        allowed_extensions = config.allowed_file_extensions
+        allowed_extensions = sorted(config.allowed_file_extensions)
         filename, file_extension = os.path.splitext(file.name)
 
         if file.size > max_allowed_size:

--- a/src/open_inwoner/accounts/views/cases.py
+++ b/src/open_inwoner/accounts/views/cases.py
@@ -351,6 +351,7 @@ class CaseDetailView(
                 "internal_upload_enabled": internal_upload_enabled,
                 "external_upload_enabled": external_upload_enabled,
                 "external_upload_url": external_upload_url,
+                "allowed_file_extensions": sorted(config.allowed_file_extensions),
             }
             context["anchors"] = self.get_anchors(statuses, documents)
         else:

--- a/src/open_inwoner/openzaak/models.py
+++ b/src/open_inwoner/openzaak/models.py
@@ -18,25 +18,27 @@ from open_inwoner.openzaak.managers import (
 
 
 def generate_default_file_extensions():
-    return [
-        "pdf",
-        "doc",
-        "docx",
-        "xls",
-        "xlsx",
-        "ppt",
-        "pptx",
-        "vsd",
-        "png",
-        "gif",
-        "jpg",
-        "tiff",
-        "msg",
-        "txt",
-        "rtf",
-        "jpeg",
-        "bmp",
-    ]
+    return sorted(
+        [
+            "pdf",
+            "doc",
+            "docx",
+            "xls",
+            "xlsx",
+            "ppt",
+            "pptx",
+            "vsd",
+            "png",
+            "gif",
+            "jpg",
+            "tiff",
+            "msg",
+            "txt",
+            "rtf",
+            "jpeg",
+            "bmp",
+        ]
+    )
 
 
 class OpenZaakConfig(SingletonModel):

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -372,6 +372,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
                 "internal_upload_enabled": False,
                 "external_upload_enabled": False,
                 "external_upload_url": "",
+                "allowed_file_extensions": sorted(self.config.allowed_file_extensions),
             },
         )
 
@@ -674,7 +675,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
             form_response.context["form"].errors,
             {
                 "file": [
-                    f"Het type bestand dat u hebt geüpload is ongeldig. Geldige bestandstypen zijn: {', '.join(self.config.allowed_file_extensions)}"
+                    f"Het type bestand dat u hebt geüpload is ongeldig. Geldige bestandstypen zijn: {', '.join(sorted(self.config.allowed_file_extensions))}"
                 ]
             },
         )

--- a/src/open_inwoner/templates/pages/cases/status.html
+++ b/src/open_inwoner/templates/pages/cases/status.html
@@ -34,7 +34,7 @@
                 {% if case.internal_upload_enabled %}
                     <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
                     <p class="p">
-                        {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=openzaak_config.allowed_file_extensions|join:', ' %}
+                        {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
                             Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}. 
                         {% endblocktranslate %}
                     </p>


### PR DESCRIPTION
This is changed in several places in case we already have created the singleton. Otherwise, the sorted version of the extensions is called when we create the instance for the first time.