### PR TITLE
[#1535] Added subheading anchors to product page sidebar

### DIFF
--- a/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
+++ b/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
@@ -6,13 +6,13 @@
         {% button href="#" icon="expand_more" icon_position="after" extra_classes="anchor-menu--mobile__title anchor-menu__toggle" bordered=False text=_("Op deze pagina") %}
         <ul class="anchor-menu__list">
             {% for anchor in anchors %}
-                <li class="anchor-menu__list__item">
+                <li class="anchor-menu__list-item">
                     <a class="link" href="{{ anchor.0 }}">{{ anchor.1 }}</a>
                     <!-- subheadings -->
                     {% if anchor.2 %}
                         <ul class="anchor-menu__sublist anchor-menu__sublist--mobile">
                             {% for subheading in anchor.2 %}
-                                <li class-"anchor-menu__sublist__item">
+                                <li class="anchor-menu__list-item">
                                     <a class="link" href="#{{ subheading.1 }}">{{ subheading.0 }}</a>
                                 </li>
                             {% endfor %}
@@ -28,13 +28,13 @@
 
     <ul class="anchor-menu__list">
         {% for anchor in anchors %}
-            <li class="anchor-menu__list__item">
+            <li class="anchor-menu__list-item">
                 <a class="link" href="{{ anchor.0 }}">{{ anchor.1 }}</a>
                 <!-- subheadings -->
                     {% if anchor.2 %}
                         <ul class="anchor-menu__sublist">
                             {% for subheading in anchor.2 %}
-                                <li>
+                                <li class="anchor-menu__list-item">
                                     <a class="link" href="#{{ subheading.1 }}">{{ subheading.0 }}</a>
                                 </li>
                             {% endfor %}

--- a/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
+++ b/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
@@ -6,8 +6,18 @@
         {% button href="#" icon="expand_more" icon_position="after" extra_classes="anchor-menu--mobile__title anchor-menu__toggle" bordered=False text=_("Op deze pagina") %}
         <ul class="anchor-menu__list">
             {% for anchor in anchors %}
-                <li class="anchor-menu__list-item">
+                <li class="anchor-menu__list__item">
                     <a class="link" href="{{ anchor.0 }}">{{ anchor.1 }}</a>
+                    <!-- subheadings -->
+                    {% if anchor.2 %}
+                        <ul class="anchor-menu__sublist anchor-menu__sublist--mobile">
+                            {% for subheading in anchor.2 %}
+                                <li class-"anchor-menu__sublist__item">
+                                    <a class="link" href="#{{ subheading.1 }}">{{ subheading.0 }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
                 </li>
             {% endfor %}
             {{ contents }}
@@ -18,8 +28,18 @@
 
     <ul class="anchor-menu__list">
         {% for anchor in anchors %}
-            <li class="anchor-menu__list-item">
+            <li class="anchor-menu__list__item">
                 <a class="link" href="{{ anchor.0 }}">{{ anchor.1 }}</a>
+                <!-- subheadings -->
+                    {% if anchor.2 %}
+                        <ul class="anchor-menu__sublist">
+                            {% for subheading in anchor.2 %}
+                                <li>
+                                    <a class="link" href="#{{ subheading.1 }}">{{ subheading.0 }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
             </li>
         {% endfor %}
         {{ contents }}

--- a/src/open_inwoner/js/components/anchor-menu/anchor-menu.js
+++ b/src/open_inwoner/js/components/anchor-menu/anchor-menu.js
@@ -5,7 +5,8 @@ export class CreateGumshoe {
 
   constructor(node) {
     new Gumshoe(CreateGumshoe.selector, {
-      navClass: 'anchor-menu__list__item--active',
+      nested: true,
+      navClass: 'anchor-menu__list-item--active',
       offset: 30,
     })
   }

--- a/src/open_inwoner/js/components/anchor-menu/anchor-menu.js
+++ b/src/open_inwoner/js/components/anchor-menu/anchor-menu.js
@@ -5,7 +5,7 @@ export class CreateGumshoe {
 
   constructor(node) {
     new Gumshoe(CreateGumshoe.selector, {
-      navClass: 'anchor-menu__list-item--active',
+      navClass: 'anchor-menu__list__item--active',
       offset: 30,
     })
   }

--- a/src/open_inwoner/pdc/tests/test_product.py
+++ b/src/open_inwoner/pdc/tests/test_product.py
@@ -276,3 +276,33 @@ class TestProductContent(WebTest):
 
         self.assertTrue(sidemenu_cta_button)
         self.assertIn(product.link, sidemenu_cta_button[0].values())
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class TestProductDetailView(WebTest):
+    def test_subheadings_in_sidebar(self):
+        product = ProductFactory(
+            content="##First subheading\rlorem ipsum...\r##Second subheading",
+            link="http://www.example.com",
+        )
+
+        response = self.app.get(
+            reverse("products:product_detail", kwargs={"slug": product.slug})
+        )
+
+        links = response.pyquery(".anchor-menu__sublist a")
+
+        # 2 x 2 links (mobile + desktop)
+        self.assertEqual(len(links), 4)
+
+        self.assertEqual(links[0].text, "First subheading")
+        self.assertEqual(links[0].attrib["href"], "#first-subheading")
+
+        self.assertEqual(links[1].text, "Second subheading")
+        self.assertEqual(links[1].attrib["href"], "#second-subheading")
+
+        self.assertEqual(links[2].text, "First subheading")
+        self.assertEqual(links[2].attrib["href"], "#first-subheading")
+
+        self.assertEqual(links[3].text, "Second subheading")
+        self.assertEqual(links[3].attrib["href"], "#second-subheading")

--- a/src/open_inwoner/pdc/tests/test_product.py
+++ b/src/open_inwoner/pdc/tests/test_product.py
@@ -296,13 +296,13 @@ class TestProductDetailView(WebTest):
         self.assertEqual(len(links), 4)
 
         self.assertEqual(links[0].text, "First subheading")
-        self.assertEqual(links[0].attrib["href"], "#first-subheading")
+        self.assertEqual(links[0].attrib["href"], "#subheader-first-subheading")
 
         self.assertEqual(links[1].text, "Second subheading")
-        self.assertEqual(links[1].attrib["href"], "#second-subheading")
+        self.assertEqual(links[1].attrib["href"], "#subheader-second-subheading")
 
         self.assertEqual(links[2].text, "First subheading")
-        self.assertEqual(links[2].attrib["href"], "#first-subheading")
+        self.assertEqual(links[2].attrib["href"], "#subheader-first-subheading")
 
         self.assertEqual(links[3].text, "Second subheading")
-        self.assertEqual(links[3].attrib["href"], "#second-subheading")
+        self.assertEqual(links[3].attrib["href"], "#subheader-second-subheading")

--- a/src/open_inwoner/pdc/utils.py
+++ b/src/open_inwoner/pdc/utils.py
@@ -1,1 +1,25 @@
+from django.utils.text import slugify
+
+import markdown
+from bs4 import BeautifulSoup
+
 PRODUCT_PATH_NAME = "products"
+
+
+def extract_subheadings(content: str, tag: str) -> list[tuple[str, str]]:
+    """
+    :returns: a list of tuples containing a subheading (the text of the `tag` element)
+    and a slug for the corresponding HTML anchor
+    """
+    md = markdown.Markdown()
+    html_string = md.convert(content)
+
+    soup = BeautifulSoup(html_string, "html.parser")
+
+    subs = []
+    for tag in soup.find_all("h2"):
+        subheading = tag.text
+        slug = slugify(subheading)
+        subs.append((subheading, slug))
+
+    return subs

--- a/src/open_inwoner/pdc/utils.py
+++ b/src/open_inwoner/pdc/utils.py
@@ -19,7 +19,7 @@ def extract_subheadings(content: str, tag: str) -> list[tuple[str, str]]:
     subs = []
     for tag in soup.find_all("h2"):
         subheading = tag.text
-        slug = slugify(subheading)
+        slug = f"subheader-{slugify(subheading)}"
         subs.append((subheading, slug))
 
     return subs

--- a/src/open_inwoner/pdc/views.py
+++ b/src/open_inwoner/pdc/views.py
@@ -16,6 +16,7 @@ from ..utils.views import CommonPageMixin
 from .choices import YesNo
 from .forms import ProductFinderForm
 from .models import Category, Product, ProductLocation, Question
+from .utils import extract_subheadings
 
 
 class CategoryBreadcrumbMixin:
@@ -201,8 +202,10 @@ class ProductDetailView(
         product = self.get_object()
         context = super().get_context_data(**kwargs)
 
+        subheadings = extract_subheadings(product.content, tag="h2")
+
         anchors = [
-            ("#title", product.name),
+            ("#title", product.name, subheadings),
         ]
         if product.question_set.exists():
             anchors.append(("#faq", _("Veelgestelde vragen")))
@@ -210,13 +213,8 @@ class ProductDetailView(
             anchors.append(("#files", _("Bestanden")))
         if product.locations.exists():
             anchors.append(("#locations", _("Locaties")))
-        if product.links.exists():
-            anchors.append(("#links", _("Links")))
         if product.contacts.exists():
             anchors.append(("#contact", _("Contact")))
-        if product.related_products.published().exists():
-            anchors.append(("#see", _("Zie ook")))
-        # anchors.append(("#share", _("Delen")))  disabled for #822
 
         context["anchors"] = anchors
         context["related_products_start"] = 6 if product.links.exists() else 1

--- a/src/open_inwoner/scss/components/Header/AnchorMenu.scss
+++ b/src/open_inwoner/scss/components/Header/AnchorMenu.scss
@@ -63,40 +63,41 @@
     margin-left: var(--spacing-large);
   }
 
-  &__list__item {
+  &__list-item {
     box-sizing: border-box;
-    padding: var(--spacing-large) var(--spacing-medium);
     font-weight: normal;
+    margin: 0;
 
     @media (min-width: 768px) {
-      border-left: var(--border-width) solid;
-      border-color: var(--color-gray-light);
-      padding: var(--spacing-large);
+      margin: 0;
     }
   }
 
-  &__list__item--active > .link {
+  &__list-item .link {
+    padding: var(--spacing-medium) 0 var(--spacing-medium) var(--spacing-medium);
+
+    @media (min-width: 768px) {
+      border-left: var(--border-width) solid var(--color-gray-light);
+    }
+  }
+
+  &__list-item--active > .link {
     font-weight: bold;
 
     @media (min-width: 768px) {
-      border-color: var(--color-primary);
+      border-left-color: var(--color-primary);
     }
   }
 
   // nested list
   &__sublist {
     list-style-type: none;
-    padding-left: var(--spacing-large);
-    padding-top: var(--spacing-large);
+    padding: 0;
     line-height: var(--spacing-large);
 
-    &__item {
-      border-left: none;
-    }
-    li:not(:last-child) {
-      margin-bottom: var(--spacing-large);
-    }
-    li > a {
+    li .link {
+      padding: var(--spacing-small) 0 var(--spacing-small)
+        var(--spacing-extra-large);
       font-size: var(--font-size-body-small);
     }
 

--- a/src/open_inwoner/scss/components/Header/AnchorMenu.scss
+++ b/src/open_inwoner/scss/components/Header/AnchorMenu.scss
@@ -63,9 +63,10 @@
     margin-left: var(--spacing-large);
   }
 
-  .link {
+  &__list__item {
     box-sizing: border-box;
     padding: var(--spacing-large) var(--spacing-medium);
+    font-weight: normal;
 
     @media (min-width: 768px) {
       border-left: var(--border-width) solid;
@@ -74,11 +75,35 @@
     }
   }
 
-  &__list-item--active .link {
+  &__list__item--active > .link {
     font-weight: bold;
 
     @media (min-width: 768px) {
       border-color: var(--color-primary);
+    }
+  }
+
+  // nested list
+  &__sublist {
+    list-style-type: none;
+    padding-left: var(--spacing-large);
+    padding-top: var(--spacing-large);
+    line-height: var(--spacing-large);
+
+    &__item {
+      border-left: none;
+    }
+    li:not(:last-child) {
+      margin-bottom: var(--spacing-large);
+    }
+    li > a {
+      font-size: var(--font-size-body-small);
+    }
+
+    &--mobile {
+      li > a {
+        font-size: var(--font-size-heading-4) !important;
+      }
     }
   }
 

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -54,7 +54,7 @@ def get_product_rendered_content(product):
             element.attrs["class"] = class_name
 
             if tag == "h2":
-                element.attrs["id"] = slugify(element.text)
+                element.attrs["id"] = f"subheader-{slugify(element.text)}"
 
             if "[CTABUTTON]" in element.text:
                 # decompose the element when product doesn't have either a link or a form

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -1,3 +1,4 @@
+from django.utils.text import slugify
 from django.utils.translation import gettext as _
 
 import markdown
@@ -51,6 +52,9 @@ def get_product_rendered_content(product):
                 continue
 
             element.attrs["class"] = class_name
+
+            if tag == "h2":
+                element.attrs["id"] = slugify(element.text)
 
             if "[CTABUTTON]" in element.text:
                 # decompose the element when product doesn't have either a link or a form


### PR DESCRIPTION
- add subheadings to product page sidebar
- remove anchors for 'links' and 'see further' ('zie ook') 

Taiga: [#1535](https://taiga.maykinmedia.nl/project/open-inwoner/task/1535)