### PR TITLE
[#1492] Capture django-cms menu output and re-use, as workaround for menu-indicators issue & context pollution

### DIFF
--- a/src/open_inwoner/cms/extensions/cms_menus.py
+++ b/src/open_inwoner/cms/extensions/cms_menus.py
@@ -38,6 +38,8 @@ class MenuModifier(Modifier):
                 # optimise and only retrieve id and related object
                 .only("id").select_related("commonextension")
             )
+            num_indicators = 0
+
             for page in pages:
                 node = page_nodes[page.id]
                 try:
@@ -65,6 +67,11 @@ class MenuModifier(Modifier):
                     node.indicator = indicator_lookup(request, namespace)
                 else:
                     node.indicator = 0
+
+                num_indicators += node.indicator
+
+            # store total on something we can access from outside the template tags
+            request.user.num_indicators = num_indicators
 
         return nodes
 

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -71,7 +71,7 @@
                             {% endif %}
                         {% endif %}
 
-                        {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}
+                        {{ rendered_cms_menu__home }}
 
                         {% if has_general_faq_questions %}
                             <li class="primary-navigation__list-item">

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -9,14 +9,13 @@
             <li class="primary-navigation__list-item">
             {% button text=_('Welkom ')|addstr:request.user.get_short_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
 
-            {% with messages_notification=request.user.get_new_messages_total plans_notification=request.user.get_plan_contact_new_count %}
-                {% if messages_notification or plans_notification %}
+                {% if request.user.num_indicators %}
+                    {# num_indicators is set from a modifier in show_menu_below_id #}
                     <span class="indicator"><span class="indicator__dot"></span></span>
                 {% endif %}
-            {% endwith %}
 
                 <ul class="primary-navigation__list subpage-list">
-                    {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}
+                    {{ rendered_cms_menu__home }}
 
                     {% if has_general_faq_questions %}
                         <li class="primary-navigation__list-item">

--- a/src/open_inwoner/components/templatetags/header_tags.py
+++ b/src/open_inwoner/components/templatetags/header_tags.py
@@ -22,24 +22,3 @@ def accessibility_header(request, **kwargs):
     config = SiteConfiguration.get_solo()
     kwargs["help_text"] = config.get_help_text(request)
     return {**kwargs, "request": request}
-
-
-@register.inclusion_tag("components/Header/Header.html")
-def header(categories, request, **kwargs):
-    """
-    Displaying the header.
-
-    Usage:
-        {% header categories=Category.objects.all request=request %}
-
-    Variables:
-        + categories: Category[] | The categories that should be displayed in the theme dropdown.
-        + request: Request | the django request object.
-        - has_general_faq_questions: boolean | If the FAQ menu item should be shown.
-    """
-
-    return {
-        **kwargs,
-        "categories": categories,
-        "request": request,
-    }

--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -38,7 +38,14 @@
 
     <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
         {% cms_toolbar %}
-        {% header categories=menu_categories request=request breadcrumbs=breadcrumbs search_form=search_form has_general_faq_questions=has_general_faq_questions cms_apps=cms_apps %}
+
+        {# render de cms menu and save for display in both mobile and desktop #}
+        {% capture as rendered_cms_menu__home %}
+            {% with menu_categories as categories %}
+                {% show_menu_below_id "home" 0 100 100 100 "cms/menu/primary.html" %}
+            {% endwith %}
+        {% endcapture %}
+        {% include "components/Header/Header.html" %}
 
         {% if anchors and not custom_anchors %}
             {% anchor_menu anchors=anchors desktop=False %}


### PR DESCRIPTION
As workaround for menu-indicators issue & context pollution.

Also dropped the `header` template tag :tada: 