### PR TITLE
:lipstick: [#1433] Add validation message for document upload

### DIFF
--- a/src/open_inwoner/js/components/upload-document/show-file-info.js
+++ b/src/open_inwoner/js/components/upload-document/show-file-info.js
@@ -1,8 +1,11 @@
 const fileUploadInput = document.getElementById('id_file')
 const sizeInfo = document.getElementById('upload_size')
 const nameInfo = document.getElementById('upload_name')
+const validationInfo = document.getElementById('upload_error')
 const closeButton = document.getElementById('close_upload')
 const submit_upload = document.getElementById('submit_upload')
+// show/hide after validation
+const iconDrive = document.querySelectorAll('.drive')
 // show info
 const formControlInfo = document.querySelectorAll('.form__control--info')
 
@@ -15,6 +18,12 @@ if (fileUploadInput) {
   }
   // initial values
   submit_upload.disabled = true
+  validationInfo.classList.add('error')
+  closeButton.classList.add('error')
+  iconDrive.forEach((elem) => {
+    elem.classList.add('error')
+  })
+
   formControlInfo.forEach((elem) => {
     elem.style.display = 'none'
   })
@@ -24,12 +33,24 @@ if (fileUploadInput) {
 
     if ((files.length === 0) | (files === null) | (files === undefined)) {
       submit_upload.disabled = true
+      validationInfo.classList.add('error')
+      closeButton.classList.add('error')
+      iconDrive.forEach((elem) => {
+        elem.classList.add('error')
+      })
+
       // Hide the size element if user doesn't choose any file
       formControlInfo.forEach((elem) => {
         elem.style.display = 'none'
       })
     } else {
       submit_upload.disabled = false
+      validationInfo.classList.remove('error')
+      closeButton.classList.remove('error')
+      iconDrive.forEach((elem) => {
+        elem.classList.remove('error')
+      })
+
       // Display info
       sizeInfo.textContent = formatFileSize(files[0].size)
       nameInfo.textContent = `${files[0].name}`
@@ -43,6 +64,12 @@ if (fileUploadInput) {
   if (closeButton) {
     closeButton.addEventListener('click', (event) => {
       submit_upload.disabled = true
+      validationInfo.classList.remove('error')
+      closeButton.classList.remove('error')
+      iconDrive.forEach((elem) => {
+        elem.classList.remove('error')
+      })
+
       formControlInfo.forEach((elem) => {
         elem.style.display = 'none'
       })

--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -148,8 +148,20 @@ input[type='file']::file-selector-button {
     }
   }
 
+  .drive {
+    display: block;
+
+    &.error {
+      display: none;
+    }
+  }
+
   .close .button--transparent {
     color: var(--color-red);
+
+    &.error {
+      display: none;
+    }
   }
 
   .info-container {
@@ -185,6 +197,28 @@ input[type='file']::file-selector-button {
         &__name {
           color: var(--font-color-body);
           font-weight: bold;
+        }
+
+        &__error {
+          display: none;
+          position: relative;
+
+          & *[class*='icon'] {
+            position: absolute;
+            top: var(--spacing-small);
+            right: -100px;
+            color: var(--color-primary);
+          }
+
+          &.error {
+            color: var(--font-color-body);
+            font-weight: bold;
+            font-size: 19px;
+            line-height: var(--spacing-giant);
+            display: block;
+            margin-left: calc(-1 * (var(--spacing-large)));
+            overflow: initial;
+          }
         }
       }
     }

--- a/src/open_inwoner/templates/pages/cases/status.html
+++ b/src/open_inwoner/templates/pages/cases/status.html
@@ -50,12 +50,14 @@
                         {% render_form id="document-upload" form=form method="POST" submit_text=_("Bestand uploaden") enctype="multipart/form-data" show_required=True %}
                             {% csrf_token %}
                             <div id="info_container" class="info-container form__control--info">
-                                <div class="drive">
+                                <div class="upload-interface__info">
                                     <fieldset class="fieldset-container">
                                         <div class="drive">{% icon icon="insert_drive_file" outlined=True icon_position="before" %}</div>
                                         <div class="fieldset__content">
-                                            <div id="upload_name" class="upload-info upload-info__name"><span>{% trans "(Titel bestand)" %}</span></div>
-                                            <div id="upload_size" class="upload-info upload-info__size"><span>{% trans "(Bestandsgrootte)" %}</span></div>
+                                            <div id="upload_error" class="upload-info upload-info__error">
+                                                <span>{% trans "Selecteer uw bestand opnieuw" %} {% icon icon="arrow_downward" outlined=True icon_position="before" %}</span></div>
+                                            <div id="upload_name" class="upload-info upload-info__name"></div>
+                                            <div id="upload_size" class="upload-info upload-info__size"></div>
                                         </div>
                                         <div class="close">{% button id="close_upload" icon="cancel" type='reset' text='' transparent=True icon_outlined=True icon_position="before" %}</div>
                                     </fieldset>


### PR DESCRIPTION
Add a message that tells the user to re-upload the document after a validation error (when user forgets to enter a document-title).
See discussion: https://taiga.maykinmedia.nl/project/open-inwoner/task/1433 

(Having to re-upload is standard HTML behaviour)