### PR TITLE
Dropped multi_browser playwright testcase-generator decorator

### DIFF
--- a/src/open_inwoner/accounts/tests/test_action_views.py
+++ b/src/open_inwoner/accounts/tests/test_action_views.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
@@ -10,8 +10,8 @@ from django_webtest import WebTest
 from playwright.sync_api import expect
 from privates.test import temp_private_root
 
-from ...utils.tests.playwright import PlaywrightSyncLiveServerTestCase, multi_browser
-from ..choices import LoginTypeChoices, StatusChoices
+from ...utils.tests.playwright import PlaywrightSyncLiveServerTestCase
+from ..choices import StatusChoices
 from ..models import Action
 from .factories import ActionFactory, DigidUserFactory, UserFactory
 
@@ -304,7 +304,7 @@ class ActionViewTests(WebTest):
         self.assertEqual(response.status_code, 404)
 
 
-@multi_browser()
+@tag("e2e")
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class ActionsPlaywrightTests(PlaywrightSyncLiveServerTestCase):
     @classmethod

--- a/src/open_inwoner/accounts/tests/test_inbox_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_page.py
@@ -1,21 +1,17 @@
 from unittest import skip
 
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from django_webtest import WebTest
-from PIL import Image
 from playwright.sync_api import expect
 from privates.test import temp_private_root
 from webtest import Upload
 
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.tests.helpers import create_image_bytes
-from open_inwoner.utils.tests.playwright import (
-    PlaywrightSyncLiveServerTestCase,
-    multi_browser,
-)
+from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
 from ..models import Message
 from .factories import DigidUserFactory, MessageFactory, UserFactory
@@ -234,7 +230,7 @@ class InboxPageTests(WebTest):
         )
 
 
-@multi_browser()
+@tag("e2e")
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class InboxPagePlaywrightTests(PlaywrightSyncLiveServerTestCase):
     @classmethod

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -1,4 +1,4 @@
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.utils.translation import gettext as _
 
 import requests_mock
@@ -30,18 +30,23 @@ from open_inwoner.openzaak.tests.shared import (
     DOCUMENTEN_ROOT,
     ZAKEN_ROOT,
 )
-from open_inwoner.utils.test import ClearCachesMixin, paginated_response
-from open_inwoner.utils.tests.playwright import (
-    PlaywrightSyncLiveServerTestCase,
-    multi_browser,
+from open_inwoner.utils.test import (
+    ClearCachesMixin,
+    DisableRequestLogMixin,
+    paginated_response,
 )
+from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
 
+@tag("e2e")
 @requests_mock.Mocker()
-@multi_browser()
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
-class CasesPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestCase):
+class CasesPlaywrightTests(
+    ClearCachesMixin, DisableRequestLogMixin, PlaywrightSyncLiveServerTestCase
+):
     def setUp(self) -> None:
+        super().setUp()
+
         self.user = DigidUserFactory(bsn="900222086")
         self.user_login_state = self.get_user_bsn_login_state(self.user)
 
@@ -430,6 +435,9 @@ class CasesPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestCase):
         with open(download.path(), "rb") as f:
             self.assertEqual(f.read(), self.uploaded_zaak_informatie_object_content)
 
+        # finally check if our mock matchers are accurate
+        self.assertMockMatchersCalledAll(self.matchers)
+
         # contact form
         contact_form = page.locator("#contact-form")
         expect(contact_form).to_be_visible()
@@ -448,3 +456,17 @@ class CasesPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestCase):
         notification = page.locator(".notification__content")
         expect(notification).to_be_visible()
         expect(notification.get_by_text(_("Vraag verstuurd!"))).to_be_visible()
+
+        # finally check if our mock matchers are accurate
+        self.assertMockMatchersCalledAll(self.contact_moment_matchers)
+
+    def assertMockMatchersCalledAll(self, matchers):
+        def _match_str(m):
+            return f"  {m._method.ljust(5, ' ')} {m._url}"
+
+        missed = [m for m in matchers if not m.called]
+        if not missed:
+            return
+
+        out = "\n".join(_match_str(m) for m in missed)
+        self.fail(f"request mock matchers not called:\n{out}")

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -1,9 +1,8 @@
 from datetime import date
-from unittest import skip
 
 from django.contrib.messages import get_messages
 from django.core import mail
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
@@ -19,12 +18,9 @@ from open_inwoner.accounts.tests.factories import (
     UserFactory,
 )
 from open_inwoner.accounts.tests.test_action_views import ActionsPlaywrightTests
-from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
-from open_inwoner.utils.tests.playwright import multi_browser
 
 from ...cms.collaborate.cms_apps import CollaborateApphook
 from ...cms.extensions.constants import Icons, IndicatorChoices
-from ...cms.profile.cms_apps import ProfileApphook
 from ...cms.tests import cms_tools
 from ..models import Plan, PlanContact
 from .factories import ActionTemplateFactory, PlanFactory, PlanTemplateFactory
@@ -1140,7 +1136,7 @@ class NewPlanContactCounterTest(WebTest):
         self.assertEqual(len(links), 1)
 
 
