### PR TITLE
[#1452] Added middleware to hide django-cms toolbar when not 2FA verified

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -238,6 +238,7 @@ MIDDLEWARE = [
     "cms.middleware.page.CurrentPageMiddleware",
     "cms.middleware.toolbar.ToolbarMiddleware",
     "cms.middleware.language.LanguageCookieMiddleware",
+    "open_inwoner.cms.utils.middleware.DropToolbarMiddleware",
     "cms.middleware.utils.ApphookReloadMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
     "open_inwoner.extended_sessions.middleware.SessionTimeoutMiddleware",
@@ -537,6 +538,8 @@ CMS_PLACEHOLDER_CONF = {
     "banner_image": {"plugins": ["BannerImagePlugin"], "name": _("Banner Image")},
     "banner_text": {"plugins": ["BannerTextPlugin"], "name": _("Banner Text")},
 }
+
+CMS_TOOLBAR_ANONYMOUS_ON = False
 
 #
 # Django-Admin-Index


### PR DESCRIPTION
I tried a bunch of approaches, like putfing an if/else around the template tag, extending the regular ToolbarMiddleware, extending the template tag and some others, but this is the simplest that doesn't break anything.

It seems to work in browser, if it is acceptable I'll figure out how to create a test for this tomorrow.