### PR TITLE
:bug: [#1467] Fix mobile navigation for old iOS devices

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -25,7 +25,7 @@
             </span>
         {% endif %}
 
-            <dialog class="header__submenu">
+            <div class="header__submenu">
 
             {% if cms_apps.products %}
             <nav class="header__actions" aria-label="Zoek navigatie mobiel">
@@ -96,7 +96,7 @@
                 </section>
 
 
-            </dialog>
+            </div>
         </div>
 {#end of mobile menu#}
 

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -7,7 +7,7 @@
     <nav class="primary-navigation primary-navigation__authenticated" aria-label="Navigatie na inloggen">
         <ul class="primary-navigation__list">
             <li class="primary-navigation__list-item">
-            {% button href="#" text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+            {% button text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
 
                 <ul class="primary-navigation__list subpage-list">
                     {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}

--- a/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
+++ b/src/open_inwoner/components/templates/components/Header/PrimaryNavigation.html
@@ -7,7 +7,7 @@
 
         {% if cms_apps.products and categories %}
         <li class="primary-navigation__list-item">
-            {% button href="#" text=_('Onderwerpen') type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+            {% button text=_('Onderwerpen') type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
 
             {% if categories %}
                 <ul class="primary-navigation__list subpage-list">

--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -2,93 +2,95 @@ import BEM from 'bem.js'
 import { Component } from '../abstract/component'
 
 /** @type {string} Header block name. */
-export const BLOCK_HEADER = 'header'
-
-/** @type {string} Button element name. */
-export const ELEMENT_BUTTON = 'button'
-
-/** @type {string} Menu element name. */
-export const ELEMENT_SUBMENU = 'submenu'
+export const BLOCK_HEADER = 'header__button'
 
 /** @type {string} Modifier describing open state. */
-export const MODIFIER_OPEN = 'open'
+export const MODIFIER_DISMISSED = 'dismissed'
 
-/** @type {NodeList<HTMLElement>} Button element name. */
+/** @type {NodeList<HTMLElement>} The primary navigation block name. */
 export const HEADERS = BEM.getBEMNodes(BLOCK_HEADER)
 
+/** Handler to bypass Safari bug */
+export const themesToggle = document.querySelectorAll('.dropdown-nav__toggle')
+
 /**
- * Controls the main header and interaction with the mobile menu.
+ * Controls the main header and interaction with the mobile menu and dismissing it using the escape key.
  */
 class Header extends Component {
   /**
    * Binds events to callbacks.
    * Callbacks should trigger `setState` which in turn triggers `render`.
+   * Focus is split to be handled in Safari
    */
   bindEvents() {
-    this.node.addEventListener('keyup', this.onKeyUp.bind(this))
     this.node.addEventListener('click', (e) => {
-      if (
-        e.target.matches('.header__button') ||
-        e.target.matches('.header__button *')
-      ) {
-        this.setState({ open: !this.state.open })
-        /**
-         * Remove focus from search in order to prevent native keyboard on mobile
-         */
-        const blurInput = document.querySelectorAll(
-          '.header__submenu .form .input'
-        )
-        blurInput.forEach((elem) => {
-          elem.blur()
-        })
-      }
+      /**
+       * Remove focus from search in order to prevent native keyboard on mobile
+       */
+      const blurInput = document.querySelectorAll(
+        '.header__submenu .form .input'
+      )
+      blurInput.forEach((elem) => {
+        elem.blur()
+      })
     })
+    this.node.addEventListener('click', this.toggleMobileNavOpen.bind(this))
+    this.node.addEventListener('focusout', this.onFocusMobileOut.bind(this))
+    window.addEventListener('keyup', this.onEscape.bind(this))
   }
 
   /**
-   * Return the menu button.
-   * @returns {HTMLButtonElement}
+   * Gets called when `node` receives focus -in or -out events.
+   * Clears the dismissed state, (prevents overriding focus/hover).
+   * Focusin and Focusout are used instead of Focus for Safari
    */
-  getButton() {
-    return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_BUTTON)
+  onFocusMobileOut() {
+    // Safari specific
+    this.setState({ dismissed: true })
   }
+
   /**
-   * Returns the menu controlled by the button.
-   * @returns {HTMLDialogElement}
+   * Gets called when `node` is clicked.
+   * Clears the dismissed state, (prevents overriding focus/toggle).
    */
-  getSubMenu() {
-    return BEM.getChildBEMNode(this.node, BLOCK_HEADER, ELEMENT_SUBMENU)
+  toggleMobileNavOpen(event) {
+    document.body.classList.toggle('body--open')
+    // Safari specific - close all when main menu closes
+    themesToggle.forEach((elem) => {
+      elem.classList.remove('nav__list--open')
+    })
+    window.scrollTo(0, 0)
   }
+
   /**
    * Gets called when a key is released.
    * If key is escape key, explicitly close the mobile menu.
-   * @param {KeyboardEvent} event
+   //* @param {KeyboardEvent} event
    */
-  onKeyUp(event) {
+  onEscape(event) {
     if (event.key === 'Escape') {
-      this.setState({ open: false })
+      this.setState({ dismissed: true })
+      this.node.blur()
+      document.body.classList.remove('body--open')
     }
   }
 
   /**
    * Persists state to DOM.
    * Rendering should be one-way traffic and not inspect any current values in DOM.
-   * @param {Object} state State to render.
+   //* @param {Object} state State to render.
    */
   render(state) {
     document.body.classList.add('body')
-    BEM.toggleModifier(document.body, MODIFIER_OPEN, state.open)
-    BEM.toggleModifier(this.getButton(), MODIFIER_OPEN, state.open)
+    BEM.toggleModifier(this.node, MODIFIER_DISMISSED, state.dismissed)
 
-    if (matchMedia('(max-width: 767px)').matches) {
-      state.open ? this.getSubMenu().show() : this.getSubMenu().close()
-    }
+    if (state.dismissed) {
+      this.node.blur()
 
-    if (state.open) {
-      window.scrollTo({ x: 0, y: 0 })
+      return this.node.querySelector('.header__button')
     }
   }
 }
 
 // Start!
-;[...HEADERS].forEach((node) => new Header(node, { open: false }))
+;[...HEADERS].forEach((node) => new Header(node, { dismissed: false }))

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -218,6 +218,7 @@ $vm: var(--spacing-large);
     bottom: 0;
     background-color: var(--color-white);
     box-sizing: border-box;
+    display: none;
     height: 100%;
     left: 0;
     margin: 0;
@@ -228,6 +229,7 @@ $vm: var(--spacing-large);
       var(--spacing-large);
     position: fixed;
     right: 0;
+    text-align: left;
     top: calc(2 * var(--row-height));
     width: 100%;
     z-index: 2;
@@ -500,6 +502,7 @@ $vm: var(--spacing-large);
       .header {
         &__submenu {
           border-top: 1px solid var(--color-white);
+          display: block;
 
           .primary-navigation {
             border-bottom: 1px solid var(--color-gray-light);
@@ -560,7 +563,7 @@ $vm: var(--spacing-large);
         width: 100%;
         flex-direction: row-reverse;
         flex-wrap: nowrap;
-        justify-content: start;
+        justify-content: flex-end;
       }
     }
   }

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -35,7 +35,7 @@
     display: flex;
     align-items: center;
     flex-direction: column;
-    justify-content: start;
+    justify-content: flex-start;
     min-height: var(--row-height);
     overflow: hidden;
     padding: 0;
@@ -266,9 +266,12 @@
     &:hover {
       transform: translateY(0);
     }
+
     &:focus,
     &:focus-visible,
     &:focus-within {
+      border-radius: var(--border-radius-large);
+      margin: 0 3px 0 0;
       transform: translateY(0);
     }
   }

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -55,7 +55,7 @@
   --color-primary-lighter: hsl(
     var(--color-primary-h),
     var(--color-primary-s),
-    calc(var(--color-primary-l) + 10%)
+    calc(var(--color-primary-l) + 30%)
   );
   --color-secondary-h: 207;
   --color-secondary-s: 80%;

--- a/src/open_inwoner/scss/views/_body.scss
+++ b/src/open_inwoner/scss/views/_body.scss
@@ -1,5 +1,6 @@
 .body--open {
   overflow: hidden;
+  position: fixed;
 
   @media (min-width: 768px) {
     height: auto;


### PR DESCRIPTION
See if navigation can be fixed for old iPhones that cannot be updated anymore to use any iOS since 15.4
(in order to make dialog tag work)
solution: replace dialog tag  with div and change flexbox styles.

I have simplified javascript too - perhaps too simple this time? Needs review.