### PR TITLE
[#1991] StatusTypeConfig configuration not refreshing 

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -98,7 +98,7 @@ class InnerCaseDetailView(
     contact_form_class = CaseContactForm
     case: Optional[Zaak] = None
 
-    def __init__(self):
+    def dispatch(self, request, *args, **kwargs):
         self.statustype_config_mapping = {
             zaaktype_statustype.statustype_url: zaaktype_statustype
             for zaaktype_statustype in ZaakTypeStatusTypeConfig.objects.all()
@@ -107,6 +107,7 @@ class InnerCaseDetailView(
             zt_resulttype.resultaattype_url: zt_resulttype
             for zt_resulttype in ZaakTypeResultaatTypeConfig.objects.all()
         }
+        return super(InnerCaseDetailView, self).dispatch(request, *args, **kwargs)
 
     @cached_property
     def crumbs(self):

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -98,16 +98,21 @@ class InnerCaseDetailView(
     contact_form_class = CaseContactForm
     case: Optional[Zaak] = None
 
-    def dispatch(self, request, *args, **kwargs):
+    def store_statustype_resulttype_mapping(self, zaaktype_identificatie):
+        # Filter on ZaakType identificatie to avoid eSuite situation where one statustype
+        # is linked to multiple zaaktypes
         self.statustype_config_mapping = {
             zaaktype_statustype.statustype_url: zaaktype_statustype
-            for zaaktype_statustype in ZaakTypeStatusTypeConfig.objects.all()
+            for zaaktype_statustype in ZaakTypeStatusTypeConfig.objects.filter(
+                zaaktype_config__identificatie=zaaktype_identificatie
+            )
         }
         self.resulttype_config_mapping = {
             zt_resulttype.resultaattype_url: zt_resulttype
-            for zt_resulttype in ZaakTypeResultaatTypeConfig.objects.all()
+            for zt_resulttype in ZaakTypeResultaatTypeConfig.objects.filter(
+                zaaktype_config__identificatie=zaaktype_identificatie
+            )
         }
-        return super(InnerCaseDetailView, self).dispatch(request, *args, **kwargs)
 
     @cached_property
     def crumbs(self):
@@ -135,6 +140,7 @@ class InnerCaseDetailView(
             # fetch data associated with `self.case`
             documents = self.get_case_document_files(self.case)
             statuses = fetch_status_history(self.case.url)
+            self.store_statustype_resulttype_mapping(self.case.zaaktype.identificatie)
             # NOTE maybe this should be cached?
             statustypen = fetch_status_types_no_cache(self.case.zaaktype.url)
 

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -152,6 +152,9 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             beginGeldigheid="2020-09-25",
             versiedatum="2020-09-25",
         )
+        cls.zaaktype_config = ZaakTypeConfigFactory.create(
+            identificatie=cls.zaaktype["identificatie"],
+        )
         #
         # statuses
         #
@@ -559,11 +562,13 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
         self.maxDiff = None
 
         ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=self.zaaktype_config,
             statustype_url=self.status_type_new["url"],
             status_indicator=StatusIndicators.warning,
             status_indicator_text="foo",
         )
         ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=self.zaaktype_config,
             statustype_url=self.status_type_finish["url"],
             status_indicator=StatusIndicators.success,
             status_indicator_text="bar",
@@ -636,16 +641,19 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
         self.maxDiff = None
 
         ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=self.zaaktype_config,
             statustype_url=self.status_type_new["url"],
             status_indicator=StatusIndicators.warning,
             status_indicator_text="foo",
         )
         ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=self.zaaktype_config,
             statustype_url=self.status_type_in_behandeling["url"],
             status_indicator=StatusIndicators.success,
             status_indicator_text="zap",
         )
         ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=self.zaaktype_config,
             statustype_url=self.status_type_finish["url"],
             status_indicator=StatusIndicators.success,
             status_indicator_text="bar",


### PR DESCRIPTION
__init__ is only called once upon app start, not per pageview

https://stackoverflow.com/questions/46599145/django-class-view-init

And we also need to filter the statustypeconfig/resulttypeconfigs on the zaaktypeconfig, as the eSuite has one statustype linked to multiple zaaktypes. Otherwise we most likely are using the statustypeconfig from a different zaaktype
