### PR TITLE
:lipstick: [#1169] Make images/icons have static sizes in cards

### DIFF
--- a/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
+++ b/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 
+<div class="registration-grid">
 {% render_grid %}
     {% render_column span=9 %}
         {% render_card tinted=True  %}
@@ -11,5 +12,6 @@
         {% endrender_card %}
     {% endrender_column %}
 {% endrender_grid %}
+</div>
 
 {% endblock content %}

--- a/src/open_inwoner/accounts/templates/django_registration/registration_form.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_form.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 
+<div class="registration-grid">
 {% render_grid %}
     {% render_column start=5 span=5 %}
         {% render_card direction='horizontal' tinted=True %}
@@ -23,5 +24,6 @@
     {% endif %}
 
 {% endrender_grid %}
+</div>
 
 {% endblock content %}

--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -10,6 +10,7 @@
 
 
 {% block content %}
+    <div class="login-grid">
     {% render_grid %}
         {% render_column start=5 span=5 %}
             {% render_card %}
@@ -24,7 +25,7 @@
                         {% link href='digid:login' text=_('Inloggen met DigiD') secondary=True icon='arrow_forward' extra_classes="link--digid" %}
                     {% endrender_card %}
 		{% endif %}
-			
+
                 {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
                 {% get_solo 'configurations.SiteConfiguration' as site_config %}
                 {% if oidc_config.enabled %}
@@ -54,4 +55,5 @@
             {% endrender_card %}
         {% endrender_column %}
     {% endrender_grid %}
+    </div>
 {% endblock content %}

--- a/src/open_inwoner/pdc/views.py
+++ b/src/open_inwoner/pdc/views.py
@@ -60,7 +60,7 @@ class HomeView(CommonPageMixin, TemplateView):
     def get_context_data(self, **kwargs):
         config = SiteConfiguration.get_solo()
 
-        limit = 3 if self.request.user.is_authenticated else 4
+        limit = 4
         kwargs.update(categories=Category.objects.published().order_by("name")[:limit])
         kwargs.update(product_locations=ProductLocation.objects.all()[:1000])
         kwargs.update(
@@ -86,7 +86,7 @@ class HomeView(CommonPageMixin, TemplateView):
             and self.request.user.selected_themes.exists()
         ):
             kwargs.update(
-                categories=self.request.user.selected_themes.order_by("name")[:3]
+                categories=self.request.user.selected_themes.order_by("name")[:limit]
             )
         elif highlighted_categories:
             kwargs.update(categories=highlighted_categories)

--- a/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
+++ b/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
@@ -31,3 +31,12 @@
 .card-container + h2 {
   margin-top: var(--gutter-width);
 }
+
+/// Exceptions for forms inside cards
+
+.registration-grid,
+.login-grid {
+  .card {
+    max-width: 100%;
+  }
+}

--- a/src/open_inwoner/scss/components/Header/AnchorMenu.scss
+++ b/src/open_inwoner/scss/components/Header/AnchorMenu.scss
@@ -17,7 +17,7 @@
   width: 100%;
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: var(--spacing-extra-large);
   z-index: 1002;
 
   &--desktop {
@@ -62,11 +62,13 @@
 
   .link {
     box-sizing: border-box;
-    padding: var(--spacing-large);
+    padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium)
+      var(--spacing-large);
 
     @media (min-width: 768px) {
       border-left: var(--border-width) solid;
       border-color: var(--color-gray-light);
+      padding: var(--spacing-large);
     }
   }
 
@@ -80,7 +82,8 @@
 
   &--mobile__title {
     box-sizing: border-box;
-    padding: var(--spacing-large);
+    padding: var(--spacing-large) var(--spacing-large) var(--spacing-medium)
+      var(--spacing-large);
 
     &.h4 {
       color: var(--color-primary);

--- a/src/open_inwoner/scss/views/Categories.scss
+++ b/src/open_inwoner/scss/views/Categories.scss
@@ -1,0 +1,24 @@
+.categories {
+  &__content {
+    .card-container {
+      grid-template-columns: repeat(auto-fit, 228px);
+
+      .card {
+        max-width: 360px;
+      }
+    }
+  }
+
+  &__products {
+    margin-top: var(--gutter-width);
+
+    .card-container {
+      margin-top: var(--gutter-width);
+      grid-template-columns: repeat(var(--card-columns), 1fr);
+
+      .card {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/src/open_inwoner/scss/views/Home.scss
+++ b/src/open_inwoner/scss/views/Home.scss
@@ -1,0 +1,11 @@
+/// Cards on Home Page and Theme page
+
+.home {
+  .card-container {
+    grid-template-columns: repeat(auto-fit, 228px);
+
+    .card {
+      max-width: 360px;
+    }
+  }
+}

--- a/src/open_inwoner/scss/views/_index.scss
+++ b/src/open_inwoner/scss/views/_index.scss
@@ -1,5 +1,7 @@
 @import './App.scss';
 @import './body';
+@import './Categories.scss';
+@import './Home.scss';
 @import './Plans.scss';
 @import './product_detail';
 @import './view';

--- a/src/open_inwoner/templates/pages/category/detail.html
+++ b/src/open_inwoner/templates/pages/category/detail.html
@@ -10,39 +10,43 @@
 {% endblock header_image %}
 
 {% block content %}
-    <h1 class="h1">
-        {{ object.name }}
-        {% if request.user.is_staff %}
-            {% button icon="edit" text=_("Open in admin") hide_text=True href="admin:pdc_category_change" object_id=object.pk %}
+    <div class="categories__content">
+        <h1 class="h1">
+            {{ object.name }}
+            {% if request.user.is_staff %}
+                {% button icon="edit" text=_("Open in admin") hide_text=True href="admin:pdc_category_change" object_id=object.pk %}
+            {% endif %}
+        </h1>
+        <p class="p">{{ object.description|linebreaksbr }}</p>
+
+        {% if subcategories %}
+            {% card_container subcategories=subcategories parent_category=object %}
         {% endif %}
-    </h1>
-    <p class="p">{{ object.description|linebreaksbr }}</p>
 
-    {% if subcategories %}
-        {% card_container subcategories=subcategories parent_category=object %}
-    {% endif %}
-
-    {% if products %}
-        {% card_container products=products small=True parent=object %}
-    {% endif %}
-
-    {% if category.question_set.all %}
-        {% render_grid %}
-            {% render_column span=6 %}
-                {% faq category.question_set.all %}
-            {% endrender_column %}
-        {% endrender_grid %}
-    {% endif %}
-
-    {% if questionnaire_roots %}
-        <div class="grid">
-            <div class="column column--start-1 column--span-6 ">
-                <aside class="questionnaire">
-                    <h2 class="h2">{{configurable_text.questionnaire_page.select_questionnaire_title}}</h2>
-                    {% optional_paragraph configurable_text.questionnaire_page.select_questionnaire_intro %}
-                    {% questionnaire root_nodes=questionnaire_roots %}
-                </aside>
+        {% if products %}
+            <div class="categories__products">
+            {% card_container products=products small=True parent=object %}
             </div>
-        </div>
-    {% endif %}
+        {% endif %}
+
+        {% if category.question_set.all %}
+            {% render_grid %}
+                {% render_column span=6 %}
+                    {% faq category.question_set.all %}
+                {% endrender_column %}
+            {% endrender_grid %}
+        {% endif %}
+
+        {% if questionnaire_roots %}
+            <div class="grid">
+                <div class="column column--start-1 column--span-6 ">
+                    <aside class="questionnaire">
+                        <h2 class="h2">{{configurable_text.questionnaire_page.select_questionnaire_title}}</h2>
+                        {% optional_paragraph configurable_text.questionnaire_page.select_questionnaire_intro %}
+                        {% questionnaire root_nodes=questionnaire_roots %}
+                    </aside>
+                </div>
+            </div>
+        {% endif %}
+    </div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/category/list.html
+++ b/src/open_inwoner/templates/pages/category/list.html
@@ -2,8 +2,10 @@
 {% load card_tags %}
 
 {% block content %}
-<h1 class="h1">{{configurable_text.theme_page.theme_title}}</h1>
-<p class="p">{{configurable_text.theme_page.theme_intro|linebreaksbr}}</p>
+<div class="categories__content">
+    <h1 class="h1">{{configurable_text.theme_page.theme_title}}</h1>
+    <p class="p">{{configurable_text.theme_page.theme_intro|linebreaksbr}}</p>
 
-{% card_container categories=object_list %}
+    {% card_container categories=object_list %}
+</div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/home.html
+++ b/src/open_inwoner/templates/pages/home.html
@@ -8,6 +8,7 @@
 {% endblock header_image %}
 
 {% block content %}
+    <div class="home">
     {% block user_content %}
         <div class="grid__welcome">
             <h1 class="h1">{{configurable_text.home_page.home_welcome_title}}</h1>
@@ -24,7 +25,7 @@
     <p class="p">{{configurable_text.home_page.home_theme_intro|linebreaksbr}}</p>
 
     {% if request.user.is_authenticated %}
-        {% card_container categories=categories columns=3 image_object_fit="cover" %}
+        {% card_container categories=categories columns=4 image_object_fit="cover" %}
     {% else %}
         {% card_container categories=categories image_object_fit="cover" %}
     {% endif %}
@@ -45,4 +46,5 @@
     {% with centroid=product_locations.get_centroid %}
         {% map centroid.lat centroid.lng geojson_feature_collection=product_locations.get_geojson_feature_collection %}
     {% endwith %}
+    </div>
 {% endblock %}

--- a/src/open_inwoner/templates/pages/user-home.html
+++ b/src/open_inwoner/templates/pages/user-home.html
@@ -14,7 +14,7 @@
         </h2>
 
         {% if plans %}
-        <div class="plans-cards card-container card-container--columns-3">
+        <div class="plans-cards card-container card-container--columns-4">
             {% for plan in plans %}
                 {% render_card image_object_fit="cover" %}
                     <h3 class="h3">{{ plan.title }}</h3>


### PR DESCRIPTION
issue here: https://taiga.maykinmedia.nl/project/open-inwoner/task/1169 
This would solve the problem where 'icons' no longer look like this (with potentially cut-off heads): when the screensize gets smaller than the container - the only way to do this would be to set static sizes for the cards on all screenwidths, and inform the user which sizes need to be used for icons.

Note: this is not for images in Product cards.

ToDo:

- [x] set statics max-sizes for Grid columns and Cards: max. of 230 px/columnsize wide, image max-height:  100px. Except for the cards on Registration page (and elsewhere?)

other todo's to make the card align with design will be done later when decision is made about horizontal scroll and about the number of carsds in 1 column on mobile

![cut-off-heads](https://user-images.githubusercontent.com/118177951/224355770-3da6b278-6f7a-4dfe-a1d6-22a08cc36f05.png)
