### PR TITLE
:lipstick: [#1594] Improving onderwerp selection and dropdowns

### DIFF
--- a/src/open_inwoner/components/templates/components/Action/ActionStatusButton.html
+++ b/src/open_inwoner/components/templates/components/Action/ActionStatusButton.html
@@ -4,7 +4,7 @@
 {% dropdown class=class text=text text_icon=icon %}
     {% for status in choices %}
     <div class="dropdown__item">
-        {% button text_icon=None icon=status.icon text=status.text class=status.class disabled=status.disabled extra_attributes=status.extra_attributes size="small" type="button" %}
+        {% button text_icon=None icon=status.icon bordered=False text=status.text class=status.class disabled=status.disabled extra_attributes=status.extra_attributes size="small" type="button" %}
     </div>
     {% endfor %}
 {% enddropdown %}

--- a/src/open_inwoner/components/templates/components/Action/Actions.html
+++ b/src/open_inwoner/components/templates/components/Action/Actions.html
@@ -20,7 +20,7 @@
                 <div class="actions__actions">
                     {% button icon="file-pdf" text=_("Export to PDF") hide_text=True href="profile:action_export" uuid=action.uuid icon_outlined=True transparent=True %}
                     {% if action|is_connected:request.user %}
-                        {% dropdown icon="settings" %}
+                        {% dropdown icon="more_horiz" %}
                             <div class="dropdown__item">
                                 {% get_action_edit_url action=action plan=plan as action_url %}
                                 {% button icon="edit" text=_("Bewerken") href=action_url icon_outlined=True transparent=True %}

--- a/src/open_inwoner/components/templates/components/Dropdown/Dropdown.html
+++ b/src/open_inwoner/components/templates/components/Dropdown/Dropdown.html
@@ -1,7 +1,7 @@
 {% load i18n button_tags %}
 
 <div class="dropdown">
-    {% button href="#" icon=icon|default:'expand_more' text_icon=text_icon icon_position='after' class=class bordered=True text=text transparent=True single=True disabled=disabled secondary=secondary size="small" %}
+    {% button href="#" icon=icon|default:'expand_more' text_icon=text_icon icon_position='after' class=class bordered=False text=text icon_outlined=True transparent=True single=True disabled=disabled secondary=secondary size="small" %}
     <div class="dropdown__content">
         {{ contents }}
     </div>

--- a/src/open_inwoner/scss/components/Actions/Actions.scss
+++ b/src/open_inwoner/scss/components/Actions/Actions.scss
@@ -64,6 +64,31 @@
     &--big {
       grid-column: 1 / span 2;
     }
+
+    .button {
+      border: 1px solid;
+
+      &.actions__status-selector {
+        &--approval {
+          border-color: var(--color-danger);
+          color: var(--color-danger);
+        }
+
+        &--open {
+          border-color: var(--color-info-darker);
+          color: var(--color-info-darker);
+        }
+
+        &--closed {
+          border-color: var(--color-success);
+          color: var(--color-success);
+        }
+      }
+    }
+
+    .dropdown__content .button {
+      border: none;
+    }
   }
 
   .actions__actions {

--- a/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
+++ b/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
@@ -16,6 +16,34 @@
     background-color: var(--color-white);
     border: 1px solid var(--color-mute);
     z-index: 1;
+
+    &::before {
+      border-bottom: 6px solid var(--color-mute);
+      border-left: 6px solid var(--color-white);
+      border-right: 6px solid var(--color-white);
+      box-sizing: border-box;
+      content: '';
+      display: block;
+      height: 6px;
+      right: 0.4em;
+      position: absolute;
+      top: -7px;
+      width: 12px;
+    }
+
+    &::after {
+      border-bottom: 6px solid var(--color-white);
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+      box-sizing: border-box;
+      content: '';
+      display: block;
+      height: 6px;
+      right: 0.4em;
+      position: absolute;
+      top: -6px;
+      width: 11px;
+    }
   }
 
   .dropdown__item {
@@ -27,7 +55,6 @@
   }
 
   .button {
-    border-color: var(--font-color-body);
     color: var(--font-color-body);
   }
 
@@ -36,5 +63,12 @@
     color: var(--font-color-body);
     height: var(--font-line-height-body);
     padding: 0;
