### PR TITLE
:lipstick: Fix case list styling issues

### DIFF
--- a/src/open_inwoner/components/templates/components/StatusIndicator/StatusIndicator.html
+++ b/src/open_inwoner/components/templates/components/StatusIndicator/StatusIndicator.html
@@ -1,10 +1,12 @@
 {% load icon_tags %}
-<div class="card__header {{ status_indicator }}">
-    {% if status_indicator == "success" %}
-        {% icon icon="check_circle" icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
-    {% elif status_indicator == "failure" %}
-        {% icon icon="cancel" icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
-    {% else %}
-        {% icon icon=status_indicator icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
-    {% endif %}
-</div>
+{% if status_indicator %}
+    <div class="card__header {{ status_indicator }}">
+        {% if status_indicator == "success" %}
+            {% icon icon="check_circle" icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
+        {% elif status_indicator == "failure" %}
+            {% icon icon="cancel" icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
+        {% else %}
+            {% icon icon=status_indicator icon_position="after" extra_classes="icon--"|add:status_indicator %} {{status_indicator_text}}
+        {% endif %}
+    </div>
+{% endif %}

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -1,6 +1,5 @@
 {% load link_tags button_tags i18n grid_tags icon_tags list_tags pagination_tags utils %}
 
-<h2 class="h2" id="cases">{% trans "Mijn aanvragen" %}</h2>
 <h2 class="h2" id="cases">{{ page_title }} ({{ paginator.count }})</h2>
 <p class="cases__title_text">{{ title_text }}</p>
 


### PR DESCRIPTION
Noticed that the heading was duplicated after the refactor of the case list
![image](https://github.com/maykinmedia/open-inwoner/assets/29249171/67dc9861-d53f-475a-bfd5-f8ca0f82e754)

Also noticed that the status indicator header was always added, even if the status indicator is empty, resulting in unnecessary spacing at the top of the card
![image](https://github.com/maykinmedia/open-inwoner/assets/29249171/76da69c5-b5fa-46dd-9b49-7ee16a7f4aca)
