### PR TITLE
:lipstick: [#1179] Add breakpoint for inputs, fix tags and other minor fixes

### DIFF
--- a/src/open_inwoner/accounts/templates/django_registration/registration_form.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 {% render_grid %}
-    {% render_column start=1 span=6 %}
+    {% render_column start=5 span=5 %}
         {% render_card direction='horizontal' tinted=True %}
             <a href="{% url 'digid:login' %}" class="link digid-logo" aria-describedby="Digid logo" title="Digid logo">
                 <img class="digid-logo__image" src="{% static 'accounts/digid_logo.svg' %}" alt="Digid logo">
@@ -14,7 +14,7 @@
     {% endrender_column %}
 
     {% if login_allow_registration %}
-        {% render_column start=7 span=13 %}
+        {% render_column start=5 span=5 %}
             {% render_card tinted=True  %}
                 <h1 class="h3">{% trans "Registreren met E-mail" %}</h1><br>
                 {% form form_object=form method="POST" id="registration-form" submit_text=_('Registreren') extra_classes="form__registration" %}

--- a/src/open_inwoner/accounts/templates/django_registration/registration_form.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_form.html
@@ -17,7 +17,7 @@
         {% render_column start=7 span=13 %}
             {% render_card tinted=True  %}
                 <h1 class="h3">{% trans "Registreren met E-mail" %}</h1><br>
-                {% form form_object=form method="POST" id="registration-form" submit_text=_('Registreren') %}
+                {% form form_object=form method="POST" id="registration-form" submit_text=_('Registreren') extra_classes="form__registration" %}
             {% endrender_card %}
         {% endrender_column %}
     {% endif %}

--- a/src/open_inwoner/components/templates/components/Action/Actions.html
+++ b/src/open_inwoner/components/templates/components/Action/Actions.html
@@ -6,7 +6,7 @@
         <div class="actions__filter-button">
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
-        <div class="actions__filter-container">
+        <div class="actions__filter-container filter__container">
             <p class="p">{% trans "Filter op:" %}</p>
             {% date_field action_form.end_date no_label=True no_help=True icon="today" %}
             {% input action_form.is_for no_label=True no_help=True icon="person" %}

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -53,7 +53,7 @@ def render_form(parser, token):
         - extra_classes: string | Extra css classes for the form.
         - form_action: string | where the form should go after submit.
         - enctype: string | set the encrypt when sending forms.
-        - id: string | set an id on the form. Usefull for testing.
+        - id: string | set an id on the form. Useful for testing.
         - data_confirm_title: string | If a confirm dialog is shown this will be the title.
         - data_confirm_cancel: string | If a confirm dialog is shown this will be the text on the cancel button.
         - data_confirm_default: string | If a confirm dialog is shown this will be the text on the confirm button.
@@ -107,7 +107,7 @@ def form(context, form_object, secondary=True, **kwargs):
         - extra_classes: string | Extra css classes for the form.
         - form_action: string | where the form should go after submit.
         - enctype: string | set the encrypt when sending forms.
-        - id: string | set an id on the form. Usefull for testing.
+        - id: string | set an id on the form. Useful for testing.
         - data_confirm_title: string | If a confirm dialog is shown this will be the title.
         - data_confirm_cancel: string | If a confirm dialog is shown this will be the text on the cancel button.
         - data_confirm_default: string | If a confirm dialog is shown this will be the text on the confirm button.
@@ -142,7 +142,7 @@ def form(context, form_object, secondary=True, **kwargs):
 @register.simple_tag()
 def autorender_field(form_object, field_name, **kwargs):
     """
-    Detecting what type of field sould be rendered.
+    Detecting what type of field should be rendered.
     TODO: Keep updating with new fields.
 
     Usage:

--- a/src/open_inwoner/scss/components/Autocomplete/Autocomplete.scss
+++ b/src/open_inwoner/scss/components/Autocomplete/Autocomplete.scss
@@ -1,6 +1,7 @@
 .autoComplete_wrapper {
   display: inline-block;
   position: relative;
+  width: 100%;
 }
 
 .autoComplete_wrapper > ul {

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -82,7 +82,7 @@
     &:focus,
     &:hover {
       background-color: var(--color-secondary-darker);
-      //color: var(--color-font-primary);
+      color: var(--color-font-primary);
     }
   }
 

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -82,6 +82,7 @@
     &:focus,
     &:hover {
       background-color: var(--color-secondary-darker);
+      //color: var(--color-font-primary);
     }
   }
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -82,6 +82,20 @@
     max-width: 100%;
   }
 
+  @media (min-width: 360px) {
+    &__control > .label .input,
+    &__control > .label .input[type='file'] {
+      max-width: 360px;
+    }
+  }
+
+  .filter__container &__control > .label .input,
+  .filter__container &__control > .label .input[type='file'],
+  .form--search &__control > .label .input {
+    width: 100%;
+    max-width: 100%;
+  }
+
   /// Registration -start.
 
   &__control > .label ul {

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -91,7 +91,8 @@
 
   .filter__container &__control > .label .input,
   .filter__container &__control > .label .input[type='file'],
-  .form--search &__control > .label .input {
+  .form--search &__control > .label .input,
+  &.form__registration .form__control .label .input{
     width: 100%;
     max-width: 100%;
   }

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -85,7 +85,7 @@
   @media (min-width: 360px) {
     &__control > .label .input,
     &__control > .label .input[type='file'] {
-      max-width: 360px;
+      max-width: 500px;
     }
   }
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -92,7 +92,7 @@
   .filter__container &__control > .label .input,
   .filter__container &__control > .label .input[type='file'],
   .form--search &__control > .label .input,
-  &.form__registration .form__control .label .input{
+  &.form__registration .form__control .label .input {
     width: 100%;
     max-width: 100%;
   }

--- a/src/open_inwoner/scss/components/Form/GroupInput.scss
+++ b/src/open_inwoner/scss/components/Form/GroupInput.scss
@@ -10,6 +10,7 @@
   textarea {
     border: none;
     resize: none;
+    width: 100%;
   }
 
   input {

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -100,7 +100,7 @@ $vm: var(--spacing-large);
     *[class*='Icon'] {
       font-size: 36px;
       cursor: pointer;
-      //color: var(--color-black);
+      color: var(--color-black);
     }
 
     @media (min-width: 768px) {

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -100,6 +100,7 @@ $vm: var(--spacing-large);
     *[class*='Icon'] {
       font-size: 36px;
       cursor: pointer;
+      //color: var(--color-black);
     }
 
     @media (min-width: 768px) {
@@ -287,6 +288,7 @@ $vm: var(--spacing-large);
 
             .link {
               gap: var(--spacing-medium);
+              vertical-align: bottom;
             }
           }
 

--- a/src/open_inwoner/scss/components/Messages/_Messages.scss
+++ b/src/open_inwoner/scss/components/Messages/_Messages.scss
@@ -80,5 +80,22 @@
 
   .message--ours {
     align-self: flex-end;
+    position: relative;
+
+    .message__body {
+      border: 1px solid transparent;
+
+      .p::before {
+        background-color: var(--color-primary);
+        border-radius: var(--border-radius);
+        bottom: 21px;
+        content: ' ';
+        left: 0;
+        opacity: 0.1;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    }
   }
 }

--- a/src/open_inwoner/scss/components/Table/Table.scss
+++ b/src/open_inwoner/scss/components/Table/Table.scss
@@ -105,8 +105,9 @@
     &--notification-danger {
       background-color: var(--color-danger-lightest);
       color: var(--color-danger-darker);
+      font-size: var(--font-size-body);
       text-align: center;
-      border-radius: var(--border-radius);
+      border-radius: var(--border-radius-large);
       padding: var(--spacing-small) 0;
     }
   }

--- a/src/open_inwoner/scss/components/Tags/TagList.scss
+++ b/src/open_inwoner/scss/components/Tags/TagList.scss
@@ -1,7 +1,7 @@
 .tag-list {
   &__list {
     display: flex;
-    //flex-wrap: wrap;
+    flex-wrap: wrap;
     gap: var(--spacing-large);
     list-style: none;
     margin: 0;

--- a/src/open_inwoner/scss/components/Tags/TagList.scss
+++ b/src/open_inwoner/scss/components/Tags/TagList.scss
@@ -1,6 +1,7 @@
 .tag-list {
   &__list {
     display: flex;
+    //flex-wrap: wrap;
     gap: var(--spacing-large);
     list-style: none;
     margin: 0;

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -14,8 +14,8 @@
   );
   --border-width: 2px;
   --border-width-thin: 1px;
-  //--border-radius: 3px;
-  --border-radius-large: 6px;
+  --border-radius: 3px;
+  --border-radius-large: 8px;
 
   // Color.
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -14,7 +14,8 @@
   );
   --border-width: 2px;
   --border-width-thin: 1px;
-  --border-radius: 3px;
+  //--border-radius: 3px;
+  --border-radius-large: 6px;
 
   // Color.
 

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -15,14 +15,14 @@
         {% button href="plans:plan_create" text=_("Start nieuwe samenwerking") primary=True icon="group" icon_outlined=True %}
     </h1>
     {% optional_paragraph configurable_text.plans_page.plans_intro %}
-    
+
     {% if plans.extended_plans %}
         {% render_form form=plan_filter_form method="GET" spaceless=True autosubmit=True form_action=form_action %}
         <div class="plan-filter">
             <div class="plan-filter__button">
                 {% button text=_("Filter") type="button" bordered=True %}
             </div>
-            <div class="plan-filter__container">
+            <div class="plan-filter__container filter__container">
                 <p class="p">{% trans "Filter op:" %}</p>
                 {% input plan_filter_form.plan_contacts no_label=True no_help=True icon="person" %}
                 {% input plan_filter_form.status no_label=True no_help=True icon="expand_more" %}
@@ -34,7 +34,7 @@
             </div>
         </div>
         {% endrender_form %}
-        
+
         <table class="table plans-extended">
             <thead class="table__heading">
                 <tr>
@@ -71,6 +71,6 @@
     {% else %}
         {% card_container plans=plans.plan_list columns=2 %}
     {% endif %}
-    
+
     {% pagination page_obj=page_obj paginator=paginator request=request %}
 {% endblock %}

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -66,7 +66,7 @@
         <div class="contacts__filter-button">
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
-        <div class="contacts__filter-container">
+        <div class="contacts__filter-container filter__container">
             <p class="p">{% trans "Filter op:" %}</p>
             {% input form.type no_label=True no_help=True icon="expand_more" class="label input" id="id_type" %}
         </div>

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -10,7 +10,7 @@
             </div>{% endspaceless %}
             <div class="grid__main">
                 <h1 class="h1">Zoeken</h1>
-                <div class="form form--columns-2 form--inline form--align-end">
+                <div class="form form--columns-2 form--inline form--align-end form--search">
                     {% input form.query %}
                     {% form_actions primary_text="Zoeken" primary_icon="arrow_forward" %}
                 </div>


### PR DESCRIPTION
Minor fixes, see Taiga issue 1179

- [x] make inputs less wide (involves adding classes and fix width for Search input)
- [x] mobile menu needs black close icon instead of ‘forced system-color’
- [x] hover on button of 'confirm' notification needs light text color
- [x] on mobile and desktop: rounder border for “actie vereist” in begeleider view
- [x] background color of sent messages needs to be the theme/city color but with light opacity
- [x] add flex-wrap to tags for mobile:

![tags-wrap](https://user-images.githubusercontent.com/118177951/225648832-cccca030-59ee-41d7-8503-4b911e37b4c8.png)
