### PR TITLE
[#1234] Remove file-upload from profile page

### DIFF
--- a/src/open_inwoner/accounts/tests/test_file_upload.py
+++ b/src/open_inwoner/accounts/tests/test_file_upload.py
@@ -5,83 +5,12 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from django_webtest import WebTest
-from furl import furl
 from privates.test import temp_private_root
 from webtest import Upload
 
-from open_inwoner.accounts.models import Action, Document, Message
+from open_inwoner.accounts.models import Action, Message
 
 from .factories import UserFactory
-
-
-class TestDocumentFileUploadLimits(WebTest):
-    def setUp(self):
-        self.user = UserFactory()
-        self.response = self.app.get(
-            reverse("accounts:documents_create"), user=self.user
-        )
-        self.form = self.response.forms["document-create"]
-
-    @temp_private_root()
-    def test_valid_type_of_file_is_uploaded(self):
-        self.form["file"] = Upload("readme.xlsx", b"data", "application/vnd.ms-excel")
-        self.form["name"] = "readme"
-        upload_response = self.form.submit()
-        self.assertEquals(Document.objects.count(), 1)
-        self.assertRedirects(upload_response, reverse("accounts:my_profile"))
-
-    @temp_private_root()
-    def test_invalid_type_of_file_is_not_uploaded(self):
-        self.form["file"] = Upload("readme.svg", b"data", "image/svg+xml")
-        self.form["name"] = "readme"
-        upload_response = self.form.submit()
-        self.assertEquals(
-            upload_response.context["errors"],
-            [
-                _(
-                    "Het type bestand dat u hebt geüpload is ongeldig. Geldige bestandstypen zijn: pdf, docx, doc, xlsx, xls, jpeg, jpg, png, txt, odt, odf, ods"
-                )
-            ],
-        )
-
-    @override_settings(MAX_UPLOAD_SIZE=2)
-    @temp_private_root()
-    def test_files_bigger_than_max_size_are_not_uploaded(self):
-        self.form["file"] = Upload("readme.png", b"data", "image/png")
-        self.form["name"] = "readme"
-        upload_response = self.form.submit()
-        self.assertEquals(
-            upload_response.context["errors"],
-            [
-                _(
-                    "Een aangeleverd bestand dient maximaal {size} te zijn, uw bestand is te groot."
-                ).format(size=filesizeformat(settings.MAX_UPLOAD_SIZE))
-            ],
-        )
-
-    @override_settings(MIN_UPLOAD_SIZE=20)
-    @temp_private_root()
-    def test_files_smaller_than_min_size_are_not_uploaded(self):
-        self.form["file"] = Upload("readme.png", b"data", "image/png")
-        self.form["name"] = "readme"
-        upload_response = self.form.submit()
-        self.assertEquals(
-            upload_response.context["errors"],
-            [
-                _(
-                    "Een aangeleverd bestand dient minimaal {size} te zijn, uw bestand is te klein."
-                ).format(size=filesizeformat(settings.MIN_UPLOAD_SIZE))
-            ],
-        )
-
-    @temp_private_root()
-    def test_files_with_no_content_are_not_uploaded(self):
-        self.form["file"] = Upload("readme.png", b"", "image/png")
-        self.form["name"] = "readme"
-        upload_response = self.form.submit()
-        self.assertEquals(
-            upload_response.context["errors"], [_("Het verstuurde bestand is leeg.")]
-        )
 
 
 class TestActionFileUploadLimits(WebTest):

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -442,30 +442,6 @@ class TestDocuments(WebTest):
         )
 
     @temp_private_root()
