### PR TITLE
[#1885] Changed document admin to be readonly

### DIFF
--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -142,7 +142,36 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
 
 @admin.register(Action)
 class ActionAdmin(UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin):
-    readonly_fields = ("uuid",)
+    fields = [
+        "uuid",
+        "name",
+        "description",
+        "status",
+        "type",
+        "end_date",
+        "file",
+        "is_for",
+        "created_on",
+        "updated_on",
+        "created_by",
+        "plan",
+        "is_deleted",
+    ]
+    readonly_fields = (
+        "uuid",
+        "name",
+        "description",
+        "status",
+        "type",
+        "end_date",
+        "file",
+        "is_for",
+        "created_on",
+        "updated_on",
+        "created_by",
+        "plan",
+        "is_deleted",
+    )
     list_display = ("name", "status", "plan", "created_on", "created_by", "is_deleted")
     list_filter = (
         "is_deleted",
@@ -156,6 +185,9 @@ class ActionAdmin(UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin):
     raw_id_fields = [
         "plan",
     ]
+
+    def has_add_permission(self, request):
+        return False
 
     @admin.action(description=_("Mark selected actions as soft-deleted by user."))
     def mark_deleted(self, request, queryset):
@@ -216,10 +248,32 @@ class AppointmentAdmin(UUIDAdminFirstInOrder, admin.ModelAdmin):
 
 @admin.register(Message)
 class MessageAdmin(PrivateMediaMixin, admin.ModelAdmin):
-    readonly_fields = ("uuid",)
+    fields = (
+        "uuid",
+        "sender",
+        "receiver",
+        "created_on",
+        "content",
+        "seen",
+        "sent",
+        "file",
+    )
+    readonly_fields = (
+        "uuid",
+        "sender",
+        "receiver",
+        "created_on",
+        "content",
+        "seen",
+        "sent",
+        "file",
+    )
     list_display = ("sender", "receiver", "created_on", "seen", "sent")
     list_filter = ("sender", "receiver")
     private_media_fields = ("file",)
+
+    def has_add_permission(self, request):
+        return False
 
 
 @admin.register(Invite)

--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.forms import ValidationError
+from django.http.request import HttpRequest
 from django.urls import reverse, reverse_lazy
 from django.utils.html import format_html
 from django.utils.translation import ngettext, ugettext_lazy as _
@@ -19,6 +20,12 @@ class ReadOnlyFileMixin:
     """
     By default, private media fields do not display the correct URL when readonly
     """
+
+    def get_fields(self, request, obj=None):
+        fields = super().get_fields(request, obj=obj)
+        if "display_file_url" not in fields and "file" in fields:
+            fields[fields.index("file")] = "display_file_url"
+        return fields
 
     def display_file_url(self, obj):
         view_name = "%(app_label)s_%(model_name)s_%(field)s" % {
@@ -164,36 +171,6 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
 class ActionAdmin(
     ReadOnlyFileMixin, UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin
 ):
-    fields = [
-        "uuid",
-        "name",
-        "description",
-        "status",
-        "type",
-        "end_date",
-        "display_file_url",
-        "is_for",
-        "created_on",
-        "updated_on",
-        "created_by",
-        "plan",
-        "is_deleted",
-    ]
-    readonly_fields = (
-        "uuid",
-        "name",
-        "description",
-        "status",
-        "type",
-        "end_date",
-        "display_file_url",
-        "is_for",
-        "created_on",
-        "updated_on",
-        "created_by",
-        "plan",
-        "is_deleted",
-    )
     list_display = ("name", "status", "plan", "created_on", "created_by", "is_deleted")
     list_filter = (
         "is_deleted",
@@ -209,6 +186,9 @@ class ActionAdmin(
     ]
 
     def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
         return False
 
     @admin.action(description=_("Mark selected actions as soft-deleted by user."))
@@ -244,20 +224,14 @@ class ActionAdmin(
 class DocumentAdmin(
     ReadOnlyFileMixin, UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin
 ):
-    fields = ["uuid", "name", "display_file_url", "created_on", "plan", "owner"]
-    readonly_fields = (
-        "uuid",
-        "name",
-        "display_file_url",
-        "plan",
-        "created_on",
-        "owner",
-    )
     list_display = ("name", "display_file_url", "created_on", "owner")
     list_filter = ("owner",)
     private_media_fields = ("file",)
 
     def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
         return False
 
 
@@ -270,31 +244,14 @@ class AppointmentAdmin(UUIDAdminFirstInOrder, admin.ModelAdmin):
 
 @admin.register(Message)
 class MessageAdmin(ReadOnlyFileMixin, PrivateMediaMixin, admin.ModelAdmin):
-    fields = (
-        "uuid",
-        "sender",
-        "receiver",
-        "created_on",
-        "content",
-        "seen",
-        "sent",
-        "display_file_url",
-    )
-    readonly_fields = (
-        "uuid",
-        "sender",
-        "receiver",
-        "created_on",
-        "content",
-        "seen",
-        "sent",
-        "display_file_url",
-    )
     list_display = ("sender", "receiver", "created_on", "seen", "sent")
     list_filter = ("sender", "receiver")
     private_media_fields = ("file",)
 
     def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
         return False
 
 

--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -188,7 +188,8 @@ class ActionAdmin(UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin):
 
 @admin.register(Document)
 class DocumentAdmin(UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin):
-    readonly_fields = ("uuid",)
+    fields = ["uuid", "name", "file", "created_on", "plan", "owner"]
+    readonly_fields = ("uuid", "name", "file", "plan", "preview", "created_on", "owner")
     list_display = ("name", "preview", "created_on", "owner")
     list_filter = ("owner",)
     private_media_fields = ("file",)
@@ -201,6 +202,9 @@ class DocumentAdmin(UUIDAdminFirstInOrder, PrivateMediaMixin, admin.ModelAdmin):
         )
 
     preview.short_description = "Preview file"
+
+    def has_add_permission(self, request):
+        return False
 
 
 @admin.register(Appointment)


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/task/1885

In the pentest you could upload here, but this is user content so no need to create/edit it through the admin.

Fields:
- [x] document.file -> frontend widget only allows `settings.UPLOAD_FILE_TYPES`
- [x] action.file -> frontend widget only allows `settings.UPLOAD_FILE_TYPES`
- [x] message.file -> frontend widget only allows `settings.UPLOAD_FILE_TYPES`
- [x] ~~siteconfig.theme_stylesheet~~ -> .css extension validation
- [x] ~~CaseUploadForm.files~~ -> configurable extension validation in admin
- [x] ProductFile.file -> filer already has validation: https://github.com/django-cms/django-filer/blob/master/filer/validation.py#L30
- [x] PlanTemplate.file -> filer already has validation: https://github.com/django-cms/django-filer/blob/master/filer/validation.py#L30
- [x] QuestionnaireStepFile.file -> filer already has validation: https://github.com/django-cms/django-filer/blob/master/filer/validation.py#L30