### PR TITLE
First pass at moving 'Mijn Berichten' into a CMS apphook

### DIFF
--- a/src/open_inwoner/accounts/management/commands/notify_about_messages.py
+++ b/src/open_inwoner/accounts/management/commands/notify_about_messages.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             )
 
     def send_email(self, receiver: User, total_senders: int, total_messages: int):
-        inbox_url = build_absolute_url(reverse("accounts:inbox"))
+        inbox_url = build_absolute_url(reverse("inbox:index"))
         template = find_template("new_messages")
         context = {
             "total_messages": total_messages,

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -257,7 +257,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         return reverse("profile:contact_edit", kwargs={"uuid": self.uuid})
 
     def get_contact_message_url(self) -> str:
-        url = reverse("accounts:inbox", kwargs={"uuid": self.uuid})
+        url = reverse("inbox:index", kwargs={"uuid": self.uuid})
         return f"{url}#messages-last"
 
     def get_contact_type_display(self) -> str:

--- a/src/open_inwoner/accounts/templates/accounts/inbox.html
+++ b/src/open_inwoner/accounts/templates/accounts/inbox.html
@@ -9,7 +9,7 @@
         {% endrender_column %}
 
         {% render_column start=10 span=3 extra_classes="fix__align-right" %}
-            {% button primary=True href='accounts:inbox_start' text=_('Nieuw bericht versturen') %}
+            {% button primary=True href='inbox:start' text=_('Nieuw bericht versturen') %}
         {% endrender_column %}
     {% endrender_grid %}
     {{ block.super }}

--- a/src/open_inwoner/accounts/tests/test_admin.py
+++ b/src/open_inwoner/accounts/tests/test_admin.py
@@ -17,6 +17,7 @@ class TestAdminUser(WebTest):
         self.user = UserFactory(
             is_superuser=True, is_staff=True, email="john@example.com"
         )
+        self.assertEqual(User.objects.count(), 1)
 
     def test_user_is_created_without_case_sensitive_email(self):
         response = self.app.get(reverse("admin:accounts_user_add"), user=self.user)

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -620,7 +620,7 @@ class TestRegistrationNecessary(WebTest):
         urls = [
             reverse("root"),
             reverse("products:category_list"),
-            reverse("accounts:my_profile"),
+            reverse("cases:open_cases"),
             reverse("profile:detail"),
             reverse("profile:data"),
             reverse("plans:plan_list"),

--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -85,7 +85,7 @@ class ContactViewTests(WebTest):
         )
 
     def test_contact_list_show_link_to_messages(self):
-        message_link = reverse("accounts:inbox", kwargs={"uuid": self.contact.uuid})
+        message_link = reverse("inbox:index", kwargs={"uuid": self.contact.uuid})
         response = self.app.get(self.list_url, user=self.user)
         self.assertContains(response, message_link)
 
@@ -366,7 +366,7 @@ class ContactViewTests(WebTest):
         self.assertContains(response, self.user.first_name)
         self.assertContains(response, self.user.last_name)
         self.assertContains(
-            response, reverse("accounts:inbox", kwargs={"uuid": self.user.uuid})
+            response, reverse("inbox:index", kwargs={"uuid": self.user.uuid})
         )
 
         # Sender contact list page
@@ -376,7 +376,7 @@ class ContactViewTests(WebTest):
         self.assertContains(response, existing_user.last_name)
         self.assertContains(
             response,
-            reverse("accounts:inbox", kwargs={"uuid": existing_user.uuid}),
+            reverse("inbox:index", kwargs={"uuid": existing_user.uuid}),
         )
 
     def test_post_with_no_params_in_contact_approval_returns_bad_request(self):

--- a/src/open_inwoner/accounts/tests/test_file_upload.py
+++ b/src/open_inwoner/accounts/tests/test_file_upload.py
@@ -155,12 +155,13 @@ class TestActionFileUploadLimits(WebTest):
         )
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestMessageFileUploadLimits(WebTest):
     def setUp(self):
         self.me = UserFactory()
         self.contact = UserFactory()
         self.me.user_contacts.add(self.contact)
-        self.response = self.app.get(reverse("accounts:inbox_start"), user=self.me)
+        self.response = self.app.get(reverse("inbox:start"), user=self.me)
         self.form = self.response.forms["start-message-form"]
 
     @temp_private_root()
