### PR TITLE
:lipstick: [#1528] Make cards responsive for very large desktop screens

### DIFF
--- a/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
+++ b/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
@@ -18,7 +18,17 @@
     }
 
     &--columns-4 {
-      grid-template-columns: repeat(auto-fit, 228px);
+      grid-template-columns: repeat(
+        auto-fit,
+        calc(230px - var(--spacing-small))
+      );
+
+      @media (min-width: 1600px) {
+        grid-template-columns: repeat(
+          auto-fit,
+          calc(25% - var(--gutter-width))
+        );
+      }
     }
   }
 

--- a/src/open_inwoner/scss/views/Categories.scss
+++ b/src/open_inwoner/scss/views/Categories.scss
@@ -1,10 +1,20 @@
 .categories {
   &__content {
     .card-container {
-      grid-template-columns: repeat(auto-fit, 228px);
+      grid-template-columns: repeat(
+        auto-fit,
+        calc(230px - var(--spacing-small))
+      );
+
+      @media (min-width: 1600px) {
+        grid-template-columns: repeat(
+          auto-fit,
+          calc(25% - var(--gutter-width))
+        );
+      }
 
       .card {
-        max-width: 360px;
+        max-width: var(--mobile-xs-width);
       }
     }
   }


### PR DESCRIPTION
for screens wider than 1600 pixels set grid margins in such a way it will always show 4 cards next to each other.
https://taiga.maykinmedia.nl/project/open-inwoner/issue/1528

Note: **unfortunately it is not possible to use css variables INSIDE a media-query screen-width declaration:
"...The var() function can not be used as property names, selectors, or anything else besides property values. ..."**

Some standard screensizes to test this with:

1600 x 900 High Definition Plus (HD+)
1920 x 1080 Full High Definition (FHD)
1920 x 1200 Wide Ultra Extended Graphics Array (WUXGA)
2560 x 1440 Quad High Definition (QHD)
3440 x 1440 Wide Quad High Definition (WQHD)
3840 x 2160 4K or Ultra High Definition (UHD)