### PR TITLE
:lipstick: [#1498] Add missing icons to plan-edit actions view

### DIFF
--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -43,13 +43,18 @@ input[type='file'] {
   color: var(--color-primary-lighter);
   border: 1px solid var(--color-mute);
   border-radius: var(--border-radius);
-  display: flex;
-  flex-direction: column;
-  min-width: var(--mobile-xs-width);
+  display: inline-block;
+  min-width: 100%;
   max-width: 500px;
   padding: 0;
   overflow: hidden;
   cursor: pointer;
+
+  @media (min-width: 768px) {
+    display: flex;
+    flex-direction: column;
+    min-width: 500px;
+  }
 }
 
 /// File-input button site wide
@@ -69,7 +74,11 @@ input[type='file']::file-selector-button {
   white-space: nowrap;
   padding: 0 12px 0 12px;
   margin: 0 12px 0 0;
-  width: 200px;
+  width: 150px;
+
+  @media (min-width: 768px) {
+    width: 200px;
+  }
 }
 
 .button-row .upload-button--disabled {

--- a/src/open_inwoner/scss/components/Form/DocumentUpload.scss
+++ b/src/open_inwoner/scss/components/Form/DocumentUpload.scss
@@ -45,7 +45,7 @@ input[type='file'] {
   border-radius: var(--border-radius);
   display: inline-block;
   min-width: 100%;
-  max-width: 500px;
+  max-width: var(--form-width);
   padding: 0;
   overflow: hidden;
   cursor: pointer;
@@ -53,7 +53,7 @@ input[type='file'] {
   @media (min-width: 768px) {
     display: flex;
     flex-direction: column;
-    min-width: 500px;
+    min-width: var(--form-width);
   }
 }
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -103,7 +103,7 @@
   @media (min-width: 360px) {
     &__control > .label .input,
     &__control > .label .input[type='file'] {
-      max-width: 500px;
+      max-width: var(--form-width);
     }
   }
 

--- a/src/open_inwoner/scss/components/Notification/_Notifications.scss
+++ b/src/open_inwoner/scss/components/Notification/_Notifications.scss
@@ -13,7 +13,7 @@
     top: 0;
     gap: 0;
     width: 100%;
-    max-width: 500px;
+    max-width: var(--form-width);
     margin: -2px var(--spacing-small) 0 0;
     padding: 0 0 var(--spacing-small) 0;
     border: none;

--- a/src/open_inwoner/scss/components/Plan/PlanCreate.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanCreate.scss
@@ -2,7 +2,7 @@
   .form__control {
     .label {
       position: relative;
-      max-width: 500px;
+      max-width: var(--form-width);
     }
 
     [class*='icon'] {

--- a/src/open_inwoner/scss/components/Plan/PlanCreate.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanCreate.scss
@@ -1,0 +1,12 @@
+.plan-create {
+  .form__control {
+    .label {
+      position: relative;
+      max-width: 500px;
+    }
+
+    [class*='icon'] {
+      right: 10px;
+    }
+  }
+}

--- a/src/open_inwoner/scss/components/Plan/PlanEdit.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanEdit.scss
@@ -1,6 +1,6 @@
 .plan-edit {
   .form {
-    max-width: 500px;
+    max-width: var(--form-width);
     .form__control [class*='icon'] {
       transform: initial;
     }
@@ -14,7 +14,7 @@
           min-width: 100%;
         }
         .input {
-          max-width: 500px;
+          max-width: var(--form-width);
         }
       }
     }

--- a/src/open_inwoner/scss/components/Plan/PlanEdit.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanEdit.scss
@@ -1,0 +1,22 @@
+.plan-edit {
+  .form {
+    max-width: 500px;
+    .form__control [class*='icon'] {
+      transform: initial;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .form {
+      max-width: 100%;
+      .form__control > .label {
+        input[type='file'] {
+          min-width: 100%;
+        }
+        .input {
+          max-width: 500px;
+        }
+      }
+    }
+  }
+}

--- a/src/open_inwoner/scss/components/_index.scss
+++ b/src/open_inwoner/scss/components/_index.scss
@@ -58,6 +58,8 @@
 @import './Notification/Notifications.scss';
 @import './Pagination/Pagination.scss';
 @import './Plan/PlanContact.scss';
+@import './Plan/PlanCreate.scss';
+@import './Plan/PlanEdit.scss';
 @import './Plan/PlanFile.scss';
 @import './Plan/PlanList.scss';
 @import './Product/product-filter.scss';

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -235,6 +235,9 @@
   --spacing-large: 16px;
   --spacing-extra-large: 24px;
   --spacing-giant: 32px;
+
+  /// Common widths
+  --form-width: 500px;
 }
 
 @font-face {

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -2,77 +2,79 @@
 {% load i18n button_tags card_tags map_tags form_tags grid_tags icon_tags string_tags link_tags %}
 
 {% block content %}
-    <h1 class="h1">{% trans "Samenwerken" %}</h1>
-    {% optional_paragraph configurable_text.plans_page.plans_intro %}
+    <div class="plan-create">
+        <h1 class="h1">{% trans "Start nieuwe samenwerking" %}</h1>
+        {% optional_paragraph configurable_text.plans_page.plans_intro %}
 
-    {% if request.user.get_active_contacts %}
-        {% render_form id="plan-form" form=form method="POST" %}
-        {% csrf_token %}
-        {% input form.title %}
-        {% input form.goal %}
-        {% input form.description %}
-        {% render_grid %}
-        {% checkboxes form.plan_contacts %}
-        {% date_field form.end_date %}
-        {% endrender_grid %}
+        {% if request.user.get_active_contacts %}
+            {% render_form id="plan-form" form=form method="POST" %}
+            {% csrf_token %}
+            {% input form.title %}
+            {% input form.goal %}
+            {% input form.description %}
+            {% render_grid %}
+            {% checkboxes form.plan_contacts %}
+            {% date_field form.end_date icon="today" icon_position="after" %}
+            {% endrender_grid %}
 
-        <div class="">
-            <div class="plan-template">
-                <div class="plan-template__header">
-                    <div>{% trans "Templates" %}</div>
-                    <div>{% trans "Doel" %}</div>
-                    <div></div>
-                </div>
-                <label class="plan-template__row radio">
-                    <div>
-                        <input class="radio__input" type="radio" name="template" value="" id="id_template_0" {% if not form.data.template %}checked{% endif %}>
-                        <label class="radio__label" for="id_template_0">Geen template</label>
+            <div class="">
+                <div class="plan-template">
+                    <div class="plan-template__header">
+                        <div>{% trans "Templates" %}</div>
+                        <div>{% trans "Doel" %}</div>
+                        <div></div>
                     </div>
-                    <div></div>
-                    <div></div>
-                </label>
-                {% for tpl_id, plan_template in form.template.field.choices %}
                     <label class="plan-template__row radio">
                         <div>
-                            <input class="radio__input" type="radio" name="template" value="{{ plan_template.id }}" id="id_template_{{ plan_template.id }}"
-                                   {% if tpl_id == form.data.template %}checked{% endif %}>
-                            <label class="radio__label" for="id_template_{{ plan_template.id }}">{{ plan_template.name }}</label>
+                            <input class="radio__input" type="radio" name="template" value="" id="id_template_0" {% if not form.data.template %}checked{% endif %}>
+                            <label class="radio__label" for="id_template_0">Geen template</label>
                         </div>
-                        <div>
-                            {{ plan_template.goal|truncatewords:8 }}
-                        </div>
-                        <div class="plan-template__icon">
-                            <div class="show-preview" data-id="template-{{ plan_template.id }}">
-                                {% icon icon="visibility" outlined=True %}
+                        <div></div>
+                        <div></div>
+                    </label>
+                    {% for tpl_id, plan_template in form.template.field.choices %}
+                        <label class="plan-template__row radio">
+                            <div>
+                                <input class="radio__input" type="radio" name="template" value="{{ plan_template.id }}" id="id_template_{{ plan_template.id }}"
+                                       {% if tpl_id == form.data.template %}checked{% endif %}>
+                                <label class="radio__label" for="id_template_{{ plan_template.id }}">{{ plan_template.name }}</label>
                             </div>
-                        </div>
-                        <div class="modal modal--no-reset" id="template-{{ plan_template.id }}">
-                            <div class="modal__container">
-                                <h2 class="h2 modal__title" id="modal__title">{{ plan_template.name }}
-                                    {% button text=_("Sluiten") hide_text=True icon="close" extra_classes="modal__button modal__close-title" %}
-                                </h2>
-                                <div class="modal__text" id="modal__text">{{ plan_template.string_preview }}</div>
-                                <div class="modal__actions modal__actions--align-right" id="modal__actions">
-                                    {% spaceless %}
-                                        {% button text=_("Sluiten") extra_classes="modal__button modal__close" primary=True %}
-                                    {% endspaceless %}
+                            <div>
+                                {{ plan_template.goal|truncatewords:8 }}
+                            </div>
+                            <div class="plan-template__icon">
+                                <div class="show-preview" data-id="template-{{ plan_template.id }}">
+                                    {% icon icon="visibility" outlined=True %}
                                 </div>
                             </div>
-                        </div>
-                    </label>
-                {% endfor %}
-            </div>
+                            <div class="modal modal--no-reset" id="template-{{ plan_template.id }}">
+                                <div class="modal__container">
+                                    <h2 class="h2 modal__title" id="modal__title">{{ plan_template.name }}
+                                        {% button text=_("Sluiten") hide_text=True icon="close" extra_classes="modal__button modal__close-title" %}
+                                    </h2>
+                                    <div class="modal__text" id="modal__text">{{ plan_template.string_preview }}</div>
+                                    <div class="modal__actions modal__actions--align-right" id="modal__actions">
+                                        {% spaceless %}
+                                            {% button text=_("Sluiten") extra_classes="modal__button modal__close" primary=True %}
+                                        {% endspaceless %}
+                                    </div>
+                                </div>
+                            </div>
+                        </label>
+                    {% endfor %}
+                </div>
 
-            {% if form.template.errors %}
-                {% errors errors=form.template.errors %}
-            {% endif %}
-        </div>
-        {% form_actions primary_text=_("Verzenden") primary_icon="arrow_forward" %}
-    {% endrender_form %}
-    {% else %}
-        <div class="p">
-            {% url 'profile:contact_create' as contact_create %}
-            {% link href=contact_create text=_("Maak je eerste contact aan voordat je een samenwerking start") icon="arrow_forward" icon_position="after" primary=True %}
-        </div>
-    {% endif %}
+                {% if form.template.errors %}
+                    {% errors errors=form.template.errors %}
+                {% endif %}
+            </div>
+            {% form_actions primary_text=_("Verzenden") primary_icon="arrow_forward" %}
+        {% endrender_form %}
+        {% else %}
+            <div class="p">
+                {% url 'profile:contact_create' as contact_create %}
+                {% link href=contact_create text=_("Maak je eerste contact aan voordat je een samenwerking start") icon="arrow_forward" icon_position="after" primary=True %}
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/src/open_inwoner/templates/pages/profile/actions/edit.html
+++ b/src/open_inwoner/templates/pages/profile/actions/edit.html
@@ -3,27 +3,29 @@
 
 
 {% block content %}
-<h1 class="h1">
-    {% if object.pk %}
-        {% trans "Wijzig actie" %}
-    {% else %}
-        {% trans "Creeer actie" %}
-    {% endif %}
-</h1>
+    <div class="plan-edit">
+        <h1 class="h1">
+            {% if object.pk %}
+                {% trans "Wijzig actie" %}
+            {% else %}
+                {% trans "Creeer actie" %}
+            {% endif %}
+        </h1>
 
-{% render_form id="action-create" form=form method="POST" enctype="multipart/form-data" %}
-    {% csrf_token %}
-    {% input form.name no_help=True %}
-    {% input form.description no_help=True %}
-    {% render_grid %}
-        {% input form.status no_help=True %}
-        {% date_field form.end_date no_help=True %}
-    {% endrender_grid %}
-    {% render_grid %}
-        {% input form.is_for no_help=True %}
-        {% input form.file no_help=True %}
-    {% endrender_grid %}
+        {% render_form id="action-create" form=form method="POST" enctype="multipart/form-data" %}
+            {% csrf_token %}
+            {% input form.name no_help=True %}
+            {% input form.description no_help=True %}
+            {% render_grid %}
+                {% input form.status no_help=True icon="expand_more" icon_position="after" %}
+                {% date_field form.end_date no_help=True icon="today" icon_position="after" %}
+            {% endrender_grid %}
+            {% render_grid %}
+                {% input form.is_for no_help=True icon="person" icon_position="after" %}
+                {% input form.file no_help=True icon="file_upload" outlined=True icon_position="after" %}
+            {% endrender_grid %}
 
-    {% form_actions primary_text=_("Actie opslaan") %}
-{% endrender_form %}
+            {% form_actions primary_text=_("Actie opslaan") %}
+        {% endrender_form %}
+    </div>
 {% endblock content %}


### PR DESCRIPTION
Make the edit-plan/add-Action look like: 
https://projects.invisionapp.com/share/XP134RWRK3MG#/screens/471522253 
Also there is another page that has missing icons (Start nieuwe samenwerking):
https://projects.invisionapp.com/share/XP134RWRK3MG#/screens/471522250 

Note: due to adding extra class I had to change indentation of the templates.