### PR TITLE
[#1851] Fixed flakey ContactView test

### DIFF
--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -48,7 +48,7 @@ class ContactViewTests(WebTest):
         self.assertNotContains(response, self.contact.first_name)
 
     def test_list_shows_pending_invitations(self):
-        existing_user = UserFactory()
+        existing_user = UserFactory(first_name="UniqueName")
         self.user.contacts_for_approval.add(existing_user)
         response = self.app.get(self.list_url, user=self.user)
 


### PR DESCRIPTION
It is kinda interesting how this happens on CI.

It feels like there is something funny going on in the random state/logic it uses to select the next name; somehow on CI it re-uses exactly the same in this same test.
