### PR TITLE
First pass at moving 'Mijn Aanvragen' into a CMS apphook

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -620,7 +620,6 @@ class TestRegistrationNecessary(WebTest):
             reverse("pdc:category_list"),
             reverse("accounts:my_profile"),
             reverse("accounts:inbox"),
-            reverse("accounts:my_open_cases"),
             reverse("accounts:my_data"),
             reverse("plans:plan_list"),
             reverse("general_faq"),

--- a/src/open_inwoner/accounts/urls.py
+++ b/src/open_inwoner/accounts/urls.py
@@ -11,9 +11,6 @@ from .views import (
     ActionPrivateMediaView,
     ActionUpdateStatusTagView,
     ActionUpdateView,
-    CaseDetailView,
-    CaseDocumentDownloadView,
-    ClosedCaseListView,
     ContactApprovalView,
     ContactCreateView,
     ContactDeleteView,
@@ -31,10 +28,8 @@ from .views import (
     MyProfileExportView,
     MyProfileView,
     NecessaryFieldsUserView,
-    OpenCaseListView,
 )
 from .views.actions import ActionDeleteView
-from .views.cases import OpenSubmissionListView
 
 app_name = "accounts"
 urlpatterns = [
@@ -101,19 +96,6 @@ urlpatterns = [
     path("contacts/", ContactListView.as_view(), name="contact_list"),
     path("onderwerpen/", MyCategoriesView.as_view(), name="my_categories"),
     path("mydata/", MyDataView.as_view(), name="my_data"),
-    path("cases/open/", OpenCaseListView.as_view(), name="my_open_cases"),
-    path("cases/closed/", ClosedCaseListView.as_view(), name="my_closed_cases"),
-    path("cases/forms/", OpenSubmissionListView.as_view(), name="open_submissions"),
-    path(
-        "cases/<str:object_id>/document/<str:info_id>/",
-        CaseDocumentDownloadView.as_view(),
-        name="case_document_download",
-    ),
-    path(
-        "cases/<str:object_id>/status/",
-        CaseDetailView.as_view(),
-        name="case_status",
-    ),
     path("edit/", EditProfileView.as_view(), name="edit_profile"),
     path("invite/<str:key>/accept/", InviteAcceptView.as_view(), name="invite_accept"),
     path("export/", MyProfileExportView.as_view(), name="profile_export"),

--- a/src/open_inwoner/accounts/views/__init__.py
+++ b/src/open_inwoner/accounts/views/__init__.py
@@ -15,12 +15,6 @@ from .auth import (
     LogPasswordResetConfirmView,
     LogPasswordResetView,
 )
-from .cases import (
-    CaseDetailView,
-    CaseDocumentDownloadView,
-    ClosedCaseListView,
-    OpenCaseListView,
-)
 from .contacts import (
     ContactApprovalView,
     ContactCreateView,

--- a/src/open_inwoner/accounts/views/cases.py
+++ b/src/open_inwoner/accounts/views/cases.py
@@ -205,7 +205,7 @@ class OpenCaseListView(
 ):
     @cached_property
     def crumbs(self):
-        return [(_("Mijn aanvragen"), reverse("accounts:my_open_cases"))]
+        return [(_("Mijn aanvragen"), reverse("cases:open_cases"))]
 
     def page_title(self):
         return _("Lopende aanvragen")
@@ -219,9 +219,9 @@ class OpenCaseListView(
 
     def get_anchors(self) -> list:
         return [
-            (reverse("accounts:open_submissions"), _("Open aanvragen")),
+            (reverse("cases:open_submissions"), _("Open aanvragen")),
             ("#cases", _("Lopende aanvragen")),
-            (reverse("accounts:my_closed_cases"), _("Afgeronde aanvragen")),
+            (reverse("cases:closed_cases"), _("Afgeronde aanvragen")),
         ]
 
 
@@ -230,7 +230,7 @@ class ClosedCaseListView(
 ):
     @cached_property
     def crumbs(self):
-        return [(_("Mijn aanvragen"), reverse("accounts:my_closed_cases"))]
+        return [(_("Mijn aanvragen"), reverse("cases:closed_cases"))]
 
     def page_title(self):
         return _("Afgeronde aanvragen")
@@ -244,8 +244,8 @@ class ClosedCaseListView(
 
     def get_anchors(self) -> list:
         return [
-            (reverse("accounts:open_submissions"), _("Open aanvragen")),
-            (reverse("accounts:my_open_cases"), _("Lopende aanvragen")),
+            (reverse("cases:open_submissions"), _("Open aanvragen")),
+            (reverse("cases:open_cases"), _("Lopende aanvragen")),
             ("#cases", _("Afgeronde aanvragen")),
         ]
 
@@ -257,7 +257,7 @@ class OpenSubmissionListView(
 
     @cached_property
     def crumbs(self):
-        return [(_("Mijn aanvragen"), reverse("accounts:open_submissions"))]
+        return [(_("Mijn aanvragen"), reverse("cases:open_submissions"))]
 
     def page_title(self):
         return _("Open aanvragen")
@@ -275,8 +275,8 @@ class OpenSubmissionListView(
     def get_anchors(self) -> list:
         return [
             ("#submissions", _("Open aanvragen")),
-            (reverse("accounts:my_open_cases"), _("Lopende aanvragen")),
-            (reverse("accounts:my_closed_cases"), _("Afgeronde aanvragen")),
+            (reverse("cases:open_cases"), _("Lopende aanvragen")),
+            (reverse("cases:closed_cases"), _("Afgeronde aanvragen")),
         ]
 
 
@@ -296,10 +296,10 @@ class CaseDetailView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Mijn aanvragen"), reverse("accounts:my_open_cases")),
+            (_("Mijn aanvragen"), reverse("cases:open_cases")),
             (
                 _("Status"),
-                reverse("accounts:case_status", kwargs=self.kwargs),
+                reverse("cases:case_detail", kwargs=self.kwargs),
             ),
         ]
 
@@ -445,7 +445,7 @@ class CaseDetailView(
                     name=info_obj.titel,
                     size=info_obj.bestandsomvang,
                     url=reverse(
-                        "accounts:case_document_download",
+                        "cases:document_download",
                         kwargs={
                             "object_id": case.uuid,
                             "info_id": info_obj.uuid,

--- a/src/open_inwoner/cms/cases/cms_apps.py
+++ b/src/open_inwoner/cms/cases/cms_apps.py
@@ -1,0 +1,13 @@
+from django.utils.translation import gettext_lazy as _
+
+from cms.app_base import CMSApp
+from cms.apphook_pool import apphook_pool
+
+
+@apphook_pool.register
+class CasesApphook(CMSApp):
+    app_name = "cases"
+    name = _("ZGW Application")
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["open_inwoner.cms.cases.urls"]

--- a/src/open_inwoner/cms/cases/urls.py
+++ b/src/open_inwoner/cms/cases/urls.py
@@ -1,0 +1,29 @@
+from django.urls import path
+from django.views.generic import RedirectView
+
+from open_inwoner.accounts.views.cases import (
+    CaseDetailView,
+    CaseDocumentDownloadView,
+    ClosedCaseListView,
+    OpenCaseListView,
+    OpenSubmissionListView,
+)
+
+app_name = "cases"
+
+urlpatterns = [
+    path("open/", OpenCaseListView.as_view(), name="open_cases"),
+    path("closed/", ClosedCaseListView.as_view(), name="closed_cases"),
+    path("forms/", OpenSubmissionListView.as_view(), name="open_submissions"),
+    path(
+        "<str:object_id>/document/<str:info_id>/",
+        CaseDocumentDownloadView.as_view(),
+        name="document_download",
+    ),
+    path(
+        "<str:object_id>/status/",
+        CaseDetailView.as_view(),
+        name="case_detail",
+    ),
+    path("", RedirectView.as_view(pattern_name="cases:open_cases"), name="index"),
+]

--- a/src/open_inwoner/cms/tests/urls.py
+++ b/src/open_inwoner/cms/tests/urls.py
@@ -4,4 +4,5 @@ from open_inwoner.urls import urlpatterns as root_urlpatterns
 
 urlpatterns = [
     # add more here
+    path(r"cases/", include("open_inwoner.cms.cases.urls")),
 ] + root_urlpatterns

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -67,7 +67,7 @@
 
                             {% if request.user.bsn and config.show_cases %}
                                 <li class="primary-navigation__list-item">
-                                    {% link text=_('Mijn aanvragen') href='accounts:my_open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                                    {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
                                 </li>
                             {% endif %}
                             {% if show_plans %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -41,7 +41,7 @@
 
             {% if request.user.bsn and config.show_cases %}
                 <li class="primary-navigation__list-item">
-                    {% link text=_('Mijn aanvragen') href='accounts:my_open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                    {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
                 </li>
             {% endif %}
             {% if show_plans %}

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -205,6 +205,7 @@ INSTALLED_APPS = [
     "open_inwoner.questionnaire",
     "open_inwoner.extended_sessions",
     "open_inwoner.custom_csp",
+    "open_inwoner.cms.cases",
 ]
 
 MIDDLEWARE = [

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -336,7 +336,7 @@ def send_case_update_email(user: User, case: Zaak):
     send the actual mail
     """
     case_detail_url = build_absolute_url(
-        reverse("accounts:case_status", kwargs={"object_id": str(case.uuid)})
+        reverse("cases:case_detail", kwargs={"object_id": str(case.uuid)})
     )
 
     template = find_template("case_notification")

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -36,6 +37,7 @@ from .shared import CATALOGI_ROOT, DOCUMENTEN_ROOT, ZAKEN_ROOT
 
 
 @requests_mock.Mocker()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestCaseDetailView(ClearCachesMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
@@ -66,7 +68,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
         cls.config.save()
 
         cls.case_detail_url = reverse(
-            "accounts:case_status",
+            "cases:case_detail",
             kwargs={"object_id": "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"},
         )
 
@@ -280,7 +282,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
             name="document_title.txt",
             size=123,
             url=reverse(
-                "accounts:case_document_download",
+                "cases:document_download",
                 kwargs={
                     "object_id": cls.zaak["uuid"],
                     "info_id": cls.informatie_object["uuid"],
@@ -451,7 +453,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         self.assertRedirects(
             response,
-            f"{reverse('login')}?next={reverse('accounts:case_status', kwargs={'object_id': 'd8bbdeb7-770f-4ca9-b1ea-77b4730bf67d'})}",
+            f"{reverse('login')}?next={reverse('cases:case_detail', kwargs={'object_id': 'd8bbdeb7-770f-4ca9-b1ea-77b4730bf67d'})}",
         )
 
     def test_no_access_when_no_roles_are_found_for_user_bsn(self, m):
@@ -525,7 +527,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak_invisible["uuid"]},
             ),
             user=self.user,
@@ -550,7 +552,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -584,7 +586,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -620,7 +622,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -650,7 +652,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -666,7 +668,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
         m.get(self.zaak["url"], status_code=500)
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -682,7 +684,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -768,7 +770,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -808,7 +810,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -843,7 +845,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -868,7 +870,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -889,7 +891,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -913,7 +915,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -936,7 +938,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,
@@ -959,7 +961,7 @@ class TestCaseDetailView(ClearCachesMixin, WebTest):
 
         response = self.app.get(
             reverse(
-                "accounts:case_status",
+                "cases:case_detail",
                 kwargs={"object_id": self.zaak["uuid"]},
             ),
             user=self.user,

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -2,7 +2,7 @@ import datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
-from django.core.cache import cache
+from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
 
 import requests_mock
@@ -24,10 +24,11 @@ from .factories import ServiceFactory
 from .shared import CATALOGI_ROOT, ZAKEN_ROOT
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class CaseListAccessTests(ClearCachesMixin, WebTest):
     urls = [
-        reverse_lazy("accounts:my_open_cases"),
-        reverse_lazy("accounts:my_closed_cases"),
+        reverse_lazy("cases:open_cases"),
+        reverse_lazy("cases:closed_cases"),
     ]
 
     @classmethod
@@ -119,9 +120,10 @@ class CaseListAccessTests(ClearCachesMixin, WebTest):
 
 
 @requests_mock.Mocker()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class CaseListViewTests(ClearCachesMixin, WebTest):
-    url_open = reverse_lazy("accounts:my_open_cases")
-    url_closed = reverse_lazy("accounts:my_closed_cases")
+    url_open = reverse_lazy("cases:open_cases")
+    url_closed = reverse_lazy("cases:closed_cases")
 
     @classmethod
     def setUpTestData(cls):

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.core.cache import cache
+from django.test.utils import override_settings
 from django.urls import reverse_lazy
 
 import requests_mock
@@ -21,8 +22,9 @@ from .shared import CATALOGI_ROOT, ZAKEN_ROOT
 
 
 @requests_mock.Mocker()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
-    url = reverse_lazy("accounts:my_open_cases")
+    url = reverse_lazy("cases:open_cases")
 
     @classmethod
     def setUpTestData(cls):
@@ -306,7 +308,7 @@ class ClosedCaseListCacheTests(OpenCaseListCacheTests):
     run the same tests as for open cases
     """
 
-    url = reverse_lazy("accounts:my_closed_cases")
+    url = reverse_lazy("cases:closed_cases")
 
     @classmethod
     def setUpTestData(cls):

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -3,6 +3,7 @@ from io import BytesIO
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -46,6 +47,7 @@ def get_temporary_text_file():
 
 @temp_private_root()
 @requests_mock.Mocker()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
@@ -157,7 +159,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
             name="my_document.txt",
             size=len(cls.informatie_object_content),
             url=reverse(
-                "accounts:case_document_download",
+                "cases:document_download",
                 kwargs={
                     "object_id": cls.zaak["uuid"],
                     "info_id": cls.informatie_object["uuid"],
@@ -203,7 +205,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
     def test_document_content_is_retrieved_when_user_logged_in_via_digid(self, m):
         self._setUpMocks(m)
         url = reverse(
-            "accounts:case_document_download",
+            "cases:document_download",
             kwargs={
                 "object_id": self.zaak["uuid"],
                 "info_id": self.informatie_object["uuid"],
@@ -227,7 +229,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
     def test_document_retrieval_logs_case_identification_and_file(self, m):
         self._setUpMocks(m)
         url = reverse(
-            "accounts:case_document_download",
+            "cases:document_download",
             kwargs={
                 "object_id": self.zaak["uuid"],
                 "info_id": self.informatie_object["uuid"],
@@ -259,7 +261,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         )
         m.get(info_object["url"], json=info_object)
         url = reverse(
-            "accounts:case_document_download",
+            "cases:document_download",
             kwargs={
                 "object_id": self.zaak["uuid"],
                 "info_id": info_object["uuid"],
@@ -282,7 +284,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         )
         m.get(info_object["url"], json=info_object)
         url = reverse(
-            "accounts:case_document_download",
+            "cases:document_download",
             kwargs={
                 "object_id": self.zaak["uuid"],
                 "info_id": info_object["uuid"],

--- a/src/open_inwoner/openzaak/tests/test_formapi.py
+++ b/src/open_inwoner/openzaak/tests/test_formapi.py
@@ -1,3 +1,4 @@
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -54,6 +55,7 @@ class ESuiteData:
 
 
 @requests_mock.Mocker()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class FormAPITest(ClearCachesMixin, WebTest):
     config: OpenZaakConfig
 
@@ -68,7 +70,7 @@ class FormAPITest(ClearCachesMixin, WebTest):
         cls.config.save()
 
         cls.user = UserFactory(bsn="900222086")
-        cls.submissions_url = reverse("accounts:open_submissions")
+        cls.submissions_url = reverse("cases:open_submissions")
 
     def test_api_fetch(self, m):
         data = ESuiteData().install_mocks(m)

--- a/src/open_inwoner/openzaak/tests/test_notification_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_utils.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.core import mail
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.formats import date_format
 
@@ -22,6 +23,7 @@ from ..utils import format_zaak_identificatie
 from .test_notification_data import MockAPIData
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class NotificationHandlerUtilsTestCase(TestCase):
     @patch(
         "open_inwoner.openzaak.notifications.format_zaak_identificatie",
@@ -36,7 +38,7 @@ class NotificationHandlerUtilsTestCase(TestCase):
         case = factory(Zaak, data.zaak)
         case.zaaktype = factory(ZaakType, data.zaak_type)
 
-        case_url = reverse("accounts:case_status", kwargs={"object_id": str(case.uuid)})
+        case_url = reverse("cases:case_detail", kwargs={"object_id": str(case.uuid)})
 
         send_case_update_email(user, case)
 

--- a/src/open_inwoner/templates/pages/cases/list.html
+++ b/src/open_inwoner/templates/pages/cases/list.html
@@ -15,7 +15,7 @@
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
                 <div class="card card--compact card--stretch">
                     <div class="card__body">
-                    <a href="{% url 'accounts:case_status' object_id=case.uuid %}" class="cases__link">
+                    <a href="{% url 'cases:case_detail' object_id=case.uuid %}" class="cases__link">
                             <p class="h4">
                                 <span class="link link__text">{{ case.description }}</span>
                             </p>


### PR DESCRIPTION
I kept the views and tests at their current sub-optimal locations and basically moved the urls.

Most of the changes are because this changed the url namespace.

There are some issues that came up, like what to do when the page using the apphook is removed while other functionality depends on it (ex: without cases apphook the ZGW notifications have nowhere to link to).