### PR TITLE
:wheelchair: [#1611] Improving robust mobile menus with aria-expanded

### DIFF
--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -8,6 +8,7 @@
         aria-label="{% firstof title text %}"
         {% if href|startswith:"http" %}target="_blank"{% endif %}
         {% as_attributes extra_attributes %}
+        {% if ariaExpanded %} aria-expanded="{{ ariaExpanded }}" {% endif %}
     >
         {% if icon %}{% icon icon=icon outlined=icon_outlined %}{% endif %}
         {% if text_icon %}
@@ -29,6 +30,7 @@
         aria-label="{% firstof title text %}"
         {% as_attributes extra_attributes %}
         {% if id %} id="{{ id }}" {% endif %}
+        {% if ariaExpanded %} aria-expanded="{{ ariaExpanded }}" {% endif %}
     >
         {% if icon %}{% icon icon=icon outlined=icon_outlined %}{% endif %}
         {% if text_icon %}

--- a/src/open_inwoner/components/templates/components/Dropdown/Dropdown.html
+++ b/src/open_inwoner/components/templates/components/Dropdown/Dropdown.html
@@ -1,7 +1,7 @@
 {% load i18n button_tags %}
 
 <div class="dropdown">
-    {% button href="#" icon=icon|default:'expand_more' text_icon=text_icon icon_position='after' class=class bordered=False text=text icon_outlined=True transparent=True single=True disabled=disabled secondary=secondary size="small" %}
+    {% button href="#" icon=icon|default:'expand_more' text_icon=text_icon icon_position='after' class=class bordered=False text=text icon_outlined=True transparent=True single=True disabled=disabled secondary=secondary size="small" ariaExpanded="false" %}
     <div class="dropdown__content">
         {{ contents }}
     </div>

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -6,7 +6,7 @@
 <header class="header" aria-label="Navigatie header">
     <div class="header__container">
         <div class="header__menu">
-            <button class="header__button">
+            <button class="header__button" aria-expanded="false">
                 <div class="header__menu-icon">
                     <span class="closed">{% trans "Menu" %}</span>
                     <span class="open">{% trans "Sluiten" %}</span>
@@ -47,7 +47,7 @@
 
                         {% if cms_apps.products and categories %}
                         <li class="primary-navigation__list-item dropdown-nav__toggle">
-                            <a href="#" class="link link--toggle link--icon link--icon-position-before" aria-label="{% trans "Onderwerpen" %}" title="{% trans "Onderwerpen" %}">
+                            <a href="#" class="link link--toggle link--icon link--icon-position-before" aria-label="{% trans "Onderwerpen" %}" title="{% trans "Onderwerpen" %}" aria-expanded="false">
                                 <span >{% trans "Onderwerpen" %}</span>
                                 <span aria-hidden="true" class="material-icons-outlined ">description</span>
                                 {% icon icon="expand_more" icon_position="after" icon_outlined=True %}

--- a/src/open_inwoner/js/components/dropdown/index.js
+++ b/src/open_inwoner/js/components/dropdown/index.js
@@ -14,7 +14,7 @@ export class Dropdown {
     event.preventDefault()
     setTimeout(() => {
       this.node.classList.add('dropdown--open')
-      this.node.setAttribute('aria-expanded', 'true')
+      this.button.setAttribute('aria-expanded', 'true')
     }, 5)
   }
 
@@ -24,7 +24,7 @@ export class Dropdown {
       (event.type === 'keydown' && event.key === 'Escape')
     ) {
       this.node.classList.remove('dropdown--open')
-      this.node.setAttribute('aria-expanded', 'false')
+      this.button.setAttribute('aria-expanded', 'false')
     }
   }
 }

--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -13,6 +13,9 @@ export const HEADERS = BEM.getBEMNodes(BLOCK_HEADER)
 /** Handler to bypass Safari bug */
 export const themesToggle = document.querySelectorAll('.dropdown-nav__toggle')
 
+/** Controls aria-expanded state for accessibility */
+export const interactiveButton = document.querySelectorAll('.header__button')
+
 /**
  * Controls the main header and interaction with the mobile menu and dismissing it using the escape key.
  */
@@ -53,11 +56,17 @@ class Header extends Component {
    * Gets called when `node` is clicked.
    * Clears the dismissed state, (prevents overriding focus/toggle).
    */
-  toggleMobileNavOpen(event) {
+  toggleMobileNavOpen() {
     document.body.classList.toggle('body--open')
     // Safari specific - close all when main menu closes
     themesToggle.forEach((elem) => {
       elem.classList.remove('nav__list--open')
+    })
+    interactiveButton.forEach((elem) => {
+      elem.setAttribute(
+        'aria-expanded',
+        elem.getAttribute('aria-expanded') === 'true' ? 'false' : 'true'
+      )
     })
     window.scrollTo(0, 0)
   }

--- a/src/open_inwoner/js/components/header/subpage-navigation.js
+++ b/src/open_inwoner/js/components/header/subpage-navigation.js
@@ -4,8 +4,12 @@ class Subpage {
     this.node.addEventListener('click', this.toggleNavOpen.bind(this))
   }
 
-  toggleNavOpen(event) {
+  toggleNavOpen() {
     this.node.parentElement.classList.toggle('nav__list--open')
+    this.node.setAttribute(
+      'aria-expanded',
+      this.node.getAttribute('aria-expanded') === 'true' ? 'false' : 'true'
+    )
   }
 }
 


### PR DESCRIPTION
issue https://taiga.maykinmedia.nl/project/open-inwoner/task/1611

The aria-expanded attribute has to be applied to the focusable, interactive control that toggles the visibility of the object - needs to be set to False initially because everything starts off in a closed state.

Also: corrects this for the dropdown... where I set the aria-expanded attribute to the wrong node.

This will set this attribute to these 2 toggle menus (3 & 4):

<img width="1248" alt="Screenshot 2023-07-18 at 16 17 36" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/5ab4ec28-d979-4b80-94e9-6fe331a624fd">
 

The aria-expanded attribute should NOT be added to the desktop menus (1 & 2),
because they need to be continuously accessible with the Tab keys: so their state is not 'invisible' for screenreaders (even though they are invisible for people that can see).:

<img width="1259" alt="Screenshot 2023-07-18 at 16 15 34" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/749694ea-57eb-461a-b6d0-69510e87a2dd">
