### PR TITLE
:recycle: [#1915] Use regular logout endpoint for eHerkenning logout

### DIFF
--- a/src/eherkenning/mock/eherkenning_urls.py
+++ b/src/eherkenning/mock/eherkenning_urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 from eherkenning.mock.views.eherkenning import (
     eHerkenningAssertionConsumerServiceMockView,
     eHerkenningLoginMockView,
-    eHerkenningLogoutMockView,
 )
 
 """
@@ -15,5 +14,4 @@ app_name = "eherkenning"
 urlpatterns = (
     path("login/", eHerkenningLoginMockView.as_view(), name="login"),
     path("acs/", eHerkenningAssertionConsumerServiceMockView.as_view(), name="acs"),
-    path("logout/", eHerkenningLogoutMockView.as_view(), name="logout"),
 )

--- a/src/eherkenning/mock/views/eherkenning.py
+++ b/src/eherkenning/mock/views/eherkenning.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import auth, messages
-from django.contrib.auth.views import LogoutView
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.urls import reverse
@@ -101,8 +100,3 @@ class eHerkenningAssertionConsumerServiceMockView(View):
         auth.login(request, user)
 
         return HttpResponseRedirect(self.get_success_url())
-
-
-class eHerkenningLogoutMockView(LogoutView):
-    # in the future we can render a custom template to emulate eHerkenning logout page
-    pass

--- a/src/eherkenning/tests/test_mock_views.py
+++ b/src/eherkenning/tests/test_mock_views.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, modify_settings, override_settings
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 
 from furl import furl
 
@@ -166,18 +166,3 @@ class PasswordLoginViewTests(eHerkenningMockTestCase):
         self.assertRedirects(
             response, str(expected_redirect), fetch_redirect_response=False
         )
-
-
-@override_settings(**OVERRIDE_SETTINGS)
-@modify_settings(**MODIFY_SETTINGS)
-class LogoutViewTests(TestCase):
-    def test_logout(self):
-        User = get_user_model()
-        user = User.objects.create_user(email="testuser@localhost", password="test")
-        self.client.force_login(user)
-
-        url = reverse("eherkenning:logout")
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, 302)
-        self.assertFalse("_auth_user_id" in self.client.session)

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -420,7 +420,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         elif self.login_type == LoginTypeChoices.eherkenning:
             if OpenIDConnectEHerkenningConfig.get_solo().enabled:
                 return reverse("eherkenning_oidc:logout")
-            return reverse("eherkenning:logout")
+            return reverse("logout")
 
     def get_contact_update_url(self):
         return reverse("profile:contact_edit", kwargs={"uuid": self.uuid})

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -103,7 +103,7 @@ class ProfileViewTests(WebTest):
                 logout_url = (
                     reverse("eherkenning_oidc:logout")
                     if oidc_enabled
-                    else reverse("eherkenning:logout")
+                    else reverse("logout")
                 )
 
                 response = self.app.get(self.url, user=self.eherkenning_user)


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/task/1915

As discussed, deleting the local session is sufficient to logout of eHerkenning