### PR TITLE
:speech_balloon: #1824 - feat: use "Laatste datum beslissing" for "en…

### DIFF
--- a/src/open_inwoner/components/templatetags/dashboard_tags.py
+++ b/src/open_inwoner/components/templatetags/dashboard_tags.py
@@ -42,7 +42,7 @@ def case_dashboard(case: dict, **kwargs) -> dict:
                 "value": case.get("start_date"),
             },
             {
-                "label": _("Verwachte uitslag:"),
+                "label": _("Laatste datum beslissing:"),
                 "value": case.get("end_date_legal"),
             },
         ]


### PR DESCRIPTION
…d_date_legal" label.