### PR TITLE
💄 [#1677] Making cookiebanner margins and modal same on mobile

### DIFF
--- a/src/open_inwoner/scss/components/CookieConsent/CookieBanner.scss
+++ b/src/open_inwoner/scss/components/CookieConsent/CookieBanner.scss
@@ -1,13 +1,17 @@
 .cookie-banner {
+  box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.2);
   bottom: var(--spacing-medium);
   display: none;
-  height: auto;
-  margin: var(--spacing-medium);
+  height: 100vh;
+  margin: 0;
+  max-height: 100vh;
   max-width: 100vw;
+  overflow: initial;
   padding: 0;
   position: fixed;
-  width: calc(100% - var(--spacing-medium) * 2);
+  top: 0;
+  width: 100%;
   z-index: 1100;
 
   @media (min-width: 768px) {
@@ -17,6 +21,7 @@
     height: 100vh;
     inset: initial;
     margin: 0;
+    padding: 0;
     max-height: 100vh;
     overflow: initial;
     top: 0;
@@ -24,18 +29,13 @@
   }
 
   &__container {
+    box-sizing: border-box;
     background-color: white;
-    border-radius: var(--border-radius);
-    border: 1px solid var(--color-gray-light);
     bottom: 0;
-    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5),
-      inset 0 -3px 3px rgba(0, 0, 0, 0.5);
     left: 0;
-    margin: var(--spacing-medium);
     max-height: 80vh;
     padding: var(--spacing-giant);
     position: absolute;
-    text-align: center;
 
     @media (min-width: 768px) {
       margin: 0;
@@ -71,7 +71,11 @@
   }
 
   &__text {
+    box-sizing: border-box;
     font-size: large;
+    margin: 0;
+    padding: 0;
+    text-align: center;
 
     @media (min-width: 500px) {
       font-size: x-large;


### PR DESCRIPTION
in order to test/review this: if you have previously clicked on the cookiebanner (making it invisible), you can make it appear in your browser again by looking in your Dev Tools for an >> Application >> Cookies/Local Storage tab and delete the "cookieBannerAccepted" cookie, or in >> Storage Tab >> Cookies >> localhost and remove "cookieBannerAccepted" (usually delete cookies via right-click)

https://taiga.maykinmedia.nl/project/open-inwoner/task/1677 