@@ -172,7 +173,7 @@ class TestMessageFileUploadLimits(WebTest):
         self.assertEquals(Message.objects.first().file.name, "readme.xlsx")
         self.assertRedirects(
             upload_response,
-            reverse("accounts:inbox", kwargs={"uuid": self.contact.uuid})
+            reverse("inbox:index", kwargs={"uuid": self.contact.uuid})
             + "#messages-last",
             fetch_redirect_response=False,
         )

--- a/src/open_inwoner/accounts/tests/test_inbox_download_view.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_download_view.py
@@ -1,4 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.urls import reverse
 
 from django_webtest import WebTest
@@ -8,12 +9,13 @@ from .factories import MessageFactory, UserFactory
 
 
 @temp_private_root()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class InboxDownloadTests(WebTest):
     def setUp(self) -> None:
         self.message = MessageFactory(
             file=SimpleUploadedFile("file.txt", b"test content"),
         )
-        self.download_url = reverse("accounts:inbox_download", args=[self.message.uuid])
+        self.download_url = reverse("inbox:download", args=[self.message.uuid])
 
     def test_download_file_receiver(self):
         response = self.app.get(self.download_url, user=self.message.receiver)

--- a/src/open_inwoner/accounts/tests/test_inbox_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_page.py
@@ -1,5 +1,6 @@
 from unittest import skip
 
+from django.test import override_settings
 from django.urls import reverse
 
 from django_webtest import WebTest
@@ -15,6 +16,7 @@ from ..models import Message
 from .factories import DigidUserFactory, MessageFactory, UserFactory
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class InboxPageTests(WebTest):
     def setUp(self) -> None:
         super().setUp()
@@ -39,10 +41,8 @@ class InboxPageTests(WebTest):
 
         self.app.set_user(self.user)
 
-        self.url = reverse("accounts:inbox")
-        self.contact1_url = reverse(
-            "accounts:inbox", kwargs={"uuid": self.contact1.uuid}
-        )
+        self.url = reverse("inbox:index")
+        self.contact1_url = reverse("inbox:index", kwargs={"uuid": self.contact1.uuid})
 
     def test_user_contacts_are_symetrical(self):
         self.assertIn(self.contact1, self.user.user_contacts.all())
