### PR TITLE
[#1805] Fix xml error

### DIFF
--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 import requests
 from lxml import etree  # nosec
+from lxml.etree import LxmlError  # nosec
 from xsdata.exceptions import ParserError
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.parsers import XmlParser
@@ -41,14 +42,19 @@ def _get_report_info(
     if not response.content:
         return None
 
-    tree = etree.fromstring(response.content)
-    node = tree.find(info_response_node)
+    try:
+        tree = etree.fromstring(response.content).getroottree()
+        node = tree.find(info_response_node)
+    except LxmlError:
+        return None
+
     parser = XmlParser(context=XmlContext(), handler=LxmlEventHandler)
 
     try:
         info = parser.parse(node, info_type)
     except ParserError:
         return None
+
     return info
 
 


### PR DESCRIPTION
Taiga [#1805](https://taiga.maykinmedia.nl/project/open-inwoner/issue/1805)

The bug is caused by incorrect use of `lxml.fromstring`, which returns an lxml element instead of the document tree, in contrast to `lxml.parse` which was used to read in the content of the file object during testing.