### PR TITLE
:lipstick: [#1164] Fix extra margin space caused by PR #525

### DIFF
--- a/src/open_inwoner/scss/components/Container/Container.scss
+++ b/src/open_inwoner/scss/components/Container/Container.scss
@@ -16,5 +16,11 @@
   @media (min-width: 768px) {
     $hm: max(calc((100vw - var(--container-width)) / 2), var(--spacing-large));
     margin: var(--row-height) $hm calc(var(--row-height) * 2);
+
+    &--no-margin {
+      min-height: 0;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
   }
 }


### PR DESCRIPTION
This refers to the container that changed for mobiles and caused the `container--no-margin` to have margins outside of 'mobile first' styles: https://github.com/maykinmedia/open-inwoner/pull/525