### PR TITLE
:lipstick: [#1495] Make desktop navigation toggle

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -7,7 +7,7 @@
     <nav class="primary-navigation primary-navigation__authenticated" aria-label="Navigatie na inloggen">
         <ul class="primary-navigation__list">
             <li class="primary-navigation__list-item">
-            {% button text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+            {% button href="#" text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
 
                 <ul class="primary-navigation__list subpage-list">
                     {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -4,9 +4,10 @@
 
 <nav class="primary-navigation primary-navigation__main" aria-label="Hoofd navigatie">
     <ul class="primary-navigation__list">
+
         {% if cms_apps.products and categories %}
         <li class="primary-navigation__list-item">
-            {% button text=_('Onderwerpen') type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+            {% button href="#" text=_('Onderwerpen') type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
 
             {% if categories %}
                 <ul class="primary-navigation__list subpage-list">

--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -33,7 +33,7 @@ class Header extends Component {
       ) {
         this.setState({ open: !this.state.open })
         /**
-         * Remove focus from search in order to prevent keyboard on mobile
+         * Remove focus from search in order to prevent native keyboard on mobile
          */
         const blurInput = document.querySelectorAll(
           '.header__submenu .form .input'

--- a/src/open_inwoner/js/components/header/primary-navigation.js
+++ b/src/open_inwoner/js/components/header/primary-navigation.js
@@ -26,7 +26,6 @@ class PrimaryNavigation extends Component {
    */
   bindEvents() {
     this.node.addEventListener('click', this.toggleDesktopNavOpen.bind(this))
-    this.node.addEventListener('focusin', this.onFocusIn.bind(this))
     this.node.addEventListener('focusout', this.onFocusOut.bind(this))
     window.addEventListener('keyup', this.onKeyUp.bind(this))
   }
@@ -36,13 +35,7 @@ class PrimaryNavigation extends Component {
    * Clears the dismissed state, (prevents overriding focus/hover).
    * Focusin and Focusout are used instead of Focus for Safari
    */
-  onFocusIn() {
-    this.setState({ dismissed: false })
-    this.node.classList.add('primary-navigation--open')
-  }
   onFocusOut() {
-    this.setState({ dismissed: true })
-    this.node.blur()
     this.node.classList.remove('primary-navigation--open')
   }
 
@@ -50,10 +43,11 @@ class PrimaryNavigation extends Component {
    * Gets called when `node` is clicked.
    * Clears the dismissed state, (prevents overriding focus/toggle).
    */
-  toggleDesktopNavOpen(event) {
-    event.stopPropagation()
-    this.setState({ dismissed: false })
-    this.node.classList.add('primary-navigation--open')
+  toggleDesktopNavOpen() {
+    this.node.classList.toggle('primary-navigation--open')
+    // Safari specific
+    this.node.classList.remove('primary-navigation--dismissed')
+    this.node.classList.remove('primary-navigation__main--dismissed')
   }
 
   /**
@@ -83,10 +77,6 @@ class PrimaryNavigation extends Component {
 
     if (state.dismissed) {
       this.node.blur()
-      // Safari specific
-      navigationToggle.forEach((elem) => {
-        elem.blur()
-      })
 
       return this.node.querySelector('.primary-navigation--toggle')
     }

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -135,7 +135,7 @@
   }
 
   &.primary-navigation__authenticated {
-    button.button--transparent.primary-navigation--toggle {
+    .button.button--transparent.primary-navigation--toggle {
       display: inline-block;
       padding-right: var(--spacing-giant);
       width: 165px;
@@ -215,6 +215,13 @@
     }
   }
 
+  &--dismissed > &__list &__list-item &__list,
+  &__main--dismissed > &__list &__list-item &__list {
+    @media (min-width: 768px) {
+      transform: scaleY(0);
+    }
+  }
+
   /// Categories and authenticated nested list
 
   &__authenticated > &__list > &__list-item &__list {
@@ -233,20 +240,19 @@
 
   /// Interaction.
 
-  &:not(#{&}--dismissed) &__list-item:focus &__list,
-  &:not(#{&}--dismissed) &__list-item:focus-within &__list,
+  &:not(#{&}--dismissed) &__list-item &__list:focus-within,
   &:not(#{&}--dismissed)[class*='--open'] &__list-item &__list {
     transform: scaleY(1);
   }
-  &:not(#{&}--dismissed) &__list-item:focus,
-  &:not(#{&}--dismissed) &__list-item:focus-within {
+
+  &:not(#{&}--dismissed)[class*='--open'] &__list-item {
     // Open subpages
-    .button--transparent.primary-navigation--toggle {
+    .button.primary-navigation--toggle {
       color: var(--color-primary);
     }
   }
 
-  button.button--transparent.primary-navigation--toggle {
+  .button.button--transparent.primary-navigation--toggle {
     font-family: var(--font-family-body);
     font-size: var(--font-size-body);
     color: var(--font-color-body);
@@ -263,12 +269,13 @@
     &:focus,
     &:focus-visible,
     &:focus-within {
+      border: 2px solid orange;
       transform: translateY(0);
     }
   }
 
   &:not(#{&}--dismissed) &__list &__list-item:focus,
-  &:not(#{&}--dismissed) &__list &__list-item:focus-within {
+  &:not(#{&}--dismissed)[class*='--open'] &__list-item {
     // animate primary navigation dropdown icons
 
     .primary-navigation--toggle > [class*='icons'] {


### PR DESCRIPTION
- Click on the desktop menu to open, and click on the same menu to close
(make it work for both main menu and authenticated menu)
(while making Tab and Escape work)

Click outside desktop menu will also close it.