### PR TITLE
:lipstick: [#1958] Update material icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "htmx.org": "^1.8.4",
         "inline-css": "^3.0.0",
         "leaflet": "^1.7.1",
-        "material-icons": "^1.10.11",
+        "material-icons": "^1.13.12",
         "microscope-sass": "latest",
         "proj4leaflet": "^1.0.2",
         "style-loader": "^2.0.0"
@@ -10934,9 +10934,9 @@
       }
     },
     "node_modules/material-icons": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.10.11.tgz",
-      "integrity": "sha512-A0LqelW1j8Ik/8Cf3nKaUyabFrUXaGOpK2CyJvwWuobCDHtuW5hbM4mzyu3C5e4QfC0l8CjFBaP1h5sm91sRjw=="
+      "version": "1.13.12",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.12.tgz",
+      "integrity": "sha512-/2YoaB79IjUK2B2JB+vIXXYGtBfHb/XG66LvoKVM5ykHW7yfrV5SP6d7KLX6iijY6/G9GqwgtPQ/sbhFnOURVA=="
     },
     "node_modules/math-random": {
       "version": "1.0.4",
@@ -27824,9 +27824,9 @@
       "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
     },
     "material-icons": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.10.11.tgz",
-      "integrity": "sha512-A0LqelW1j8Ik/8Cf3nKaUyabFrUXaGOpK2CyJvwWuobCDHtuW5hbM4mzyu3C5e4QfC0l8CjFBaP1h5sm91sRjw=="
+      "version": "1.13.12",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.12.tgz",
+      "integrity": "sha512-/2YoaB79IjUK2B2JB+vIXXYGtBfHb/XG66LvoKVM5ykHW7yfrV5SP6d7KLX6iijY6/G9GqwgtPQ/sbhFnOURVA=="
     },
     "math-random": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "htmx.org": "^1.8.4",
     "inline-css": "^3.0.0",
     "leaflet": "^1.7.1",
-    "material-icons": "^1.10.11",
+    "material-icons": "^1.13.12",
     "microscope-sass": "latest",
     "proj4leaflet": "^1.0.2",
     "style-loader": "^2.0.0"


### PR DESCRIPTION
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/1958

Note, besides 'Material **ICONS**' there is also something called 'Material **SYMBOLS**' which is being developed by Google and seems to have been incorporated into Figma - some icons look slightly different, bit it also uses a very different technology (instead of regular/bold thickness, it uses a GRADUAL way to increase linethickness for these icons) so no need to change into that one yet.
https://fonts.google.com/icons?icon.set=Material+Icons&icon.query=key  
versus 
https://fonts.google.com/icons?icon.set=Material+Symbols&icon.query=key