### PR TITLE
[#1553] Fix duplicate messages in contact form

### DIFF
--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -61,39 +61,23 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
             return messages.add_message(
                 self.request, messages.SUCCESS, _("Vraag verstuurd!")
             )
-        return messages.add_message(
-            self.request,
-            messages.ERROR,
-            _("Probleem bij versturen van de vraag."),
-        )
+        else:
+            return messages.add_message(
+                self.request,
+                messages.ERROR,
+                _("Probleem bij versturen van de vraag."),
+            )
 
     def form_valid(self, form):
         config = OpenKlantConfig.get_solo()
+
+        success = True
         if config.register_email:
-            registered_by_email = self.register_by_email(form, config.register_email)
+            success = self.register_by_email(form, config.register_email) and success
         if config.register_contact_moment:
-            registered_by_api = self.register_by_api(form, config)
+            success = self.register_by_api(form, config) and success
 
-        # email setup
-        if config.register_email and not config.register_contact_moment:
-            if registered_by_email:
-                self.get_result_message(success=True)
-            else:
-                self.get_result_message(success=False)
-
-        # api setup
-        elif config.register_contact_moment and not config.register_email:
-            if registered_by_api:
-                self.get_result_message(success=True)
-            else:
-                self.get_result_message(success=False)
-
-        # both
-        elif config.register_email and config.register_contact_moment:
-            if registered_by_email and registered_by_api:
-                self.get_result_message(success=True)
-            else:
-                self.get_result_message(success=False)
+        self.get_result_message(success=success)
 
         return super().form_valid(form)
 

--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -5,7 +5,6 @@ from django.views.generic import FormView
 
 from mail_editor.helpers import find_template
 from view_breadcrumbs import BaseBreadcrumbMixin
-from zds_client import ClientError
 
 from open_inwoner.openklant.forms import ContactForm
 from open_inwoner.openklant.models import OpenKlantConfig
@@ -21,9 +20,6 @@ from open_inwoner.utils.views import CommonPageMixin, LogMixin
 class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
     form_class = ContactForm
     template_name = "pages/contactform/form.html"
-
-    message_success = _("Vraag verstuurd!")
-    message_failure = _("Probleem bij versturen van de vraag.")
 
     @cached_property
     def crumbs(self):
@@ -60,12 +56,45 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
         context["has_configuration"] = config.has_form_configuration()
         return context
 
+    def get_result_message(self, success=False):
+        if success:
+            return messages.add_message(
+                self.request, messages.SUCCESS, _("Vraag verstuurd!")
+            )
+        return messages.add_message(
+            self.request,
+            messages.ERROR,
+            _("Probleem bij versturen van de vraag."),
+        )
+
     def form_valid(self, form):
         config = OpenKlantConfig.get_solo()
         if config.register_email:
-            self.register_by_email(form, config.register_email)
+            registered_by_email = self.register_by_email(form, config.register_email)
         if config.register_contact_moment:
-            self.register_by_api(form, config)
+            registered_by_api = self.register_by_api(form, config)
+
+        # email setup
+        if config.register_email and not config.register_contact_moment:
+            if registered_by_email:
+                self.get_result_message(success=True)
+            else:
+                self.get_result_message(success=False)
+
+        # api setup
+        elif config.register_contact_moment and not config.register_email:
+            if registered_by_api:
+                self.get_result_message(success=True)
+            else:
+                self.get_result_message(success=False)
+
+        # both
+        elif config.register_email and config.register_contact_moment:
+            if registered_by_email and registered_by_api:
+                self.get_result_message(success=True)
+            else:
+                self.get_result_message(success=False)
+
         return super().form_valid(form)
 
     def register_by_email(self, form, recipient_email):
@@ -87,16 +116,16 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
         success = template.send_email([recipient_email], context)
 
         if success:
-            messages.add_message(self.request, messages.SUCCESS, self.message_success)
             self.log_system_action(
                 "registered contactmoment by email", user=self.request.user
             )
+            return True
         else:
-            messages.add_message(self.request, messages.ERROR, self.message_failure)
             self.log_system_action(
                 "error while registering contactmoment by email",
                 user=self.request.user,
             )
+            return False
 
     def register_by_api(self, form, config: OpenKlantConfig):
         assert config.has_api_configuration()
@@ -180,12 +209,12 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
         contactmoment = create_contactmoment(data, klant=klant)
 
         if contactmoment:
-            messages.add_message(self.request, messages.SUCCESS, self.message_success)
             self.log_system_action(
                 "registered contactmoment by API", user=self.request.user
             )
+            return True
         else:
-            messages.add_message(self.request, messages.ERROR, self.message_failure)
             self.log_system_action(
                 "error while registering contactmoment by API", user=self.request.user
             )
+            return False


### PR DESCRIPTION
When both email and api are activated the success/error message is shown twice.