### PR TITLE
[#1928] Check missing volgnummer for second status preview

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -251,6 +251,10 @@ class InnerCaseDetailView(
         """
         statustype_numbers = [s.volgnummer for s in statustypen]
 
+        # status_types retrieved via eSuite don't always have a volgnummer
+        if not all(statustype_numbers):
+            return
+
         # only 1 statustype for `self.case`
         # (this scenario is blocked by openzaak, but not part of the zgw standard)
         if len(statustype_numbers) < 2:

--- a/src/open_inwoner/openzaak/api_models.py
+++ b/src/open_inwoner/openzaak/api_models.py
@@ -229,7 +229,7 @@ class StatusType(ZGWModel):
     url: str  # bug: not required according to OAS
     zaaktype: str
     omschrijving: str
-    volgnummer: int
+    volgnummer: Optional[int]  # not in eSuite
     omschrijving_generiek: str = ""
     statustekst: str = ""
     is_eindstatus: bool = False


### PR DESCRIPTION
`InnerCaseDetailView.get_second_status_preview` occasionally failed due to a `TypeError` because case status types retrieved via the eSuite don't always contain a `volgnummer`.

I added a check to the function and updated the annotation of our `StatusType` api model

Taiga [#1928](https://taiga.maykinmedia.nl/project/open-inwoner/issue/1928)