### PR TITLE
[#1814] Upgraded digid-eherkenning to 0.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -161,7 +161,7 @@ django-csp==3.7
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning==0.7.0
+django-digid-eherkenning==0.9.0
     # via -r requirements/base.in
 django-elasticsearch-dsl==7.2.1
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -249,7 +249,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.7.0
+django-digid-eherkenning==0.9.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -276,7 +276,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-digid-eherkenning==0.7.0
+django-digid-eherkenning==0.9.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.contrib.sites.models import Site
@@ -68,7 +69,11 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
             furl(reverse("digid:login")).add({"next": necessary_url}).url,
         )
 
-    def test_digid_fail_without_invite_redirects_to_login_page(self):
+    @patch("digid_eherkenning.validators.Proef11ValidatorBase.__call__")
+    def test_digid_fail_without_invite_redirects_to_login_page(self, m):
+        # disable mock form validation to check redirect
+        m.return_value = True
+
         self.assertNotIn("invite_url", self.client.session.keys())
 
         url = reverse("digid-mock:password")
@@ -87,7 +92,11 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
 
         self.assertRedirectsLogin(response, with_host=True)
 
-    def test_digid_fail_without_invite_and_next_url_redirects_to_login_page(self):
+    @patch("digid_eherkenning.validators.Proef11ValidatorBase.__call__")
+    def test_digid_fail_without_invite_and_next_url_redirects_to_login_page(self, m):
+        # disable mock form validation to check redirect
+        m.return_value = True
+
         self.assertNotIn("invite_url", self.client.session.keys())
 
         url = reverse("digid-mock:password")
@@ -106,7 +115,10 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
 
         self.assertRedirectsLogin(response, with_host=True)
 
-    def test_digid_fail_with_invite_redirects_to_register_page(self):
+    @patch("digid_eherkenning.validators.Proef11ValidatorBase.__call__")
+    def test_digid_fail_with_invite_redirects_to_register_page(self, m):
+        # disable mock form validation to check redirect
+        m.return_value = True
         invite = InviteFactory()
         session = self.client.session
         session[
@@ -149,7 +161,7 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
         url = f"{url}?{urlencode(params)}"
 
         data = {
-            "auth_name": "123456789",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
 
@@ -175,7 +187,7 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
             "next": reverse("profile:registration_necessary"),
         }
         data = {
-            "auth_name": "123456789",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         url = f"{url}?{urlencode(params)}"
@@ -223,7 +235,7 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
             "next": reverse("profile:registration_necessary"),
         }
         data = {
-            "auth_name": "123456789",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         url = f"{url}?{urlencode(params)}"
@@ -260,7 +272,7 @@ class DigiDRegistrationTest(AssertRedirectsMixin, HaalCentraalMixin, WebTest):
         url = f"{url}?{urlencode(params)}"
 
         data = {
-            "auth_name": "123456782",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         # post our password to the IDP
@@ -691,7 +703,7 @@ class DuplicateEmailRegistrationTest(WebTest):
         """Assert that digid users can register with duplicate emails"""
         test_user = DigidUserFactory.create(
             email="test@example.com",
-            bsn="123456789",
+            bsn="648197724",
         )
 
         url = reverse("digid-mock:password")
@@ -703,7 +715,7 @@ class DuplicateEmailRegistrationTest(WebTest):
 
         data = {
             # different BSN
-            "auth_name": "112083948",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         # post our password to the IDP
@@ -780,7 +792,7 @@ class DuplicateEmailRegistrationTest(WebTest):
         url = f"{url}?{urlencode(params)}"
 
         data = {
-            "auth_name": "123456789",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         # post our password to the IDP
@@ -816,7 +828,7 @@ class DuplicateEmailRegistrationTest(WebTest):
         url = f"{url}?{urlencode(params)}"
 
         data = {
-            "auth_name": "123456782",
+            "auth_name": "533458225",
             "auth_pass": "bar",
         }
         # post our password to the IDP


### PR DESCRIPTION
The new version validates BSN numbers during the mock login flow.

This will prevent issues like Taiga [#1814](https://taiga.maykinmedia.nl/project/open-inwoner/issue/1814) by requiring users to enter a BSN that satifies pattern validation as well as the 11-check.
