### PR TITLE
:lipstick: [#1385] Fix heading size for plans on homepage

### DIFF
--- a/src/open_inwoner/scss/_cms_dev.scss
+++ b/src/open_inwoner/scss/_cms_dev.scss
@@ -1,4 +1,0 @@
-.debug-cms-block {
-  outline: 2px red dashed;
-  background-color: lightcoral;
-}

--- a/src/open_inwoner/scss/screen.scss
+++ b/src/open_inwoner/scss/screen.scss
@@ -13,4 +13,3 @@
 @import 'views';
 @import 'overwrites';
 @import './_fixes';
-@import './_cms_dev';

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -8,7 +8,7 @@
 <div class="plans-cards card-container card-container--columns-4">
     {% for plan in plans %}
         {% render_card image_object_fit="cover" %}
-            <a href="{{ plan.get_absolute_url }}" class="plan-list"><h4 class="h4">{{ plan.title }}</h4>
+            <a href="{{ plan.get_absolute_url }}" class="plan-list"><p class="h4">{{ plan.title }}</p>
             <p class="p">{{ plan.goal|truncatewords:20 }}</p>
             <p class="p">{{ plan.description|truncatewords:20 }}</p></a>
             <a

--- a/src/open_inwoner/templates/cms/fullwidth.html
+++ b/src/open_inwoner/templates/cms/fullwidth.html
@@ -6,7 +6,5 @@
 {% endblock header_image %}
 
 {% block content %}
-    <div class="debug-cms-block">
     {% placeholder 'content' or %}{% trans "There is no content." %}{% endplaceholder %}
-    </div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/user-home.html
+++ b/src/open_inwoner/templates/pages/user-home.html
@@ -17,7 +17,7 @@
         <div class="plans-cards card-container card-container--columns-4">
             {% for plan in plans %}
                 {% render_card image_object_fit="cover" %}
-                    <a href="{{ plan.get_absolute_url }}" class="plan-list"><h4 class="h4">{{ plan.title }}</h4>
+                    <a href="{{ plan.get_absolute_url }}" class="plan-list"><p class="h4">{{ plan.title }}</p>
                     <p class="p">{{ plan.goal|truncatewords:20 }}</p>
                     <p class="p">{{ plan.description|truncatewords:20 }}</p></a>
                     <a


### PR DESCRIPTION
make headings the same like all the others: 
taiga issue/1385 

extra: remove red/dashed debug styles