### PR TITLE
:lipstick: [#1445] Fix alignment of notification indicator numbers

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -8,9 +8,6 @@
         <ul class="primary-navigation__list">
             <li class="primary-navigation__list-item">
             {% button text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
-            {% if indicator %}
-                <span class="indicator"><span class="indicator__dot">indicator</span></span>
-            {% endif %}
 
                 <ul class="primary-navigation__list subpage-list">
                     {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -19,12 +19,9 @@ $vm: var(--spacing-large);
   .indicator {
     display: inline-block;
     position: relative;
-    margin-left: var(--spacing-medium);
+    margin-left: var(--spacing-large);
     overflow: visible;
     text-align: center;
-    @media (min-width: 768px) {
-      top: -6px;
-    }
 
     .link,
     &__link {
@@ -277,10 +274,6 @@ $vm: var(--spacing-large);
           overflow-x: visible;
           justify-content: flex-end;
           position: relative;
-
-          &-item > .indicator > .indicator__dot {
-            right: var(--spacing-large);
-          }
         }
       }
     }

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -67,6 +67,10 @@
 
       .primary-navigation__list-item {
         list-style-type: none;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
       }
 
       @media (min-width: 768px) {
@@ -123,33 +127,46 @@
     }
   }
 
-  &.primary-navigation__authenticated .subpage-list {
-    @media (min-width: 768px) {
-      &::before {
-        box-sizing: border-box;
-        border-bottom: 6px solid var(--color-primary);
-        border-left: 6px solid var(--color-white);
-        border-right: 6px solid var(--color-white);
-        content: '';
-        display: block;
-        height: 6px;
-        left: 3em;
+  &.primary-navigation__authenticated {
+    button.button--transparent.primary-navigation--toggle {
+      display: inline-block;
+      padding-right: var(--spacing-giant);
+      width: 165px;
+
+      & [class*='icon'] {
         position: absolute;
-        top: -7px;
-        width: 12px;
+        top: 10px;
+        right: 13px;
       }
-      &::after {
-        box-sizing: border-box;
-        border-bottom: 6px solid var(--color-white);
-        border-left: 6px solid transparent;
-        border-right: 6px solid transparent;
-        content: '';
-        display: block;
-        height: 6px;
-        left: 3em;
-        position: absolute;
-        top: -6px;
-        width: 11px;
+    }
+    .subpage-list {
+      @media (min-width: 768px) {
+        &::before {
+          box-sizing: border-box;
+          border-bottom: 6px solid var(--color-primary);
+          border-left: 6px solid var(--color-white);
+          border-right: 6px solid var(--color-white);
+          content: '';
+          display: block;
+          height: 6px;
+          right: var(--spacing-large);
+          position: absolute;
+          top: -7px;
+          width: 12px;
+        }
+        &::after {
+          box-sizing: border-box;
+          border-bottom: 6px solid var(--color-white);
+          border-left: 6px solid transparent;
+          border-right: 6px solid transparent;
+          content: '';
+          display: block;
+          height: 6px;
+          right: var(--spacing-large);
+          position: absolute;
+          top: -6px;
+          width: 11px;
+        }
       }
     }
   }
@@ -164,6 +181,7 @@
     padding-bottom: var(--spacing-medium);
     display: grid;
     grid-template-columns: repeat(1, 1fr);
+    gap: var(--spacing-small);
     width: 100%;
 
     @media (min-width: 768px) {
@@ -181,7 +199,7 @@
 
     .link {
       font-size: var(--font-size-body-large);
-      line-height: var(--font-line-height-body-large);
+      line-height: var(--row-height);
 
       @media (min-width: 768px) {
         font-size: var(--font-size-body);
@@ -190,7 +208,7 @@
     }
   }
 
-  /// Categgories and authenticated nested list
+  /// Categories and authenticated nested list
 
   &__main > &__list > &__list-item &__list {
     @media (min-width: 768px) {
@@ -199,7 +217,7 @@
   }
   &__authenticated > &__list > &__list-item &__list {
     @media (min-width: 768px) {
-      left: calc(-1 * var(--spacing-giant));
+      right: 0;
     }
     [class*='icons'] {
       margin-right: var(--spacing-large);
@@ -244,11 +262,6 @@
     &:focus-visible,
     &:focus-within {
       transform: translateY(0);
-      //border: 1px solid var(--color-primary);
-      // orange focus
-      // box-shadow: 0 3px 6px var(--color-primary);
-      //border-radius: 4px;
-      // outline: -webkit-focus-ring-color auto 5px;
     }
   }
 
@@ -260,8 +273,8 @@
       display: inline-block;
       transition: transform 0.3s;
       transform: rotate(180deg);
-      top: 8px;
-      right: var(--spacing-large);
+      top: 10px;
+      right: 13px;
     }
   }
 


### PR DESCRIPTION
- background lighter and a bigger left-margin
- red dot has white border 
- red dot needs to be outside of grey area
- authenticated submenu should not be outside of the container (so dropdown title needs to be aligned a bit more to the left in order for triangle to line -up with arrow)
- make ellipsis truncation work for long usernames

also solves another issue #1472: 
Space between FAQ and Uitloggen in submenu items/icons.