### PR TITLE
First pass at moving 'Samenwerken' into a CMS apphook

### DIFF
--- a/src/open_inwoner/accounts/tests/factories.py
+++ b/src/open_inwoner/accounts/tests/factories.py
@@ -19,7 +19,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker("last_name")
     # Note that 'example.org' addresses are always redirected to the registration_necessary view
     email = factory.LazyAttribute(
-        lambda o: "%s%d@example.com" % (o.first_name, random.randint(0, 10000))
+        lambda o: "%s%d@example.com" % (o.first_name, random.randint(0, 10000000))
     )
     password = factory.PostGenerationMethodCall("set_password", "secret")
     phonenumber = factory.Faker("numerify", text="06########")

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -623,7 +623,7 @@ class TestRegistrationNecessary(WebTest):
             reverse("cases:open_cases"),
             reverse("profile:detail"),
             reverse("profile:data"),
-            reverse("plans:plan_list"),
+            reverse("collaborate:plan_list"),
             reverse("general_faq"),
         ]
 

--- a/src/open_inwoner/cms/collaborate/cms_apps.py
+++ b/src/open_inwoner/cms/collaborate/cms_apps.py
@@ -1,0 +1,13 @@
+from django.utils.translation import gettext_lazy as _
+
+from cms.app_base import CMSApp
+from cms.apphook_pool import apphook_pool
+
+
+@apphook_pool.register
+class CollaborateApphook(CMSApp):
+    app_name = "collaborate"
+    name = _("Collaborate Application")
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["open_inwoner.cms.collaborate.urls"]

--- a/src/open_inwoner/cms/collaborate/cms_plugins.py
+++ b/src/open_inwoner/cms/collaborate/cms_plugins.py
@@ -1,0 +1,24 @@
+from django.utils.translation import ugettext_lazy as _
+
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
+
+from open_inwoner.plans.models import Plan
+
+
+@plugin_pool.register_plugin
+class ActivePlansPlugin(CMSPluginBase):
+    module = _("Collaborate")
+    name = _("Active Plans Plugin")
+    render_template = "cms/collaborate/active_plans_plugin.html"
+    cache = False
+    disable_child_plugins = True
+
+    # own variables
+    limit = 4
+
+    def render(self, context, instance, placeholder):
+        request = context["request"]
+        if request.user.is_authenticated:
+            context["plans"] = Plan.objects.connected(request.user)[: self.limit]
+        return context