-    def test_document_upload_is_logged(self):
-        form = self.app.get(
-            reverse("accounts:documents_create"),
-            user=self.user,
-        ).forms["document-create"]
-        form["name"] = "readme"
-        form["file"] = Upload("readme.png", b"data", "image/png")
-        form.submit()
-        log_entry = TimelineLog.objects.last()
-
-        self.assertEqual(
-            log_entry.timestamp.strftime("%m/%d/%Y, %H:%M:%S"), "10/18/2021, 13:00:00"
-        )
-        self.assertEqual(log_entry.content_object.id, Document.objects.all()[1].id)
-        self.assertEqual(
-            log_entry.extra_data,
-            {
-                "message": _("file was uploaded"),
-                "action_flag": list(LOG_ACTIONS[4]),
-                "content_object_repr": "readme",
-            },
-        )
-
-    @temp_private_root()
     def test_document_deletion_is_logged(self):
         self.app.post(
             reverse("accounts:documents_delete", kwargs={"uuid": self.document.uuid}),

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -123,6 +123,23 @@ class ProfileViewTests(WebTest):
         self.assertEquals(response.status_code, 302)
         self.assertEquals(response.url, reverse("digid:logout"))
 
+    def test_get_documents_sorted(self):
+        """
+        check that the new document is shown first
+        """
+        doc_old = DocumentFactory.create(name="some-old", owner=self.user)
+        doc_new = DocumentFactory.create(name="some-new", owner=self.user)
+
+        response = self.app.get(self.url, user=self.user)
+        self.assertEquals(response.status_code, 200)
+
+        file_tags = response.html.find(class_="file-list").find_all(
+            class_="file-list__list-item"
+        )
+        self.assertEquals(len(file_tags), 2)
+        self.assertTrue(doc_new.name in file_tags[0].prettify())
+        self.assertTrue(doc_old.name in file_tags[1].prettify())
+
     def test_mydata_shown_with_digid_and_brp(self):
         user = UserFactory(
             bsn="999993847",

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -123,23 +123,6 @@ class ProfileViewTests(WebTest):
         self.assertEquals(response.status_code, 302)
         self.assertEquals(response.url, reverse("digid:logout"))
 
-    def test_get_documents_sorted(self):
-        """
-        check that the new document is shown first
-        """
-        doc_old = DocumentFactory.create(name="some-old", owner=self.user)
-        doc_new = DocumentFactory.create(name="some-new", owner=self.user)
-
-        response = self.app.get(self.url, user=self.user)
-        self.assertEquals(response.status_code, 200)
-
-        file_tags = response.html.find(class_="file-list").find_all(
-            class_="file-list__list-item"
-        )
-        self.assertEquals(len(file_tags), 2)
-        self.assertTrue(doc_new.name in file_tags[0].prettify())
-        self.assertTrue(doc_old.name in file_tags[1].prettify())
-
     def test_mydata_shown_with_digid_and_brp(self):
         user = UserFactory(
             bsn="999993847",

--- a/src/open_inwoner/accounts/urls.py
+++ b/src/open_inwoner/accounts/urls.py
@@ -18,7 +18,6 @@ from .views import (
     ContactCreateView,
     ContactDeleteView,
     ContactListView,
-    DocumentCreateView,
     DocumentDeleteView,
     DocumentPrivateMediaView,
     EditProfileView,
@@ -47,7 +46,6 @@ urlpatterns = [
         name="inbox_download",
     ),
     path("setup/", HomeView.as_view(), name="setup_1"),
-    path("documents/create/", DocumentCreateView.as_view(), name="documents_create"),
     path(
         "documents/<str:uuid>/delete/",
         DocumentDeleteView.as_view(),

--- a/src/open_inwoner/accounts/views/__init__.py
+++ b/src/open_inwoner/accounts/views/__init__.py
@@ -29,7 +29,7 @@ from .contacts import (
 )
 from .csrf import csrf_failure
 from .document import DocumentPrivateMediaView
-from .documents import DocumentCreateView, DocumentDeleteView
+from .documents import DocumentDeleteView
 from .inbox import InboxPrivateMediaView, InboxStartView, InboxView
 from .invite import InviteAcceptView
 from .password_reset import PasswordResetView

--- a/src/open_inwoner/accounts/views/document.py
+++ b/src/open_inwoner/accounts/views/document.py
@@ -20,7 +20,11 @@ class DocumentPrivateMediaView(LogMixin, PrivateMediaView):
         if not self.request.user.is_authenticated:
             return False  # If user is not authenticated, the file is not visible
 
-        if self.request.user == object.owner or self.request.user.is_superuser:
+        if (
+            self.request.user == object.owner
+            or self.request.user.is_superuser
+            or (object.plan and self.request.user in object.plan.plan_contacts.all())
+        ):
             self.log_user_action(object, _("file was downloaded"))
             return True
 

--- a/src/open_inwoner/accounts/views/documents.py
+++ b/src/open_inwoner/accounts/views/documents.py
@@ -2,32 +2,11 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http.response import HttpResponseRedirect
 from django.urls.base import reverse_lazy
 from django.utils.translation import gettext as _
-from django.views.generic import CreateView, DeleteView
+from django.views.generic import DeleteView
 
-from open_inwoner.utils.views import CommonPageMixin, LogMixin
+from open_inwoner.utils.views import LogMixin
 
-from ..forms import DocumentForm
 from ..models import Document
-
-
-class DocumentCreateView(LogMixin, LoginRequiredMixin, CommonPageMixin, CreateView):
-    template_name = "pages/profile/documents/edit.html"
-    model = Document
-    form_class = DocumentForm
-    success_url = reverse_lazy("accounts:my_profile")
-
-    def page_title(self):
-        return _("Voeg document toe")
-
-    def get_queryset(self):
-        base_qs = super().get_queryset()
-        return base_qs.filter(owner=self.request.user)
-
-    def form_valid(self, form):
-        self.object = form.save(self.request.user)
-
-        self.log_user_action(self.object, _("file was uploaded"))
-        return HttpResponseRedirect(self.get_success_url())
 
 
 class DocumentDeleteView(LogMixin, LoginRequiredMixin, DeleteView):

--- a/src/open_inwoner/plans/admin.py
+++ b/src/open_inwoner/plans/admin.py
@@ -3,11 +3,16 @@ from django.contrib import admin
 from open_inwoner.accounts.admin import ActionInlineAdmin
 from open_inwoner.utils.mixins import UUIDAdminFirstInOrder
 
-from .models import ActionTemplate, Plan, PlanTemplate
+from .models import ActionTemplate, Plan, PlanContact, PlanTemplate
 
 
 class ActionTempalteInlineAdmin(admin.TabularInline):
     model = ActionTemplate
+    extra = 1
+
+
+class PlanContactInlineAdmin(admin.TabularInline):
+    model = PlanContact
     extra = 1
 
 
@@ -28,5 +33,5 @@ class PlanAdmin(UUIDAdminFirstInOrder, admin.ModelAdmin):
         "end_date",
         "created_by",
     )
-    inlines = [ActionInlineAdmin]
+    inlines = [PlanContactInlineAdmin, ActionInlineAdmin]
     filter_horizontal = ("plan_contacts",)

--- a/src/open_inwoner/plans/forms.py
+++ b/src/open_inwoner/plans/forms.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from io import BytesIO
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.core.files.base import File
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -54,8 +55,17 @@ class PlanForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
+
         goal = cleaned_data.get("goal")
         template = cleaned_data.get("template")
+        plan_contacts = cleaned_data.get("plan_contacts")
+
+        if not plan_contacts or (
+            plan_contacts and not plan_contacts.exclude(pk=self.user.pk)
+        ):
+            raise ValidationError(
+                _("At least one collaborator is required for a plan.")
+            )
         if not template and not goal:
             self.add_error(
                 "goal", _("This field is required when not using a template")

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -83,10 +83,12 @@ class PlanViewTests(WebTest):
         form["plan_contacts"] = [self.contact]
         response = form.submit()
         created_plan = Plan.objects.last()
+
         self.assertIn(self.user, created_plan.plan_contacts.all())
         self.assertEqual(created_plan.created_by, self.user)
 
         contact = PlanContact.objects.filter(plan=created_plan)[0]
+
         self.assertEqual(contact.user, self.user)
         self.assertEqual(contact.notify_new, True)
 

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -80,15 +80,15 @@ class PlanViewTests(WebTest):
         form["title"] = plan.title
         form["goal"] = plan.goal
         form["end_date"] = plan.end_date
-        form["plan_contacts"] = [self.contact]
+        form["plan_contacts"] = [self.contact.pk]
         response = form.submit()
-        created_plan = Plan.objects.last()
+
+        created_plan = Plan.objects.get(title=plan.title)
 
         self.assertIn(self.user, created_plan.plan_contacts.all())
         self.assertEqual(created_plan.created_by, self.user)
 
-        contact = PlanContact.objects.filter(plan=created_plan)[0]
-
+        contact = PlanContact.objects.last()
         self.assertEqual(contact.user, self.user)
         self.assertEqual(contact.notify_new, True)
 

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -5,19 +5,15 @@
     <h1 class="h1">{% trans "Samenwerken" %}</h1>
     {% optional_paragraph configurable_text.plans_page.plans_intro %}
 
-    {% render_form id="plan-form" form=form method="POST" %}
+    {% if request.user.get_active_contacts %}
+        {% render_form id="plan-form" form=form method="POST" %}
         {% csrf_token %}
         {% input form.title %}
         {% input form.goal %}
         {% input form.description %}
         {% render_grid %}
-            {% if request.user.get_active_contacts %}
-                {% checkboxes form.plan_contacts %}
-            {% else %}
-                {% url 'accounts:contact_create' as contact_create %}
-                {% link href=contact_create text=_("Maak je eerste contact aan voordat je een samenwerking start") icon="arrow_forward" icon_position="after" primary=True %}
-            {% endif %}
-            {% date_field form.end_date %}
+        {% checkboxes form.plan_contacts %}    
+        {% date_field form.end_date %}
         {% endrender_grid %}
 
         <div class="">
@@ -73,4 +69,10 @@
         </div>
         {% form_actions primary_text=_("Verzenden") primary_icon="arrow_forward" %}
     {% endrender_form %}
+    {% else %}
+        <div class="p">
+            {% url 'accounts:contact_create' as contact_create %}
+            {% link href=contact_create text=_("Maak je eerste contact aan voordat je een samenwerking start") icon="arrow_forward" icon_position="after" primary=True %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -96,4 +96,9 @@
     {% endif %}
 </div>
 
+{% render_form form=form method="POST" id="deactivate-form" extra_classes="confirm" spaceless=True data_confirm_title=_("Weet je het zeker dat je je account wilt deactiveren?") data_confirm_cancel=_("Nee") data_confirm_default=_("Ja") %}
+    {% csrf_token %}
+    {% form_actions primary_text=_("Profiel deactiveren") primary_icon="close" transparent=True %}
+{% endrender_form %}
+
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -101,4 +101,6 @@
     {% form_actions primary_text=_("Profiel deactiveren") primary_icon="close" transparent=True %}
 {% endrender_form %}
 
+{% file_list h1=True files=files allow_delete=True title=_("Bestanden") download_view="accounts:documents_download" %}
+
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -94,21 +94,6 @@
         <div class="tabled__item tabled__item--force-right tabled__item--mobile-big">{% link href="accounts:action_list" text="Aanpassen" icon="arrow_forward" icon_position="after" primary=True %}</div>
     </div>
     {% endif %}
-    {% comment %} <div class="tabled__row">
-        <div class="tabled__item tabled__item--bold">{% trans "Afspraken" %}</div>
-        <div class="tabled__item">4 afspraken, eerstvolgende voor 6 september</div>
-        <div class="tabled__item tabled__item--force-right tabled__item--mobile-big">{% link href="#" text="Aanpassen" icon="arrow_forward" icon_position="after" primary=True %}</div>
-    </div> {% endcomment %}
 </div>
 
-{% render_form form=form method="POST" id="deactivate-form" extra_classes="confirm" spaceless=True data_confirm_title=_("Weet je het zeker dat je je account wilt deactiveren?") data_confirm_cancel=_("Nee") data_confirm_default=_("Ja") %}
-    {% csrf_token %}
-    {% form_actions primary_text=_("Profiel deactiveren") primary_icon="close" transparent=True %}
-{% endrender_form %}
-
-{% file_list h1=True files=files allow_delete=True title=_("Bestanden") download_view="accounts:documents_download" %}
-
-{% button_row align="right" %}
-    {% button href="accounts:documents_create" text=_("Bestand toevoegen") primary=True %}
-{% endbutton_row %}
 {% endblock content %}


### PR DESCRIPTION
- [x] remove file-upload from Profile page
- [x] make it impossible to start a Plan with yourself (when no contacts exist, the form is not rendered and the link for creating a contact first, is shown)
- [x] all collaborators can have access to plan documents

issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/1234