### PR TITLE
:lipstick: [#1529] Improve contact-form styles

### DIFF
--- a/src/open_inwoner/components/templates/components/Contact/ContactForm.html
+++ b/src/open_inwoner/components/templates/components/Contact/ContactForm.html
@@ -1,9 +1,35 @@
-{% load i18n form_tags %}
+{% load i18n form_tags grid_tags %}
 
-<div class="contactform__content">
-    {% if has_form_configuration %}
-        {% form form_object=form_object method="POST" id="contactmoment-form" submit_text=_('Verzenden') %}
-    {% else %}
-        <p class="p">{% trans "Contact formulier niet geconfigureerd." %}</p>
-    {% endif %}
-</div>
+{% render_grid %}
+    {% render_column start=1 span=6 %}
+        <div class="contactform__content">
+        {% if has_form_configuration %}
+
+            {% render_form form=form_object method="POST" id="contactmoment-form" show_required=True submit_text=_('Verzenden') %}
+                {% csrf_token %}
+                {% input form_object.subject icon="expand_more" icon_position="after" icon_outlined=True %}
+                {% if form_object.first_name %}
+                    {% input form_object.first_name %}
+                {% endif %}
+                {% if form_object.infix %}
+                    {% input form_object.infix %}
+                {% endif %}
+                {% if form_object.last_name %}
+                    {% input form_object.last_name %}
+                {% endif %}
+                {% if form_object.email %}
+                    {% input form_object.email %}
+                {% endif %}
+                {% if form_object.phonenumber %}
+                    {% input form_object.phonenumber %}
+                {% endif %}
+                {% input form_object.question %}
+                {% form_actions primary_text=_("Verzenden") primary_icon="arrow_forward" %}
+            {% endrender_form %}
+
+        {% else %}
+            <p class="p">{% trans "Contact formulier niet geconfigureerd." %}</p>
+        {% endif %}
+        </div>
+    {% endrender_column %}
+{% endrender_grid %}

--- a/src/open_inwoner/components/templatetags/contact_tags.py
+++ b/src/open_inwoner/components/templatetags/contact_tags.py
@@ -14,7 +14,7 @@ def contact_form(form_object, **kwargs):
         {% contact_form form_object %}
 
     Variables:
-        + form_object: Form | the form that need to be rendered.
+        + form_object: Form | the form that needs to be rendered.
     """
     config = OpenKlantConfig.get_solo()
     return {

--- a/src/open_inwoner/openklant/forms.py
+++ b/src/open_inwoner/openklant/forms.py
@@ -12,6 +12,7 @@ class ContactForm(Form):
         label=_("Onderwerp"),
         required=True,
         queryset=ContactFormSubject.objects.none(),
+        empty_label=_("Selecteren"),
     )
     first_name = forms.CharField(
         label=_("Voornaam"),

--- a/src/open_inwoner/scss/components/ContactForm/ContactForm.scss
+++ b/src/open_inwoner/scss/components/ContactForm/ContactForm.scss
@@ -1,0 +1,22 @@
+.contactform__content {
+  .form {
+    /// Make required asterisk visible for this component
+    .label__label--required {
+      color: var(--color-red);
+      padding-left: var(--spacing-tiny);
+      //make asterisks invisible by default, only make them visible if component has the caption
+      display: inline;
+    }
+
+    .form__control [class*='icon'] {
+      transform: translateY(0);
+    }
+
+    // tablet sizes
+    @media screen and (min-width: 360px) and (max-width: 768px) {
+      &__control > .label .input {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/src/open_inwoner/scss/components/Form/Input.scss
+++ b/src/open_inwoner/scss/components/Form/Input.scss
@@ -29,7 +29,3 @@
     color: var(--color-gray-lighter);
   }
 }
-
-textarea.input {
-  height: auto;
-}

--- a/src/open_inwoner/scss/components/Form/Select.scss
+++ b/src/open_inwoner/scss/components/Form/Select.scss
@@ -1,6 +1,6 @@
 .select {
   /// Resets.
-  /// TODO: RESET AND SET CHEVRON BACKGROUND IMAGE
+  /// RESET AND SET CHEVRON BACKGROUND IMAGE
   //appearance: none;
   //-moz-appearance: none;
   //-webkit-appearance: none;
@@ -16,7 +16,31 @@
   padding: var(--spacing-medium) var(--spacing-large);
 
   /// font.
-  color: var(--font-color-body);
   font-family: var(--font-family-body);
   font-size: var(--font-size-body);
+
+  &,
+  &.input {
+    // cross-browser styling
+    &:required:invalid {
+      color: var(--color-mute);
+    }
+    // Windows only
+    option,
+    option:checked {
+      color: var(--font-color-body);
+    }
+  }
+}
+
+// add defaults
+select {
+  &:required:invalid {
+    color: var(--color-mute);
+  }
+  // Windows only
+  option,
+  option:checked {
+    color: var(--font-color-body);
+  }
 }

--- a/src/open_inwoner/scss/components/Form/Textarea.scss
+++ b/src/open_inwoner/scss/components/Form/Textarea.scss
@@ -18,4 +18,17 @@
   color: var(--font-color-body);
   font-family: var(--font-family-body);
   font-size: var(--font-size-body);
+
+  &.input {
+    height: auto;
+  }
+}
+
+// add defaults
+textarea {
+  &.input {
+    max-width: var(--form-width);
+    width: 100%;
+    height: auto;
+  }
 }

--- a/src/open_inwoner/scss/components/_index.scss
+++ b/src/open_inwoner/scss/components/_index.scss
@@ -8,6 +8,7 @@
 @import './CardContainer/CardContainer.scss';
 @import './Cases/Cases.scss';
 @import './Condition/Condition.scss';
+@import './ContactForm/ContactForm.scss';
 @import './Contactmomenten/Contactmomenten.scss';
 @import './Contacts/Contacts.scss';
 @import './Container/Container.scss';

--- a/src/open_inwoner/templates/pages/contactform/form.html
+++ b/src/open_inwoner/templates/pages/contactform/form.html
@@ -1,6 +1,9 @@
 {% extends 'master.html' %}
-{% load contact_tags %}
+{% load i18n contact_tags %}
 
 {% block content %}
+    <h1 class="h1">
+        {% trans "Contactformulier" %}
+    </h1>
 {% contact_form form_object=form %}
 {% endblock content %}


### PR DESCRIPTION
Contact form needs icon in select + different placeholder text, and styles for textarea.
https://projects.invisionapp.com/share/UF134RWMWCK8#/screens/471596624
In order to just change the Select styles, I needed to break open the form and turn it into a render_form.

Side Note: all Selects in the entire projects should 'actually' have a muted style, but it is impossible to do this with CSS if all fields have a value AND are not 'required' (or else all of the Options inside the Select will look muted) - **only required and invalid values can be targeted with CSS across most common browsers**.
"...The problem is that these elements have very different default looks across browsers, and while you can style them in some ways, some parts of their internals are literally impossible to style..." (new issue nr.#1556)