### PR TITLE
[#1735] Fix cookiebanner position for mobile devices

### DIFF
--- a/src/open_inwoner/scss/components/CookieConsent/CookieBanner.scss
+++ b/src/open_inwoner/scss/components/CookieConsent/CookieBanner.scss
@@ -35,7 +35,8 @@
     left: 0;
     max-height: 80vh;
     padding: var(--spacing-giant);
-    position: absolute;
+    position: fixed;
+    z-index: 1101;
 
     @media (min-width: 768px) {
       margin: 0;


### PR DESCRIPTION
This issue only occurs on mobile devices (margins on desktop are not affected by scroll or size of URL bar)
PR can only be reviewed on mobile devices, so either use Gronk or use Browserstack.

issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1735