### PR TITLE
:lipstick: [#1493] Improve document-upload style and texts

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -463,7 +463,7 @@ class ActionListForm(forms.ModelForm):
 
 class CaseUploadForm(forms.Form):
     title = forms.CharField(
-        label=_("Titel bestand"), max_length=255, validators=[validate_charfield_entry]
+        label=_("Titel document"), max_length=255, validators=[validate_charfield_entry]
     )
     type = forms.ModelChoiceField(
         ZaakTypeInformatieObjectTypeConfig.objects.none(),

--- a/src/open_inwoner/components/templates/components/Form/Form.html
+++ b/src/open_inwoner/components/templates/components/Form/Form.html
@@ -27,7 +27,7 @@
     {% endif %}
 
     {% if show_required %}
-        <span class="caption__content" id="caption">{% trans "Velden gemarkeerd met een" %}<span class="label__label--required"> * </span>{% trans "zijn verplicht" %}</span>
+        <span class="caption__content" id="caption">{% trans "Velden gemarkeerd met een sterretje (" %}<span class="label__label--required">*</span>{% trans ") zijn verplicht" %}</span>
     {% endif %}
 
     {% if auto_render %}

--- a/src/open_inwoner/components/templates/components/Form/Form.html
+++ b/src/open_inwoner/components/templates/components/Form/Form.html
@@ -27,7 +27,11 @@
     {% endif %}
 
     {% if show_required %}
-        <span class="caption__content" id="caption">{% trans "Velden gemarkeerd met een sterretje (" %}<span class="label__label--required">*</span>{% trans ") zijn verplicht" %}</span>
+        <span class="caption__content" id="caption">
+        {% blocktrans trimmed with star='(<span class="label__label--required">*</span>)'|safe %}
+            Velden gemarkeerd met een sterretje {{star}} zijn verplicht
+        {% endblocktrans%}
+        </span>
     {% endif %}
 
     {% if auto_render %}

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -279,7 +279,7 @@ def file_input(file, text, **kwargs):
     Displaying a file upload interface.
 
     Usage:
-        {% file_input form.field text="Bestanden uploaden" %}
+        {% file_input form.field text="Document selecteren" %}
 
     Variables:
         + field: Field | The field that needs to be rendered.

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -279,7 +279,7 @@ def file_input(file, text, **kwargs):
     Displaying a file upload interface.
 
     Usage:
-        {% file_input form.field text="Document selecteren" %}
+        {% file_input form.field text=_('Document selecteren') %}
 
     Variables:
         + field: Field | The field that needs to be rendered.

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -660,7 +660,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
         )
 
         self.assertContains(
-            response, _("Grootte max. 50 MB, toegestane bestandsformaten")
+            response, _("Grootte max. 50 MB, toegestane document formaten:")
         )
 
     def test_upload_form_is_not_rendered_when_no_case_exists(self, m):

--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -28,6 +28,12 @@
     .close {
       display: block;
     }
+
+    .input-file {
+      .label__label--required {
+        display: none;
+      }
+    }
   }
 }
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -166,8 +166,10 @@
   }
 
   .label__label--required {
+    font-size: var(--font-size-body-large);
     color: var(--color-red);
     padding-left: var(--spacing-tiny);
+    vertical-align: sub;
     //make asterisks invisible by default, only make them visible if component has the caption
     display: none;
   }

--- a/src/open_inwoner/templates/pages/cases/status.html
+++ b/src/open_inwoner/templates/pages/cases/status.html
@@ -33,13 +33,13 @@
                 {% endif %}
 
                 {% if case.internal_upload_enabled %}
-                    <h2 class="h2" id=>{% trans "Document toevoegen" %}</h2>
+                    <h2 class="h2" id=>{% trans "Document uploaden" %}</h2>
                     {% if case.case_type_config_description %}
                         <p class="p">{{ case.case_type_config_description }}</p>
                     {% else %}
-                        <p class="p p--muted">
+                        <p class="p">
                             {% blocktranslate with max_filesize=openzaak_config.max_upload_size allowed_extensions=case.allowed_file_extensions|join:', ' %}
-                                Grootte max. {{ max_filesize }} MB, toegestane bestandsformaten {{ allowed_extensions }}.
+                                Grootte max. {{ max_filesize }} MB, toegestane document formaten: {{ allowed_extensions }}.
                             {% endblocktranslate %}
                         </p>
                     {% endif %}
@@ -70,10 +70,10 @@
 
                             <div class="form__control upload">
                                 <div class="upload__container">
-                                    {% file_input form.file text=_("Bestanden uploaden") no_label=False no_help=True extra_classes="file-upload" %}
+                                    {% file_input form.file text=_("Document selecteren") no_label=False no_help=True extra_classes="file-upload" %}
                                     <div class="form__submit">
                                         {% button_row %}
-                                            {% button type="submit" text=_("Document toevoegen") id="submit_upload" primary=True %}
+                                            {% button type="submit" text=_("Document uploaden") id="submit_upload" primary=True %}
                                         {% endbutton_row %}
                                     </div>
                                 </div>
@@ -90,7 +90,7 @@
                         <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
                     {% endif %}
                     {% button_row %}
-                        {% button href=case.external_upload_url text=_("Document toevoegen") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
+                        {% button href=case.external_upload_url text=_("Document uploaden") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
                     {% endbutton_row %}
                 {% endif %}
 


### PR DESCRIPTION
- [x] write out completely: 'Velden gemarkeerd met een sterretje (*) zijn verplicht.'
- [x] make asterisk bigger
- [x] remove asterisk next to upload-button
- [x] 'Bestanden uploaden' => Document selecteren'
- [x] 'Document toevoegen' => 'Document uploaden'
- [x] Allowed extensions text: 'bestandsformaat' => 'document formaat'
- [x] 'Titel bestand' => 'Titel document'
- [x] Allowed extensions text: make black instead of gray