### PR TITLE
[#1566] Add email registration to case detail contact form

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -5,8 +5,7 @@ from typing import List
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404, StreamingHttpResponse
-from django.shortcuts import redirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views import View
@@ -14,6 +13,7 @@ from django.views.generic import FormView, TemplateView
 
 from django_htmx.http import HttpResponseClientRedirect
 from glom import glom
+from mail_editor.helpers import find_template
 from view_breadcrumbs import BaseBreadcrumbMixin
 from zgw_consumers.api_models.constants import RolOmschrijving
 
@@ -203,7 +203,7 @@ class InnerCaseDetailView(
             "external_upload_enabled": external_upload_enabled,
             "external_upload_url": external_upload_url,
             "contact_form_enabled": (
-                contact_form_enabled and open_klant_config.has_api_configuration()
+                contact_form_enabled and open_klant_config.has_register()
             ),
         }
 
@@ -414,11 +414,26 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()
+
         if form.is_valid():
-            form.cleaned_data[
-                "question"
-            ] += f"\n\nCase number: {self.case.identificatie}"
-            return self.register_by_api(form)
+            config = OpenKlantConfig.get_solo()
+
+            success = True
+            if config.register_email:
+                form.cleaned_data[
+                    "question"
+                ] += f"\n\nCase number: {self.case.identificatie}"
+                success = (
+                    self.register_by_email(form, config.register_email) and success
+                )
+            if config.register_contact_moment:
+                success = self.register_by_api(form, config) and success
+
+            self.get_result_message(success=success)
+
+            return HttpResponseClientRedirect(
+                reverse("cases:case_detail", kwargs={"object_id": str(self.case.uuid)})
+            )
         else:
             return self.form_invalid(form)
 
@@ -427,8 +442,52 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
             "cases:case_detail_contact_form", kwargs={"object_id": str(self.case.uuid)}
         )
 
-    def register_by_api(self, form):
-        config = OpenKlantConfig.get_solo()
+    def get_result_message(self, success=False):
+        if success:
+            return messages.add_message(
+                self.request, messages.SUCCESS, _("Vraag verstuurd!")
+            )
+        else:
+            return messages.add_message(
+                self.request,
+                messages.ERROR,
+                _("Probleem bij versturen van de vraag."),
+            )
+
+    def register_by_email(self, form, recipient_email):
+        template = find_template("contactform_registration")
+
+        context = {
+            "subject": _("Case: {case_identification}").format(
+                case_identification=self.case.identificatie
+            ),
+            "email": self.request.user.email,
+            "phonenumber": self.request.user.phonenumber,
+            "question": form.cleaned_data["question"],
+        }
+
+        parts = [
+            self.request.user.first_name,
+            self.request.user.infix if self.request.user.infix else "",
+            self.request.user.last_name,
+        ]
+        context["name"] = " ".join(p for p in parts)
+
+        success = template.send_email([recipient_email], context)
+
+        if success:
+            self.log_system_action(
+                "registered contactmoment by email", user=self.request.user
+            )
+            return True
+        else:
+            self.log_system_action(
+                "error while registering contactmoment by email",
+                user=self.request.user,
+            )
+            return False
+
+    def register_by_api(self, form, config: OpenKlantConfig):
         assert config.has_api_configuration()
 
         klant = fetch_klant_for_bsn(self.request.user.bsn)
@@ -475,17 +534,15 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
         contactmoment = create_contactmoment(data, klant=klant)
 
         if contactmoment:
-            messages.add_message(self.request, messages.SUCCESS, _("Vraag verstuurd!"))
-            self.log_system_action(f"registered contactmoment by API")
-        else:
-            messages.add_message(
-                self.request, messages.ERROR, _("Probleem bij versturen van de vraag.")
+            self.log_system_action(
+                "registered contactmoment by API", user=self.request.user
             )
-            self.log_system_action(f"error while registering contactmoment by API")
-
-        return HttpResponseClientRedirect(
-            reverse("cases:case_detail", kwargs={"object_id": str(self.case.uuid)})
-        )
+            return True
+        else:
+            self.log_system_action(
+                "error while registering contactmoment by API", user=self.request.user
+            )
+            return False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/src/open_inwoner/openklant/models.py
+++ b/src/open_inwoner/openklant/models.py
@@ -79,9 +79,11 @@ class OpenKlantConfig(SingletonModel):
     class Meta:
         verbose_name = _("Open Klant configuration")
 
+    def has_register(self) -> bool:
+        return self.register_email or self.has_api_configuration()
+
     def has_form_configuration(self) -> bool:
-        has_register = self.register_email or self.has_api_configuration()
-        return has_register and self.contactformsubject_set.exists()
+        return self.has_register() and self.contactformsubject_set.exists()
 
     def has_api_configuration(self):
         return all(getattr(self, f, "") for f in self.register_api_required_fields)

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -22,3 +22,7 @@
     display: inline;
   }
 }
+
+#cases-contact-form-content > h2 {
+  margin-top: var(--spacing-large);
+}


### PR DESCRIPTION
FYI, currently we have the contact form in the case detail view but we only support sending a question via the api configuration. With this task we want to add the email configuration as well. 

It will be easier to review this if you take a look at [https://github.com/maykinmedia/open-inwoner/blob/develop/src/open_inwoner/openklant/views/contactform.py](url), where Bart had already implemented this for the basic contact form page.