### PR TITLE
[#1701] Changed User.get_full_name() to prefer .display_name over .first_name

### DIFF
--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -313,8 +313,9 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self._seed
 
     def get_full_name(self):
-        first_name = self.display_name or self.first_name
-        parts = (first_name, self.infix, self.last_name)
+        # validator allowed spaces as values
+        first_name = self.display_name.strip() or self.first_name.strip()
+        parts = (first_name, self.infix.strip(), self.last_name.strip())
         return " ".join(p for p in parts if p)
 
     def get_short_name(self):

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -313,7 +313,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self._seed
 
     def get_full_name(self):
-        parts = (self.first_name, self.infix, self.last_name)
+        first_name = self.display_name or self.first_name
+        parts = (first_name, self.infix, self.last_name)
         return " ".join(p for p in parts if p)
 
     def get_short_name(self):

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -30,6 +30,19 @@ class UserTests(TestCase):
         user = User(first_name="Foo", display_name="Flexi", infix="de", last_name="Bar")
         self.assertEqual(user.get_full_name(), "Flexi de Bar")
 
+        # spaces everywhere
+        user = User(first_name="Foo", display_name="    ", infix="de", last_name="Bar")
+        self.assertEqual(user.get_full_name(), "Foo de Bar")
+
+        user = User(
+            first_name="  ",
+            display_name="  ",
+            infix="  ",
+            last_name="  ",
+            email="foo@bar.nl",
+        )
+        self.assertEqual(user.get_full_name(), "")
+
     @freeze_time("2021-07-07 12:00:00")
     def test_get_age_same_day(self):
         with freeze_time("1990-07-07"):

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -26,6 +26,10 @@ class UserTests(TestCase):
         user = User(first_name="", infix="", last_name="Bar")
         self.assertEqual(user.get_full_name(), "Bar")
 
+        # use display_name instead of first_name
+        user = User(first_name="Foo", display_name="Flexi", infix="de", last_name="Bar")
+        self.assertEqual(user.get_full_name(), "Flexi de Bar")
+
     @freeze_time("2021-07-07 12:00:00")
     def test_get_age_same_day(self):
         with freeze_time("1990-07-07"):


### PR DESCRIPTION
Ability to change this centrally shows why DRY code (like a method) is preferred over spreading ad-hoc code.