### PR TITLE
:lipstick: [#1309] Make upload widget correspond with design

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -451,7 +451,7 @@ class ActionListForm(forms.ModelForm):
 
 class CaseUploadForm(forms.Form):
     title = forms.CharField(
-        label=_("Titel"), max_length=255, validators=[validate_charfield_entry]
+        label=_("Titel bestand"), max_length=255, validators=[validate_charfield_entry]
     )
     type = forms.ModelChoiceField(
         ZaakTypeInformatieObjectTypeConfig.objects.none(),

--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -28,6 +28,7 @@
         title="{% firstof title text %}"
         aria-label="{% firstof title text %}"
         {% as_attributes extra_attributes %}
+        {% if id %} id="{{ id }}" {% endif %}
     >
         {% if icon %}{% icon icon=icon outlined=icon_outlined %}{% endif %}
         {% if text_icon %}

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -1,0 +1,21 @@
+{% load i18n form_tags button_tags icon_tags %}
+
+<div class="form__control {{ extra_classes|default:"upload" }}">
+    <div id="inputfile-group" class="inputfile-group">
+        <label class="label">
+            <span class="input-file">
+            {{ field|addclass:"inputfile" }}
+
+            <label class="label__label">
+            {% icon icon="cloud_upload" icon_position="before" outlined=True %}
+                {{ text }}
+                {% if field.field.required %}<span class="label__label--required"> * </span>{% endif %}
+            </label>
+            </span>
+
+            {% if field.errors %}
+                {% errors errors=field.errors %}
+            {% endif %}
+        </label>
+    </div>
+</div>

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -1,7 +1,7 @@
-{% load i18n form_tags button_tags icon_tags %}
+{% load i18n form_tags icon_tags %}
 
 <div class="form__control {{ extra_classes|default:"upload" }}">
-    <div id="inputfile-group" class="inputfile-group">
+    <div class="inputfile-group">
         <label class="label">
             <span class="input-file">
             {{ field|addclass:"inputfile" }}
@@ -9,8 +9,8 @@
             <label class="label__label">
             {% icon icon="cloud_upload" icon_position="before" outlined=True %}
                 {{ text }}
-                {% if field.field.required %}<span class="label__label--required"> * </span>{% endif %}
-            </label>
+
+            </label>{% if field.field.required %}<span class="label__label--required"> * </span>{% endif %}
             </span>
 
             {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Form.html
+++ b/src/open_inwoner/components/templates/components/Form/Form.html
@@ -14,6 +14,9 @@
         hx-select="{{ async_selector }}"
         hx-target="{{ async_selector }}"
     {% endif %}
+
+{#    HTML attribute to bypass browser defaults and show validation #}
+    novalidate
 >
     {% if form.non_field_errors %}
         {% errors errors=form.non_field_errors %}

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -285,8 +285,7 @@ def file_input(file, text, **kwargs):
         + field: Field | The field that needs to be rendered.
         - extra_classes: string| classes which should be added to the top-level container
     """
-    kwargs["text"] = text
-    return {**kwargs, "field": file}
+    return {**kwargs, "field": file, "text": text}
 
 
 @register.inclusion_tag("components/Form/DateField.html")

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -273,6 +273,22 @@ def input(field, **kwargs):
     return {**kwargs, "field": field}
 
 
+@register.inclusion_tag("components/Form/FileInput.html")
+def file_input(file, text, **kwargs):
+    """
+    Displaying a file upload interface.
+
+    Usage:
+        {% file_input form.field text="Bestanden uploaden" %}
+
+    Variables:
+        + field: Field | The field that needs to be rendered.
+        - extra_classes: string| classes which should be added to the top-level container
+    """
+    kwargs["text"] = text
+    return {**kwargs, "field": file}
+
+
 @register.inclusion_tag("components/Form/DateField.html")
 def date_field(field, **kwargs):
     return {**kwargs, "field": field}

--- a/src/open_inwoner/js/components/index.js
+++ b/src/open_inwoner/js/components/index.js
@@ -21,6 +21,7 @@ import './preview'
 import './questionnaire'
 import './search'
 import './toggle'
+import './upload-document'
 import './session'
 
 const htmx = (window.htmx = require('htmx.org'))

--- a/src/open_inwoner/js/components/upload-document/file-input-errors.js
+++ b/src/open_inwoner/js/components/upload-document/file-input-errors.js
@@ -1,0 +1,17 @@
+const documentUpload = document.getElementById('formOpenUpload')
+const uploadError = document.querySelectorAll('.notifications')
+// get info
+const getFormInfo = document.querySelectorAll('.form__control--info')
+
+// if errors are present, scroll and trigger opened state
+if (uploadError.length > 1) {
+  console.log(uploadError)
+  documentUpload.scrollIntoView({
+    block: 'center',
+    behavior: 'smooth',
+  })
+  documentUpload.classList.add('upload--open')
+  for (let i = 0, max = getFormInfo.length; i < max; i++) {
+    getFormInfo[i].style.display = 'block'
+  }
+}

--- a/src/open_inwoner/js/components/upload-document/file-input-errors.js
+++ b/src/open_inwoner/js/components/upload-document/file-input-errors.js
@@ -1,17 +1,16 @@
-const documentUpload = document.getElementById('formOpenUpload')
+const documentUpload = document.getElementById('form_upload')
 const uploadError = document.querySelectorAll('.notifications')
 // get info
 const getFormInfo = document.querySelectorAll('.form__control--info')
 
 // if errors are present, scroll and trigger opened state
 if (uploadError.length > 1) {
-  console.log(uploadError)
   documentUpload.scrollIntoView({
     block: 'center',
     behavior: 'smooth',
   })
-  documentUpload.classList.add('upload--open')
-  for (let i = 0, max = getFormInfo.length; i < max; i++) {
-    getFormInfo[i].style.display = 'block'
-  }
+  // documentUpload.classList.add('upload--open')
+  getFormInfo.forEach((elem) => {
+    elem.style.display = 'block'
+  })
 }

--- a/src/open_inwoner/js/components/upload-document/index.js
+++ b/src/open_inwoner/js/components/upload-document/index.js
@@ -1,0 +1,2 @@
+import './show-file-info'
+import './file-input-errors'

--- a/src/open_inwoner/js/components/upload-document/show-file-info.js
+++ b/src/open_inwoner/js/components/upload-document/show-file-info.js
@@ -1,8 +1,8 @@
 const fileUploadInput = document.getElementById('id_file')
-const sizeInfo = document.getElementById('uploadSize')
-const nameInfo = document.getElementById('uploadName')
-const closeButton = document.getElementById('closeUpload')
-const submitUpload = document.getElementById('submitUpload')
+const sizeInfo = document.getElementById('upload_size')
+const nameInfo = document.getElementById('upload_name')
+const closeButton = document.getElementById('close_upload')
+const submit_upload = document.getElementById('submit_upload')
 // show info
 const formControlInfo = document.querySelectorAll('.form__control--info')
 
@@ -14,60 +14,38 @@ if (fileUploadInput) {
     return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${suffixes[i]}`
   }
   // initial values
-  submitUpload.style.cssText = `
-  opacity: 0.5;
-  filter: grayscale(100%);
-  cursor: default;
-`
-  sizeInfo.style.display = 'none'
-  nameInfo.style.display = 'none'
-  for (let i = 0, max = formControlInfo.length; i < max; i++) {
-    formControlInfo[i].style.display = 'none'
-  }
+  submit_upload.disabled = true
+  formControlInfo.forEach((elem) => {
+    elem.style.display = 'none'
+  })
 
   fileUploadInput.addEventListener('change', function (e) {
     const files = e.target.files
 
     if ((files.length === 0) | (files === null) | (files === undefined)) {
-      submitUpload.style.cssText = `
-      opacity: 0.5;
-      filter: grayscale(100%);
-      cursor: default;
-    `
+      submit_upload.disabled = true
       // Hide the size element if user doesn't choose any file
-      sizeInfo.style.display = 'none'
-      nameInfo.style.display = 'none'
-      for (let i = 0, max = formControlInfo.length; i < max; i++) {
-        formControlInfo[i].style.display = 'none'
-      }
+      formControlInfo.forEach((elem) => {
+        elem.style.display = 'none'
+      })
     } else {
-      submitUpload.style.cssText = `
-      opacity: 1;
-      filter: none;
-      cursor: pointer;
-    `
+      submit_upload.disabled = false
       // Display info
       sizeInfo.textContent = formatFileSize(files[0].size)
       nameInfo.textContent = `${files[0].name}`
       // Display in DOM
-      sizeInfo.style.display = 'inline-block'
-      nameInfo.style.display = 'inline-block'
-      for (let i = 0, max = formControlInfo.length; i < max; i++) {
-        formControlInfo[i].style.display = 'block'
-      }
+      formControlInfo.forEach((elem) => {
+        elem.style.display = 'block'
+      })
     }
   })
 
   if (closeButton) {
     closeButton.addEventListener('click', (event) => {
-      submitUpload.style.cssText = `
-        opacity: 0.5;
-        filter: grayscale(100%);
-        cursor: default;
-      `
-      for (let i = 0, max = formControlInfo.length; i < max; i++) {
-        formControlInfo[i].style.display = 'none'
-      }
+      submit_upload.disabled = true
+      formControlInfo.forEach((elem) => {
+        elem.style.display = 'none'
+      })
     })
   }
 
@@ -75,7 +53,6 @@ if (fileUploadInput) {
   document
     .querySelectorAll('.file-type__select')
     .forEach(function (selectType) {
-      console.log(selectType)
       if (selectType.querySelector('input[type="hidden"]')) {
         selectType.style.display = 'none'
       }

--- a/src/open_inwoner/js/components/upload-document/show-file-info.js
+++ b/src/open_inwoner/js/components/upload-document/show-file-info.js
@@ -1,0 +1,91 @@
+const fileUploadInput = document.getElementById('id_file')
+const sizeInfo = document.getElementById('uploadSize')
+const nameInfo = document.getElementById('uploadName')
+const closeButton = document.getElementById('closeUpload')
+const submitUpload = document.getElementById('submitUpload')
+// show info
+const formControlInfo = document.querySelectorAll('.form__control--info')
+
+if (fileUploadInput) {
+  // Convert the file size to a readable format
+  const formatFileSize = function (bytes) {
+    const suffixes = ['B', 'kB', 'MB', 'GB', 'TB']
+    const i = Math.floor(Math.log(bytes) / Math.log(1024))
+    return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${suffixes[i]}`
+  }
+  // initial values
+  submitUpload.style.cssText = `
+  opacity: 0.5;
+  filter: grayscale(100%);
+  cursor: default;
+`
+  sizeInfo.style.display = 'none'
+  nameInfo.style.display = 'none'
+  for (let i = 0, max = formControlInfo.length; i < max; i++) {
+    formControlInfo[i].style.display = 'none'
+  }
+
+  fileUploadInput.addEventListener('change', function (e) {
+    const files = e.target.files
+
+    if ((files.length === 0) | (files === null) | (files === undefined)) {
+      submitUpload.style.cssText = `
+      opacity: 0.5;
+      filter: grayscale(100%);
+      cursor: default;
+    `
+      // Hide the size element if user doesn't choose any file
+      sizeInfo.style.display = 'none'
+      nameInfo.style.display = 'none'
+      for (let i = 0, max = formControlInfo.length; i < max; i++) {
+        formControlInfo[i].style.display = 'none'
+      }
+    } else {
+      submitUpload.style.cssText = `
+      opacity: 1;
+      filter: none;
+      cursor: pointer;
+    `
+      // Display info
+      sizeInfo.textContent = formatFileSize(files[0].size)
+      nameInfo.textContent = `${files[0].name}`
+      // Display in DOM
+      sizeInfo.style.display = 'inline-block'
+      nameInfo.style.display = 'inline-block'
+      for (let i = 0, max = formControlInfo.length; i < max; i++) {
+        formControlInfo[i].style.display = 'block'
+      }
+    }
+  })
+
+  if (closeButton) {
+    closeButton.addEventListener('click', (event) => {
+      submitUpload.style.cssText = `
+        opacity: 0.5;
+        filter: grayscale(100%);
+        cursor: default;
+      `
+      for (let i = 0, max = formControlInfo.length; i < max; i++) {
+        formControlInfo[i].style.display = 'none'
+      }
+    })
+  }
+
+  // if there is only 1 case-type, remove select and its surrounding label
+  document
+    .querySelectorAll('.file-type__select')
+    .forEach(function (selectType) {
+      console.log(selectType)
+      if (selectType.querySelector('input[type="hidden"]')) {
+        selectType.style.display = 'none'
+      }
+    })
+
+  // Firefox focus bug fix
+  fileUploadInput.addEventListener('focus', function () {
+    fileUploadInput.classList.add('has-focus')
+  })
+  fileUploadInput.addEventListener('blur', function () {
+    fileUploadInput.classList.remove('has-focus')
+  })
+}

--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -1,8 +1,188 @@
 #document-upload {
+  gap: var(--spacing-tiny);
+
   .button[type='submit']:disabled {
+    background-color: var(--color-gray) !important;
     border-color: var(--color-gray) !important;
     color: var(--color-gray-light);
     pointer-events: none;
     cursor: default;
+  }
+
+  .form__control.upload .form__submit {
+    *[class*='icon'],
+    .button {
+      position: initial;
+      margin-top: 2em;
+    }
+  }
+
+  input[type='text'] {
+    max-width: var(--mobile-xs-width);
+  }
+
+  .inputfile-group {
+    display: block;
+
+    .label,
+    .close {
+      display: block;
+    }
+  }
+}
+
+/// File-input site wide
+input[type='file'] {
+  background-color: var(--color-white);
+  color: var(--color-primary-lighter);
+  border: 1px solid var(--color-mute);
+  border-radius: var(--border-radius);
+  display: flex;
+  flex-direction: column;
+  min-width: var(--mobile-xs-width);
+  max-width: 500px;
+  padding: 0;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+/// File-input button site wide
+input[type='file']::file-selector-button {
+  color: var(--color-white);
+  background-color: var(--color-primary);
+  text-transform: uppercase;
+  border: 1px;
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-body);
+  line-height: var(--font-line-height-body);
+  height: var(--row-height);
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 0 12px 0 12px;
+  margin: 0 12px 0 0;
+  width: 200px;
+}
+
+.button-row .upload-button--disabled {
+  background-color: var(--color-gray) !important;
+  border-color: var(--color-gray) !important;
+}
+
+.form__open-upload {
+  .file-type__select {
+    max-width: var(--mobile-xs-width);
+  }
+  .form__control > .label *[class*='icon'] {
+    top: 69%;
+  }
+
+  .input-file {
+    position: relative;
+    max-width: var(--mobile-xs-width);
+
+    *[class*='icons'] {
+      position: absolute;
+      top: 18px;
+      left: 12px;
+      color: orange;
+    }
+
+    /// Hidden file-input for cases
+    .inputfile {
+      display: inline-block;
+      margin-top: var(--spacing-large);
+      width: var(--mobile-xs-width);
+      height: var(--row-height);
+      opacity: 0;
+      overflow: hidden;
+      z-index: 200;
+    }
+
+    .inputfile + label {
+      display: inline-block;
+      position: absolute;
+      top: -6px;
+      left: 0;
+      padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium)
+        calc(2 * (var(--spacing-extra-large)));
+      font-size: var(--font-size-body);
+      color: var(--color-font-primary);
+      background-color: var(--color-primary);
+      border: 1px solid var(--color-primary);
+      border-radius: var(--border-radius);
+      width: 200px;
+      z-index: -1;
+    }
+
+    .inputfile:focus + label,
+    .inputfile.has-focus + label,
+    .inputfile:hover + label,
+    .inputfile + label:hover {
+      background-color: var(--color-primary-darker);
+      top: -5px;
+      transition: all 0.3s, background-color 0.3s;
+    }
+
+    .inputfile + label *[class*='icons'] {
+      width: 1.3em;
+      height: 1em;
+      vertical-align: middle;
+      color: white;
+      margin-top: -0.15em;
+    }
+
+    .inputfile + label {
+      cursor: pointer; /* "hand" cursor */
+    }
+
+    .inputfile:focus + label {
+      outline: 2px solid orange;
+      outline: -webkit-focus-ring-color auto 5px;
+    }
+  }
+
+  .close .button--transparent {
+    color: var(--color-red);
+  }
+
+  .info-container {
+    display: none;
+  }
+
+  .fieldset-container {
+    display: flex;
+    box-sizing: border-box;
+    flex-direction: row;
+    justify-content: space-around;
+    border: 1px solid lightgray;
+    border-radius: 4px;
+    max-width: var(--mobile-xs-width);
+    height: 80px;
+    padding-top: var(--spacing-large);
+    margin-bottom: 20px;
+
+    .fieldset__content {
+      color: var(--color-mute);
+      width: 200px;
+
+      .upload-info {
+        display: inline-block;
+        font-family: var(--font-family-body);
+        font-size: var(--font-size-body);
+        color: var(--color-mute);
+        width: 200px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        &__name {
+          color: var(--font-color-body);
+          font-weight: bold;
+        }
+      }
+    }
   }
 }

--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -4,7 +4,7 @@
   .button[type='submit']:disabled {
     background-color: var(--color-gray) !important;
     border-color: var(--color-gray) !important;
-    color: var(--color-gray-light);
+    color: var(--color-white);
     pointer-events: none;
     cursor: default;
   }
@@ -80,8 +80,13 @@ input[type='file']::file-selector-button {
   }
 
   .input-file {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 7px;
     position: relative;
-    max-width: var(--mobile-xs-width);
+    //width: 200px;
 
     *[class*='icons'] {
       position: absolute;
@@ -93,8 +98,8 @@ input[type='file']::file-selector-button {
     /// Hidden file-input for cases
     .inputfile {
       display: inline-block;
-      margin-top: var(--spacing-large);
-      width: var(--mobile-xs-width);
+      margin-top: var(--spacing-medium);
+      min-width: 200px;
       height: var(--row-height);
       opacity: 0;
       overflow: hidden;
@@ -104,16 +109,16 @@ input[type='file']::file-selector-button {
     .inputfile + label {
       display: inline-block;
       position: absolute;
-      top: -6px;
+      top: 5px;
       left: 0;
       padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium)
-        calc(2 * (var(--spacing-extra-large)));
+        calc(3 * (var(--spacing-extra-large)));
       font-size: var(--font-size-body);
       color: var(--color-font-primary);
       background-color: var(--color-primary);
       border: 1px solid var(--color-primary);
       border-radius: var(--border-radius);
-      width: 200px;
+      min-width: 202px;
       z-index: -1;
     }
 
@@ -122,16 +127,15 @@ input[type='file']::file-selector-button {
     .inputfile:hover + label,
     .inputfile + label:hover {
       background-color: var(--color-primary-darker);
-      top: -5px;
+      top: 4px;
       transition: all 0.3s, background-color 0.3s;
     }
 
     .inputfile + label *[class*='icons'] {
       width: 1.3em;
-      height: 1em;
       vertical-align: middle;
       color: white;
-      margin-top: -0.15em;
+      margin-left: var(--spacing-medium);
     }
 
     .inputfile + label {

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -156,9 +156,10 @@
 
   .caption__content {
     display: block;
-    color: var(--font-color-body);
+    color: var(--color-mute);
     font-family: var(--font-family-body);
     font-size: var(--font-size-body);
+    font-style: italic;
     .label__label--required {
       vertical-align: sub;
     }

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -77,6 +77,14 @@
       }
     }
   }
+  &__control
+    .label
+    .notifications__errors
+    .notification--warning
+    *[class*='icon'] {
+    position: static;
+    transform: translateY(-5px);
+  }
 
   &__control > .label .p:last-child {
     font-size: var(--font-size-body-small);

--- a/src/open_inwoner/scss/components/Header/AnchorMenu.scss
+++ b/src/open_inwoner/scss/components/Header/AnchorMenu.scss
@@ -113,7 +113,7 @@
     position: fixed;
     bottom: var(--spacing-large);
     right: var(--spacing-large);
-    z-index: 401;
+    z-index: 1005;
 
     @media (min-width: 768px) {
       position: static;

--- a/src/open_inwoner/scss/components/Notification/_Notifications.scss
+++ b/src/open_inwoner/scss/components/Notification/_Notifications.scss
@@ -14,7 +14,7 @@
     gap: 0;
     width: 100%;
     max-width: 500px;
-    margin: -6px var(--spacing-small) 0 0;
+    margin: -2px var(--spacing-small) 0 0;
     padding: 0 0 var(--spacing-small) 0;
     border: none;
   }

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -16,6 +16,10 @@
     line-height: var(--font-line-height-body-small);
   }
 
+  &--muted {
+    color: var(--color-mute);
+  }
+
   &:empty {
     margin: 0 !important;
   }

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -2,6 +2,8 @@
   // Layout.
 
   --container-width: 1024px;
+  --mobile-s-width: 768px;
+  --mobile-xs-width: 360px;
   --header-height: 187px;
 
   // Border.

--- a/src/open_inwoner/scss/views/Home.scss
+++ b/src/open_inwoner/scss/views/Home.scss
@@ -5,7 +5,7 @@
     grid-template-columns: repeat(auto-fit, 228px);
 
     .card {
-      max-width: 360px;
+      max-width: var(--mobile-xs-width);
     }
   }
 }

--- a/src/open_inwoner/templates/pages/cases/status.html
+++ b/src/open_inwoner/templates/pages/cases/status.html
@@ -11,93 +11,92 @@
     {% get_solo 'openzaak.OpenZaakConfig' as openzaak_config %}
 
     <div class="cases__detail">
-        {% if case %}
-            {% render_grid %}
-                {% render_column span=9 %}
+    {% if case %}
+        {% render_grid %}
+            {% render_column span=9 %}
 
-                    {# Title/dashboard. #}
-                    <h1 class="h1" id="title">{{ case.description }}</h1>
-                    {% case_dashboard case %}
-                    {% case_table case %}
+                {# Title/dashboard. #}
+                <h1 class="h1" id="title">{{ case.description }}</h1>
+                {% case_dashboard case %}
+                {% case_table case %}
 
-                    {#  Status history. #}
-                    {% if case.statuses %}
-                        <h2 class="h2" id="statuses">{% trans 'Status' %}</h2>
-                        {% status_list case.statuses %}
+                {#  Status history. #}
+                {% if case.statuses %}
+                    <h2 class="h2" id="statuses">{% trans 'Status' %}</h2>
+                    {% status_list case.statuses %}
+                {% endif %}
+
+                {#  Documents. #}
+                {% if case.documents %}
+                    <h2 class="h2" id="documents">{% trans 'Documenten' %}</h2>
+                    {% case_document_list case.documents %}
+                {% endif %}
+
+                {% if case.internal_upload_enabled %}
+                    <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
+                    {% if case.case_type_config_description %}
+                        <p class="p">{{ case.case_type_config_description }}</p>
+                    {% else %}
+                        <p class="p p--muted">
+                            {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
+                                Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}.
+                            {% endblocktranslate %}
+                        </p>
                     {% endif %}
 
-                    {#  Documents. #}
-                    {% if case.documents %}
-                        <h2 class="h2" id="documents">{% trans 'Documenten' %}</h2>
-                        {% case_document_list case.documents %}
-                    {% endif %}
-
-                    {% if case.internal_upload_enabled %}
-                        <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
-                        {% if case.case_type_config_description %}
-                            <p class="p">{{ case.case_type_config_description }}</p>
-                        {% else %}
-                            <p class="p p--muted">
-                                {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
-                                    Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}.
-                                {% endblocktranslate %}
-                            </p>
-                        {% endif %}
-
-                <section id="formOpenUpload" class="form__open-upload">
-
-                    <div class="upload-interface">
-                    {#  if local upload is enabled #}
-                    {% render_form id="document-upload" form=form method="POST" submit_text=_("Bestand uploaden") enctype="multipart/form-data" show_required=True %}
-                        {% csrf_token %}
-                        <section id="infoContainer" class="info-container form__control--info">
-                            <div class="drive">
-                                <fieldset class="fieldset-container">
-                                    <div class="drive">{% icon icon="insert_drive_file" outlined=True icon_position="before" %}</div>
-                                    <div class="fieldset__content">
-                                        <div id="uploadName" class="upload-info upload-info__name"><span>{% trans "(Titel bestand)" %}</span></div>
-                                        <div id="uploadSize" class="upload-info upload-info__size"><span>{% trans "(Bestandsgrootte)" %}</span></div>
-                                    </div>
-                                    <div class="close">{% button for="document-upload" id="closeUpload" icon="cancel" type='reset' text='' transparent=True icon_outlined=True icon_position="before" %}</div>
-                                </fieldset>
-                            </div>
-                        </section>
-
-                        <div class="form__control--info">{% input form.title no_label=False no_help=True class="label input" id="id_title" %}</div>
-
-                        <div class="form__control--info">{% input form.type no_label=False no_help=True icon="expand_more" icon_position="after" class="label input" id="id_title" extra_classes="file-type__select" %}</div>
-
-                        <div class="form__control upload">
-                            <div class="upload__container">
-                                {% file_input form.file text="Bestanden uploaden" no_label=False no_help=True extra_classes="file-upload" %}
-                                <div class="form__submit">
-                                    {% button_row %}
-                                        {% button for="document-upload" type="submit" text=_("Document toevoegen") id="submitUpload" primary=True %}
-                                    {% endbutton_row %}
+                    <section id="form_upload" class="form__open-upload">
+                        <div class="upload-interface">
+                        {#  if local upload is enabled #}
+                        {% render_form id="document-upload" form=form method="POST" submit_text=_("Bestand uploaden") enctype="multipart/form-data" show_required=True %}
+                            {% csrf_token %}
+                            <div id="info_container" class="info-container form__control--info">
+                                <div class="drive">
+                                    <fieldset class="fieldset-container">
+                                        <div class="drive">{% icon icon="insert_drive_file" outlined=True icon_position="before" %}</div>
+                                        <div class="fieldset__content">
+                                            <div id="upload_name" class="upload-info upload-info__name"><span>{% trans "(Titel bestand)" %}</span></div>
+                                            <div id="upload_size" class="upload-info upload-info__size"><span>{% trans "(Bestandsgrootte)" %}</span></div>
+                                        </div>
+                                        <div class="close">{% button id="close_upload" icon="cancel" type='reset' text='' transparent=True icon_outlined=True icon_position="before" %}</div>
+                                    </fieldset>
                                 </div>
                             </div>
+
+                            <div class="form__control--info">{% input form.title no_label=False no_help=True id="id_title" %}</div>
+
+                            <div class="form__control--info">{% input form.type no_label=False no_help=True icon="expand_more" icon_position="after" class="label input" id="id_type" extra_classes="file-type__select" %}</div>
+
+                            <div class="form__control upload">
+                                <div class="upload__container">
+                                    {% file_input form.file text=_("Bestanden uploaden") no_label=False no_help=True extra_classes="file-upload" %}
+                                    <div class="form__submit">
+                                        {% button_row %}
+                                            {% button type="submit" text=_("Document toevoegen") id="submit_upload" primary=True %}
+                                        {% endbutton_row %}
+                                    </div>
+                                </div>
+                            </div>
+                        {% endrender_form %}
                         </div>
-                    {% endrender_form %}
-                    </div>
+                    </section>
 
-                    {% elif case.external_upload_enabled %}
-                        <h2 class="h2">{% trans "Document toevoegen" %}</h2>
-                        {% if case.case_type_config_description %}
-                            <p class="p">{{ case.case_type_config_description }}</p>
-                        {% else %}
-                            <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
-                        {% endif %}
-                        {% button_row %}
-                            {% button href=case.external_upload_url text=_("Document toevoegen") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
-                        {% endbutton_row %}
+                {% elif case.external_upload_enabled %}
+                    <h2 class="h2">{% trans "Document toevoegen" %}</h2>
+                    {% if case.case_type_config_description %}
+                        <p class="p">{{ case.case_type_config_description }}</p>
+                    {% else %}
+                        <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
                     {% endif %}
+                    {% button_row %}
+                        {% button href=case.external_upload_url text=_("Document toevoegen") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
+                    {% endbutton_row %}
+                {% endif %}
 
-                </section>
 
-                {% endrender_column %}
-            {% endrender_grid %}
-        {% else %}
-            <h2 class="h2">{% trans 'There is no available data at the moment.' %}</h2>
-        {% endif %}
+            {% endrender_column %}
+        {% endrender_grid %}
+    {% else %}
+        <h2 class="h2">{% trans 'There is no available data at the moment.' %}</h2>
+    {% endif %}
     </div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/cases/status.html
+++ b/src/open_inwoner/templates/pages/cases/status.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n anchor_menu_tags card_tags dashboard_tags file_tags grid_tags status_tags table_tags solo_tags form_tags button_tags %}
+{% load i18n anchor_menu_tags card_tags dashboard_tags file_tags grid_tags status_tags table_tags solo_tags form_tags button_tags icon_tags %}
 
 {% block sidebar_content %}
     {% if case %}
@@ -11,55 +11,93 @@
     {% get_solo 'openzaak.OpenZaakConfig' as openzaak_config %}
 
     <div class="cases__detail">
-    {% if case %}
-        {% render_grid %}
-            {% render_column span=9 %}
+        {% if case %}
+            {% render_grid %}
+                {% render_column span=9 %}
 
-                {# Title/dashboard. #}
-                <h1 class="h1" id="title">{{ case.description }}</h1>
-                {% case_dashboard case %}
-                {% case_table case %}
+                    {# Title/dashboard. #}
+                    <h1 class="h1" id="title">{{ case.description }}</h1>
+                    {% case_dashboard case %}
+                    {% case_table case %}
 
-                {#  Status history. #}
-                {% if case.statuses %}
-                    <h2 class="h2" id="statuses">{% trans 'Status' %}</h2>
-                    {% status_list case.statuses %}
-                {% endif %}
-
-                {#  Documents. #}
-                {% if case.documents %}
-                    <h2 class="h2" id="documents">{% trans 'Documenten' %}</h2>
-                    {% case_document_list case.documents %}
-                {% endif %}
-
-                {% if case.internal_upload_enabled %}
-                    <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
-                    {% if case.case_type_config_description %}
-                        <p class="p">{{case.case_type_config_description}}</p>
-                    {% else %}
-                    <p class="p">
-                        {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
-                            Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}.
-                        {% endblocktranslate %}
-                    </p>
+                    {#  Status history. #}
+                    {% if case.statuses %}
+                        <h2 class="h2" id="statuses">{% trans 'Status' %}</h2>
+                        {% status_list case.statuses %}
                     {% endif %}
-                    {% form id="document-upload" form_object=form method="POST" submit_text=_("Bestand uploaden") enctype="multipart/form-data" show_required=True %}
-                {% elif case.external_upload_enabled %}
-                    <h2 class="h2">{% trans "Document toevoegen" %}</h2>
-                    {% if case.case_type_config_description %}
-                        <p class="p">{{case.case_type_config_description}}</p>
-                    {% else %}
-                        <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
-                    {% endif %}
-                    {% button_row %}
-                        {% button href=case.external_upload_url text=_("Document toevoegen") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
-                    {% endbutton_row %}
-                {% endif %}
 
-            {% endrender_column %}
-        {% endrender_grid %}
-    {% else %}
-        <h2 class="h2">{% trans 'There is no available data at the moment.' %}</h2>
-    {% endif %}
+                    {#  Documents. #}
+                    {% if case.documents %}
+                        <h2 class="h2" id="documents">{% trans 'Documenten' %}</h2>
+                        {% case_document_list case.documents %}
+                    {% endif %}
+
+                    {% if case.internal_upload_enabled %}
+                        <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
+                        {% if case.case_type_config_description %}
+                            <p class="p">{{ case.case_type_config_description }}</p>
+                        {% else %}
+                            <p class="p p--muted">
+                                {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
+                                    Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}.
+                                {% endblocktranslate %}
+                            </p>
+                        {% endif %}
+
+                <section id="formOpenUpload" class="form__open-upload">
+
+                    <div class="upload-interface">
+                    {#  if local upload is enabled #}
+                    {% render_form id="document-upload" form=form method="POST" submit_text=_("Bestand uploaden") enctype="multipart/form-data" show_required=True %}
+                        {% csrf_token %}
+                        <section id="infoContainer" class="info-container form__control--info">
+                            <div class="drive">
+                                <fieldset class="fieldset-container">
+                                    <div class="drive">{% icon icon="insert_drive_file" outlined=True icon_position="before" %}</div>
+                                    <div class="fieldset__content">
+                                        <div id="uploadName" class="upload-info upload-info__name"><span>{% trans "(Titel bestand)" %}</span></div>
+                                        <div id="uploadSize" class="upload-info upload-info__size"><span>{% trans "(Bestandsgrootte)" %}</span></div>
+                                    </div>
+                                    <div class="close">{% button for="document-upload" id="closeUpload" icon="cancel" type='reset' text='' transparent=True icon_outlined=True icon_position="before" %}</div>
+                                </fieldset>
+                            </div>
+                        </section>
+
+                        <div class="form__control--info">{% input form.title no_label=False no_help=True class="label input" id="id_title" %}</div>
+
+                        <div class="form__control--info">{% input form.type no_label=False no_help=True icon="expand_more" icon_position="after" class="label input" id="id_title" extra_classes="file-type__select" %}</div>
+
+                        <div class="form__control upload">
+                            <div class="upload__container">
+                                {% file_input form.file text="Bestanden uploaden" no_label=False no_help=True extra_classes="file-upload" %}
+                                <div class="form__submit">
+                                    {% button_row %}
+                                        {% button for="document-upload" type="submit" text=_("Document toevoegen") id="submitUpload" primary=True %}
+                                    {% endbutton_row %}
+                                </div>
+                            </div>
+                        </div>
+                    {% endrender_form %}
+                    </div>
+
+                    {% elif case.external_upload_enabled %}
+                        <h2 class="h2">{% trans "Document toevoegen" %}</h2>
+                        {% if case.case_type_config_description %}
+                            <p class="p">{{ case.case_type_config_description }}</p>
+                        {% else %}
+                            <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
+                        {% endif %}
+                        {% button_row %}
+                            {% button href=case.external_upload_url text=_("Document toevoegen") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
+                        {% endbutton_row %}
+                    {% endif %}
+
+                </section>
+
+                {% endrender_column %}
+            {% endrender_grid %}
+        {% else %}
+            <h2 class="h2">{% trans 'There is no available data at the moment.' %}</h2>
+        {% endif %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1309 

multiple tasks:

- [x] - needs custom template for input with type=file
- [x] - form needs to be overridden with a render_form
- [x] - toggle open/close interface to show/hide file-upload input field
- [x] - show filename info
- [x] - show filesize info
- [x] Disable submit button when no file is chosen and on cancel

other task:

- [x] - fix failing test "`@requests_mock.Mocker() /class TestCaseDetailView(ClearCachesMixin, WebTest):`'
- [x] - errors need to be shown and scrolled into view
- [x] - client-side errorhandling (browser defaults) needs to be overriden somehow, so the error notifications actually gets shown (with "novalidate"?)
- [x] - add reset 'close' button to clear the field and the information