@@ -129,7 +129,7 @@ class InboxPageTests(WebTest):
             self.assertFalse(message.seen)
 
         response = self.app.get(
-            reverse("accounts:inbox", kwargs={"uuid": other_user.uuid}),
+            reverse("inbox:index", kwargs={"uuid": other_user.uuid}),
             auto_follow=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -179,6 +179,7 @@ class InboxPageTests(WebTest):
 
 
 @multi_browser()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class InboxPagePlaywrightTests(PlaywrightSyncLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
@@ -208,7 +209,7 @@ class InboxPagePlaywrightTests(PlaywrightSyncLiveServerTestCase):
             sender=self.contact_2,
         )
         self.contact_1_conversation_url = self.live_reverse(
-            "accounts:inbox",
+            "inbox:index",
             kwargs={"uuid": self.contact_1.uuid},
         )
 

--- a/src/open_inwoner/accounts/tests/test_inbox_start_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_start_page.py
@@ -1,4 +1,5 @@
-from django.urls import reverse, reverse_lazy
+from django.test import override_settings
+from django.urls import reverse
 
 from django_webtest import WebTest
 from furl import furl
@@ -8,6 +9,7 @@ from ..models import Message
 from .factories import DocumentFactory, UserFactory
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class InboxPageTests(WebTest):
     def setUp(self) -> None:
         super().setUp()
@@ -15,7 +17,7 @@ class InboxPageTests(WebTest):
         self.user = UserFactory.create()
         self.app.set_user(self.user)
 
-        self.url = reverse("accounts:inbox_start")
+        self.url = reverse("inbox:start")
 
     def test_contact_choices_include_only_active_contacts(self):
         active_contact = UserFactory()
@@ -53,7 +55,7 @@ class InboxPageTests(WebTest):
         response = form.submit()
 
         self.assertEqual(response.status_code, 302)
-        url = reverse("accounts:inbox", kwargs={"uuid": contact.uuid})
+        url = reverse("inbox:index", kwargs={"uuid": contact.uuid})
         self.assertEqual(response.url, url + "#messages-last")
         self.assertEqual(Message.objects.count(), 1)
 
@@ -80,7 +82,7 @@ class InboxPageTests(WebTest):
         response = form.submit()
 
         self.assertEqual(response.status_code, 302)
-        url = reverse("accounts:inbox", kwargs={"uuid": contact.uuid})
+        url = reverse("inbox:index", kwargs={"uuid": contact.uuid})
         self.assertEqual(response.url, url + "#messages-last")
         self.assertEqual(Message.objects.count(), 1)
 
@@ -131,7 +133,7 @@ class InboxPageTests(WebTest):
         response = form.submit()
 
         self.assertEqual(response.status_code, 302)
-        url = reverse("accounts:inbox", kwargs={"uuid": contact.uuid})
+        url = reverse("inbox:index", kwargs={"uuid": contact.uuid})
         self.assertEqual(response.url, url + "#messages-last")
         self.assertEqual(Message.objects.count(), 1)
 

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -620,6 +620,7 @@ class TestActions(WebTest):
 
 
 @freeze_time("2021-10-18 13:00:00")
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestMessages(WebTest):
     def setUp(self):
         self.user = UserFactory()
@@ -628,7 +629,7 @@ class TestMessages(WebTest):
 
     def test_created_message_action_from_contacts_is_logged(self):
         response = self.app.get(
-            reverse("accounts:inbox", kwargs={"uuid": self.other_user.uuid}),
+            reverse("inbox:index", kwargs={"uuid": self.other_user.uuid}),
             user=self.user,
             auto_follow=True,
         )
@@ -654,7 +655,7 @@ class TestMessages(WebTest):
 
     def test_created_message_action_from_start_is_logged(self):
         response = self.app.get(
-            reverse("accounts:inbox_start"),
+            reverse("inbox:start"),
             user=self.user,
         )
         form = response.forms["start-message-form"]
@@ -682,7 +683,7 @@ class TestMessages(WebTest):
         message = MessageFactory(
             file=SimpleUploadedFile("file.txt", b"test content"),
         )
-        download_url = reverse("accounts:inbox_download", args=[message.uuid])
+        download_url = reverse("inbox:download", args=[message.uuid])
         self.app.get(download_url, user=message.receiver)
         log_entry = TimelineLog.objects.last()
 

--- a/src/open_inwoner/accounts/tests/test_notify_about_messages.py
+++ b/src/open_inwoner/accounts/tests/test_notify_about_messages.py
@@ -1,11 +1,12 @@
 from django.core import mail
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from .factories import MessageFactory, UserFactory
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class NotifyComandTests(TestCase):
     def test_notify_about_received_message(self):
         user, sender1, sender2 = UserFactory.create_batch(3)
@@ -25,7 +26,7 @@ class NotifyComandTests(TestCase):
         self.assertEqual(sent_mail.subject, "New messages at Open Inwoner Platform")
         self.assertEqual(sent_mail.to, [user.email])
         self.assertIn("You've received 3 new messages from 2 users", sent_mail.body)
-        self.assertIn(reverse("accounts:inbox"), html_body)
+        self.assertIn(reverse("inbox:index"), html_body)
 
         for message in messages:
             message.refresh_from_db()
@@ -71,7 +72,7 @@ class NotifyComandTests(TestCase):
         for email in [email1, email2]:
             self.assertEqual(email.subject, "New messages at Open Inwoner Platform")
             html_body = email.alternatives[0][0]
-            self.assertIn(reverse("accounts:inbox"), html_body)
+            self.assertIn(reverse("inbox:index"), html_body)
 
         self.assertEqual(email1.to, [user2.email])
         self.assertIn("You've received 2 new messages from 1 users", email1.body)

--- a/src/open_inwoner/accounts/urls.py
+++ b/src/open_inwoner/accounts/urls.py
@@ -1,15 +1,4 @@
 from django.urls import path
 
-from .views import InboxPrivateMediaView, InboxStartView, InboxView
-
 app_name = "accounts"
-urlpatterns = [
-    path("inbox/", InboxView.as_view(), name="inbox"),
-    path("inbox/conversation/<str:uuid>/", InboxView.as_view(), name="inbox"),
-    path("inbox/start/", InboxStartView.as_view(), name="inbox_start"),
-    path(
-        "inbox/files/<str:uuid>/download/",
-        InboxPrivateMediaView.as_view(),
-        name="inbox_download",
-    ),
-]
+urlpatterns = []

--- a/src/open_inwoner/accounts/views/__init__.py
+++ b/src/open_inwoner/accounts/views/__init__.py
@@ -24,7 +24,6 @@ from .contacts import (
 from .csrf import csrf_failure
 from .document import DocumentPrivateMediaView
 from .documents import DocumentCreateView, DocumentDeleteView
-from .inbox import InboxPrivateMediaView, InboxStartView, InboxView
 from .invite import InviteAcceptView
 from .password_reset import PasswordResetView
 from .profile import (

--- a/src/open_inwoner/accounts/views/inbox.py
+++ b/src/open_inwoner/accounts/views/inbox.py
@@ -47,7 +47,7 @@ class InboxView(
 
         if other_user:
             conversation_url = reverse(
-                "accounts:inbox", kwargs={self.slug_field: other_user.uuid}
+                "inbox:index", kwargs={self.slug_field: other_user.uuid}
             )
         else:
             conversation_url = ""
@@ -76,7 +76,7 @@ class InboxView(
     def annotate_conversations(self, conversations):
         for c in conversations:
             c.thread_url = reverse(
-                "accounts:inbox", kwargs={self.slug_field: c.other_user_uuid}
+                "inbox:index", kwargs={self.slug_field: c.other_user_uuid}
             )
             # note these are annotations (not models)
             c.other_user_full_name = " ".join(
@@ -153,7 +153,7 @@ class InboxView(
         object = form.save()
 
         url = reverse(
-            "accounts:inbox",
+            "inbox:index",
             kwargs={self.slug_field: form.cleaned_data["receiver"].uuid},
         )
 
@@ -184,7 +184,7 @@ class InboxView(
 class InboxStartView(LogMixin, LoginRequiredMixin, CommonPageMixin, FormView):
     template_name = "accounts/inbox_start.html"
     form_class = InboxForm
-    success_url = reverse_lazy("accounts:inbox")
+    success_url = reverse_lazy("inbox:index")
 
     def page_title(self):
         return _("Nieuw bericht")
@@ -199,7 +199,7 @@ class InboxStartView(LogMixin, LoginRequiredMixin, CommonPageMixin, FormView):
         object = form.save()
         # build redirect url based on form hidden data
         url = reverse(
-            "accounts:inbox", kwargs={InboxView.slug_field: form.data["receiver"]}
+            "inbox:index", kwargs={InboxView.slug_field: form.data["receiver"]}
         )
         self.log_addition(object, _("message was created"))
         return HttpResponseRedirect(f"{url}#messages-last")

--- a/src/open_inwoner/cms/inbox/cms_apps.py
+++ b/src/open_inwoner/cms/inbox/cms_apps.py
@@ -1,0 +1,13 @@
+from django.utils.translation import gettext_lazy as _
+
+from cms.app_base import CMSApp
+from cms.apphook_pool import apphook_pool
+
+
+@apphook_pool.register
+class InboxApphook(CMSApp):
+    app_name = "inbox"
+    name = _("Inbox Application")
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["open_inwoner.cms.inbox.urls"]

--- a/src/open_inwoner/cms/inbox/urls.py
+++ b/src/open_inwoner/cms/inbox/urls.py
@@ -1,0 +1,20 @@
+from django.urls import path
+
+from open_inwoner.accounts.views.inbox import (
+    InboxPrivateMediaView,
+    InboxStartView,
+    InboxView,
+)
+
+app_name = "inbox"
+
+urlpatterns = [
+    path("", InboxView.as_view(), name="index"),
+    path("conversation/<str:uuid>/", InboxView.as_view(), name="index"),
+    path("start/", InboxStartView.as_view(), name="start"),
+    path(
+        "files/<str:uuid>/download/",
+        InboxPrivateMediaView.as_view(),
+        name="download",
+    ),
+]

--- a/src/open_inwoner/cms/tests/urls.py
+++ b/src/open_inwoner/cms/tests/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("cases/", include("open_inwoner.cms.cases.urls")),
     path("profile/", include("open_inwoner.cms.profile.urls")),
     path("products/", include("open_inwoner.cms.products.urls")),
+    path(r"inbox/", include("open_inwoner.cms.inbox.urls")),
 ] + root_urlpatterns

--- a/src/open_inwoner/components/readme.md
+++ b/src/open_inwoner/components/readme.md
@@ -96,7 +96,7 @@ Given an example of a hyperlink with an icon:
 
 ```html
 {% load i18n %}
-<a class="button button--primary" href="{% url 'accounts:inbox' %}">
+<a class="button button--primary" href="{% url 'inbox:index' %}">
     <span class="material-icon">arrow_forward</span>
     {% trans 'My messages' %}
 </a>
@@ -117,7 +117,7 @@ Replacing this link with a simple:
 
 ```django
 {% load i18n %}
-{% link href='accounts:inbox' text=_('My messages') button=True primary=True icon='arrow_forward' %}
+{% link href='inbox:index' text=_('My messages') button=True primary=True icon='arrow_forward' %}
 ```
 
 Gives us the ability to alter (upgrade) the implementation anytime without worrying about the existing usages. As a

--- a/src/open_inwoner/components/templates/components/File/File.html
+++ b/src/open_inwoner/components/templates/components/File/File.html
@@ -20,7 +20,7 @@
     {% if allow_delete %}
         {% dropdown icon="more_horiz" %}
             <div class="dropdown__item">
-                {% url 'accounts:inbox_start' as inbox_url %}
+                {% url 'inbox:start' as inbox_url %}
                 {% with inbox_url|addstr:"?file="|addstr:uuid as share_url %}
                     {% button icon="send" text=_("Deel") href=share_url icon_outlined=True transparent=True %}
                 {% endwith %}

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -55,11 +55,11 @@
                                 {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}
                             </li>
                             <li class="primary-navigation__list-item">
-                                {% link text=_('Mijn berichten') href='accounts:inbox' icon="inbox" icon_position="before" %}
+                                {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}
                                 {% with request.user.get_new_messages_total as total_messages %}
                                     {% if total_messages %}
                                         {% with "("|addstr:total_messages|addstr:")" as message_total %}
-                                            {% link text=message_total href='accounts:inbox' secondary=True %}
+                                            {% link text=message_total href='inbox:index' secondary=True %}
                                         {% endwith %}
                                     {% endif %}
                                 {% endwith %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -27,11 +27,11 @@
                 {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}
             </li>
             <li class="primary-navigation__list-item">
-                {% link text=_('Mijn berichten') href='accounts:inbox' icon="inbox" icon_position="before" %}
+                {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}
                 {% with request.user.get_new_messages_total as total_messages %}
                     {% if total_messages %}
                         {% with "("|addstr:total_messages|addstr:")" as message_total %}
-                            {% link text=message_total href='accounts:inbox' secondary=True %}
+                            {% link text=message_total href='inbox:index' secondary=True %}
                         {% endwith %}
                     {% endif %}
                 {% endwith %}

--- a/src/open_inwoner/components/templates/components/Messages/Message.html
+++ b/src/open_inwoner/components/templates/components/Messages/Message.html
@@ -4,7 +4,7 @@
 <aside class="message{% if ours %} message--ours{% else %} message--theirs{% endif %}" id="message-{{ message.pk }}" title="{% trans 'Bericht van:' %} {{ message.sender }}" aria-label="{% trans "Bericht" %}">
     <div class="message__body">
         {% if file %}
-            {% url "accounts:inbox_download" uuid=message.uuid as download_url %}
+            {% url "inbox:download" uuid=message.uuid as download_url %}
             {% link href=download_url text=message.file secondary=True download=True %}
         {% else %}
             <p class="p">{{ message.content|linebreaksbr }}</p>

--- a/src/open_inwoner/components/templates/components/Messages/Messages.html
+++ b/src/open_inwoner/components/templates/components/Messages/Messages.html
@@ -43,7 +43,7 @@
         </ol>
 
         {% if other_user.is_active %}
-            {% url 'accounts:inbox' as form_action %}
+            {% url 'inbox:index' as form_action %}
             {% render_form id="message-form" form=form method="POST" form_action=form_action enctype="multipart/form-data" %}
                 {% csrf_token %}
                 {% hidden form.receiver %}

--- a/src/open_inwoner/components/templatetags/link_tags.py
+++ b/src/open_inwoner/components/templatetags/link_tags.py
@@ -14,7 +14,7 @@ def link(href, text, **kwargs):
 
     Usage:
         {% link 'http://www.example.com' text=_('Example.com') %}
-        {% link href='accounts:inbox' text=_('Mijn berichten') %}
+        {% link href='inbox:index' text=_('Mijn berichten') %}
 
     Variables:
         + href: str | where the link links to (can be url name to resolve).

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -206,8 +206,9 @@ INSTALLED_APPS = [
     "open_inwoner.extended_sessions",
     "open_inwoner.custom_csp",
     "open_inwoner.cms.profile",
-    "open_inwoner.cms.products",
     "open_inwoner.cms.cases",
+    "open_inwoner.cms.inbox",
+    "open_inwoner.cms.products",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Same as the other first-passes:
 
> I kept the views and tests at their current sub-optimal locations and basically moved the urls.
> 
> Most of the changes are because this changed the url namespace.
