### PR TITLE
:bug: [#1523] Set empty confirmation text for file-deletion modal

### DIFF
--- a/src/open_inwoner/js/components/confirmation/index.js
+++ b/src/open_inwoner/js/components/confirmation/index.js
@@ -13,7 +13,8 @@ class Confirmation {
       const modalId = document.getElementById('modal')
       const modal = new Modal(modalId)
       modal.setTitle(this.form.dataset.confirmTitle)
-      modal.setText(this.form.dataset.confirmText)
+      // Only show confirmation if text is set
+      modal.setText(this.form.dataset.confirmText || '')
       modal.setClose(this.form.dataset.confirmCancel)
       modal.setConfirm(
         this.form.dataset.confirmDefault,


### PR DESCRIPTION
If the text is not set or if it is an empty string - do not make it render as "undefined" but rather as an empty string in the modal.
<img width="1298" alt="Screenshot 2023-06-08 at 09 52 32" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/7fb11caf-2c75-47f5-96b6-1c744e1dac26">