--- a/src/open_inwoner/cms/collaborate/urls.py
+++ b/src/open_inwoner/cms/collaborate/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (
+from open_inwoner.plans.views import (
     PlanActionCreateView,
     PlanActionDeleteView,
     PlanActionEditStatusTagView,
@@ -15,7 +15,8 @@ from .views import (
     PlanListView,
 )
 
-app_name = "plans"
+app_name = "collaborate"
+
 urlpatterns = [
     path("", PlanListView.as_view(), name="plan_list"),
     path("create/", PlanCreateView.as_view(), name="plan_create"),

--- a/src/open_inwoner/cms/tests/urls.py
+++ b/src/open_inwoner/cms/tests/urls.py
@@ -3,9 +3,9 @@ from django.urls import include, path
 from open_inwoner.urls import urlpatterns as root_urlpatterns
 
 urlpatterns = [
-    # add more here
     path("cases/", include("open_inwoner.cms.cases.urls")),
     path("profile/", include("open_inwoner.cms.profile.urls")),
     path("products/", include("open_inwoner.cms.products.urls")),
-    path(r"inbox/", include("open_inwoner.cms.inbox.urls")),
+    path("inbox/", include("open_inwoner.cms.inbox.urls")),
+    path("collaborate/", include("open_inwoner.cms.collaborate.urls")),
 ] + root_urlpatterns

--- a/src/open_inwoner/components/templates/components/Action/Actions.html
+++ b/src/open_inwoner/components/templates/components/Action/Actions.html
@@ -27,7 +27,7 @@
                             </div>
                             <div class="dropdown__item">
                                 {% if plan %}
-                                    {% url 'plans:plan_action_history' plan_uuid=plan.uuid uuid=action.uuid as action_history_url %}
+                                    {% url 'collaborate:plan_action_history' plan_uuid=plan.uuid uuid=action.uuid as action_history_url %}
                                     {% button icon="history" text=_("History") href=action_history_url uuid=action.uuid icon_outlined=True transparent=True %}
                                 {% else %}
                                     {% button icon="history" text=_("History") href="profile:action_history" uuid=action.uuid icon_outlined=True transparent=True %}

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -72,7 +72,7 @@
                             {% endif %}
                             {% if show_plans %}
                                 <li class="primary-navigation__list-item">
-                                    {% link text=_('Samenwerken') href='plans:plan_list' icon="people" icon_outlined=True icon_position="before" %}
+                                    {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}
                                 </li>
                             {% endif %}
                         {% endif %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -46,11 +46,11 @@
             {% endif %}
             {% if show_plans %}
             <li class="primary-navigation__list-item">
-            {% link text=_('Samenwerken') href='plans:plan_list' icon="people" icon_outlined=True icon_position="before" %}
+            {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}
             {% with request.user.get_plan_contact_new_count as plan_count %}
                 {% if plan_count %}
                     {% with "("|addstr:plan_count|addstr:")" as plan_count %}
-                        {% link text=plan_count href='plans:plan_list' secondary=True %}
+                        {% link text=plan_count href='collaborate:plan_list' secondary=True %}
                     {% endwith %}
                 {% endif %}
             {% endwith %}

--- a/src/open_inwoner/components/templatetags/action_tags.py
+++ b/src/open_inwoner/components/templatetags/action_tags.py
@@ -55,7 +55,7 @@ def action_status_button(action, request, plan=None, **kwargs):
     """
     if plan:
         action_url = reverse(
-            "plans:plan_action_edit_status",
+            "collaborate:plan_action_edit_status",
             kwargs={"plan_uuid": plan.uuid, "uuid": action.uuid},
         )
     else:
@@ -109,7 +109,7 @@ def get_action_edit_url(action, plan=None):
     """
     if plan:
         return reverse(
-            "plans:plan_action_edit",
+            "collaborate:plan_action_edit",
             kwargs={"plan_uuid": plan.uuid, "uuid": action.uuid},
         )
     return reverse("profile:action_edit", kwargs={"uuid": action.uuid})
@@ -130,7 +130,7 @@ def get_action_delete_url(action, plan=None):
     """
     if plan:
         return reverse(
-            "plans:plan_action_delete",
+            "collaborate:plan_action_delete",
             kwargs={"plan_uuid": plan.uuid, "uuid": action.uuid},
         )
     return reverse("profile:action_delete", kwargs={"uuid": action.uuid})

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -514,6 +514,7 @@ CMS_PLACEHOLDER_CONF = {
             "TextPlugin",
             "PicturePlugin",
             "CategoriesPlugin",
+            "ActivePlansPlugin",
         ],
         "text_only_plugins": ["LinkPlugin"],
         "name": _("Content"),

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -209,6 +209,7 @@ INSTALLED_APPS = [
     "open_inwoner.cms.cases",
     "open_inwoner.cms.inbox",
     "open_inwoner.cms.products",
+    "open_inwoner.cms.collaborate",
 ]
 
 MIDDLEWARE = [

--- a/src/open_inwoner/configurations/models.py
+++ b/src/open_inwoner/configurations/models.py
@@ -486,7 +486,7 @@ class SiteConfiguration(SingletonModel):
             "search:search": "search_help_text",
             "profile:detail": "account_help_text",
             "questionnaire:questionnaire_list": "questionnaire_help_text",
-            "plans:plan_list": "plan_help_text",
+            "collaborate:plan_list": "plan_help_text",
         }
 
         attr = lookup.get(match.view_name, "")

--- a/src/open_inwoner/configurations/tests/test_help_modal.py
+++ b/src/open_inwoner/configurations/tests/test_help_modal.py
@@ -134,7 +134,7 @@ class TestHelpContext(WebTest):
         self.assertEquals(help_text, config.questionnaire_help_text)
 
     def test_default_help_text_on_plan_page(self):
-        response = self.app.get(reverse("plans:plan_list"), user=self.user)
+        response = self.app.get(reverse("collaborate:plan_list"), user=self.user)
         help_text = response.context.get("help_text")
 
         self.assertEquals(
@@ -147,7 +147,7 @@ class TestHelpContext(WebTest):
     def test_custom_help_text_on_plan_page(self):
         SiteConfigurationFactory()
         config = SiteConfiguration.get_solo()
-        response = self.app.get(reverse("plans:plan_list"), user=self.user)
+        response = self.app.get(reverse("collaborate:plan_list"), user=self.user)
         help_text = response.context.get("help_text")
 
         self.assertEquals(help_text, config.plan_help_text)

--- a/src/open_inwoner/configurations/tests/test_show_plans.py
+++ b/src/open_inwoner/configurations/tests/test_show_plans.py
@@ -9,6 +9,7 @@ from ...plans.tests.factories import PlanFactory
 from ..models import SiteConfiguration
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestShowPlans(WebTest):
     def setUp(self):
         self.user = UserFactory()
@@ -17,9 +18,9 @@ class TestShowPlans(WebTest):
         self.plan = PlanFactory(plan_contacts=[self.user])
         self.action = ActionFactory(created_by=self.user, plan=self.plan)
 
-        self.plan_list_url = reverse("plans:plan_list")
+        self.plan_list_url = reverse("collaborate:plan_list")
         self.plan_detail_url = reverse(
-            "plans:plan_detail", kwargs={"uuid": self.plan.uuid}
+            "collaborate:plan_detail", kwargs={"uuid": self.plan.uuid}
         )
 
     def test_default_enabled(self):
@@ -79,20 +80,20 @@ class TestShowPlans(WebTest):
 
     def test_plan_pages_show_404_when_disabled(self):
         urls = [
-            reverse("plans:plan_list"),
-            reverse("plans:plan_create"),
-            reverse("plans:plan_detail", kwargs={"uuid": self.plan.uuid}),
-            reverse("plans:plan_edit", kwargs={"uuid": self.plan.uuid}),
-            reverse("plans:plan_edit_goal", kwargs={"uuid": self.plan.uuid}),
-            reverse("plans:plan_add_file", kwargs={"uuid": self.plan.uuid}),
-            reverse("plans:plan_export", kwargs={"uuid": self.plan.uuid}),
-            reverse("plans:plan_action_create", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_list"),
+            reverse("collaborate:plan_create"),
+            reverse("collaborate:plan_detail", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_edit", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_edit_goal", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_add_file", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_export", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_action_create", kwargs={"uuid": self.plan.uuid}),
             reverse(
-                "plans:plan_action_edit",
+                "collaborate:plan_action_edit",
                 kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
             ),
             reverse(
-                "plans:plan_action_delete",
+                "collaborate:plan_action_delete",
                 kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
             ),
         ]

--- a/src/open_inwoner/plans/management/commands/plans_expire.py
+++ b/src/open_inwoner/plans/management/commands/plans_expire.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             )
 
     def send_email(self, receiver: User, plans: List[Plan]):
-        plan_list_link = build_absolute_url(reverse("plans:plan_list"))
+        plan_list_link = build_absolute_url(reverse("collaborate:plan_list"))
         template = find_template("expiring_plan")
         context = {
             "plans": plans,

--- a/src/open_inwoner/plans/models.py
+++ b/src/open_inwoner/plans/models.py
@@ -145,7 +145,7 @@ class Plan(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("plans:plan_detail", kwargs={"uuid": self.uuid})
+        return reverse("collaborate:plan_detail", kwargs={"uuid": self.uuid})
 
     def get_latest_file(self):
         file = self.documents.order_by("-created_on").first()

--- a/src/open_inwoner/plans/tests/test_logging.py
+++ b/src/open_inwoner/plans/tests/test_logging.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.models import ADDITION, CHANGE
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -17,6 +18,7 @@ from .factories import PlanFactory
 
 
 @freeze_time("2021-10-18 13:00:00")
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestPlans(WebTest):
     def setUp(self):
         self.user = UserFactory()
@@ -24,7 +26,7 @@ class TestPlans(WebTest):
 
     def test_created_plan_is_logged(self):
         plan = PlanFactory.build(created_by=self.user)
-        form = self.app.get(reverse("plans:plan_create"), user=self.user).forms[
+        form = self.app.get(reverse("collaborate:plan_create"), user=self.user).forms[
             "plan-form"
         ]
         form["title"] = plan.title
@@ -53,7 +55,8 @@ class TestPlans(WebTest):
 
     def test_modified_plan_is_logged(self):
         form = self.app.get(
-            reverse("plans:plan_edit", kwargs={"uuid": self.plan.uuid}), user=self.user
+            reverse("collaborate:plan_edit", kwargs={"uuid": self.plan.uuid}),
+            user=self.user,
         ).forms["plan-form"]
         form["title"] = "Updated title"
         form.submit()
@@ -75,7 +78,7 @@ class TestPlans(WebTest):
     def test_plan_goal_modified_is_logged(self):
         self.plan.plan_contacts.add(self.user)
         form = self.app.get(
-            reverse("plans:plan_edit_goal", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_edit_goal", kwargs={"uuid": self.plan.uuid}),
             user=self.user,
         ).forms["goal-edit"]
 
@@ -100,7 +103,7 @@ class TestPlans(WebTest):
     def test_plan_file_upload_is_logged(self):
         self.plan.plan_contacts.add(self.user)
         form = self.app.get(
-            reverse("plans:plan_add_file", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_add_file", kwargs={"uuid": self.plan.uuid}),
             user=self.user,
         ).forms["document-create"]
 
@@ -126,7 +129,7 @@ class TestPlans(WebTest):
         self.plan.plan_contacts.add(self.user)
         action = ActionFactory.build(created_by=self.user)
         form = self.app.get(
-            reverse("plans:plan_action_create", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_action_create", kwargs={"uuid": self.plan.uuid}),
             user=self.user,
         ).forms["action-create"]
         form["name"] = action.name
@@ -153,7 +156,7 @@ class TestPlans(WebTest):
         action = ActionFactory(created_by=self.user)
         form = self.app.get(
             reverse(
-                "plans:plan_action_edit",
+                "collaborate:plan_action_edit",
                 kwargs={"plan_uuid": self.plan.uuid, "uuid": action.uuid},
             ),
             user=self.user,
@@ -182,7 +185,7 @@ class TestPlans(WebTest):
         action = ActionFactory(created_by=self.user)
         form = self.app.get(
             reverse(
-                "plans:plan_action_edit",
+                "collaborate:plan_action_edit",
                 kwargs={"plan_uuid": self.plan.uuid, "uuid": action.uuid},
             ),
             user=self.user,
@@ -194,7 +197,7 @@ class TestPlans(WebTest):
     def test_plan_export_is_logged(self):
         self.plan.plan_contacts.add(self.user)
         self.app.get(
-            reverse("plans:plan_export", kwargs={"uuid": self.plan.uuid}),
+            reverse("collaborate:plan_export", kwargs={"uuid": self.plan.uuid}),
             user=self.user,
         )
         log_entry = TimelineLog.objects.filter(object_id=self.user.id).last()

--- a/src/open_inwoner/plans/tests/test_plans_expire.py
+++ b/src/open_inwoner/plans/tests/test_plans_expire.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 from django.core import mail
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from open_inwoner.accounts.tests.factories import UserFactory
@@ -11,6 +11,7 @@ from open_inwoner.plans.models import Plan
 from .factories import PlanFactory
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class NotifyComandTests(TestCase):
     def test_notify_about_expiring_plan(self):
         user = UserFactory()
@@ -28,7 +29,7 @@ class NotifyComandTests(TestCase):
         self.assertEqual(sent_mail.to, [user.email])
         self.assertIn(plan.title, html_body)
         self.assertIn(plan.goal, html_body)
-        self.assertIn(reverse("plans:plan_list"), html_body)
+        self.assertIn(reverse("collaborate:plan_list"), html_body)
 
     def test_plan_does_not_expire_yet(self):
         user = UserFactory()
@@ -67,7 +68,7 @@ class NotifyComandTests(TestCase):
         self.assertEqual(sent_mail.to, [user.email])
         self.assertIn(plan.title, html_body)
         self.assertIn(plan.goal, html_body)
-        self.assertIn(reverse("plans:plan_list"), html_body)
+        self.assertIn(reverse("collaborate:plan_list"), html_body)
 
         sent_mail2 = mail.outbox[1]
         html_body2 = sent_mail.alternatives[0][0]
@@ -78,4 +79,4 @@ class NotifyComandTests(TestCase):
         self.assertEqual(sent_mail2.to, [contact.email])
         self.assertIn(plan.title, html_body2)
         self.assertIn(plan.goal, html_body2)
-        self.assertIn(reverse("plans:plan_list"), html_body2)
+        self.assertIn(reverse("collaborate:plan_list"), html_body2)

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -20,6 +20,7 @@ from ..models import Plan, PlanContact
 from .factories import ActionTemplateFactory, PlanFactory, PlanTemplateFactory
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class PlanViewTests(WebTest):
     def setUp(self) -> None:
         self.user = UserFactory()
@@ -35,36 +36,42 @@ class PlanViewTests(WebTest):
         )
 
         self.login_url = reverse("login")
-        self.list_url = reverse("plans:plan_list")
-        self.create_url = reverse("plans:plan_create")
-        self.detail_url = reverse("plans:plan_detail", kwargs={"uuid": self.plan.uuid})
-        self.edit_url = reverse("plans:plan_edit", kwargs={"uuid": self.plan.uuid})
+        self.list_url = reverse("collaborate:plan_list")
+        self.create_url = reverse("collaborate:plan_create")
+        self.detail_url = reverse(
+            "collaborate:plan_detail", kwargs={"uuid": self.plan.uuid}
+        )
+        self.edit_url = reverse(
+            "collaborate:plan_edit", kwargs={"uuid": self.plan.uuid}
+        )
         self.goal_edit_url = reverse(
-            "plans:plan_edit_goal", kwargs={"uuid": self.plan.uuid}
+            "collaborate:plan_edit_goal", kwargs={"uuid": self.plan.uuid}
         )
         self.file_add_url = reverse(
-            "plans:plan_add_file", kwargs={"uuid": self.plan.uuid}
+            "collaborate:plan_add_file", kwargs={"uuid": self.plan.uuid}
         )
         self.action_add_url = reverse(
-            "plans:plan_action_create", kwargs={"uuid": self.plan.uuid}
+            "collaborate:plan_action_create", kwargs={"uuid": self.plan.uuid}
         )
         self.action_edit_url = reverse(
-            "plans:plan_action_edit",
+            "collaborate:plan_action_edit",
             kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
         )
         self.action_history_url = reverse(
-            "plans:plan_action_history",
+            "collaborate:plan_action_history",
             kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
         )
         self.action_edit_status_url = reverse(
-            "plans:plan_action_edit_status",
+            "collaborate:plan_action_edit_status",
             kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
         )
         self.action_delete_url = reverse(
-            "plans:plan_action_delete",
+            "collaborate:plan_action_delete",
             kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action.uuid},
         )
-        self.export_url = reverse("plans:plan_export", kwargs={"uuid": self.plan.uuid})
+        self.export_url = reverse(
+            "collaborate:plan_export", kwargs={"uuid": self.plan.uuid}
+        )
 
     def test_plan_list_login_required(self):
         response = self.app.get(self.list_url)
@@ -454,7 +461,7 @@ class PlanViewTests(WebTest):
 
     def test_plan_action_edit_deleted_action(self):
         url = reverse(
-            "plans:plan_action_edit",
+            "collaborate:plan_action_edit",
             kwargs={"plan_uuid": self.plan.uuid, "uuid": self.action_deleted.uuid},
         )
         self.app.get(url, user=self.user, status=404)
@@ -617,6 +624,7 @@ class PlanViewTests(WebTest):
         self.assertEqual(response.status_code, 404)
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class PlanBegeleiderListViewTests(WebTest):
     def setUp(self):
         self.contact = UserFactory()
@@ -631,7 +639,7 @@ class PlanBegeleiderListViewTests(WebTest):
             plan=self.begeleider_plan, created_by=self.begeleider
         )
         self.login_url = reverse("login")
-        self.list_url = reverse("plans:plan_list")
+        self.list_url = reverse("collaborate:plan_list")
 
     @freeze_time("2022-01-01")
     def test_plan_list_renders_template_for_begeleider(self):
@@ -1018,6 +1026,7 @@ class PlanBegeleiderListViewTests(WebTest):
         )
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class NewPlanContactCounterTest(WebTest):
     def test_plan_contact_new_count(self):
         owner = UserFactory()
@@ -1027,7 +1036,7 @@ class NewPlanContactCounterTest(WebTest):
         user = UserFactory()
 
         root_url = reverse("root")
-        list_url = reverse("plans:plan_list")
+        list_url = reverse("collaborate:plan_list")
 
         # check no number shows by default
         response = self.app.get(root_url, user=user)
@@ -1067,6 +1076,7 @@ class NewPlanContactCounterTest(WebTest):
 
 
 @multi_browser()
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class PlanActionStatusPlaywrightTests(ActionsPlaywrightTests):
     def setUp(self) -> None:
         super().setUp()
@@ -1079,5 +1089,5 @@ class PlanActionStatusPlaywrightTests(ActionsPlaywrightTests):
 
         # override the url to show plan detail page
         self.action_list_url = reverse(
-            "plans:plan_detail", kwargs={"uuid": self.plan.uuid}
+            "collaborate:plan_detail", kwargs={"uuid": self.plan.uuid}
         )

--- a/src/open_inwoner/plans/views.py
+++ b/src/open_inwoner/plans/views.py
@@ -86,7 +86,7 @@ class PlanListView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerken"), reverse("plans:plan_list")),
+            (_("Samenwerken"), reverse("collaborate:plan_list")),
         ]
 
     def get_queryset(self):
@@ -183,8 +183,11 @@ class PlanDetailView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerken"), reverse("plans:plan_list")),
-            (self.get_object().title, reverse("plans:plan_detail", kwargs=self.kwargs)),
+            (_("Samenwerken"), reverse("collaborate:plan_list")),
+            (
+                self.get_object().title,
+                reverse("collaborate:plan_detail", kwargs=self.kwargs),
+            ),
         ]
 
     def get_queryset(self):
@@ -228,8 +231,8 @@ class PlanCreateView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerken"), reverse("plans:plan_list")),
-            (_("Start nieuwe samenwerking"), reverse("plans:plan_create")),
+            (_("Samenwerken"), reverse("collaborate:plan_list")),
+            (_("Start nieuwe samenwerking"), reverse("collaborate:plan_create")),
         ]
 
     def get_form_kwargs(self):
@@ -267,9 +270,12 @@ class PlanEditView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerkingsplannen"), reverse("plans:plan_list")),
-            (self.get_object().title, reverse("plans:plan_detail", kwargs=self.kwargs)),
-            (_("Bewerken"), reverse("plans:plan_edit", kwargs=self.kwargs)),
+            (_("Samenwerkingsplannen"), reverse("collaborate:plan_list")),
+            (
+                self.get_object().title,
+                reverse("collaborate:plan_detail", kwargs=self.kwargs),
+            ),
+            (_("Bewerken"), reverse("collaborate:plan_edit", kwargs=self.kwargs)),
         ]
 
     def get_queryset(self):
@@ -312,9 +318,15 @@ class PlanGoalEditView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerkingsplannen"), reverse("plans:plan_list")),
-            (self.get_object().title, reverse("plans:plan_detail", kwargs=self.kwargs)),
-            (_("Doel bewerken"), reverse("plans:plan_edit_goal", kwargs=self.kwargs)),
+            (_("Samenwerkingsplannen"), reverse("collaborate:plan_list")),
+            (
+                self.get_object().title,
+                reverse("collaborate:plan_detail", kwargs=self.kwargs),
+            ),
+            (
+                _("Doel bewerken"),
+                reverse("collaborate:plan_edit_goal", kwargs=self.kwargs),
+            ),
         ]
 
     def get_queryset(self):
@@ -347,11 +359,14 @@ class PlanFileUploadView(
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerkingsplannen"), reverse("plans:plan_list")),
-            (self.get_object().title, reverse("plans:plan_detail", kwargs=self.kwargs)),
+            (_("Samenwerkingsplannen"), reverse("collaborate:plan_list")),
+            (
+                self.get_object().title,
+                reverse("collaborate:plan_detail", kwargs=self.kwargs),
+            ),
             (
                 _("Nieuw bestand uploaden"),
-                reverse("plans:plan_add_file", kwargs=self.kwargs),
+                reverse("collaborate:plan_add_file", kwargs=self.kwargs),
             ),
         ]
 
@@ -381,11 +396,14 @@ class PlanActionCreateView(PlansEnabledMixin, ActionCreateView):
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerkingsplannen"), reverse("plans:plan_list")),
-            (self.get_object().title, reverse("plans:plan_detail", kwargs=self.kwargs)),
+            (_("Samenwerkingsplannen"), reverse("collaborate:plan_list")),
+            (
+                self.get_object().title,
+                reverse("collaborate:plan_detail", kwargs=self.kwargs),
+            ),
             (
                 _("Maak actie aan"),
-                reverse("plans:plan_action_create", kwargs=self.kwargs),
+                reverse("collaborate:plan_action_create", kwargs=self.kwargs),
             ),
         ]
 
@@ -427,14 +445,16 @@ class PlanActionEditView(PlansEnabledMixin, ActionUpdateView):
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerkingsplannen"), reverse("plans:plan_list")),
+            (_("Samenwerkingsplannen"), reverse("collaborate:plan_list")),
             (
                 self.get_plan().title,
-                reverse("plans:plan_detail", kwargs={"uuid": self.get_plan().uuid}),
+                reverse(
+                    "collaborate:plan_detail", kwargs={"uuid": self.get_plan().uuid}
+                ),
             ),
             (
                 _("Bewerk {}").format(self.object.name),
-                reverse("plans:plan_action_edit", kwargs=self.kwargs),
+                reverse("collaborate:plan_action_edit", kwargs=self.kwargs),
             ),
         ]
 
@@ -529,14 +549,16 @@ class PlanActionHistoryView(ActionHistoryView):
     @cached_property
     def crumbs(self):
         return [
-            (_("Samenwerking"), reverse("plans:plan_list")),
+            (_("Samenwerking"), reverse("collaborate:plan_list")),
             (
                 self.get_plan().title,
-                reverse("plans:plan_detail", kwargs={"uuid": self.get_plan().uuid}),
+                reverse(
+                    "collaborate:plan_detail", kwargs={"uuid": self.get_plan().uuid}
+                ),
             ),
             (
                 _("History of {}").format(self.object.name),
-                reverse("plans:plan_action_history", kwargs=self.kwargs),
+                reverse("collaborate:plan_action_history", kwargs=self.kwargs),
             ),
         ]
 

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -1,0 +1,28 @@
+{% load i18n button_tags card_tags utils icon_tags %}
+{% if request.user.is_authenticated %}
+<h2 class="h2">
+    {% trans 'Samenwerken' %}
+    {% button href="collaborate:plan_list" text=_("Naar samenwerken") icon="arrow_forward" icon_position="after" %}
+</h2>
+{% if plans %}
+<div class="plans-cards card-container card-container--columns-4">
+    {% for plan in plans %}
+        {% render_card image_object_fit="cover" %}
+            <a href="{{ plan.get_absolute_url }}" class="plan-list"><h3 class="h3">{{ plan.title }}</h3>
+            <p class="p">{{ plan.goal|truncatewords:20 }}</p>
+            <p class="p">{{ plan.description|truncatewords:20 }}</p></a>
+            <a
+                class="button button--icon-before button--transparent button--secondary"
+                href="{{ plan.get_absolute_url }}"
+                aria-label="{{ plan.title }}"
+                aria-hidden="true"
+            >
+                {% icon icon="arrow_forward" %}
+            </a>
+        {% endrender_card %}
+    {% endfor %}
+</div>
+{% else %}
+    <p class="p">{{configurable_text.plans_page.plans_no_plans_message}}</p>
+{% endif %}
+{% endif %}

--- a/src/open_inwoner/templates/pages/plans/detail.html
+++ b/src/open_inwoner/templates/pages/plans/detail.html
@@ -14,11 +14,11 @@
 	    {% if is_creator %}
               {% dropdown icon="settings" secondary=True %}
                   <div class="dropdown__item">
-                      {% button icon="edit" text=_("Bewerken") href="plans:plan_edit" uuid=object.uuid icon_outlined=True transparent=True %}
+                      {% button icon="edit" text=_("Bewerken") href="collaborate:plan_edit" uuid=object.uuid icon_outlined=True transparent=True %}
                   </div>
 	      {% enddropdown %}
             {% endif %}
-            {% button href="plans:plan_export" uuid=object.uuid icon="file-pdf" text=_("Exporteer naar PDF") hide_text=True icon_outlined=True transparent=True secondary=True %}
+            {% button href="collaborate:plan_export" uuid=object.uuid icon="file-pdf" text=_("Exporteer naar PDF") hide_text=True icon_outlined=True transparent=True secondary=True %}
         {% endbutton_row %}
 
     </h1>
@@ -63,7 +63,7 @@
     <p class="p">{{ object.description|linebreaksbr }}</p>
     {% endif %}
 
-    {% button href="plans:plan_edit_goal" uuid=object.uuid text=_("Doel en omschrijving bewerken") primary=True %}
+    {% button href="collaborate:plan_edit_goal" uuid=object.uuid text=_("Doel en omschrijving bewerken") primary=True %}
 
     <h2 class="h2" id="files">{% trans "Bestanden" %}</h2>
     {% if object.get_latest_file %}
@@ -74,10 +74,10 @@
             {% file_table files=object.get_other_files download_view="profile:documents_download" %}
         {% endif %}
     {% endif %}
-    {% button href="plans:plan_add_file" uuid=object.uuid text=_("Upload nieuwe versie") primary=True %}
+    {% button href="collaborate:plan_add_file" uuid=object.uuid text=_("Upload nieuwe versie") primary=True %}
 
     <h2 class="h2" id="actions">{% trans "Acties" %}</h2>
     {% actions actions=actions request=request action_form=action_form form_action=request.path|add:"#actions" plan=plan %}
-    {% button href="plans:plan_action_create" uuid=object.uuid text=_("Nieuw actie toevoegen") icon="date_range" primary=True %}
+    {% button href="collaborate:plan_action_create" uuid=object.uuid text=_("Nieuw actie toevoegen") icon="date_range" primary=True %}
 </div>
 {% endblock %}

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -12,7 +12,7 @@
 {% block content %}
     <h1 class="h1">
         {% trans "Samenwerken" %}
-        {% button href="plans:plan_create" text=_("Start nieuwe samenwerking") primary=True icon="group" icon_outlined=True %}
+        {% button href="collaborate:plan_create" text=_("Start nieuwe samenwerking") primary=True icon="group" icon_outlined=True %}
     </h1>
     {% optional_paragraph configurable_text.plans_page.plans_intro %}
 
@@ -30,7 +30,7 @@
                     {% input plan_filter_form.query no_label=True no_help=True %}
                     {% form_actions primary_icon="search" single=True transparent=True %}
                 </div>
-                {% button text=_("Reset filters") href="plans:plan_list" icon="undo" transparent=True icon_position="before" %}
+                {% button text=_("Reset filters") href="collaborate:plan_list" icon="undo" transparent=True icon_position="before" %}
             </div>
         </div>
         {% endrender_form %}

--- a/src/open_inwoner/templates/pages/user-home.html
+++ b/src/open_inwoner/templates/pages/user-home.html
@@ -10,7 +10,7 @@
     {% if show_plans %}
         <h2 class="h2">
             Samenwerken
-            {% button href="plans:plan_list" text=_("Naar samenwerken") icon="arrow_forward" icon_position="after" %}
+            {% button href="collaborate:plan_list" text=_("Naar samenwerken") icon="arrow_forward" icon_position="after" %}
         </h2>
 
         {% if plans %}

--- a/src/open_inwoner/urls.py
+++ b/src/open_inwoner/urls.py
@@ -86,7 +86,6 @@ urlpatterns = [
     path("accounts/", include("open_inwoner.accounts.urls", namespace="accounts")),
     path("pages/", include("django.contrib.flatpages.urls"), name="flatpages"),
     path("mail-editor/", include("mail_editor.urls", namespace="mail_editor")),
-    path("plans/", include("open_inwoner.plans.urls", namespace="plans")),
     path(
         "questionnaire/",
         include("open_inwoner.questionnaire.urls", namespace="questionnaire"),

--- a/src/open_inwoner/utils/tests/test_timeline_logger.py
+++ b/src/open_inwoner/utils/tests/test_timeline_logger.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -14,6 +15,7 @@ from ..admin import CustomTimelineLogAdmin
 from ..logentry import LOG_ACTIONS
 
 
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestAdminTimelineLogging(WebTest):
     csrf_checks = False
 


### PR DESCRIPTION
Same as the other first-passes:

> I kept the views and tests at their current sub-optimal locations and basically moved the urls.
> 
> Most of the changes are because this changed the url namespace.

