### PR TITLE
Removed xmltodict

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -51,7 +51,6 @@ playwright
 django-yubin
 django-image-cropping
 django-log-outgoing-requests
-xmltodict
 
 # django cms
 django-cms

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -535,8 +535,6 @@ xlwt==1.3.0
     # via tablib
 xmlsec==1.3.12
     # via maykin-python3-saml
-xmltodict==0.13.0
-    # via -r requirements/base.in
 zgw-consumers==0.25.0
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -965,10 +965,6 @@ xmlsec==1.3.12
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-python3-saml
-xmltodict==0.13.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
 zgw-consumers==0.25.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1108,10 +1108,6 @@ xmlsec==1.3.12
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-python3-saml
-xmltodict==0.13.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 zgw-consumers==0.25.0
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
No longer needed with the SSD refactor [PR](https://github.com/maykinmedia/open-inwoner/pull/766) which uses xsdata instead