### PR TITLE
:wheelchair: [#1608] Setting up focus trap for accordion and mobile menu

### DIFF
--- a/src/open_inwoner/js/components/questionnaire/index.js
+++ b/src/open_inwoner/js/components/questionnaire/index.js
@@ -5,7 +5,7 @@ const stepIndicator = document.querySelector(
 
 if (stepIndicator && question) {
   /*
-   * Focus on the question only if it's the not the first one and if it's accessed via a mobile phone
+   * Focus on the question only if it's not the first one and if it's accessed via a mobile phone
    */
   if (window.innerWidth < 768 && stepIndicator.dataset.step > 1) {
     question.scrollIntoView()

--- a/src/open_inwoner/js/components/toggle/toggle.js
+++ b/src/open_inwoner/js/components/toggle/toggle.js
@@ -7,7 +7,7 @@ export const BLOCK_TOGGLE = 'toggle'
 const TOGGLES = BEM.getBEMNodes(BLOCK_TOGGLE)
 
 /**
- * Class for generic toggles.
+ * Class for generic toggles (like FAQ accordion).
  *
  * Toggle should have BLOCK_TOGGLE present in classList for detection.
  * Toggle should have data-toggle-target set to query selector for target.

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -67,6 +67,7 @@
   }
 
   &__answer:not(#{&}__answer--open) {
+    display: none;
     opacity: 0;
     height: 0;
     transition: all 0.3s, height 0s, opacity 0.01s;

--- a/src/open_inwoner/scss/views/_body.scss
+++ b/src/open_inwoner/scss/views/_body.scss
@@ -2,6 +2,12 @@
   overflow: hidden;
   position: fixed;
 
+  // Hide focus for accessibility
+  .container,
+  .footer {
+    display: none;
+  }
+
   @media (min-width: 768px) {
     height: auto;
     overflow: auto;


### PR DESCRIPTION
https://taiga.maykinmedia.nl/project/open-inwoner/task/1608
+ make mobile menu the **only Tabbable focus**, hide everything else 
+ make accordion FAQ titles the **only** focus on Tab key when collapsed/hidden; then again make accordion-panel focusable when answer is open, so user can tab towards links inside the panels.

info: the mobile 'view' will become visible when users zoom in more than 200% - hence why this needs to be accessible with keyboard tabs as well.