### PR TITLE
:wheelchair: [#1613] Increasing color contrast in footer + scrollbutton

### DIFF
--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -118,6 +118,7 @@
     background-color: #fff;
     position: relative;
     color: var(--color-primary);
+    filter: saturate(50%);
     border-radius: 100px; // This is big to make sure the corners are rounded properly.
 
     &:before {
@@ -129,7 +130,7 @@
       left: 0;
       right: 0;
       background-color: var(--color-primary);
-      opacity: 0.2;
+      opacity: 0.15;
     }
   }
 

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -27,7 +27,7 @@
   --color-gray-dark: #4b4b4b;
   --color-gray-lighter: #7a7a7a;
   --color-gray-light: #d2d2d2;
-  --color-gray-lightest: #f1f1f1;
+  --color-gray-lightest: #f3f3f3;
   --color-green: #d5e7d4;
   --color-green-dark: #248641;
   --color-red: #e50026;


### PR DESCRIPTION
set contrast to minimum of 4,5 to 1,0 (4,5:1)
https://taiga.maykinmedia.nl/project/open-inwoner/task/1613
can only be properly reviewed with "Web Developer" browser extension (=https://chrispederick.com/work/web-developer/) + any contrast-checker (like https://www.siegemedia.com/contrast-ratio).