### PR TITLE
[#1248] Redirect user to next after login

### DIFF
--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -21,7 +21,10 @@
                         <a href="{% url 'digid:login' %}" class="link digid-logo" aria-describedby="Digid logo" title="Digid logo">
                             <img class="digid-logo__image" src="{% static 'accounts/digid_logo.svg' %}" alt="Digid logo">
                         </a>
-                        {% link href='digid:login' next=next text=_('Inloggen met DigiD') secondary=True icon='arrow_forward' extra_classes="link--digid" %}
+                        {% url 'digid:login' as href %}
+                        {% with href|addnexturl:next as href_with_next %}
+                            {% link href=href_with_next text=_('Inloggen met DigiD') secondary=True icon='arrow_forward' extra_classes="link--digid" %}
+                        {% endwith %}
                     {% endrender_card %}
 		{% endif %}
 			
@@ -36,7 +39,10 @@
                     {% else %}
                         <div></div>
                     {% endif %}
-                        {% link text=site_config.openid_connect_login_text href='oidc_authentication_init' next=next secondary=True icon='arrow_forward' icon_position="after" %}
+                        {% url 'oidc_authentication_init' as href %}
+                        {% with href|addnexturl:next as href_with_next %}
+                            {% link text=site_config.openid_connect_login_text href=href_with_next secondary=True icon='arrow_forward' icon_position="after" %}
+                        {% endwith %}
                     {% endrender_card %}
                 {% endif %}
 
@@ -44,9 +50,10 @@
                     {% render_card tinted=True %}
                         {% render_form id="login-form" method="POST" form=form %}
                             {% csrf_token %}
+                            <input type="hidden" name="next" value="{{next}}" />
                             {% input form.username %}
                             {% input form.password %}
-                            {% button text=_('Wachtwoord vergeten?') href='password_reset' next=next secondary=True transparent=True align='right' %}
+                            {% button text=_('Wachtwoord vergeten?') href='password_reset' secondary=True transparent=True align='right' %}
                             {% form_actions primary_text=_("Inloggen") primary_icon="arrow_forward" secondary_href='django_registration_register' secondary_text=_('Registreer') secondary_icon='arrow_forward' single=True %}
                         {% endrender_form %}
                     {% endrender_card %}

--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -21,7 +21,7 @@
                         <a href="{% url 'digid:login' %}" class="link digid-logo" aria-describedby="Digid logo" title="Digid logo">
                             <img class="digid-logo__image" src="{% static 'accounts/digid_logo.svg' %}" alt="Digid logo">
                         </a>
-                        {% link href='digid:login' text=_('Inloggen met DigiD') secondary=True icon='arrow_forward' extra_classes="link--digid" %}
+                        {% link href='digid:login' next=next text=_('Inloggen met DigiD') secondary=True icon='arrow_forward' extra_classes="link--digid" %}
                     {% endrender_card %}
 		{% endif %}
 			
@@ -36,7 +36,7 @@
                     {% else %}
                         <div></div>
                     {% endif %}
-                        {% link text=site_config.openid_connect_login_text href='oidc_authentication_init' secondary=True icon='arrow_forward' icon_position="after" %}
+                        {% link text=site_config.openid_connect_login_text href='oidc_authentication_init' next=next secondary=True icon='arrow_forward' icon_position="after" %}
                     {% endrender_card %}
                 {% endif %}
 
@@ -46,7 +46,7 @@
                             {% csrf_token %}
                             {% input form.username %}
                             {% input form.password %}
-                            {% button text=_('Wachtwoord vergeten?') href='password_reset' secondary=True transparent=True align='right' %}
+                            {% button text=_('Wachtwoord vergeten?') href='password_reset' next=next secondary=True transparent=True align='right' %}
                             {% form_actions primary_text=_("Inloggen") primary_icon="arrow_forward" secondary_href='django_registration_register' secondary_text=_('Registreer') secondary_icon='arrow_forward' single=True %}
                         {% endrender_form %}
                     {% endrender_card %}

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -822,9 +822,13 @@ class TestLoginLogoutFunctionality(WebTest):
     def test_login_page_has_next_url(self):
         response = self.app.get(reverse("accounts:contact_list"))
         self.assertRedirects(
-            response, f"{reverse('login')}?next={reverse('accounts:contact_list')}"
+            response,
+            furl(reverse("login")).add({"next": reverse("accounts:contact_list")}).url,
         )
-        self.assertIn(f"?next={reverse('accounts:contact_list')}", response.follow())
+        self.assertIn(
+            furl("").add({"next": reverse("accounts:contact_list")}).url,
+            response.follow(),
+        )
 
     def test_login(self):
         """Test that a user is successfully logged in."""

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -820,10 +820,11 @@ class TestLoginLogoutFunctionality(WebTest):
         self.config.save()
 
     def test_login_page_has_next_url(self):
-        response = self.app.get(
-            f"{reverse('login')}?next={reverse('accounts:contact_list')}"
+        response = self.app.get(reverse("accounts:contact_list"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('accounts:contact_list')}"
         )
-        self.assertIn(f"?next={reverse('accounts:contact_list')}", response)
+        self.assertIn(f"?next={reverse('accounts:contact_list')}", response.follow())
 
     def test_login(self):
         """Test that a user is successfully logged in."""

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -819,6 +819,12 @@ class TestLoginLogoutFunctionality(WebTest):
         self.config.login_allow_registration = True
         self.config.save()
 
+    def test_login_page_has_next_url(self):
+        response = self.app.get(
+            f"{reverse('login')}?next={reverse('accounts:contact_list')}"
+        )
+        self.assertIn(f"?next={reverse('accounts:contact_list')}", response)
+
     def test_login(self):
         """Test that a user is successfully logged in."""
         form = self.app.get(reverse("login")).forms["login-form"]

--- a/src/open_inwoner/components/templates/components/Typography/Link.html
+++ b/src/open_inwoner/components/templates/components/Typography/Link.html
@@ -1,7 +1,7 @@
 {% load i18n helpers icon_tags %}
 
 <a
-    href="{{href}}"
+    href="{{href}}{% if next %}?next={{next}}{% endif %}"
     {% if id %}{{ id }}{% endif %}
     {% if download %}download{% endif %}
     {% if blank is True %}target="_blank"{% endif %}

--- a/src/open_inwoner/components/templates/components/Typography/Link.html
+++ b/src/open_inwoner/components/templates/components/Typography/Link.html
@@ -1,7 +1,7 @@
 {% load i18n helpers icon_tags %}
 
 <a
-    href="{{href}}{% if next %}?next={{next}}{% endif %}"
+    href="{{href}}"
     {% if id %}{{ id }}{% endif %}
     {% if download %}download{% endif %}
     {% if blank is True %}target="_blank"{% endif %}

--- a/src/open_inwoner/components/templatetags/link_tags.py
+++ b/src/open_inwoner/components/templatetags/link_tags.py
@@ -2,6 +2,8 @@ from django import template
 from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
+from furl import furl
+
 register = template.Library()
 
 
@@ -119,8 +121,6 @@ def addnexturl(href, next_url):
     """
     Concatenates href & next_url.
     """
-    if "?" in href:
-        href += f"&next={next_url}"
-        return href
-
-    return href + f"?next={next_url}"
+    f = furl(href)
+    f.args["next"] = next_url
+    return f.url

--- a/src/open_inwoner/components/templatetags/link_tags.py
+++ b/src/open_inwoner/components/templatetags/link_tags.py
@@ -112,3 +112,15 @@ def link(href, text, **kwargs):
     kwargs["href"] = get_href()
     kwargs["text"] = text
     return kwargs
+
+
+@register.filter
+def addnexturl(href, next_url):
+    """
+    Concatenates href & next_url.
+    """
+    if "?" in href:
+        href += f"&next={next_url}"
+        return href
+
+    return href + f"?next={next_url}"


### PR DESCRIPTION
Next is not used somewhere in the project (for instance if we click from an email the link to approve a contact we are not redirected to the contacts) so I added it for all the possible login methods.