### PR TITLE
Removed HTMX debug template-tag as it is not in active use and generates too much CSP noise

### DIFF
--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -82,6 +82,5 @@
         </dialog>
 
         <script nonce="{{ request.csp_nonce }}" src="{% static 'bundles/open_inwoner-js.js' %}" type="text/javascript"></script>
-        {% django_htmx_script %}
     </body>
 </html>


### PR DESCRIPTION
If we need it we can put it back, possibly add a fix that uses `request.csp_nonce` like the other script-tags.