### PR TITLE
:art:  [#1341] Show cases in mobile menu

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -65,9 +65,7 @@
                                 {% endwith %}
                             </li>
 
-                            {% get_solo 'configurations.SiteConfiguration' as config %}
-
-                            {% if request.user.bsn and show_cases %}
+                            {% if request.user.bsn and config.show_cases %}
                                 <li class="primary-navigation__list-item">
                                     {% link text=_('Mijn aanvragen') href='accounts:my_open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
                                 </li>


### PR DESCRIPTION
issue : https://taiga.maykinmedia.nl/project/open-inwoner/issue/1341
my mistake: `{% get_solo "configurations.SiteConfiguration" as config %}` was already put in in file,
and config needed to be put in the tag itself.