### PR TITLE
[#1739] :bug: Fix infinite loop for search page filters

### DIFF
--- a/src/open_inwoner/js/components/search/index.js
+++ b/src/open_inwoner/js/components/search/index.js
@@ -11,15 +11,17 @@ const radioButtons = document.querySelectorAll(
   })
 })
 
-var timerId = 0
+let timerId = null
 
 const searchForm = document.getElementById('search-form')
 
 const filterButtons = document.querySelectorAll('.filter .checkbox__input')
 ;[...filterButtons].forEach((checkbox) => {
   checkbox.addEventListener('change', (event) => {
-    clearInterval(timerId)
-    timerId = setInterval(() => {
+    clearTimeout(timerId)
+
+    // Set a new timeout
+    timerId = setTimeout(() => {
       searchForm.submit()
     }, 250)
   })


### PR DESCRIPTION
https://taiga.maykinmedia.nl/project/open-inwoner/issue/1739

+ Preferably use '`let` 'instead of '`var`' for scope
+ Replaced `setInterval` with `setTimeout` to avoid continuous looping. Code inside setTimeout will execute once after the specified delay (250 milliseconds) 
+ Setting `timerId` to null instead of zero is a common practice in JavaScript when using variables to represent timers or intervals + makes it clear that the timerId variable is not currently associated with any active timer - a way to indicate that there is no ongoing timer operation. 