### PR TITLE
[#1732] Make password-reset subject translatable

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1252,7 +1252,7 @@ class TestPasswordResetFunctionality(WebTest):
 
     def test_password_reset_form_custom_template_is_rendered(self):
         response = self.app.get(reverse("password_reset"))
-        self.assertContains(response, _("Wachtwoord opnieuw instellen"))
+        self.assertContains(response, _("Reset password"))
 
     def test_password_reset_email_contains_proper_data(self):
         current_site = Site.objects.get_current()
@@ -1262,19 +1262,17 @@ class TestPasswordResetFunctionality(WebTest):
         sent_mail = mail.outbox[0]
         body = sent_mail.body
         self.assertEqual(
-            _("Wachtwoordherinitialisatie voor {domain}").format(
-                domain=current_site.domain
-            ),
+            _("Password reset for {domain}").format(domain=current_site.domain),
             sent_mail.subject,
         )
         self.assertIn(
             _(
-                "U ontvangt deze e-mail, omdat u een aanvraag voor opnieuw instellen van het wachtwoord voor uw account op {domain} hebt gedaan."
+                "You're receiving this email because for your user account at example.com you requested a password reset."
             ).format(domain=current_site.domain),
             body,
         )
         self.assertIn(
-            _("Uw gebruikersnaam, mocht u deze vergeten zijn: {user_email}").format(
+            _("Your username, in case you’ve forgotten: {user_email}").format(
                 user_email=self.user.email
             ),
             body,
@@ -1308,11 +1306,11 @@ class TestPasswordChange(WebTest):
 
     def test_password_change_form_custom_template_is_rendered(self):
         response = self.app.get(reverse("password_change"), user=self.user)
-        self.assertContains(response, _("Wachtwoordwijziging"))
+        self.assertContains(response, _("Password reset"))
 
     def test_password_change_form_done_custom_template_is_rendered(self):
         response = self.app.get(reverse("password_change_done"), user=self.user)
-        self.assertContains(response, _("Uw wachtwoord is gewijzigd."))
+        self.assertContains(response, _("Your password has been changed."))
 
     def test_password_change_button_is_rendered_with_default_login_type(self):
         response = self.app.get(reverse("profile:detail"), user=self.user)

--- a/src/open_inwoner/templates/registration/password_change_done.html
+++ b/src/open_inwoner/templates/registration/password_change_done.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <h1 class="h1">{% trans "Wachtwoordwijziging is geslaagd" %}</h1>
-    <p class="p">{% trans "Uw wachtwoord is gewijzigd." %}</p>
+    <h1 class="h1">{% trans "Password reset was successful" %}</h1>
+    <p class="p">{% trans "Your password has been changed." %}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_change_form.html
+++ b/src/open_inwoner/templates/registration/password_change_form.html
@@ -2,15 +2,15 @@
 {% load i18n form_tags %}
 
 {% block content %}
-    <h1 class="h1">{% trans "Wachtwoordwijziging" %}</h1>
-    <p class="p">{% trans "Voer omwille van beveiliging uw oude en twee keer uw nieuwe wachtwoord in, zodat we kunnen controleren of u geen typefouten hebt gemaakt." %}</p>
+    <h1 class="h1">{% trans "Password reset" %}</h1>
+    <p class="p">{% trans "For security reasons, please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
 
     {% render_form id="password-change-form" method="POST" form=form%}
         {% csrf_token %}
         {% input form.old_password %}
         {% input form.new_password1 %}
         {% input form.new_password2 %}
-        {% form_actions primary_text=_("Mijn wachtwoord wijzigen") primary_icon="arrow_forward" %}
+        {% form_actions primary_text=_("Change my password") primary_icon="arrow_forward" %}
     {% endrender_form %}
 
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_complete.html
+++ b/src/open_inwoner/templates/registration/password_reset_complete.html
@@ -2,10 +2,10 @@
 {% load i18n button_tags %}
 
 {% block content %}
-    <h1 class="h1">{% trans "Wachtwoordherinitialisatie voltooid" %}</h1>
-    <p class="p">{% trans "Uw wachtwoord is ingesteld. U kunt nu verdergaan en zich aanmelden." %}</p>
-    
+    <h1 class="h1">{% trans "Password reset complete" %}</h1>
+    <p class="p">{% trans "Your password has been set. You can now continue and log in." %}</p>
+
     {% with login_url as login_url %}
-        <p class="p">{% button href=login_url text=_("Aanmelden") primary=True %}</p>
+        <p class="p">{% button href=login_url text=_("Log in") primary=True %}</p>
     {% endwith %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_confirm.html
+++ b/src/open_inwoner/templates/registration/password_reset_confirm.html
@@ -3,11 +3,11 @@
 
 {% block content %}
     {% if validlink %}
-        <h1 class="h1">{% trans "Voer nieuw wachtwoord in" %}</h1>
-        <p class="p">{% trans "Voer het nieuwe wachtwoord twee keer in, zodat we kunnen controleren of er geen typefouten zijn gemaakt." %}</p>
-        {% form form_object=form method="POST" submit_text=_('Mijn wachtwoord wijzigen') id="password-reset-confirm" %}
+        <h1 class="h1">{% trans "Enter new password" %}</h1>
+        <p class="p">{% trans "Please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
+        {% form form_object=form method="POST" submit_text=_('Change my password') id="password-reset-confirm" %}
     {% else %}
-        <h1 class="h1">{% trans "Wachtwoordherinitialisatie mislukt" %}</h1>
-        <p class="p">{% trans "De link voor het herstellen van het wachtwoord is ongeldig, waarschijnlijk omdat de link al eens is gebruikt. Vraag opnieuw een wachtwoord aan." %}</p>
+        <h1 class="h1">{% trans "Password reset failed" %}</h1>
+        <p class="p">{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>
     {% endif %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_done.html
+++ b/src/open_inwoner/templates/registration/password_reset_done.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-    <h1 class="h1">{% trans "Wachtwoordherinitialisatie verstuurd" %}</h1>
-    <p class="p">{% trans "We hebben u instructies gestuurd voor het instellen van uw wachtwoord, als er een account bestaat met het door u ingevoerde e-mailadres. U zou deze straks moeten ontvangen." %}</p>
-    <p class="p">{% trans "Als u geen e-mail ontvangt, controleer dan of u het e-mailadres hebt ingevoerd waarmee u zich hebt geregistreerd, en controleer uw spam-map." %}</p>
+    <h1 class="h1">{% trans "Password reset email sent" %}</h1>
+    <p class="p">{% trans "We have sent you instructions on how to set your password, if an account exists with the email address you entered. You should receive this shortly." %}</p>
+    <p class="p">{% trans "If you did not receive an email, please make sure you entered the email address you registered with and check your spam folder." %}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_email.html
+++ b/src/open_inwoner/templates/registration/password_reset_email.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 
-{% trans "Beste" %},
+{% trans "Dear" %},
 
-{% trans "U ontvangt deze e-mail, omdat u een aanvraag voor opnieuw instellen van het wachtwoord voor uw account op " %}{{ domain }}{% trans " hebt gedaan." %}
-{% trans "Ga naar de volgende pagina en kies een nieuw wachtwoord: " %}
+{% trans "You're receiving this email because for your user account at " %}{{ domain }}{% trans " you requested a password reset." %}
+{% trans "Please go to the following page and choose a new password: " %}
 
 {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 
-{% trans "Uw gebruikersnaam, mocht u deze vergeten zijn: " %}{{ user.get_username }}
+{% trans "Your username, in case you’ve forgotten: " %}{{ user.get_username }}
 
-{% trans "Met vriendelijke groet" %}, 
-{{ site_name }} 
+{% trans "With kind regards" %},
+{{ site_name }}

--- a/src/open_inwoner/templates/registration/password_reset_form.html
+++ b/src/open_inwoner/templates/registration/password_reset_form.html
@@ -2,14 +2,14 @@
 {% load i18n static form_tags %}
 
 {% block content %}
-  <h1 class="h1">{% trans "Wachtwoord opnieuw instellen" %}</h1>
-  <p class="p">{% trans "Wachtwoord vergeten? Vul hieronder je e-mailadres in. Je krijgt dan een mail met instructies om een nieuw wachtwoord in te stellen." %}</p>
-  <p class="p">{% trans "Let op: dit werkt alleen als je geen DigiD gebruikt om in te loggen." %}</p>
+  <h1 class="h1">{% trans "Reset password" %}</h1>
+  <p class="p">{% trans "Forgot your password? Enter your email address below. Then you will receive an email with instructions to set a new password." %}</p>
+  <p class="p">{% trans "Please note: this only works if you do are not using DigiD to log in." %}</p>
 
   {% render_form id="password-reset-form" method="POST" form=form%}
     {% csrf_token %}
     {% input form.email %}
-    {% form_actions primary_text=_("Wachtwoord opnieuw instellen") primary_icon="arrow_forward" %}
+    {% form_actions primary_text=_("Reset password") primary_icon="arrow_forward" %}
   {% endrender_form %}
 
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_subject.txt
+++ b/src/open_inwoner/templates/registration/password_reset_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktranslate %}Password reset for {{ site_name }}{% endblocktranslate %}
+{% endautoescape %}


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1732

New file `password_reset_subject.txt` added here:

https://github.com/maykinmedia/open-inwoner/pull/771/files#diff-01d2a103e38c25a357a69204ee48bb109142c26b3da6271f5ac3f1ba94e33725

also connected to the translations issue where we're keeping track of English defaults, instead of Dutch in the code
(anything that is now called 'Wachtwoordherinitialisatie' shall later be renamed to B1 'Wachtwoordwijziging')