+  }
+}
+
+/// Specific dropdowns
+.table__item {
+  .dropdown {
+    padding-left: var(--spacing-medium);
   }
 }

--- a/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
+++ b/src/open_inwoner/scss/components/Dropdown/Dropdown.scss
@@ -28,7 +28,6 @@
       right: 0.4em;
       position: absolute;
       top: -7px;
-      width: 12px;
     }
 
     &::after {
@@ -42,7 +41,6 @@
       right: 0.4em;
       position: absolute;
       top: -6px;
-      width: 11px;
     }
   }
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -238,6 +238,24 @@
       top: var(--spacing-large);
     }
   }
+
+  /// specific inner forms
+
+  &.select-grid > .form__control > .form__grid-box {
+    grid-template-columns: 1fr;
+
+    @media screen and (min-width: 500px) and (max-width: 768px) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media screen and (min-width: 769px) and (max-width: 904px) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+
+    @media (min-width: 905px) {
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
+  }
 }
 
 /// Specific forms

--- a/src/open_inwoner/scss/components/Plan/PlanCreate.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanCreate.scss
@@ -9,4 +9,8 @@
       right: 10px;
     }
   }
+
+  .modal--open {
+    background: rgba(0, 0, 0, 0.25);
+  }
 }

--- a/src/open_inwoner/scss/components/Preview/Preview.scss
+++ b/src/open_inwoner/scss/components/Preview/Preview.scss
@@ -1,5 +1,9 @@
 .show-preview {
   cursor: pointer;
+
+  & *[class*='icon'] {
+    font-size: var(--font-size-body-large);
+  }
 }
 
 .preview {

--- a/src/open_inwoner/templates/pages/profile/categories.html
+++ b/src/open_inwoner/templates/pages/profile/categories.html
@@ -9,5 +9,5 @@
     {% trans "Selecteer hier uw interessegebieden om op maat gemaakte content voorgeschoteld te krijgen en nog beter te kunnen zoeken en vinden" %}
 </p>
 
-{% form form_object=form method="POST" id="change-categories" submit_text=_("Opslaan") secondary_href='profile:contact_list' secondary_text=_('Terug') secondary_icon='arrow_backward' secondary_icon_position="before" %}
+{% form form_object=form method="POST" id="change-categories" submit_text=_("Opslaan") secondary_href='profile:contact_list' secondary_text=_('Terug') secondary_icon='arrow_backward' secondary_icon_position="before" extra_classes="select-grid" %}
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -106,7 +106,7 @@
 			{% if inbox_page_is_published %}
 			    <td class="table__item">{% button text=_('Stuur bericht') icon="message" icon_position="before" icon_outlined=True transparent=True disabled=True %}</td>
 			{% endif %}
-			<td class="table__item">{% button icon="settings" icon_position="before" text="" hide_text=True transparent=True disabled=True %}<td>
+			<td class="table__item">{% button icon="settings" icon_outlined=True icon_position="before" text="" hide_text=True transparent=True disabled=True %}<td>
                     </tr>
                 {% endfor %}
 
@@ -121,7 +121,7 @@
 			{% if inbox_page_is_published %}
 			    <td class="table__item">{% button text=_('Stuur bericht') icon="message" icon_position="before" icon_outlined=True transparent=True disabled=True %}</td>
 			{% endif %}
-                        <td class="table__item">{% button icon="settings" icon_position="before" text="" hide_text=True transparent=True disabled=True %}<td>
+                        <td class="table__item">{% button icon="settings" icon_outlined=True icon_position="before" text="" hide_text=True transparent=True disabled=True %}<td>
                     </tr>
                 {% endfor %}
 


### PR DESCRIPTION
- [x] set Categories 'interesses' desktop grid to 4 columns on desktop, and less for multiple small-screen media queries,
- [x] remove borders around dropdown icons and correct the names of certain icons named 'settings' to 'horizontal' dots.
- [x]  add  small triangle on top of border of dropdown content
- [x] make sure styling doesn't impact _everything everywhere all at once_
- [x] EXTRA: i also added correct modal background color: https://projects.invisionapp.com/share/XP134RWRK3MG#/screens/471522251

https://taiga.maykinmedia.nl/project/open-inwoner/issue/1594

<img width="1302" alt="Screenshot 2023-07-10 at 11 37 26" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/a2ddfbb5-7cea-4975-b696-76a37f035cc5">
