### PR TITLE
[#1733] Product sharing X icon

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -300,7 +300,7 @@ face==20.1.1
     # via glom
 faker==9.9.0
     # via zgw-consumers
-fontawesomefree==6.1.1
+fontawesomefree==6.4.2
     # via -r requirements/base.in
 fonttools[woff]==4.29.1
     # via weasyprint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -501,7 +501,7 @@ faker==9.9.0
     #   -r requirements/base.txt
     #   factory-boy
     #   zgw-consumers
-fontawesomefree==6.1.1
+fontawesomefree==6.4.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -540,7 +540,7 @@ faker==9.9.0
     #   zgw-consumers
 flake8==3.9.2
     # via -r requirements/dev.in
-fontawesomefree==6.1.1
+fontawesomefree==6.4.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1733

NPM keeps on hanging on 6.1.1 but needs to become 6.4.2 everywhere
`npm install --save @fortawesome/free-brands-svg-icons --force`

or:
`npm ci --legacy-peer-deps`