### PR TITLE
:wheelchair: [#1613] Setting title and aria-label when required

### DIFF
--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -3,9 +3,9 @@
 {% if href %}
     <a
         class="{{ classes }}"
-        href="{{href}}"
-        title="{% firstof title text %}"
-        aria-label="{% firstof title text %}"
+        href="{{ href }}"
+        title="{{ title }}"
+        {% if hide_text %}aria-label="{% firstof title text %}"{% endif %}
         {% if href|startswith:"http" %}target="_blank"{% endif %}
         {% as_attributes extra_attributes %}
     >
@@ -13,20 +13,20 @@
         {% if text_icon %}
             <span class="button__text-wrapper">
             {% icon icon=text_icon outlined=icon_outlined %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
             </span>
         {% else %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
         {% endif %}
     </a>
 {% else %}
     <button
         class="{{ classes }}"
-        type="{{type}}"
+        type="{{ type }}"
         name="{{ name }}"
         value="{{ value }}"
-        title="{% firstof title text %}"
-        aria-label="{% firstof title text %}"
+        title="{{ title }}"
+        {% if hide_text %}aria-label="{% firstof title text %}"{% endif %}
         {% as_attributes extra_attributes %}
         {% if id %} id="{{ id }}" {% endif %}
     >
@@ -34,10 +34,10 @@
         {% if text_icon %}
             <span class="button__text-wrapper">
             {% icon icon=text_icon outlined=icon_outlined %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
             </span>
         {% else %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
         {% endif %}
     </button>
 {% endif %}

--- a/src/open_inwoner/components/templates/components/Typography/Link.html
+++ b/src/open_inwoner/components/templates/components/Typography/Link.html
@@ -16,8 +16,10 @@
         data-use-aria="true"
     {% endif %}
     {% if toggle_exclusive %}data-toggle-exclusive="{{ toggle_exclusive }}"{% endif %}
+    {% if hide_text %}
     aria-label="{{ text }}"
-    title="{% firstof title text %}"
+    {% endif %}
+    title="{{ title }}"
 >
     {% if src %}
         <img class="logo__image" src="{{src}}" alt="{{ text }}"{{ svg_height_attr }}/>


### PR DESCRIPTION
issue  https://taiga.maykinmedia.nl/project/open-inwoner/task/1623

- [ ] make title attribute in links and buttons optional
- [ ] make aria-label appear only when there is hidden/inaccessible text
- [ ] check all templates to configure specific use of title attribute and give it meaningful textcontent

title should not be the same as content/alt by default, and should only be configured when needed.
"It is generally recommended to use either the title attribute or the aria-label attribute, but not both, to avoid redundancy and confusion for screen reader users. But title is usually ignored for blind users anyway. 
Also title should ONLY be used if the title text is different from content text (like advisory text with info about a link), so. title attributes should only be present if they are consciously chosen to give more information."

extra info
- title attribute should always be different/extra from the other accessible text, so can stay but must be configurable
- title attribute is not good for accessibility, use aria-label in case of a textless button or ALT on images
- Button&Link custom template improvement - by only setting aria-label/title if there is no text inside the anchor (=a button with hide_text).
- Note: any element (link/button) that needs an additional title attribute, from now on will need to be 'set' in the template code, because it is no longer 'inherited' automatically from the content - it should really not be exactly the same as the text.
## Failing tests when removing title attributes:


======================================================================
FAIL: test_registration_page_only_digid (open_inwoner.accounts.tests.test_auth.TestDigid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/open-inwoner/open-inwoner/src/open_inwoner/accounts/tests/test_auth.py", line 363, in test_registration_page_only_digid
    self.assertIsNotNone(digid_tag)
AssertionError: unexpectedly None

======================================================================
FAIL: test_registration_page_only_digid_with_invite (open_inwoner.accounts.tests.test_auth.TestDigid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/open-inwoner/open-inwoner/src/open_inwoner/accounts/tests/test_auth.py", line 380, in test_registration_page_only_digid_with_invite
    self.assertIsNotNone(digid_tag)
AssertionError: unexpectedly None

======================================================================
FAIL: test_messages_enabled_disabled (open_inwoner.accounts.tests.test_profile_views.ProfileViewTests)
Assert that `Stuur een bericht` is displayed if and only if the message page is published
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/open-inwoner/open-inwoner/src/open_inwoner/accounts/tests/test_profile_views.py", line 188, in test_messages_enabled_disabled
    self.assertEqual(link_text(), _("Stuur een bericht"))
AssertionError: '' != 'Stuur een bericht'

======================================================================
FAIL: test_admin_only_disabled (open_inwoner.configurations.tests.test_oidc.OIDCConfigTest)
Assert that the OIDC login option is only displayed for regular users
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/open-inwoner/open-inwoner/src/open_inwoner/configurations/tests/test_oidc.py", line 57, in test_admin_only_disabled
    self.assertEqual(link_text, _("Login with Azure AD"))
AssertionError: '' != 'Login with Azure AD'

----------------------------------------------------------------------