### PR TITLE
Fixed case filtering in list view and AttributeError in detail view

### DIFF
--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -45,7 +45,6 @@ class InnerCaseListView(
     def get_cases(self):
         raw_cases = fetch_cases(self.request.user.bsn)
         preprocessed_cases = preprocess_data(raw_cases)
-        preprocessed_cases.sort(key=lambda case: case.startdatum, reverse=True)
         return preprocessed_cases
 
     def get_submissions(self):

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -201,11 +201,13 @@ class InnerCaseDetailView(
                 zt_statustype_config = ztc.zaaktypestatustypeconfig_set.get(
                     statustype_url=case.status.statustype.url
                 )
+            # case has no status, or status type not found
+            except (AttributeError, ObjectDoesNotExist):
+                pass
+            else:
                 case_type_document_upload_description = (
                     zt_statustype_config.document_upload_description
                 )
-            except ObjectDoesNotExist:
-                pass
 
         return {
             "case_type_config_description": case_type_config_description,

--- a/src/open_inwoner/openzaak/cases.py
+++ b/src/open_inwoner/openzaak/cases.py
@@ -335,20 +335,23 @@ def add_status_type_config(case: Zaak) -> None:
         pass
 
 
-def filter_visible(cases: list[Zaak]) -> list[Zaak]:
-    return [case for case in cases if is_zaak_visible(case)]
-
-
 def preprocess_data(cases: list[Zaak]) -> list[Zaak]:
     """
     Resolve zaaktype and statustype, add status type config, filter for visibility
+
+    Note: we need to iterate twice over `cases` because the `zaak_type` must be
+          resolved to a `ZaakType` object before we can filter by visibility
     """
     for case in cases:
         resolve_zaak_type(case)
 
-        if case.status:
-            resolve_status(case)
-            resolve_status_type(case)
-            add_status_type_config(case)
+    cases = [case for case in cases if case.status and is_zaak_visible(case)]
 
-    return filter_visible(cases)
+    for case in cases:
+        resolve_status(case)
+        resolve_status_type(case)
+        add_status_type_config(case)
+
+    cases.sort(key=lambda case: case.startdatum, reverse=True)
+
+    return cases


### PR DESCRIPTION
Fixes two problems with the recent refactor of the case list ([PR 804](https://github.com/maykinmedia/open-inwoner/pull/804/files))
- the filtering of non-visible zaken was performed in the wrong place, which slowed down page load
- the addition of info_context to upload documents needs to check for `AttributeError` to account for zaken without status