### PR TITLE
:wheelchair: [#1598] Improving accessibility relational information

### DIFF
--- a/src/open_inwoner/components/templates/components/Faq/Faq.html
+++ b/src/open_inwoner/components/templates/components/Faq/Faq.html
@@ -6,9 +6,11 @@
     <ul class="faq__list">
         {% for question in questions %}
             <li class="faq__list-item">
-                {% firstof question.pk|slugify as id %}
-                {% firstof 'question-'|add:id|add:'-answer' as answer_id %}
-                {% link bold=True href='#'|add:answer_id icon='keyboard_arrow_down' secondary=True text=question.question toggle="open"  %}
+                <h3 class="h3">
+                    {% firstof question.pk|slugify as id %}
+                    {% firstof 'question-'|add:id|add:'-answer' as answer_id %}
+                    {% link bold=True href='#'|add:answer_id icon='keyboard_arrow_down' secondary=True text=question.question toggle="open"  %}
+                </h3>
                 <div id="{{ answer_id }}" class="p faq__answer">{{ question.answer|ckeditor_content|safe }}</div>
             </li>
         {% endfor %}

--- a/src/open_inwoner/components/templates/components/Step/StepIndicator.html
+++ b/src/open_inwoner/components/templates/components/Step/StepIndicator.html
@@ -4,7 +4,7 @@
     <aside class="step-indicator" aria-label="{% trans "Stappen indicator" %}">
         <ol class="step-indicator__list">
             {% for step in steps %}
-                <li class="step-indicator__list-item{% if step.is_current %} step-indicator__list-item--active{% elif step.is_completed %} step-indicator__list-item--completed{% endif %} P" data-step={{ step.step }} {% if step.is_current %}aria-current="step"{% endif %} aria-label="{{ step.is_completed|yesno:_("afgerond,huidige stap") }}">
+                <li class="step-indicator__list-item{% if step.is_current %} step-indicator__list-item--active{% elif step.is_completed %} step-indicator__list-item--completed{% endif %}" data-step={{ step.step }} {% if step.is_current %}aria-current="step"{% endif %} aria-label="{{ step.is_completed|yesno:_("afgerond,huidige stap") }}">
                     {% if step.object %}
                         {% link href=step.object.get_absolute_url secondary=True bold=True text=step.object_display %}
                     {% endif %}

--- a/src/open_inwoner/components/templates/components/Step/StepIndicator.html
+++ b/src/open_inwoner/components/templates/components/Step/StepIndicator.html
@@ -4,7 +4,7 @@
     <aside class="step-indicator" aria-label="{% trans "Stappen indicator" %}">
         <ol class="step-indicator__list">
             {% for step in steps %}
-                <li class="step-indicator__list-item{% if step.is_current %} step-indicator__list-item--active{% elif step.is_completed %} step-indicator__list-item--completed{% endif %} P" data-step={{ step.step }} aria-checked="{{ step.is_completed|yesno:"true,false" }}">
+                <li class="step-indicator__list-item{% if step.is_current %} step-indicator__list-item--active{% elif step.is_completed %} step-indicator__list-item--completed{% endif %} P" data-step={{ step.step }} {% if step.is_current %}aria-current="step"{% endif %} aria-label="{{ step.is_completed|yesno:_("afgerond,huidige stap") }}">
                     {% if step.object %}
                         {% link href=step.object.get_absolute_url secondary=True bold=True text=step.object_display %}
                     {% endif %}

--- a/src/open_inwoner/js/components/dropdown/index.js
+++ b/src/open_inwoner/js/components/dropdown/index.js
@@ -14,6 +14,7 @@ export class Dropdown {
     event.preventDefault()
     setTimeout(() => {
       this.node.classList.add('dropdown--open')
+      this.node.setAttribute('aria-expanded', 'true')
     }, 5)
   }
 
@@ -23,6 +24,7 @@ export class Dropdown {
       (event.type === 'keydown' && event.key === 'Escape')
     ) {
       this.node.classList.remove('dropdown--open')
+      this.node.setAttribute('aria-expanded', 'false')
     }
   }
 }

--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -7,6 +7,10 @@
     margin-bottom: var(--spacing-large);
   }
 
+  .h3 {
+    margin: 0;
+  }
+
   &__list {
     list-style: none;
     margin: 0;

--- a/src/open_inwoner/scss/views/_accessibility.scss
+++ b/src/open_inwoner/scss/views/_accessibility.scss
@@ -1,0 +1,12 @@
+// for screen-readers only
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  border-width: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/src/open_inwoner/scss/views/_index.scss
+++ b/src/open_inwoner/scss/views/_index.scss
@@ -1,3 +1,4 @@
+@import './accessibility';
 @import './App.scss';
 @import './body';
 @import './Categories.scss';


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/task/1598

- [x] FAQ titles must be Headings
- [x] corrected: `aria-checked `can only be used for checkbox/radio inputs; instead needs `aria-current`. In the previous version someone used the aria-checked attribute on the List-item, but this aria tag only works on elements that act like checkboxes/radio buttons etc.
- [x] extra: give attribute aria-expanded to dropdown when it is opened (because: when it is closed, contents are not visible for screen-readers and bind users need some feedback for this)
- [x] added our own `.sr-only` CSS class because we are using it in Pagination.html, but it's now only in the third-party Bootstrap CSS, with no guarantee it will work in future; also: we will need this class for future accessibility issues, so also added accessibility as a separate SASS inlcude
- [x]  Note: Depending on the configuration, some screen readers read out the legend either with every form element, once, or, rarely, **not at all**.) When you se semantic and correct HTML you should not worry about how different brands of screen readers read things differently - so there is no "sr-only" class needed for invisible Spans in the Labels inside these fieldsets here. 


Note to self:
HTML `<li>` tags do not necessarily need an aria-label attribute to indicate that they are the current step in a step-indicator. Instead, you can use the aria-current attribute with the value of "step" to convey the current state. The aria-label attribute, in this case, is not required.
When a screen reader encounters an element with an aria-label attribute, it will read out the content of the aria-label attribute. However, it's important to note that screen readers typically **prioritize the accessible name of an element**. The accessible name is determined by various factors, including the element's text content and associated labels
....screen readers will typically read out both the content of the list item (the text within the `<li>` tags) and any additional accessible information provided, such as the aria-label attribute. This ensures that screen reader users receive the complete context and understanding of the content within the list item.

Screenreaders will usually read the number of inputs: 
<img width="723" alt="Screenshot 2023-07-13 at 12 32 03" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/ec6a7b5b-1d7e-4c87-8d6e-8a5852c04cd0">

No need to change the Fieldset heading for now: 
<img width="1076" alt="Screenshot 2023-07-11 at 17 07 42" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/b1b1f95e-f112-42cd-9e9a-37236057b3be">

