### PR TITLE
[#1717] Make warningbanner not overlap opened mobile menu

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -27,18 +27,19 @@
                 {% button text="" title="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True transparent=True %}
             </span>
         {% endif %}
+        </div>
+        {# end of mobile header-menu with logo #}
 
-            <div class="header__submenu">
-
+        <div class="header__submenu">
             {% if cms_apps.products %}
             {% if request.user.is_authenticated or not config.hide_search_from_anonymous_users %}
-              <nav class="header__actions" aria-label="Zoek navigatie mobiel">
-                  {% url 'search:search' as search_url %}
-                  {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}
-                      {% input search_form.query no_label=True %}
-                      {% form_actions primary_icon="search" primary_text=_("Zoeken") hide_primary_text=True %}
-                  {% endrender_form %}
-              </nav>
+                <nav class="header__actions header__actions--open" aria-label="Zoek navigatie mobiel">
+                {% url 'search:search' as search_url %}
+                {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}
+                    {% input search_form.query no_label=True %}
+                    {% form_actions primary_icon="search" primary_text=_("Zoeken") hide_primary_text=True %}
+                {% endrender_form %}
+                </nav>
             {% endif %}
             {% endif %}
 
@@ -102,10 +103,8 @@
                     </div>
                 </section>
 
-
             </div>
-        </div>
-{#end of mobile menu#}
+            {# end of submenu items #}
 
     {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
         <div class="logo__desktop">{% logo src=config.logo.file.url alt="Homepage "|add:logo_alt_text svg_height=75 %}</div>
@@ -126,11 +125,12 @@
 
         {% include "components/Header/NavigationAuthenticated.html" %}
     </div>
+    {# end of header container #}
 </header>
 
 {% if cms_apps.products %}
     {% if request.user.is_authenticated or not config.hide_search_from_anonymous_users %}
-        <section class="search search__mobile">
+        <section class="search search__mobile search__mobile--closed">
             <nav class="search__actions " aria-label="Zoek navigatie mobiel">
                 {% url 'search:search' as search_url %}
                 {% render_form form=search_form method="GET" form_action=search_url inline=True spaceless=False %}

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -80,7 +80,7 @@ $vm: var(--spacing-large);
 
       > .header__actions {
         display: block;
-        position: static;
+        position: initial;
         grid-row: 1;
         grid-column: 6 / span 5;
         margin-left: var(--spacing-large);
@@ -228,10 +228,10 @@ $vm: var(--spacing-large);
     overflow-y: auto;
     padding: 0 var(--spacing-large) var(--spacing-extra-large)
       var(--spacing-large);
-    position: fixed;
+    position: relative;
     right: 0;
     text-align: left;
-    top: calc(2 * var(--row-height));
+    top: 0;
     width: 100%;
     z-index: 2;
 
@@ -432,7 +432,9 @@ $vm: var(--spacing-large);
     }
 
     .header {
-      border-bottom: var(--border-width) dotted var(--color-white);
+      &__container {
+        height: 100vh;
+      }
 
       .primary-navigation
         > .primary-navigation__list
@@ -462,7 +464,6 @@ $vm: var(--spacing-large);
             }
 
             .header__menu-icon .open {
-              //height: var(--row-height);
               width: 100%;
               height: var(--font-size-body);
               background-color: var(--color-white);
@@ -482,7 +483,6 @@ $vm: var(--spacing-large);
       .header {
         &__actions {
           box-sizing: border-box;
-          //width: calc(100% - var(--spacing-extra-large));
           padding: 0;
           margin: 0;
 
@@ -513,7 +513,7 @@ $vm: var(--spacing-large);
 
       .header {
         &__submenu {
-          border-top: 1px solid var(--color-white);
+          border-top: none;
           display: block;
 
           .primary-navigation {


### PR DESCRIPTION
Self-identified problem: https://taiga.maykinmedia.nl/project/open-inwoner/task/1717
This needed restructering in the mobile menu in order to push elements to their initial positions.

<img width="1110" alt="navigation-menu-headerlogo-disappears" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/6613f18a-a96d-4eb7-86d1-f12faf8f0a26">
