### PR TITLE
:art: [#1131] Dropdown on mobile partly rendered off-screen

### DIFF
--- a/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
+++ b/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
@@ -11,7 +11,7 @@
     flex-direction: column;
     padding: var(--spacing-medium) 0;
     position: absolute;
-    left: 0;
+    right: 0;
     border-radius: var(--border-radius);
     background-color: var(--color-white);
     border: 1px solid var(--color-mute);
@@ -36,12 +36,5 @@
     color: var(--font-color-body);
     height: var(--font-line-height-body);
     padding: 0;
-  }
-
-  @media (max-width: 767px) {
-    .dropdown__content {
-      left: initial;
-      right: 0;
-    }
   }
 }

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -37,9 +37,10 @@
 
   &__file .dropdown {
     padding-right: var(--spacing-large);
-     .dropdown__content {
-       margin-right: var(--spacing-large);
-     }
+
+    .dropdown__content {
+      margin-right: var(--spacing-large);
+    }
   }
 
   &__file + .p {

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -37,6 +37,9 @@
 
   &__file .dropdown {
     padding-right: var(--spacing-large);
+     .dropdown__content {
+       margin-right: var(--spacing-large);
+     }
   }
 
   &__file + .p {


### PR DESCRIPTION
issue in Taiga: [#1131 Dropdown on mobile partly rendered off-screen](https://taiga.maykinmedia.nl/project/open-inwoner/issue/1131)
In the original design it already showed the drop down should have been aligned to the right:
(https://projects.invisionapp.com/share/Y211V6JRHPC4#/screens/470665006)

![Screenshot from 2023-02-16 14-24-27](https://user-images.githubusercontent.com/118177951/219376741-9f6f8075-8beb-4ef0-8c24-5e0c5e22ee67.png)
