### PR TITLE
:zap:  [#1485] Hide extra expiration warning before DigiD session ends

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1265,7 +1265,7 @@ class TestLoginLogoutFunctionality(AssertRedirectsMixin, WebTest):
         """Test that a user is able to log out and page redirects to root endpoint."""
         # Log out user and redirection
         logout_response = self.app.get(reverse("logout"), user=self.user)
-        self.assertRedirects(logout_response, reverse("pages-root"))
+        self.assertRedirects(logout_response, reverse("login"))
         self.assertFalse(logout_response.follow().context["user"].is_authenticated)
 
 

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -526,7 +526,7 @@ class ProfileDeleteTest(WebTest):
         # check redirect
         self.assertRedirects(
             self.app.get(response.url),
-            reverse("pages-root"),
+            reverse("login"),
             status_code=302,
             target_status_code=200,
             fetch_redirect_response=True,
@@ -545,7 +545,7 @@ class ProfileDeleteTest(WebTest):
         # check redirect
         self.assertRedirects(
             self.app.get(response.url),
-            reverse("pages-root"),
+            reverse("login"),
             status_code=302,
             target_status_code=200,
             fetch_redirect_response=True,

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -482,10 +482,10 @@ ADMIN_SESSION_COOKIE_AGE = config(
     "ADMIN_SESSION_COOKIE_AGE", 3600
 )  # Default 1 hour max session duration for admins
 SESSION_WARN_DELTA = 60  # Warn 1 minute before end of session.
-SESSION_COOKIE_AGE = 900  # Set to 15 minutes
+SESSION_COOKIE_AGE = 900  # Set to 15 minutes or less for testing
 
 LOGIN_REDIRECT_URL = "/"
-LOGOUT_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/accounts/login/"
 
 #
 # SECURITY settings

--- a/src/open_inwoner/js/components/modal/index.js
+++ b/src/open_inwoner/js/components/modal/index.js
@@ -30,14 +30,8 @@ export default class Modal {
   }
 
   setListeners() {
-    this.node.addEventListener('click', (event) => {
-      event.preventDefault()
-      this.hide()
-    })
-
     this.close.addEventListener('click', (event) => {
       event.preventDefault()
-
       this.hide()
     })
 

--- a/src/open_inwoner/js/components/session/index.js
+++ b/src/open_inwoner/js/components/session/index.js
@@ -33,21 +33,17 @@ class SessionTimeout {
       this.warnTime * 1000
     )
     this.expiredTimeout = setTimeout(
-      this.showExpiredModal,
+      this.showExpiredModal.bind(this),
       (this.expiryAge + 1) * 1000
     )
   }
 
   setDataset() {
-    console.log('setDataset')
     this.expiryAge = parseInt(this.element.dataset.expiryAge)
     this.warnTime = parseInt(this.element.dataset.warnTime)
-    console.log('this.expiryAge', this.expiryAge)
-    console.log('this.warnTime', this.warnTime)
   }
 
   showWarningModal() {
-    console.log('showWarningModal')
     if (this.userActive) {
       this.restartSession()
       return
@@ -113,6 +109,7 @@ class SessionTimeout {
       this.restartNoActivity.bind(this),
       30 * 1000
     )
+    // SESSION_COOKIE_AGE in seconds - (minus) 30 = warnTime
   }
 
   restartNoActivity() {


### PR DESCRIPTION
https://taiga.maykinmedia.nl/project/open-inwoner/issue/1485

**_Note: can only be reproduced when logging in as a DigiD user!
and only works when clicking the buttons - not by clicking outside modal_** so clicking outside the buttons needs to be removed.

Explanation: clicking outside the modal, closes it, but also bypasses any necessary Confirm/Submit.

1. There is one warning that needs to stay (14 minutes in - but it has to disappear after 15 minutes, which it doesn't right now):
<img width="1406" alt="Screenshot 2023-06-08 at 11 50 26" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/cc31bc7f-f97a-45ec-b857-ef4cd8333799">

2. This one needs to stay - it appears after 15 minutes of inactivity - if this one is clicked, it should redirect to the LOGIN page, not to the Home page:
<img width="1473" alt="Screenshot 2023-06-08 at 11 47 02" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/0a6fa760-eba5-4a75-a6ea-9576e1538534">

But if you keep on having inactivity after more than 15 minutes the first modal needs to be invisible (the first one pops up after clicking the second one again, should not happen).
