### PR TITLE
[#1505] upgrade django-digid-eherkenning to 0.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -136,7 +136,6 @@ django-better-admin-arrayfield==1.4.2
 django-choices==1.7.2
     # via
     #   -r requirements/base.in
-    #   django-digid-eherkenning
     #   mail-editor
 django-ckeditor==6.2.0
     # via mail-editor
@@ -161,7 +160,7 @@ django-csp==3.7
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning==0.4.1
+django-digid-eherkenning==0.7.0
     # via -r requirements/base.in
 django-elasticsearch-dsl==7.2.1
     # via -r requirements/base.in
@@ -232,12 +231,15 @@ django-sessionprofile==1.0
     #   -r requirements/base.in
     #   django-digid-eherkenning
 django-simple-certmanager==1.3.0
-    # via zgw-consumers
+    # via
+    #   django-digid-eherkenning
+    #   zgw-consumers
 django-sniplates==0.7.0
     # via -r requirements/base.in
 django-solo==1.2.0
     # via
     #   -r requirements/base.in
+    #   django-digid-eherkenning
     #   django-open-forms-client
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -357,7 +359,9 @@ markuppy==1.14
 maykin-django-two-factor-auth==2.0.4
     # via -r requirements/base.in
 maykin-python3-saml==1.14.0.post0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   django-digid-eherkenning
 messagebird==2.1.0
     # via -r requirements/base.in
 mozilla-django-oidc==2.0.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -210,7 +210,6 @@ django-choices==1.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-digid-eherkenning
     #   mail-editor
 django-ckeditor==6.2.0
     # via
@@ -249,7 +248,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.4.1
+django-digid-eherkenning==0.7.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -383,6 +382,7 @@ django-simple-certmanager==1.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   zgw-consumers
 django-sniplates==0.7.0
     # via
@@ -392,6 +392,7 @@ django-solo==1.2.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-open-forms-client
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -628,6 +629,7 @@ maykin-python3-saml==1.14.0.post0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
 mccabe==0.6.1
     # via pylint
 messagebird==2.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -235,7 +235,6 @@ django-choices==1.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-digid-eherkenning
     #   mail-editor
 django-ckeditor==6.2.0
     # via
@@ -276,7 +275,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-digid-eherkenning==0.4.1
+django-digid-eherkenning==0.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -412,6 +411,7 @@ django-simple-certmanager==1.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   zgw-consumers
 django-sniplates==0.7.0
     # via
@@ -421,6 +421,7 @@ django-solo==1.2.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   django-open-forms-client
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -686,6 +687,7 @@ maykin-python3-saml==1.14.0.post0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
 mccabe==0.6.1
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
The upgrade should remove the intermediate screen shown when logging in via DigiD.

Taiga: 1505