### PR TITLE
:art: [#1066] Wordwrapping on mobile

### DIFF
--- a/src/open_inwoner/scss/components/Actions/Actions.scss
+++ b/src/open_inwoner/scss/components/Actions/Actions.scss
@@ -58,7 +58,8 @@
 
   .actions__label {
     padding: var(--spacing-medium);
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
 
     &--big {
       grid-column: 1 / span 2;

--- a/src/open_inwoner/scss/components/Typography/H1.scss
+++ b/src/open_inwoner/scss/components/Typography/H1.scss
@@ -11,7 +11,8 @@
   justify-content: space-between;
 
   @include mobile-only {
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
   }
 
   &:first-of-type {

--- a/src/open_inwoner/scss/components/Typography/H2.scss
+++ b/src/open_inwoner/scss/components/Typography/H2.scss
@@ -15,7 +15,8 @@
   }
 
   @include mobile-only {
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
See issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1066
might not just be a problem on mobile but anywhere where text overflows;
words that are too long can be broken to the next line with a hyphen.
Note: `word-break: break-word` has been deprecated. 