### PR TITLE
:iphone: [#1140] mobile: Samenwerken-listview

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/AccessibilityHeader.html
+++ b/src/open_inwoner/components/templates/components/Header/AccessibilityHeader.html
@@ -1,7 +1,7 @@
 {% load i18n link_tags %}
 
 <div class="accessibility-header">
-    <ul class="accessibility-header__list" role="complementary" aria-label="{% trans "Toegangkelijkheids help" %}">
+    <ul class="accessibility-header__list" role="complementary" aria-label="{% trans "Toegankelijkheids help" %}">
         <li class="accessibility-header__list-item">
             {% trans "Doorgaan naar hoofdinhoud" as link_text %}
             {% link href="#content" icon="south" text=link_text extra_classes="skip-link" %}

--- a/src/open_inwoner/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/open_inwoner/conf/locale/nl/LC_MESSAGES/django.po
@@ -1402,7 +1402,7 @@ msgid "Zoeken"
 msgstr "Zoeken"
 
 #: components/templates/components/Header/AccessibilityHeader.html:4
-msgid "Toegangkelijkheids help"
+msgid "Toegankelijkheids help"
 msgstr ""
 
 #: components/templates/components/Header/AccessibilityHeader.html:6

--- a/src/open_inwoner/scss/components/Typography/H1.scss
+++ b/src/open_inwoner/scss/components/Typography/H1.scss
@@ -11,6 +11,8 @@
   justify-content: space-between;
 
   @include mobile-only {
+    flex-direction: column;
+    align-items: flex-start;
     word-break: normal;
     overflow-wrap: break-word;
   }
@@ -22,6 +24,7 @@
   &--bottom {
     margin-bottom: calc(var(--row-height) / 2) !important;
   }
+
 }
 
 h1 + .card-container {

--- a/src/open_inwoner/scss/components/Typography/H1.scss
+++ b/src/open_inwoner/scss/components/Typography/H1.scss
@@ -24,7 +24,6 @@
   &--bottom {
     margin-bottom: calc(var(--row-height) / 2) !important;
   }
-
 }
 
 h1 + .card-container {


### PR DESCRIPTION
Responsive design: fix issue where header text and button should be on top of each other, not next to each other;
see https://taiga.maykinmedia.nl/project/open-inwoner/task/1140 
⚠ Note: the current structure of templates, (where the entire H1 heading is surrounding the button), makes word-breaking behave strange again sometimes (causes letter-breaking in very long words on _very_ tiny screens).