### PR TITLE
:sparkles: [#1878] Post-login registration form for eHerkenning

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -208,6 +208,9 @@ class NecessaryUserForm(forms.ModelForm):
                 del self.fields["last_name"]
             if not user.infix:
                 del self.fields["infix"]
+        elif user.login_type == LoginTypeChoices.eherkenning:
+            for field_name in ["first_name", "infix", "last_name"]:
+                del self.fields[field_name]
 
 
 class CustomPasswordResetForm(PasswordResetForm):

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -387,8 +387,15 @@ class User(AbstractBaseUser, PermissionsMixin):
                 or not self.email
                 or self.email.endswith("@example.org")
             )
-        elif self.login_type == LoginTypeChoices.oidc:
-            return not self.email or self.email.endswith("@example.org")
+        elif self.login_type in (
+            LoginTypeChoices.oidc,
+            LoginTypeChoices.eherkenning,
+        ):
+            return (
+                not self.email
+                or self.email.endswith("@example.org")
+                or self.email.endswith("localhost")
+            )
         return False
 
     def get_logout_url(self) -> str:

--- a/src/open_inwoner/accounts/templates/django_registration/registration_form.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_form.html
@@ -5,7 +5,7 @@
 
 <div class="registration-grid">
   {% render_grid %}
-   {% if digit_url %}
+   {% if settings.DIGID_ENABLED and digit_url %}
     {% render_column start=5 span=5 %}
         {% render_card direction='horizontal' tinted=True %}
             <a href="{{ digit_url }}" class="link digid-logo">
@@ -16,7 +16,7 @@
     {% endrender_column %}
   {% endif %}
 
-  {% if eherkenning_url %}
+  {% if eherkenning_enabled and eherkenning_url %}
     {% render_column start=5 span=5 %}
         {% render_card direction='horizontal' tinted=True %}
             <a href="{{ eherkenning_url }}" class="link eherkenning-logo">

--- a/src/open_inwoner/accounts/templates/django_registration/registration_form.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_form.html
@@ -8,10 +8,21 @@
    {% if digit_url %}
     {% render_column start=5 span=5 %}
         {% render_card direction='horizontal' tinted=True %}
-            <a href="{% url 'digid:login' %}" class="link digid-logo">
+            <a href="{{ digit_url }}" class="link digid-logo">
                 <img class="digid-logo__image" src="{% static 'accounts/digid_logo.svg' %}" alt="DigiD inlogpagina">
             </a>
             {% link bold=True href=digit_url text=_('Registreren met DigiD') secondary=True icon='arrow_forward' %}
+        {% endrender_card %}
+    {% endrender_column %}
+  {% endif %}
+
+  {% if eherkenning_url %}
+    {% render_column start=5 span=5 %}
+        {% render_card direction='horizontal' tinted=True %}
+            <a href="{{ eherkenning_url }}" class="link eherkenning-logo">
+                <img class="eherkenning-logo__image" src="{% static 'accounts/eherkenning.png' %}" height=30 alt="eHerkenning inlogpagina">
+            </a>
+            {% link bold=True href=eherkenning_url text=_('Registreren met eHerkenning') secondary=True icon='arrow_forward' %}
         {% endrender_card %}
     {% endrender_column %}
   {% endif %}

--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -30,7 +30,7 @@
         {% if eherkenning_enabled %}
             {% render_card direction='horizontal' tinted=True %}
                 <a href="{% url 'eherkenning:login' %}" class="link eherkenning-logo">
-                    <img class="eherkenning-logo__image" src="{% static 'accounts/eherkenning.png' %}" height=40 alt="eHerkenning inlogpagina">
+                    <img class="eherkenning-logo__image" src="{% static 'accounts/eherkenning.png' %}" height=30 alt="eHerkenning inlogpagina">
                 </a>
                 {% url 'eherkenning:login' as href %}
                 {% with href|addnexturl:next as href_with_next %}

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -419,7 +419,11 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
     def setUpTestData(cls):
         cms_tools.create_homepage()
 
-    def test_registration_page_eherkenning(self):
+    @patch("open_inwoner.configurations.models.SiteConfiguration.get_solo")
+    def test_registration_page_eherkenning(self, mock_solo):
+        mock_solo.return_value.eherkenning_enabled = True
+        mock_solo.return_value.login_allow_registration = False
+
         response = self.app.get(self.url)
 
         self.assertEqual(response.status_code, 200)
@@ -434,7 +438,11 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
             .url,
         )
 
-    def test_registration_page_eherkenning_with_invite(self):
+    @patch("open_inwoner.configurations.models.SiteConfiguration.get_solo")
+    def test_registration_page_eherkenning_with_invite(self, mock_solo):
+        mock_solo.return_value.eherkenning_enabled = True
+        mock_solo.return_value.login_allow_registration = False
+
         invite = InviteFactory.create()
 
         response = self.app.get(f"{self.url}?invite={invite.key}")

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -150,6 +150,7 @@ class NecessaryFieldsUserView(LogMixin, LoginRequiredMixin, InviteMixin, UpdateV
         if not invite and (
             (user.bsn and user.email == generate_email_from_string(user.bsn))
             or (user.oidc_id and user.email == generate_email_from_string(user.oidc_id))
+            or (user.kvk and user.email == f"user-{user.kvk}@localhost")
         ):
             initial["email"] = ""
 

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -101,6 +101,15 @@ class CustomRegistrationView(LogMixin, InviteMixin, RegistrationView):
             )
         except:
             context["digit_url"] = ""
+
+        try:
+            context["eherkenning_url"] = (
+                furl(reverse("eherkenning:login"))
+                .add({"next": necessary_fields_url})
+                .url
+            )
+        except:
+            context["eherkenning_url"] = ""
         return context
 
     def get(self, request, *args, **kwargs):

--- a/src/open_inwoner/conf/ci.py
+++ b/src/open_inwoner/conf/ci.py
@@ -35,6 +35,7 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     # mock login like dev.py
     "digid_eherkenning.mock.backends.DigiDBackend",
+    "eherkenning.mock.backends.eHerkenningBackend",
     "open_inwoner.accounts.backends.CustomOIDCBackend",
 ]
 


### PR DESCRIPTION
Based on https://github.com/maykinmedia/open-inwoner/pull/859, so that should be merged first

task: https://taiga.maykinmedia.nl/project/open-inwoner/task/1878

Aside from adapting the necessary registration form, the following was also changed/added:
- added eHerkenning link to registration page
- made DigiD/eHerkenning links on registration page conditional based on `settings.DIGID_ENABLED` and `SiteConfiguration.eherkenning_enabled`