### PR TITLE
:art: [#1378] Header multiple navigation (mobile and desktop)

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Breadcrumbs.html
+++ b/src/open_inwoner/components/templates/components/Header/Breadcrumbs.html
@@ -6,7 +6,7 @@
             <li class="breadcrumbs__list-item">
                 {% if forloop.first %}
                     <a class="link link--secondary" href="{{url}}" title="{{ name }}" aria-label="{{ name }}">
-                        {% icon icon="apps" %}
+                        {% icon icon="home" outlined=True %}
                     </a>
                 {% else %}
                     {% icon icon="chevron_right" %}

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -5,79 +5,136 @@
 {% accessibility_header request=request %}
 <header class="header" aria-label="Navigatie header">
     <div class="header__container">
-        {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
-        {% logo src=config.logo.file.url alt=logo_alt_text svg_height=75 %}
 
         <div class="header__menu">
             <button class="header__button">
                 <div class="header__menu-icon">
-                    <span class="closed">{% icon icon="menu" %}</span><span class="open">{% icon icon="close" %}</span>
+                    <span class="closed">{% trans "Menu" %}</span>
+                    <span class="open">{% trans "Sluiten" %}</span>
                 </div>
             </button>
+        {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
+        {% logo src=config.logo.file.url alt=logo_alt_text svg_height=75 %}
+
+        {% if request.user.is_authenticated %}
+            <span class="nav-login--icon">{% icon icon="how_to_reg" icon_position="before" icon_outlined=True %}</span>
+        {% elif config.login_show %}
+            <span class="nav-login--icon">
+                {% url 'login' as login_url %}
+                {% trans "Inloggen" as login %}
+                {% button text="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True transparent=True %}
+            </span>
+        {% endif %}
 
             <dialog class="header__submenu">
-                <nav class="header__actions" aria-label="Zoek navigatie mobiel">
-                    {% url 'search:search' as search_url %}
-                    {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}
-                        {% input search_form.query no_label=True %}
-                        {% form_actions primary_icon="search" primary_text=_("Zoeken") hide_primary_text=True %}
-                    {% endrender_form %}
-                </nav>
+
+            <nav class="header__actions" aria-label="Zoek navigatie mobiel">
+                {% url 'search:search' as search_url %}
+                {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}
+                    {% input search_form.query no_label=True %}
+                    {% form_actions primary_icon="search" primary_text=_("Zoeken") hide_primary_text=True %}
+                {% endrender_form %}
+            </nav>
+
+{#         * * *     Start DISABLED * * * Django CMS dynamic mobile menu#}
+{#                <nav class="primary-navigation" aria-label="Hoofd navigatie">#}
+{#                    <ul class="primary-navigation__list">#}
+{#                        {% show_menu 0 100 100 100 "cms/menu/primary.html" %}#}
+{##}
+{#                        {% if has_general_faq_questions %}#}
+{#                            <li class="primary-navigation__list-item">#}
+{#                                {% link text=_('FAQ') href='general_faq' icon="help_outline" icon_position="before" icon_outlined=True %}#}
+{#                            </li>#}
+{#                        {% endif %}#}
+{#                    </ul>#}
+{##}
+{#                <section class="header__actions" aria-label="Navigatie mobiel voor inloggen en uitloggen">#}
+{#                    <div class="header__text-actions">#}
+{#                        <p class="p">#}
+{#                            {% if request.user.is_authenticated %}{% icon icon="person" icon_position="before" icon_outlined=True %}{% trans "Ingelogd als" %} {{ request.user.get_short_name }}{% endif %}#}
+{#                        </p>#}
+{##}
+{#                        {% if request.user.is_authenticated %}#}
+{#                            <ul class="header__list">#}
+{#                                <li class="header__list-item">#}
+{#                                    {% trans "Logout" as logout %}#}
+{#                                    {% link text=logout href=request.user.get_logout_url icon="arrow_forward" icon_position="before" primary=True %}#}
+{#                                </li>#}
+{#                            </ul>#}
+{#                        {% elif config.login_show %}#}
+{#                            <ul class="header__list">#}
+{#                                <li class="header__list-item">#}
+{#                                    {% url 'login' as login_url %}#}
+{#                                    {% trans "Inloggen" as login %}#}
+{#                                    {% button text="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True transparent=True %}#}
+{#                                </li>#}
+{#                            </ul>#}
+{#                        {% endif %}#}
+{#                    </div>#}
+{#                </section>#}
+{#                </nav>#}
+{#         * * *     End of DISABLED * * * Django CMS dynamic mobile menu#}
 
                 <nav class="primary-navigation" aria-label="Hoofd navigatie">
                     <ul class="primary-navigation__list">
-                        {% show_menu 0 100 100 100 "cms/menu/primary.html" %}
 
-{#                        <li class="primary-navigation__list-item">#}
-{#                            {% trans "Home" as link_text %}#}
-{#                            {% url 'root' as link %}#}
-{#                            {% link text=link_text href=link icon="apps" icon_position="before" %}#}
-{#                        </li>#}
-{#                        <li class="primary-navigation__list-item dropdown-nav__toggle">#}
-{#                            <a href="#" class="link link--toggle link--icon link--icon-position-before" aria-label="{% trans "Onderwerpen" %}" title="{% trans "Onderwerpen" %}">#}
-{#                                <span >{% trans "Onderwerpen" %}</span>#}
-{#                                <span aria-hidden="true" class="material-icons-outlined ">description</span>#}
-{#                                {% icon icon="expand_more" icon_position="after" icon_outlined=True %}#}
-{#                            </a>#}
-{##}
-{#                            {% if categories %}#}
-{#                                <ul class="primary-navigation__list subpage-list">#}
-{#                                    {% for category in categories %}#}
-{#                                        <li class="primary-navigation__list-item">#}
-{#                                            {% url 'products:category_detail' slug=category.slug as category_href %}#}
-{#                                            {% link text=category.name href=category_href %}#}
-{#                                        </li>#}
-{#                                    {% endfor %}#}
-{#                                </ul>#}
-{#                            {% endif %}#}
-{#                        </li>#}
-{##}
-{#                        {% if request.user.is_authenticated %}#}
-{#                            <li class="primary-navigation__list-item">#}
-{#                                {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}#}
-{#                            </li>#}
-{#                            <li class="primary-navigation__list-item">#}
-{#                                {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}#}
-{#                                {% with request.user.get_new_messages_total as total_messages %}#}
-{#                                    {% if total_messages %}#}
-{#                                        {% with "("|addstr:total_messages|addstr:")" as message_total %}#}
-{#                                            {% link text=message_total href='inbox:index' secondary=True %}#}
-{#                                        {% endwith %}#}
-{#                                    {% endif %}#}
-{#                                {% endwith %}#}
-{#                            </li>#}
-{##}
-{#                            {% if request.user.bsn and config.show_cases %}#}
-{#                                <li class="primary-navigation__list-item">#}
-{#                                    {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}#}
-{#                                </li>#}
-{#                            {% endif %}#}
-{#                            {% if show_plans %}#}
-{#                                <li class="primary-navigation__list-item">#}
-{#                                    {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}#}
-{#                                </li>#}
-{#                            {% endif %}#}
-{#                        {% endif %}#}
+                        <li class="primary-navigation__list-item">
+                            {% trans "Overzicht" as link_text %}
+                            {% url 'root' as link %}
+                            {% link text=link_text href=link icon="grid_view" icon_position="before" %}
+                        </li>
+                        <li class="primary-navigation__list-item dropdown-nav__toggle">
+                            <a href="#" class="link link--toggle link--icon link--icon-position-before" aria-label="{% trans "Onderwerpen" %}" title="{% trans "Onderwerpen" %}">
+                                <span >{% trans "Onderwerpen" %}</span>
+                                <span aria-hidden="true" class="material-icons-outlined ">description</span>
+                                {% icon icon="expand_more" icon_position="after" icon_outlined=True %}
+                            </a>
+
+                            {% if categories %}
+                                <ul class="primary-navigation__list subpage-list">
+                                    {% for category in categories %}
+                                        <li class="primary-navigation__list-item">
+                                            {% url 'products:category_detail' slug=category.slug as category_href %}
+                                            {% link text=category.name href=category_href %}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                        </li>
+
+                        {% if request.user.is_authenticated %}
+                            <li class="primary-navigation__list-item">
+                                {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                            </li>
+                            <li class="primary-navigation__list-item">
+                                {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}
+                                {% with request.user.get_new_messages_total as total_messages %}
+                                    {% if total_messages %}
+                                        {% with ""|addstr:total_messages|addstr:"" as message_total %}
+                                            <span class="indicator">{% link text=message_total href='inbox:index' secondary=True extra_classes="indicator__link" %}<span class="indicator__dot"></span></span>
+                                        {% endwith %}
+                                    {% endif %}
+                                {% endwith %}
+                            </li>
+
+                            {% if request.user.bsn and config.show_cases %}
+                                <li class="primary-navigation__list-item">
+                                    {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                                </li>
+                            {% endif %}
+                            {% if show_plans %}
+                            <li class="primary-navigation__list-item">
+                            {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}
+                            {% with request.user.get_plan_contact_new_count as plan_count %}
+                                {% if plan_count %}
+                                    {% with ""|addstr:plan_count|addstr:"" as plan_count %}
+                                        <span class="indicator">{% link text=plan_count href='collaborate:plan_list' secondary=True %}<span class="indicator__dot"></span></span>
+                                    {% endwith %}
+                                {% endif %}
+                            {% endwith %}
+                            </li>
+                            {% endif %}
+                        {% endif %}
                         {% if has_general_faq_questions %}
                             <li class="primary-navigation__list-item">
                                 {% link text=_('FAQ') href='general_faq' icon="help_outline" icon_position="before" icon_outlined=True %}
@@ -86,13 +143,13 @@
                     </ul>
                 </nav>
 
-                <nav class="header__actions" aria-label="Navigatie mobiel voor inloggen en uitloggen">
+                <section class="header__actions" aria-label="Navigatie mobiel voor inloggen en uitloggen">
                     <div class="header__text-actions">
-                        <p class="p">
-                            {% if request.user.is_authenticated %}{% icon icon="person_outline" %}{% trans "Welkom" %} {{ request.user.get_short_name }}{% endif %}
-                        </p>
 
                         {% if request.user.is_authenticated %}
+                            <p class="p">
+                                {% icon icon="person" icon_position="before" icon_outlined=True %}{% trans "Ingelogd als" %} {{ request.user.get_short_name }}
+                            </p>
                             <ul class="header__list">
                                 <li class="header__list-item">
                                     {% trans "Logout" as logout %}
@@ -100,43 +157,22 @@
                                 </li>
                             </ul>
                         {% elif config.login_show %}
-                            <ul class="header__list">
-                                <li class="header__list-item">
-                                    {% url 'login' as login_url %}
-                                    {% trans "Login" as login %}
-                                    {% button text=login href=login_url icon="person" icon_position="before" primary=True icon_outlined=True transparent=True %}
-                                </li>
-                            </ul>
+                            <p></p>
                         {% endif %}
                     </div>
-                </nav>
+                </section>
+
+
             </dialog>
         </div>
+{#end of mobile menu#}
+
+    {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
+        <div class="logo__desktop">{% logo src=config.logo.file.url alt=logo_alt_text svg_height=75 %}</div>
+
+        {% primary_navigation categories=categories request=request has_general_faq_questions=has_general_faq_questions show_plans=show_plans %}
 
         <nav class="header__actions" aria-label="Zoek navigatie desktop">
-            <div class="header__text-actions">
-                <p class="p">
-                    {% if request.user.is_authenticated %}{% trans "Welkom" %} {{ request.user.get_full_name }}{% endif %}
-                </p>
-
-                {% if request.user.is_authenticated %}
-                    <ul class="header__list">
-                        <li class="header__list-item">
-                            {% trans "Logout" as logout %}
-                            {% link text=logout href=request.user.get_logout_url primary=True %}
-                        </li>
-                    </ul>
-                {% elif config.login_show %}
-                    <ul class="header__list">
-                        <li class="header__list-item">
-                            {% url 'login' as login_url %}
-                            {% trans "Login" as login %}
-                            {% link text=login href=login_url primary=True %}
-                        </li>
-                    </ul>
-                {% endif %}
-            </div>
-
             {% url 'search:search' as search_url %}
             {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=True %}
                 {% input search_form.query no_label=True %}
@@ -144,6 +180,16 @@
             {% endrender_form %}
         </nav>
 
-        {% primary_navigation categories=categories request=request has_general_faq_questions=has_general_faq_questions %}
+        {% navigation_authenticated categories=categories request=request has_general_faq_questions=has_general_faq_questions %}
+
     </div>
 </header>
+<section class="search search__mobile">
+    <nav class="search__actions " aria-label="Zoek navigatie mobiel">
+        {% url 'search:search' as search_url %}
+        {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}
+            {% input search_form.query no_label=True %}
+            {% form_actions primary_icon="search" primary_text=_("Zoeken") hide_primary_text=True %}
+        {% endrender_form %}
+    </nav>
+</section>

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -1,0 +1,69 @@
+{% load i18n header_tags form_tags icon_tags link_tags string_tags solo_tags menu_tags button_tags %}
+
+{% get_solo "configurations.SiteConfiguration" as config %}
+
+{% if request.user.is_authenticated %}
+
+    <nav class="primary-navigation primary-navigation__authenticated" aria-label="Navigatie na inloggen">
+        <ul class="primary-navigation__list">
+            <li class="primary-navigation__list-item">
+            {% button text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+
+                <ul class="primary-navigation__list subpage-list">
+                    <li class="primary-navigation__list-item">
+                        {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                    </li>
+                    <li class="primary-navigation__list-item">
+                        {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}
+                        {% with request.user.get_new_messages_total as total_messages %}
+                            {% if total_messages %}
+                                {% with ""|addstr:total_messages|addstr:"" as message_total %}
+                                    <span class="indicator">{% link text=message_total href='inbox:index' secondary=True extra_classes="indicator__link" %}<span class="indicator__dot"></span></span>
+                                {% endwith %}
+                            {% endif %}
+                        {% endwith %}
+                    </li>
+
+                    {% get_solo 'configurations.SiteConfiguration' as config %}
+
+                    {% if request.user.bsn and config.show_cases %}
+                        <li class="primary-navigation__list-item">
+                            {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}
+                        </li>
+                    {% endif %}
+                    {% if show_plans %}
+                    <li class="primary-navigation__list-item">
+                    {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}
+                    {% with request.user.get_plan_contact_new_count as plan_count %}
+                        {% if plan_count %}
+                            {% with ""|addstr:plan_count|addstr:"" as plan_count %}
+                                <span class="indicator">{% link text=plan_count href='collaborate:plan_list' secondary=True %}<span class="indicator__dot"></span></span>
+                            {% endwith %}
+                        {% endif %}
+                    {% endwith %}
+                    </li>
+                    {% endif %}
+
+                    {% if has_general_faq_questions %}
+                        <li class="primary-navigation__list-item">
+                            {% link text=_('FAQ') href='general_faq' icon="help_outline" icon_position="before" icon_outlined=True %}
+                        </li>
+                    {% endif %}
+
+                    <li class="header__list-item">
+                        {% trans "Logout" as logout %}
+                        {% link text=logout href=request.user.get_logout_url icon="logout" icon_position="before" primary=True %}
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </nav>
+{% elif config.login_show %}
+    <div class="desktop-login">
+        <span class="desktop-login__link">
+            {% url 'login' as login_url %}
+            {% trans "Inloggen" as login %}
+            {% button text="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True transparent=True %}
+        </span>
+    </div>
+{% endif %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -1,68 +1,38 @@
-{% load i18n icon_tags link_tags string_tags solo_tags menu_tags %}
+{% load i18n header_tags form_tags icon_tags link_tags string_tags solo_tags menu_tags button_tags %}
 
-<nav class="primary-navigation" aria-label="Hoofd navigatie">
-    <ul class="primary-navigation__list">
-        {% show_menu 0 100 100 100 "cms/menu/primary.html" %}
-
-{#        <li class="primary-navigation__list-item">#}
-{#            {% trans "Home" as link_text %}#}
-{#            {% url 'root' as link %}#}
-{#            {% link text=link_text href=link icon="apps" icon_position="before" %}#}
-{#        </li>#}
-{#        <li class="primary-navigation__list-item">#}
-{#            {% link text=_("Onderwerpen") href='products:category_list' icon="description" icon_position="before" icon_outlined=True %}#}
-{#            {% icon icon="expand_more" %}#}
+{#     * * *   Start of DISABLED * * * Django CMS dynamic Desktop menu#}
+{#<nav class="primary-navigation" aria-label="Hoofd navigatie">#}
+{#    <ul class="primary-navigation__list">#}
+{#        {% show_menu 0 100 100 100 "cms/menu/primary.html" %}#}
 {##}
-{#            {% if categories %}#}
-{#                <ul class="primary-navigation__list subpage-list">#}
-{#                    {% for category in categories %}#}
-{#                        <li class="primary-navigation__list-item">#}
-{#                            {% url 'products:category_detail' slug=category.slug as category_href %}#}
-{#                            {% link text=category.name href=category_href %}#}
-{#                        </li>#}
-{#                    {% endfor %}#}
-{#                </ul>#}
-{#            {% endif %}#}
-{#        </li>#}
-{#        {% if request.user.is_authenticated %}#}
+{#        {% if has_general_faq_questions %}#}
 {#            <li class="primary-navigation__list-item">#}
-{#                {% link text=_("Mijn profiel") href='profile:detail' icon="inventory_2" icon_position="before" icon_outlined=True %}#}
+{#                {% link text=_('FAQ') href='general_faq' icon="help_outline" icon_position="before" icon_outlined=True %}#}
 {#            </li>#}
-{#            <li class="primary-navigation__list-item">#}
-{#                {% link text=_('Mijn berichten') href='inbox:index' icon="inbox" icon_position="before" %}#}
-{#                {% with request.user.get_new_messages_total as total_messages %}#}
-{#                    {% if total_messages %}#}
-{#                        {% with "("|addstr:total_messages|addstr:")" as message_total %}#}
-{#                            {% link text=message_total href='inbox:index' secondary=True %}#}
-{#                        {% endwith %}#}
-{#                    {% endif %}#}
-{#                {% endwith %}#}
-{#            </li>#}
-{##}
-{#            {% get_solo 'configurations.SiteConfiguration' as config %}#}
-{##}
-{#            {% if request.user.bsn and config.show_cases %}#}
-{#                <li class="primary-navigation__list-item">#}
-{#                    {% link text=_('Mijn aanvragen') href='cases:open_cases' icon="inventory_2" icon_position="before" icon_outlined=True %}#}
-{#                </li>#}
-{#            {% endif %}#}
-{#            {% if show_plans %}#}
-{#            <li class="primary-navigation__list-item">#}
-{#            {% link text=_('Samenwerken') href='collaborate:plan_list' icon="people" icon_outlined=True icon_position="before" %}#}
-{#            {% with request.user.get_plan_contact_new_count as plan_count %}#}
-{#                {% if plan_count %}#}
-{#                    {% with "("|addstr:plan_count|addstr:")" as plan_count %}#}
-{#                        {% link text=plan_count href='collaborate:plan_list' secondary=True %}#}
-{#                    {% endwith %}#}
-{#                {% endif %}#}
-{#            {% endwith %}#}
-{#            </li>#}
-{#            {% endif %}#}
 {#        {% endif %}#}
-        {% if has_general_faq_questions %}
-            <li class="primary-navigation__list-item">
-                {% link text=_('FAQ') href='general_faq' icon="help_outline" icon_position="before" icon_outlined=True %}
-            </li>
-        {% endif %}
+{#    </ul>#}
+{#</nav>#}
+{#     * * *   End of DISABLED * * * Django CMS dynamic Desktop menu#}
+
+{% get_solo "configurations.SiteConfiguration" as config %}
+
+<nav class="primary-navigation primary-navigation__main" aria-label="Hoofd navigatie">
+    <ul class="primary-navigation__list">
+
+        <li class="primary-navigation__list-item">
+            {% button text=_('Onderwerpen') type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+
+            {% if categories %}
+                <ul class="primary-navigation__list subpage-list">
+                    {% for category in categories %}
+                        <li class="primary-navigation__list-item">
+                            {% url 'products:category_detail' slug=category.slug as category_href %}
+                            {% link text=category.name href=category_href %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </li>
+
     </ul>
 </nav>

--- a/src/open_inwoner/components/templatetags/header_tags.py
+++ b/src/open_inwoner/components/templatetags/header_tags.py
@@ -66,3 +66,26 @@ def primary_navigation(categories, request, **kwargs):
         "categories": categories,
         "request": request,
     }
+
+
+@register.inclusion_tag("components/Header/NavigationAuthenticated.html")
+def navigation_authenticated(categories, request, **kwargs):
+    """
+    Displaying the desktop navigation when user is authenticated
+
+    Usage:
+        {% navigation_authenticated categories=Category.objects.all request=request %}
+
+    Variables:
+        + categories: Category[] | The categories that should be displayed in the theme dropdown.
+        + request: Request | The django request object.
+        + questionnaire: QuestionnaireStep | The default QuestionnaireStep, if any.
+        - has_general_faq_questions: boolean | If the FAQ menu item should be shown.
+        - show_plans: boolean | If the Plan item should be shown.
+    """
+
+    return {
+        **kwargs,
+        "categories": categories,
+        "request": request,
+    }

--- a/src/open_inwoner/js/components/header/primary-navigation.js
+++ b/src/open_inwoner/js/components/header/primary-navigation.js
@@ -1,7 +1,7 @@
 import BEM from 'bem.js'
 import { Component } from '../abstract/component'
 
-/** @type {string} The primary navibation block name. */
+/** @type {string} The primary navigation block name. */
 const BLOCK_PRIMARY_NAVIGATION = 'primary-navigation'
 
 /** @type {NodeList<HTMLElement>} The primary navigation block name. */
@@ -10,6 +10,11 @@ const PRIMARY_NAVIGATIONS = BEM.getBEMNodes(BLOCK_PRIMARY_NAVIGATION)
 /** @type {string} The dismissed modifier state, overrides focus/hover. */
 const MODIFIER_DISMISSED = 'dismissed'
 
+/** Handler to bypass Safari bug */
+const navigationToggle = document.querySelectorAll(
+  '.primary-navigation--toggle'
+)
+
 /**
  * Controls the primary navigation and dismissing it using the escape key.
  */
@@ -17,68 +22,73 @@ class PrimaryNavigation extends Component {
   /**
    * Binds events to callbacks.
    * Callbacks should trigger `setState` which in turn triggers `render`.
+   * Focus is split to be handled in Safari
    */
   bindEvents() {
-    this.node.addEventListener('focus', this.onFocus.bind(this))
-    this.node.addEventListener('mouseenter', this.onHover.bind(this))
+    this.node.addEventListener('click', this.toggleDesktopNavOpen.bind(this))
+    this.node.addEventListener('focusin', this.onFocusIn.bind(this))
+    this.node.addEventListener('focusout', this.onFocusOut.bind(this))
     window.addEventListener('keyup', this.onKeyUp.bind(this))
   }
 
   /**
-   * Gets called when `node` receives focus.
+   * Gets called when `node` receives focus -in or -out events.
    * Clears the dismissed state, (prevents overriding focus/hover).
+   * Focusin and Focusout are used instead of Focus for Safari
    */
-  onFocus() {
+  onFocusIn() {
     this.setState({ dismissed: false })
+    this.node.classList.add('primary-navigation--open')
+  }
+  onFocusOut() {
+    this.setState({ dismissed: true })
+    this.node.blur()
+    this.node.classList.remove('primary-navigation--open')
   }
 
   /**
-   * Gets called when `node` receives focus.
-   * Clears the dismissed state, (prevents overriding focus/hover).
+   * Gets called when `node` is clicked.
+   * Clears the dismissed state, (prevents overriding focus/toggle).
    */
-  onHover() {
+  toggleDesktopNavOpen(event) {
+    event.stopPropagation()
     this.setState({ dismissed: false })
+    this.node.classList.add('primary-navigation--open')
   }
 
   /**
    * Gets called when a key is released.
    * If key is escape key, explicitly dismiss the menu (overriding focus/hover).
-   * @param {KeyboardEvent} event
+   //* @param {KeyboardEvent} event
    */
   onKeyUp(event) {
     if (event.key === 'Escape') {
-      if (this.getFocussedChild() || this.getHoveredChild()) {
-        this.setState({ dismissed: true })
-      }
+      this.setState({ dismissed: true })
+      this.node.blur()
+      this.node.classList.remove('primary-navigation--open')
+      // Safari specific
+      navigationToggle.forEach((elem) => {
+        elem.blur()
+      })
     }
-  }
-
-  /**
-   * Returns the child node in focus (if any).
-   * @return {HTMLElement|null}
-   */
-  getFocussedChild() {
-    return this.node.querySelector(':focus') || null
-  }
-
-  /**
-   * Returns the hovered child node (if any).
-   * @return {HTMLElement|null}
-   */
-  getHoveredChild() {
-    return this.node.querySelector(':hover') || null
   }
 
   /**
    * Persists state to DOM.
    * Rendering should be one-way traffic and not inspect any current values in DOM.
-   * @param {Object} state State to render.
+   //* @param {Object} state State to render.
    */
   render(state) {
     BEM.toggleModifier(this.node, MODIFIER_DISMISSED, state.dismissed)
 
     if (state.dismissed) {
-      this.getFocussedChild().blur()
+      this.node.blur()
+      // Safari specific
+      navigationToggle.forEach((elem) => {
+        elem.blur()
+      })
+
+      return this.node.querySelector('.primary-navigation--toggle')
     }
   }
 }

--- a/src/open_inwoner/js/components/header/subpage-navigation.js
+++ b/src/open_inwoner/js/components/header/subpage-navigation.js
@@ -1,11 +1,10 @@
 class Subpage {
   constructor(node) {
     this.node = node
-    this.node.addEventListener('click', this.toggleOpen.bind(this))
+    this.node.addEventListener('click', this.toggleNavOpen.bind(this))
   }
 
-  toggleOpen(event) {
-    event.preventDefault()
+  toggleNavOpen(event) {
     this.node.parentElement.classList.toggle('nav__list--open')
   }
 }
@@ -13,7 +12,7 @@ class Subpage {
 /**
  * Controls the toggling of subpages if there are any
  */
-const filterButtons = document.querySelectorAll(
+const toggleSubitems = document.querySelectorAll(
   '.dropdown-nav__toggle .link--toggle'
 )
-;[...filterButtons].forEach((filterButton) => new Subpage(filterButton))
+;[...toggleSubitems].forEach((toggleSubitem) => new Subpage(toggleSubitem))

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -113,7 +113,7 @@ class PlanViewTests(WebTest):
 
         response = self.app.get(self.detail_url, user=self.contact)
         self.assertContains(response, self.user.get_full_name())
-        self.assertContains(response, self.contact.get_full_name())
+        self.assertContains(response, self.contact.first_name)
 
         # Contact for one user, but not the other
         # Check if all users can see eachother in the plan
@@ -128,12 +128,12 @@ class PlanViewTests(WebTest):
 
         response = self.app.get(self.detail_url, user=self.contact)
         self.assertContains(response, self.user.get_full_name())
-        self.assertContains(response, self.contact.get_full_name())
+        self.assertContains(response, self.contact.first_name)
         self.assertContains(response, new_contact.get_full_name())
 
         response = self.app.get(self.detail_url, user=new_contact)
         self.assertContains(response, self.user.get_full_name())
-        self.assertContains(response, new_contact.get_full_name())
+        self.assertContains(response, new_contact.first_name)
         self.assertContains(response, self.contact.get_full_name())
 
         new_contact.delete()

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -237,3 +237,17 @@
     }
   }
 }
+
+/// Specific forms
+
+.search__mobile,
+.header__submenu {
+  .form {
+    // tablet sizes
+    @media screen and (min-width: 360px) and (max-width: 768px) {
+      &__control > .label .input {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -6,23 +6,58 @@ $vm: var(--spacing-large);
 
 .header {
   z-index: 1003;
-  position: sticky;
+  position: static;
   top: 0;
+  min-height: 100px;
   background-color: var(--color-white);
-  border-bottom: var(--border-width) solid;
-  border-image: var(--border-image);
-  border-image-slice: 1;
+  width: calc(100% - var(--spacing-large));
 
   @media (min-width: 768px) {
     position: relative;
+    margin-bottom: var(--spacing-medium);
+  }
+
+  .indicator {
+    display: inline-block;
+    position: relative;
+    margin-left: var(--spacing-medium);
+    text-align: center;
+
+    .link,
+    &__link {
+      font-size: var(--font-size-body-small);
+      color: var(--color-black);
+      display: inline-block;
+      position: relative;
+      background-color: var(--color-gray);
+      border-radius: var(--border-radius);
+      padding: var(--spacing-small);
+      min-width: var(--spacing-large);
+      height: var(--spacing-large);
+
+      .link__text {
+        font-size: var(--font-size-body-small);
+      }
+    }
+
+    &__dot {
+      position: absolute;
+      top: 1px;
+      right: -2px;
+      background-color: var(--color-red);
+      height: 6px;
+      width: 6px;
+      display: inline-block;
+      border-radius: 100px; // This is big to make sure the corners are rounded properly.
+    }
   }
 
   &__container {
     box-sizing: border-box;
     display: grid;
-    grid-column-gap: var(--gutter-width);
+    grid-column-gap: var(--spacing-tiny);
     position: relative;
-    grid-template-columns: 1fr calc(2 * var(--row-height));
+    grid-template-columns: 1fr;
     grid-template-rows: calc(2 * var(--row-height));
 
     > .header__actions {
@@ -36,18 +71,54 @@ $vm: var(--spacing-large);
     @media (min-width: 768px) {
       padding: 0 $hm;
       grid-template-columns: repeat(12, 1fr);
-      grid-template-rows: calc(var(--header-height) - var(--row-height) * 2) var(
-          --row-height
-        );
+      grid-auto-flow: column;
+      grid-row: 1;
+      align-items: center;
 
       > .header__actions {
         display: block;
-        grid-column: 9 / span 4;
+        position: static;
+        grid-row: 1;
+        grid-column: 6 / span 5;
       }
 
       > .primary-navigation {
         display: block;
         grid-column: 1 / span 12;
+      }
+    }
+
+    // Tablet search bar
+    @media screen and (min-width: 768px) and (max-width: 910px) {
+      > .header__actions {
+        grid-column: 4 / span 8;
+        grid-row: 2;
+      }
+    }
+
+    .logo__desktop {
+      display: none;
+
+      @media (min-width: 768px) {
+        display: inline-block;
+        grid-row: 1;
+        grid-column: 1 / span 3;
+      }
+    }
+
+    .desktop-login {
+      display: none;
+
+      @media (min-width: 768px) {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        grid-column: 11 / span 2;
+        grid-row: 1;
+      }
+
+      @media screen and (min-width: 768px) and (max-width: 910px) {
+        grid-column: 9 / span 3;
       }
     }
   }
@@ -63,49 +134,69 @@ $vm: var(--spacing-large);
     @media (min-width: 768px) {
       height: auto;
       grid-column: 1 / span 6;
-      margin: var(--spacing-large) var(--spacing-large) var(--spacing-large) 0;
+      margin: 0;
     }
     @media (max-width: 767px) {
       padding: 8px;
+      margin-right: auto;
+      margin-left: 1em;
     }
 
     img {
       max-height: 75px;
+      width: 100%;
+      max-width: fit-content;
     }
   }
 
   &__menu {
+    display: flex;
+    justify-content: space-between;
+    margin: 0 var(--spacing-large) 0 var(--spacing-large);
+
     @media (min-width: 768px) {
       display: none;
+    }
+
+    .nav-login--icon {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: calc(var(--row-height) * 2);
     }
   }
 
   &__menu &__button {
     appearance: none;
-    background-color: transparent;
-    border: 1px solid var(--color-gray-light);
-    border-bottom: none;
-    height: calc(2 * var(--row-height));
-    width: calc(2 * var(--row-height));
-  }
-
-  &__menu &__button &__menu-icon {
-    user-select: none;
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    background-color: transparent;
+    border: none;
+    height: calc(2 * var(--row-height));
+    width: calc(2 * var(--row-height));
+    padding: 0;
+    margin-right: var(--spacing-tiny);
+  }
 
-    *[class*='icon'],
-    *[class*='Icon'] {
-      font-size: 36px;
-      cursor: pointer;
-      color: var(--color-black);
-    }
+  &__menu &__button &__menu-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    cursor: pointer;
+    border: 1px solid var(--color-primary);
+    border-radius: var(--border-radius);
+    height: var(--row-height);
+    width: 80px;
 
     @media (min-width: 768px) {
       display: none;
     }
+  }
+
+  &__menu &__button--open &__menu-icon {
+    background-color: white;
   }
 
   &__submenu {
@@ -138,11 +229,18 @@ $vm: var(--spacing-large);
     display: none;
   }
 
+  .header__button .header__menu-icon {
+    background-color: var(--color-primary);
+  }
   .header__button .header__menu-icon .open {
     display: none;
   }
   .header__button .header__menu-icon .closed {
-    display: inline;
+    height: 15px;
+    width: 100%;
+    color: var(--color-white);
+    display: inline-block;
+    font-size: var(--font-size-body);
   }
 
   .primary-navigation {
@@ -153,8 +251,29 @@ $vm: var(--spacing-large);
       grid-area: none;
       left: 0;
       bottom: 0;
-      position: absolute;
-      padding: 0 $hm;
+      padding: 0;
+      min-width: 150px;
+
+      &__main {
+        grid-row: 1;
+        grid-column: 4 / span 2;
+      }
+
+      &__authenticated {
+        display: flex;
+        flex-direction: row;
+        grid-row: 1;
+        grid-column: 11 / span 2;
+
+        @media screen and (min-width: 768px) and (max-width: 910px) {
+          grid-column: 9 / span 3;
+        }
+
+        .primary-navigation__list {
+          overflow-x: visible;
+          justify-content: flex-end;
+        }
+      }
     }
   }
 
@@ -163,17 +282,35 @@ $vm: var(--spacing-large);
   }
 
   &__actions {
-    align-items: flex-end;
-    display: flex;
-    flex-direction: column;
-    align-self: center;
-    justify-content: flex-end;
+    border-left: none;
+    border-right: none;
+    bottom: 0;
+    background-color: var(--color-white);
+    box-sizing: border-box;
+    height: calc(2 * var(--row-height));
+    left: 0;
+    margin: 0;
+    max-width: 100%;
+    padding: 0 var(--spacing-medium) var(--spacing-medium) var(--spacing-medium);
+    position: initial;
+    right: 0;
+    top: calc(2 * var(--row-height));
+    width: 100%;
+    z-index: 5;
+
+    .form {
+      padding: 0;
+    }
+
+    @media (min-width: 768px) {
+      position: relative;
+      height: var(--row-height);
+    }
   }
 
   &__text-actions {
     align-items: center;
     display: flex;
-    order: 3;
     justify-content: space-between;
     height: var(--row-height);
     white-space: nowrap;
@@ -200,7 +337,6 @@ $vm: var(--spacing-large);
 
     @media (min-width: 768px) {
       justify-content: flex-end;
-      order: 1;
 
       > .p {
         display: flex;
@@ -239,25 +375,64 @@ $vm: var(--spacing-large);
   }
 }
 
+/// Search section mobile - under header
+
+.search__mobile {
+  display: block;
+  margin: 0 var(--spacing-large) 0 var(--spacing-large);
+  max-width: var(--container-width);
+  position: relative;
+
+  .form {
+    padding: 0 0 var(--spacing-medium) 0;
+  }
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+}
+
 ///
 /// Header - when mobile menu/body is open.
 ///
 
 @media (max-width: 767px) {
   .body--open {
+    .search__mobile {
+      display: none;
+    }
+
     .header {
       border-bottom: var(--border-width) dotted var(--color-white);
-      border-image-slice: unset;
-      border-image: none;
 
-      // Hamburger icons
+      .primary-navigation
+        > .primary-navigation__list
+        > .primary-navigation__list-item {
+        display: flex;
+        flex-direction: row;
+
+        &.dropdown-nav__toggle {
+          flex-direction: column;
+        }
+      }
+
+      // Responsive menu-button
       &__menu {
         .header {
           &__button--open {
             border: 1px solid var(--color-white);
 
+            .header__menu-icon {
+              background-color: white;
+            }
+
             .header__menu-icon .open {
-              display: inline;
+              //height: var(--row-height);
+              width: 100%;
+              background-color: var(--color-white);
+              color: var(--color-primary);
+              display: inline-block;
+              font-size: var(--font-size-body);
             }
 
             .header__menu-icon .closed {
@@ -270,20 +445,19 @@ $vm: var(--spacing-large);
       .header {
         &__actions {
           box-sizing: border-box;
-          width: calc(100% - var(--spacing-extra-large));
-          padding: 0 0 0 var(--spacing-medium);
+          //width: calc(100% - var(--spacing-extra-large));
+          padding: 0;
           margin: 0;
 
           .header__text-actions {
-            border-top: 1px solid var(--color-gray-light);
-            padding: var(--spacing-extra-large) 0 var(--spacing-extra-large);
-            margin: var(--spacing-extra-large) 0 0 0;
+            padding: var(--spacing-medium) 0 var(--spacing-extra-large);
+            margin: var(--spacing-medium) 0 0 0;
 
             .p {
               display: flex;
               align-items: center;
               justify-content: space-between;
-              gap: var(--spacing-medium);
+              gap: var(--spacing-tiny);
             }
 
             .link {
@@ -293,7 +467,6 @@ $vm: var(--spacing-large);
           }
 
           .form--inline {
-            border-bottom: 1px solid var(--color-gray-light);
             padding: var(--spacing-extra-large) 0 var(--spacing-extra-large);
             margin: 0;
           }
@@ -304,14 +477,17 @@ $vm: var(--spacing-large);
         &__submenu {
           border-top: 1px solid var(--color-white);
 
+          .primary-navigation {
+            border-bottom: 1px solid var(--color-gray-light);
+          }
+
           > .primary-navigation
             > .primary-navigation__list
             > .primary-navigation__list-item.dropdown-nav__toggle {
             position: relative;
+            border-bottom: 1px solid var(--color-gray-light);
 
             &.nav__list--open {
-              margin-top: 10px;
-
               .link--toggle {
                 line-height: calc(var(--font-line-height-body) - 1px);
                 color: var(--color-primary);
@@ -327,6 +503,8 @@ $vm: var(--spacing-large);
               }
 
               .subpage-list {
+                margin-top: var(--spacing-extra-large);
+                margin-left: 11px;
                 display: grid;
                 height: auto;
                 overflow: initial;

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -17,11 +17,13 @@
     grid-area: nav;
     display: flex;
     flex-direction: column;
+    align-self: flex-start;
     gap: var(--spacing-medium);
     list-style: none;
+    font-size: var(--font-size-body-large);
     margin: 0;
     padding: 0;
-    overflow-x: auto;
+    overflow-x: hidden;
 
     @media (min-width: 768px) {
       flex-direction: row;
@@ -32,12 +34,23 @@
     box-sizing: border-box;
     display: flex;
     align-items: start;
-    justify-content: center;
     flex-direction: column;
+    justify-content: start;
     min-height: var(--row-height);
+    overflow: hidden;
     padding: 0;
 
-    > .material-icons {
+    .link {
+      font-size: var(--font-size-body-large);
+      line-height: var(--font-line-height-body);
+      @media (min-width: 768px) {
+        font-size: var(--font-size-body);
+        overflow: hidden;
+        word-wrap: normal;
+      }
+    }
+
+    > [class*='icons'] {
       display: none;
 
       @media (min-width: 768px) {
@@ -45,13 +58,19 @@
       }
     }
 
+    /// Subpages desktop for categories-list and authenticated page-list
+
     .subpage-list {
-      padding-left: var(--spacing-extra-large);
-      padding-top: var(--spacing-large);
-      gap: var(--spacing-extra-large) !important;
+      row-gap: var(--spacing-extra-large);
+      padding: 0 var(--spacing-large);
+      margin: 0 var(--spacing-large);
 
       .primary-navigation__list-item {
         list-style-type: none;
+      }
+
+      @media (min-width: 768px) {
+        row-gap: 1px;
       }
     }
 
@@ -71,55 +90,186 @@
     }
   }
 
+  /// Dropdown triangles
+
+  &.primary-navigation__main .subpage-list {
+    @media (min-width: 768px) {
+      &::before {
+        box-sizing: border-box;
+        border-bottom: 6px solid var(--color-primary);
+        border-left: 6px solid var(--color-white);
+        border-right: 6px solid var(--color-white);
+        content: '';
+        display: block;
+        height: 6px;
+        left: 6.7em;
+        position: absolute;
+        top: -7px;
+        width: 12px;
+      }
+      &::after {
+        box-sizing: border-box;
+        border-bottom: 6px solid var(--color-white);
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        content: '';
+        display: block;
+        height: 6px;
+        left: 6.7em;
+        position: absolute;
+        top: -6px;
+        width: 11px;
+      }
+    }
+  }
+
+  &.primary-navigation__authenticated .subpage-list {
+    @media (min-width: 768px) {
+      &::before {
+        box-sizing: border-box;
+        border-bottom: 6px solid var(--color-primary);
+        border-left: 6px solid var(--color-white);
+        border-right: 6px solid var(--color-white);
+        content: '';
+        display: block;
+        height: 6px;
+        left: 3em;
+        position: absolute;
+        top: -7px;
+        width: 12px;
+      }
+      &::after {
+        box-sizing: border-box;
+        border-bottom: 6px solid var(--color-white);
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        content: '';
+        display: block;
+        height: 6px;
+        left: 3em;
+        position: absolute;
+        top: -6px;
+        width: 11px;
+      }
+    }
+  }
+
   /// Nested list.
 
-  & > &__list > &__list-item > &__list {
+  & > &__list &__list-item &__list,
+  & > &__list &__list-item &dropdown-nav__toggle &__list {
     box-sizing: border-box;
     margin: 0;
-    width: 100%;
     z-index: 100;
     padding-bottom: var(--spacing-medium);
-    margin-top: 0;
     display: grid;
     grid-template-columns: repeat(1, 1fr);
-    gap: var(--spacing-medium);
+    width: 100%;
 
     @media (min-width: 768px) {
       list-style: none;
-      background-color: var(--color-accent);
+      background-color: var(--color-white);
       transform: scaleY(0);
-      left: 0;
-      top: 100%;
+      right: 0;
+      top: var(--row-height-big);
       position: absolute;
-      padding: var(--spacing-large)
-        max(calc((100vw - var(--container-width)) / 2), var(--spacing-large));
-      grid-template-columns: repeat(4, 1fr);
+      padding: var(--spacing-large) var(--spacing-extra-large);
+      border: 1px solid var(--color-primary);
+      border-radius: 4px;
+      min-width: 240px;
     }
 
     .link {
+      font-size: var(--font-size-body-large);
+      line-height: var(--font-line-height-body-large);
+
       @media (min-width: 768px) {
-        color: var(--color-font-accent);
+        font-size: var(--font-size-body);
+        color: var(--font-color-body);
       }
+    }
+  }
+
+  /// Categgories and authenticated nested list
+
+  &__main > &__list > &__list-item &__list {
+    @media (min-width: 768px) {
+      left: -11px;
+    }
+  }
+  &__authenticated > &__list > &__list-item &__list {
+    @media (min-width: 768px) {
+      left: calc(-1 * var(--spacing-giant));
+    }
+    [class*='icons'] {
+      margin-right: var(--spacing-large);
     }
   }
 
   & > &__list > &__list-item > &__list > &__list-item {
     line-height: var(--row-height);
+    overflow: hidden;
   }
 
   /// Interaction.
 
-  &:not(#{&}--dismissed) > &__list > &__list-item:focus &__list,
-  &:not(#{&}--dismissed) > &__list > &__list-item:focus-within &__list,
-  &:not(#{&}--dismissed) > &__list > &__list-item:hover &__list {
+  &:not(#{&}--dismissed) &__list-item:focus &__list,
+  &:not(#{&}--dismissed) &__list-item:focus-within &__list,
+  &:not(#{&}--dismissed)[class*='--open'] &__list-item &__list {
     transform: scaleY(1);
+  }
+  &:not(#{&}--dismissed) &__list-item:focus,
+  &:not(#{&}--dismissed) &__list-item:focus-within {
+    // Open subpages
+    .button--transparent.primary-navigation--toggle {
+      color: var(--color-primary);
+    }
+  }
+
+  button.button--transparent.primary-navigation--toggle {
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-body);
+    color: var(--font-color-body);
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(0);
+    }
+    &:focus,
+    &:focus-visible,
+    &:focus-within {
+      transform: translateY(0);
+      border: 1px solid orange;
+      // orange focus
+      box-shadow: 0 3px 6px rgba(255, 165, 0, 0.9);
+      border-radius: 4px;
+      outline: -webkit-focus-ring-color auto 5px;
+    }
+  }
+
+  &:not(#{&}--dismissed) &__list &__list-item:focus,
+  &:not(#{&}--dismissed) &__list &__list-item:focus-within {
+    // animate primary navigation dropdown icons
+
+    .primary-navigation--toggle > [class*='icons'] {
+      display: inline-block;
+      transition: transform 0.3s;
+      transform: rotate(180deg);
+      top: 8px;
+      right: var(--spacing-large);
+    }
   }
 
   /// Mobile nested list.
 
   @media (max-width: 767px) {
     & > &__list > &__list-item > &__list.subpage-list {
-      margin-top: var(--spacing-medium);
+      margin-bottom: var(--spacing-medium);
     }
   }
 }

--- a/src/open_inwoner/scss/components/Logo/Logo.scss
+++ b/src/open_inwoner/scss/components/Logo/Logo.scss
@@ -1,7 +1,5 @@
 .logo {
   &__image {
-    max-width: 100%;
-
     @media (min-width: 768px) {
       display: block;
     }

--- a/src/open_inwoner/scss/components/Typography/Link.scss
+++ b/src/open_inwoner/scss/components/Typography/Link.scss
@@ -71,6 +71,6 @@
 
   *[class*='icon']:first-child,
   *[class*='Icon']:first-child {
-    transform: scale(0.75);
+    transform: scale(1);
   }
 }

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -214,8 +214,10 @@
   --font-size-body: 16px;
   --font-line-height-body: 21px;
 
-  --font-size-body-small: 12px;
+  --font-size-body-small: 14px;
+  --font-size-body-large: 20px;
   --font-line-height-body-small: 20px;
+  --font-line-height-body-large: 28px;
 
   /// Spacing.
 
@@ -303,5 +305,7 @@ html {
 }
 
 body {
+  // default CMS style
   margin: 0;
+  font-family: var(--font-family-body);
 }

--- a/src/open_inwoner/templates/cms/menu/primary.html
+++ b/src/open_inwoner/templates/cms/menu/primary.html
@@ -4,7 +4,7 @@
     <li class="primary-navigation__list-item child{% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}{% if child.sibling %} sibling{% endif %}{% if child.descendant %} descendant{% endif %}">
         {% link text=child.get_menu_title href=url icon=child.common.menu_icon icon_position="before" %}
         {% if child.indicator %}
-        <a class="link secondary" href="{{ url }}">({{ child.indicator }})</a>
+            <span class="indicator"><a class="link secondary indicator__link" href="{{ url }}">{{ child.indicator }}<span class="indicator__dot"></span></a></span>
         {% endif %}
         {% if child.children %}
         <ul class="primary-navigation__list subpage-list">
@@ -14,3 +14,4 @@
     </li>
 {% endwith %}
 {% endfor %}
+lhg


### PR DESCRIPTION
new mobile header designs + 2 new desktop menus:
https://projects.invisionapp.com/share/B3137YU0PZY2#/screens?browse 

In order to view the styles correctly for review: turn off the Django CMS-toolbar
(http://127.0.0.1:8000/?toolbar_off)

adds feature to issue mobile: https://taiga.maykinmedia.nl/project/open-inwoner/task/1378 
also adds feature to issue for desktop header: https://taiga.maykinmedia.nl/project/open-inwoner/task/1377
and adds feature to issue for indicator + dot: https://taiga.maykinmedia.nl/project/open-inwoner/task/1398

📲 Mobile menu:

- [x] visually looks like 1 list of all pages + subpages for Onderwerpen
- [x] no stickies:  menu + search bar must scroll out of view when menu is closed
- [x] search bar is visible in opened mobile menu
- [x] message/plans notifications visible
- [x] some new icons
Mobile menu works in all browsers the same

🖥️ Desktop menu:

- [x]  two separate menus for 1) Onderwerpen and 2) is_authenticated
- [x]  subpages must not be visible on **hover**, only on toggle/click
- [x] message/plans notifications visible
- [x] needs to be accessible (close on Escape and out-of-Focus, open on Tab and open on 1 click)

🔔 Note:
NB: in Firefox desktop the Tab can't reach the submenu-items unless accessibility.tabfocus is set to number=7 in the about:config settings - which may be an issue on Mac only: https://support.mozilla.org/en-US/questions/1278793
NB: In Safari Tab won't work if user forgets to turn on accessibility (Settings > Advanced > Turn on Tab...).

