### PR TITLE
[#1137] Feature/update django simple cert manager to v1.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -124,7 +124,6 @@ django-choices==1.7.2
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
-    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -195,7 +194,7 @@ django-sessionprofile==1.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
-django-simple-certmanager==1.2.0
+django-simple-certmanager==1.3.0
     # via zgw-consumers
 django-sniplates==0.7.0
     # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -177,7 +177,7 @@ django-phonenumber-field==5.2.0
     # via maykin-django-two-factor-auth
 django-polymorphic==3.0.0
     # via django-filer
-django-privates==1.2.2
+django-privates==1.5.0
     # via
     #   -r requirements/base.in
     #   django-simple-certmanager
@@ -195,7 +195,7 @@ django-sessionprofile==1.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
-django-simple-certmanager==1.1.2
+django-simple-certmanager==1.2.0
     # via zgw-consumers
 django-sniplates==0.7.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -195,7 +195,6 @@ django-choices==1.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -332,7 +331,7 @@ django-sessionprofile==1.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager==1.2.0
+django-simple-certmanager==1.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -300,7 +300,7 @@ django-polymorphic==3.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-filer
-django-privates==1.2.2
+django-privates==1.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -332,7 +332,7 @@ django-sessionprofile==1.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager==1.1.2
+django-simple-certmanager==1.2.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -329,7 +329,7 @@ django-polymorphic==3.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-filer
-django-privates==1.2.2
+django-privates==1.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -361,7 +361,7 @@ django-sessionprofile==1.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-django-simple-certmanager==1.1.2
+django-simple-certmanager==1.2.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -220,7 +220,6 @@ django-choices==1.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-    #   django-simple-certmanager
     #   mail-editor
     #   zgw-consumers
 django-ckeditor==6.2.0
@@ -361,7 +360,7 @@ django-sessionprofile==1.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-django-simple-certmanager==1.2.0
+django-simple-certmanager==1.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
This has to wait for a bug fix in the library [(PR20).](https://github.com/maykinmedia/django-simple-certmanager/pull/20)