### PR TITLE
[#1867] Prevent retrieval of zaken with missing rsin

### DIFF
--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -59,11 +59,11 @@ class InnerCaseListView(
 
     def get_cases(self):
         if self.request.user.kvk:
-            identifier = self.request.user.kvk
+            kvk_or_rsin = self.request.user.kvk
             config = OpenZaakConfig.get_solo()
             if config.fetch_eherkenning_zaken_with_rsin:
-                identifier = self.request.user.rsin
-            raw_cases = fetch_cases_by_kvk_or_rsin(identifier)
+                kvk_or_rsin = self.request.user.rsin
+            raw_cases = fetch_cases_by_kvk_or_rsin(kvk_or_rsin=kvk_or_rsin)
         else:
             raw_cases = fetch_cases(self.request.user.bsn)
         preprocessed_cases = preprocess_data(raw_cases)

--- a/src/open_inwoner/openzaak/cases.py
+++ b/src/open_inwoner/openzaak/cases.py
@@ -67,21 +67,24 @@ def fetch_cases(
 
 
 @cache_result(
-    "cases:{kvk_or_rsin}:{max_cases}:{identificatie}",
+    "cases:{kvk_or_rsin}:{max_cases}:{zaak_identificatie}",
     timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
 )
 def fetch_cases_by_kvk_or_rsin(
-    kvk_or_rsin: str,
+    kvk_or_rsin: Optional[str],
     max_cases: Optional[int] = 100,
-    identificatie: Optional[str] = None,
+    zaak_identificatie: Optional[str] = None,
 ) -> List[Zaak]:
     """
     retrieve cases for particular company with allowed confidentiality level
 
-    :param:max_cases - used to limit the number of requests to list_zaken resource. The default
+    :param max_cases: - used to limit the number of requests to list_zaken resource. The default
     value = 100, which means only one 1 request
-    :param:identificatie - used to filter the cases by a specific identification
+    :param zaak_identificatie: - used to filter the cases by a unique Zaak identification number
     """
+    if not kvk_or_rsin:
+        return []
+
     client = build_client("zaak")
 
     if client is None:
@@ -93,8 +96,8 @@ def fetch_cases_by_kvk_or_rsin(
         "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": kvk_or_rsin,
         "maximaleVertrouwelijkheidaanduiding": config.zaak_max_confidentiality,
     }
-    if identificatie:
-        params.update({"identificatie": identificatie})
+    if zaak_identificatie:
+        params.update({"identificatie": zaak_identificatie})
 
     try:
         response = get_paginated_results(


### PR DESCRIPTION
Prevents retrieval of Zaken if fetching with RSIN is enabled but RSIN is missing

Taiga [#1867](https://taiga.maykinmedia.nl/project/open-inwoner/task/1867)