-@multi_browser()
+@tag("e2e")
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class PlanActionStatusPlaywrightTests(ActionsPlaywrightTests):
     def setUp(self) -> None:

--- a/src/open_inwoner/utils/tests/playwright.py
+++ b/src/open_inwoner/utils/tests/playwright.py
@@ -1,8 +1,6 @@
-import importlib
 import os
-from typing import Callable, Dict, Iterable
+from typing import Callable
 
-from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
 
@@ -11,12 +9,24 @@ from playwright.sync_api import Browser, Playwright, sync_playwright
 
 from open_inwoner.accounts.models import User
 
+BROWSER_DRIVERS = {
+    # keys for the E2E_DRIVER environment variable (likely from test matrix)
+    "chromium": lambda p: p.chromium.launch(),
+    "firefox": lambda p: p.firefox.launch(),
+    "webkit": lambda p: p.webkit.launch(),
+    "msedge": lambda p: p.chromium.launch(channel="msedge"),
+    # MORE here, with interesting launch options
+}
+BROWSER_DEFAULT = "chromium"
+
 
 class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
     """
     base class for convenient synchronous Playwright in Django
 
     to help with debugging set the environment variable PWDEBUG=1 or PWDEBUG=console
+
+    to set the browser define E2E_DRIVER environment variable, with a value from the BROWSER_DRIVERS dictionary above.
 
     usage:
 
@@ -57,15 +67,17 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
     _old_async_unsafe: str
 
     @classmethod
-    def launch_browser(cls, playwright):
-        """
-        extend and override to launch different browser for same case
+    def launch_browser(cls, playwright: Playwright) -> Browser:
+        launcher = cls.get_browser_launcher()
+        return launcher(playwright)
 
-        see also the @multi_browser()-decorator on how to automate browser variations
-
-        using vanilla chromium as sane default
-        """
-        return playwright.chromium.launch()
+    @classmethod
+    def get_browser_launcher(cls) -> Callable[[Playwright], Browser]:
+        name = os.environ.get("E2E_DRIVER", BROWSER_DEFAULT)
+        if name in BROWSER_DRIVERS:
+            return BROWSER_DRIVERS[name]
+        else:
+            raise Exception(f"cannot find browser end-2-end driver '{name}'")
 
     @classmethod
     def setUpClass(cls):
@@ -153,85 +165,3 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
         login_state = context.storage_state()
         context.close()
         return login_state
-
-
-class Generated:
-    pass
-
-
-class multi_browser:
-    """
-    class-decorator to generate browser variations of test classes based on PlaywrightSyncLiveServerTestCase
-
-    usage:
-
-    @multi_browser()
-    class MyPageTest(PlaywrightSyncLiveServerTestCase):
-        pass
-
-    """
-
-    default_browsers = {
-        "chromium": lambda p: p.chromium.launch(),
-        "firefox": lambda p: p.firefox.launch(),
-        "webkit": lambda p: p.webkit.launch(),
-        "msedge": lambda p: p.chromium.launch(channel="msedge"),
-        # MORE here, with interesting launch options
-    }
-
-    def __init__(self, extra_browsers: Dict[str, Callable] = None):
-        # TODO support some options/settings here
-        self.extra_browsers = extra_browsers
-
-    @property
-    def only_default(self):
-        # ignore multi-browser (put in local.py for dev)
-        return settings.PLAYWRIGHT_MULTI_ONLY_DEFAULT
-
-    def get_browsers(self, cls) -> Iterable:
-        if self.only_default:
-            return []
-
-        ret = self.default_browsers.copy()
-        if self.extra_browsers:
-            ret.update(self.extra_browsers)
-
-        return ret.items()
-
-    def __call__(self, cls):
-        if not issubclass(cls, PlaywrightSyncLiveServerTestCase):
-            # for now just test for our base-class, in the future we might be more flexible
-            raise Exception(
-                "decorated class must extend PlaywrightSyncLiveServerTestCase"
-            )
-
-        # import the (partially initialized) parent module
-        module = importlib.import_module(cls.__module__)
-        prefix = f"__{cls.__module__}."
-
-        variations = self.get_browsers(cls)
-        if not variations:
-            # keep it if we don't have variations
-            return cls
-
-        for name, launcher in variations:
-            # clean and generate new name
-            new_name = "".join(c if c.isalnum() else "_" for c in name)
-            new_name = f"{new_name[0].upper()}{new_name[1:]}"
-            new_name = f"{prefix}{cls.__name__}__{new_name}"
-
-            # new class
-            inst_dict = {"launch_browser": launcher}
-            new_type = type(
-                new_name,
-                (
-                    Generated,
-                    cls,
-                ),
-                inst_dict,
-            )
-            # update module
-            # NOTE we add it to module but the generated class's string is still located here
-            setattr(module, new_name, new_type)
-
-        return cls


### PR DESCRIPTION
The generated classes don't work with parallel tests and have problems with decorators like requests mocker

We're going to move the multiple browser testing to a Github actions test matrix. This PR also prepares for that be exposing a. environment variable E2E_DRIVER and tagging the relevant tests with `@tag('e2e')`