### PR TITLE
:art: [#1021] Make entire Product card clickable

### DIFF
--- a/src/open_inwoner/components/templates/components/Card/CardContainer.html
+++ b/src/open_inwoner/components/templates/components/Card/CardContainer.html
@@ -20,7 +20,7 @@
     {% if products %}
         {% for product in products %}
             {% get_product_url product as product_url %}
-            {% description_card title=product.name description=product.summary url=product_url image=product.icon image_object_fit=image_object_fit %}
+            {% product_card title=product.name description=product.summary url=product_url image=product.icon image_object_fit=image_object_fit %}
         {% endfor %}
     {% endif %}
 

--- a/src/open_inwoner/components/templates/components/Card/CategoryCard.html
+++ b/src/open_inwoner/components/templates/components/Card/CategoryCard.html
@@ -1,12 +1,13 @@
 {% load card_tags icon_tags link_tags helpers utils %}
 
+{# template for subcategory cards #}
 {# create tag for anchor around card - never use anchors within anchors for valid HTML. #}
 {% if category.products.published %}
 <div title="{{ category }}" aria-label="{{ category.name }}" class="card">
     <div class="card__body">
         {% if category %}
             <p class="h3">
-                <a href="{{ category.slug }}" class="link link__text">{{ category }}</a>
+                <a href="{{ category.slug }}" class="link link__text">{{ category }} cat1</a>
             </p>
         {% endif %}
         {% for product in category.products.published %}
@@ -25,7 +26,7 @@
         <div class="card__body">
             {% if category %}
                 <p class="h3">
-                    <span class="link link__text">{{ category }}</span>
+                    <span class="link link__text">{{ category }} cat2</span>
                 </p>
             {% endif %}
         </div>

--- a/src/open_inwoner/components/templates/components/Card/CategoryCard.html
+++ b/src/open_inwoner/components/templates/components/Card/CategoryCard.html
@@ -1,13 +1,13 @@
-{% load card_tags icon_tags link_tags helpers utils %}
+{% load icon_tags link_tags helpers utils %}
 
-{# template for subcategory cards #}
+{# template for subcategory cards with or without product-links #}
 {# create tag for anchor around card - never use anchors within anchors for valid HTML. #}
 {% if category.products.published %}
 <div title="{{ category }}" aria-label="{{ category.name }}" class="card">
     <div class="card__body">
         {% if category %}
             <p class="h3">
-                <a href="{{ category.slug }}" class="link link__text">{{ category }} cat1</a>
+                <a href="{{ category.slug }}" class="link link__text">{{ category }}</a>
             </p>
         {% endif %}
         {% for product in category.products.published %}
@@ -26,7 +26,7 @@
         <div class="card__body">
             {% if category %}
                 <p class="h3">
-                    <span class="link link__text">{{ category }} cat2</span>
+                    <span class="link link__text">{{ category }}</span>
                 </p>
             {% endif %}
         </div>

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -1,20 +1,26 @@
-{% load card_tags icon_tags link_tags button_tags i18n grid_tags thumbnail %}
+{% load card_tags icon_tags link_tags i18n grid_tags thumbnail %}
 
-{# template for plans cards without any images #}
-{% render_card href=url grid=image title=title%}
-    <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
-    <p class="p">{{ description }}</p>
-    {% if object.end_date %}
-        <div class="card__tabled">
-            <div>{% trans "Einddatum" %}:</div>
-            <div>{{ object.end_date }}</div>
-            <div>{% trans "Created by" %}:</div>
-            <div>{{ object.created_by.get_full_name }}</div>
-        </div>
-    {% endif %}
+{# template for plans cards and product cards without any images #}
+<a href="{{ url }}" title="{{ title }}" aria-label="{{ title }}" class="card">
+    <div class="card__body">
+        {% if title %}
+            <p class="h4">
+                <span class="link link__text">{{ title }}</span>
+            </p>
+        {% endif %}
+        <p class="p">{{ description }}</p>
+        {% if object.end_date %}
+            <div class="card__tabled">
+                <div>{% trans "Einddatum" %}:</div>
+                <div>{{ object.end_date }}</div>
+                <div>{% trans "Created by" %}:</div>
+                <div>{{ object.created_by.get_full_name }}</div>
+            </div>
+        {% endif %}
 
-    <span class="button button--icon-before button--transparent button--secondary">
-    {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-    </span>
+        <span class="button button--icon-before button--transparent button--secondary">
+        {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+        </span>
 
-{% endrender_card %}
+    </div>
+</a>

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -1,13 +1,8 @@
-{% load card_tags icon_tags link_tags i18n grid_tags thumbnail %}
+{% load card_tags icon_tags link_tags button_tags i18n grid_tags thumbnail %}
 
-{% render_card grid=image %}
-    {% if image %}
-        <a href="{{ url }}" class="card__image-container">
-            <img class="card__image" src="{{ image|thumbnail_url:'card-image' }}" alt="{{ image.default_alt_text }}" />
-        </a>
-        <div class="card__content">
-    {% endif %}
-    <h2 class="h2">{% link url text=title %}</h2>
+{# template for plans cards without any images #}
+{% render_card href=url grid=image title=title%}
+    <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
     <p class="p">{{ description }}</p>
     {% if object.end_date %}
         <div class="card__tabled">
@@ -17,8 +12,9 @@
             <div>{{ object.created_by.get_full_name }}</div>
         </div>
     {% endif %}
-    {% link url text=title hide_text=True icon='arrow_forward' button=True transparent=True %}
-    {% if image %}
-        </div>
-    {% endif %}
+
+    <span class="button button--icon-before button--transparent button--secondary">
+    {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+    </span>
+
 {% endrender_card %}

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -1,4 +1,4 @@
-{% load card_tags icon_tags link_tags i18n grid_tags thumbnail %}
+{% load icon_tags link_tags i18n grid_tags thumbnail %}
 
 {# template for plans cards and product cards without any images #}
 <a href="{{ url }}" title="{{ title }}" aria-label="{{ title }}" class="card">
@@ -21,6 +21,5 @@
         <span class="button button--icon-before button--transparent button--secondary">
         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
         </span>
-
     </div>
 </a>

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -1,4 +1,4 @@
-{% load card_tags icon_tags link_tags i18n grid_tags thumbnail %}
+{% load icon_tags link_tags i18n grid_tags thumbnail %}
 
 {# template for product cards with images #}
 <a href="{{ url }}" title="{{ title }}" aria-label="{{ title }}" class="card">

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -1,0 +1,31 @@
+{% load card_tags icon_tags link_tags button_tags i18n grid_tags thumbnail %}
+
+{# template for product cards with images #}
+{% render_card href=url grid=image title=title %}
+    {% if image %}
+        <div class="card__image-container">
+            <img class="card__image" src="{{ image|thumbnail_url:'card-image' }}" alt="{{ image.default_alt_text }}"/>
+        </div>
+        <div class="card__content">
+                <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
+            {% else %}
+                <div class="card__content">
+                <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
+            {% endif %}
+        <p class="p">{{ description }}</p>
+        {% if object.end_date %}
+            <div class="card__tabled">
+                <div>{% trans "Einddatum" %}:</div>
+                <div>{{ object.end_date }}</div>
+                <div>{% trans "Created by" %}:</div>
+                <div>{{ object.created_by.get_full_name }}</div>
+            </div>
+        {% endif %}
+
+        <span class="button button--icon-before button--transparent button--secondary">
+            {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+        </span>
+
+        </div>
+        {# end of card__content #}
+{% endrender_card %}

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -1,31 +1,36 @@
-{% load card_tags icon_tags link_tags button_tags i18n grid_tags thumbnail %}
+{% load card_tags icon_tags link_tags i18n grid_tags thumbnail %}
 
 {# template for product cards with images #}
-{% render_card href=url grid=image title=title %}
+<a href="{{ url }}" title="{{ title }}" aria-label="{{ title }}" class="card">
+
     {% if image %}
+    <div class="card__body card__body--grid">
         <div class="card__image-container">
             <img class="card__image" src="{{ image|thumbnail_url:'card-image' }}" alt="{{ image.default_alt_text }}"/>
         </div>
         <div class="card__content">
                 <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
-            {% else %}
-                <div class="card__content">
-                <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
-            {% endif %}
-        <p class="p">{{ description }}</p>
-        {% if object.end_date %}
+    {% else %}
+        <div class="card__body">
+            <div class="card__content">
+            <h2 class="h2"><span class="link link__text">{{ title }}</span></h2>
+    {% endif %}
+            <p class="p">{{ description }}</p>
+            {% if object.end_date %}
             <div class="card__tabled">
                 <div>{% trans "Einddatum" %}:</div>
                 <div>{{ object.end_date }}</div>
                 <div>{% trans "Created by" %}:</div>
                 <div>{{ object.created_by.get_full_name }}</div>
             </div>
-        {% endif %}
+            {% endif %}
 
-        <span class="button button--icon-before button--transparent button--secondary">
+            <span class="button button--icon-before button--transparent button--secondary">
             {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-        </span>
+            </span>
 
         </div>
         {# end of card__content #}
-{% endrender_card %}
+    </div>
+
+</a>

--- a/src/open_inwoner/components/templates/components/Card/RenderCard.html
+++ b/src/open_inwoner/components/templates/components/Card/RenderCard.html
@@ -12,11 +12,9 @@
 
     <div class="card__body{% if direction %} card__body--direction-{{ direction }}{% endif %}{% if grid %} card__body--grid{% endif %}">
         {% if title %}
-            {% if compact %}
-            <p class="h4">
+            <p class="{% if compact %}h4{% else %}h3{% endif %}">
                 <span class="link link__text">{{ title }}</span>
             </p>
-            {% endif %}
         {% endif %}
         {{ contents }}
     </div>

--- a/src/open_inwoner/components/templates/components/Card/RenderCard.html
+++ b/src/open_inwoner/components/templates/components/Card/RenderCard.html
@@ -12,9 +12,11 @@
 
     <div class="card__body{% if direction %} card__body--direction-{{ direction }}{% endif %}{% if grid %} card__body--grid{% endif %}">
         {% if title %}
-            <p class="{% if compact %}h4{% else %}h3{% endif %}">
+            {% if compact %}
+            <p class="h4">
                 <span class="link link__text">{{ title }}</span>
             </p>
+            {% endif %}
         {% endif %}
         {{ contents }}
     </div>

--- a/src/open_inwoner/components/templatetags/card_tags.py
+++ b/src/open_inwoner/components/templatetags/card_tags.py
@@ -90,6 +90,25 @@ def description_card(title, description, url, **kwargs):
     return kwargs
 
 
+@register.inclusion_tag("components/Card/ProductCard.html")
+def product_card(description, url, **kwargs):
+    """
+    Renders a card with or without an image prepopulated based on `product`.
+
+    Usage:
+        {% product_card title=product.title description=product.intro url=product.get_absolute_url %}
+
+    Available options:
+        + description: string | The description that needs to be displayed.
+        + url: string | The url that the card should point to.
+        - title: string | The title of the card that may be displayed if there is no image.
+        - object: any | The object that needs to render aditional data.
+        - image: FilerImageField | an image that should be used.
+    """
+    kwargs.update(description=description, url=url)
+    return kwargs
+
+
 @register.inclusion_tag("components/Card/CardContainer.html")
 def card_container(categories=[], subcategories=[], products=[], plans=[], **kwargs):
     """

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -73,6 +73,11 @@
   }
   &__body {
     padding: var(--card-spacing);
+
+    /// clickable plans on home page after authenticated
+    .plan-list {
+      text-decoration: none;
+    }
   }
 
   &__body--grid {
@@ -159,7 +164,8 @@
   }
 
   /// Arrow button on product cards.
-  a.button:last-child {
+  a.button:last-child,
+  span.button:last-child {
     float: right;
   }
 

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -1,3 +1,10 @@
 .cases {
   margin-top: var(--spacing-giant);
+
+  /// cards on cases page
+  .card {
+    .cases__link {
+      text-decoration: none;
+    }
+  }
 }

--- a/src/open_inwoner/scss/components/List/_List.scss
+++ b/src/open_inwoner/scss/components/List/_List.scss
@@ -4,6 +4,10 @@
   padding: 0;
   width: 100%;
   overflow-y: auto;
+
+  .case-list {
+    text-decoration: none;
+  }
 }
 
 .search + .list {

--- a/src/open_inwoner/templates/pages/cases/list.html
+++ b/src/open_inwoner/templates/pages/cases/list.html
@@ -15,9 +15,11 @@
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
                     {% render_card compact=True stretch=True title=case.identificatie %}
                         {% render_list %}
+                            <a href="/accounts/cases/{{ case.uuid }}/status/" class="case-list">
                             {% list_item case.current_status caption=_("Status") compact=True strong=False %}
                             {% list_item case.start_date caption=_("Ontvangstdatum") compact=True strong=False %}
                             {% list_item case.description caption=_("Omschrijving") compact=True strong=False %}
+                            </a>
                         {% endrender_list %}
 
                         {% link href="accounts:case_status" object_id=case.uuid icon="arrow_forward" primary=True text=_("Bekijk aanvraag") %}

--- a/src/open_inwoner/templates/pages/cases/list.html
+++ b/src/open_inwoner/templates/pages/cases/list.html
@@ -15,7 +15,7 @@
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
                     {% render_card compact=True stretch=True title=case.identificatie %}
                         {% render_list %}
-                            <a href="/accounts/cases/{{ case.uuid }}/status/" class="case-list">
+                            <a href="{% url 'accounts:case_status' object_id=case.uuid %}" class="case-list">
                             {% list_item case.current_status caption=_("Status") compact=True strong=False %}
                             {% list_item case.start_date caption=_("Ontvangstdatum") compact=True strong=False %}
                             {% list_item case.description caption=_("Omschrijving") compact=True strong=False %}

--- a/src/open_inwoner/templates/pages/cases/list.html
+++ b/src/open_inwoner/templates/pages/cases/list.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n anchor_menu_tags card_tags grid_tags icon_tags link_tags list_tags pagination_tags utils %}
+{% load i18n anchor_menu_tags grid_tags icon_tags link_tags list_tags pagination_tags utils %}
 
 {% block sidebar_content %}
     {% anchor_menu anchors=anchors desktop=True %}
@@ -13,17 +13,27 @@
         {% render_grid %}
             {% for case in cases %}
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
-                    {% render_card compact=True stretch=True title=case.identificatie %}
-                        {% render_list %}
-                            <a href="{% url 'accounts:case_status' object_id=case.uuid %}" class="case-list">
-                            {% list_item case.current_status caption=_("Status") compact=True strong=False %}
-                            {% list_item case.start_date caption=_("Ontvangstdatum") compact=True strong=False %}
-                            {% list_item case.description caption=_("Omschrijving") compact=True strong=False %}
-                            </a>
-                        {% endrender_list %}
+                <div class="card card--compact card--stretch">
+                    <div class="card__body">
+                    <a href="{% url 'accounts:case_status' object_id=case.uuid %}" class="cases__link">
+                            <p class="h4">
+                                <span class="link link__text">{{ case.identificatie }}</span>
+                            </p>
+                            {% render_list %}
+                                <span class="case-list">
+                                {% list_item case.current_status caption=_("Status") compact=True strong=False %}
+                                {% list_item case.start_date caption=_("Ontvangstdatum") compact=True strong=False %}
+                                {% list_item case.description caption=_("Omschrijving") compact=True strong=False %}
+                                </span>
+                            {% endrender_list %}
 
-                        {% link href="accounts:case_status" object_id=case.uuid icon="arrow_forward" primary=True text=_("Bekijk aanvraag") %}
-                    {% endrender_card %}
+                            <span class="link link--icon link--primary" aria-label="{% trans "Bekijk aanvraag" %}" title="{% trans "Bekijk aanvraag" %}">
+                                <span class="link__text">{% trans "Bekijk aanvraag" %}</span>
+                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                            </span>
+                    </a>
+                    </div>
+                </div>
                 {% endrender_column %}
             {% endfor %}
         {% endrender_grid %}

--- a/src/open_inwoner/templates/pages/user-home.html
+++ b/src/open_inwoner/templates/pages/user-home.html
@@ -17,9 +17,9 @@
         <div class="plans-cards card-container card-container--columns-4">
             {% for plan in plans %}
                 {% render_card image_object_fit="cover" %}
-                    <h3 class="h3">{{ plan.title }}</h3>
+                    <a href="{{ plan.get_absolute_url }}" class="plan-list"><h3 class="h3">{{ plan.title }}</h3>
                     <p class="p">{{ plan.goal|truncatewords:20 }}</p>
-                    <p class="p">{{ plan.description|truncatewords:20 }}</p>
+                    <p class="p">{{ plan.description|truncatewords:20 }}</p></a>
                     <a
                         class="button button--icon-before button--transparent button--secondary"
                         href="{{ plan.get_absolute_url }}"


### PR DESCRIPTION
New clean branch for [old issue](https://github.com/maykinmedia/open-inwoner/pull/457).
Templates will need some more simplification, because currently they are not very maintainable.