### PR TITLE
[#1404] Implemented possible/partial solutions to support CSP in CMS pages

### DIFF
--- a/src/open_inwoner/cms/csp/middleware.py
+++ b/src/open_inwoner/cms/csp/middleware.py
@@ -1,0 +1,59 @@
+import logging
+
+from django.http import HttpResponse
+
+from lxml.etree import ParseError, ParserError
+from lxml.html import document_fromstring, tostring
+
+logger = logging.getLogger(__name__)
+
+
+class DjangoCMSCSPMiddleware:
+    """
+    middleware to add CSP nonce to (some) script tags
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response: HttpResponse = self.get_response(request)
+        if response.streaming:
+            return response
+
+        if response.status_code != 200:
+            return response
+
+        content_type = response["Content-Type"].split(";")[0]
+        if content_type != "text/html":
+            return response
+
+        # TODO decide if we want staff-user filtering here
+        if not request.user.is_authenticated or not request.user.is_staff:
+            return response
+
+        csp_nonce = getattr(request, "csp_nonce", None)
+        if not csp_nonce:
+            logger.error("requires django-csp and response.csp_nonce")
+            return response
+
+        html_content = response.content.decode(response.charset)
+        try:
+            response.content = process_cms_csp(
+                html_content, str(csp_nonce), response.charset
+            )
+        except (ParseError, ParserError):
+            # what
+            return response
+
+        return response
+
+
+def process_cms_csp(html, csp_nonce, encoding):
+    tree = document_fromstring(html)
+
+    for elem in tree.cssselect("script[data-cms]"):
+        elem.set("nonce", csp_nonce)
+
+    html = tostring(tree, encoding=encoding)
+    return html

--- a/src/open_inwoner/cms/csp/sekizai.py
+++ b/src/open_inwoner/cms/csp/sekizai.py
@@ -1,0 +1,27 @@
+from lxml.etree import ParseError, ParserError
+from lxml.html import fragments_fromstring, tostring
+
+
+def process_csp(context, data, namespace):
+    """
+    contextprocessor to add CSP nonce to (some) script tags in sekizai blocks
+    usage:
+
+    {% render_block "js"  postprocessor "open_inwoner.cms.csp.sekizai.process_csp" %}
+    """
+    request = context["request"]
+
+    # TODO decide if we want staff-user filtering here
+    if not request.user.is_authenticated or not request.user.is_staff:
+        return data
+
+    try:
+        fragments = fragments_fromstring(data)
+    except (ParseError, ParserError):
+        return data
+    for fragment in fragments:
+        for elem in fragment.cssselect("script[data-cms]"):
+            elem.set("nonce", str(request.csp_nonce))
+
+    html = "\n".join(tostring(f, encoding="unicode") for f in fragments)
+    return html

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -216,6 +216,7 @@ MIDDLEWARE = [
     "sessionprofile.middleware.SessionProfileMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     # 'django.middleware.locale.LocaleMiddleware',
+    "open_inwoner.cms.csp.middleware.DjangoCMSCSPMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -526,6 +527,7 @@ CMS_PLACEHOLDER_CONF = {
         # },
     },
 }
+CMS_TOOLBAR_ANONYMOUS_ON = False
 
 #
 # Django-Admin-Index


### PR DESCRIPTION
Instead of blanketing everything in (conditional) unsafe-inlines for staff users I found that we can detect (most) of the django-cms script tags based on a data attribute.

So I made a middleware that adds the CSP nonce to all the script-tags that do that, and this works for most functionality except some vendored jquery library that doesn't seem essential. Except this approach is flawed, as an attacker could just inject evil tags with that data attribute and its basically `script-src 'unsafe-line'` with extra steps.

An alternate way that uses a django-sekizai block postprocessor to add the nonce, this is safer as it only processes the scripts added to sekizai (eg: significant smaller attack surface). A problem here is that it needs some work to cover other cms/admin template tag output (like the cms_toolbar-tag). So this also doesn't process the plugin placeholders but I think that is fine.

We should discus this as each solution has some flaws.