### PR TITLE
[#1509] fix template 'form.html'

### DIFF
--- a/src/open_inwoner/pdc/views.py
+++ b/src/open_inwoner/pdc/views.py
@@ -228,17 +228,6 @@ class ProductFormView(
             (_("Formulier"), self.request.path),
         ]
 
-    def get_context_data(self, **kwargs):
-        product = self.get_object()
-        context = super().get_context_data(**kwargs)
-
-        anchors = [
-            ("#title", product.name),
-        ]
-
-        context["anchors"] = anchors
-        return context
-
 
 class ProductFinderView(CommonPageMixin, FormView):
     template_name = "pages/product/finder.html"

--- a/src/open_inwoner/templates/pages/product/form.html
+++ b/src/open_inwoner/templates/pages/product/form.html
@@ -8,6 +8,9 @@
 
 {% endblock %}
 
+{% block sidebar_content %}
+{% endblock %}
+
 {% block content %}
 
     <h1 class="h1" id="title">
@@ -17,7 +20,6 @@
         {% endif %}
     </h1>
     {% tag tags=object.tags.all %}
-    <p class="p">{{ object.summary }}</p>
 
     {% if object.form %}
         {% openforms_form object.form  csp_nonce=request.csp_nonce %}


### PR DESCRIPTION
Removed sidebar and form overview from the form template so that they are no longer displayed once a form has been started.

Taiga: #1509