### PR TITLE
:recycle: [#2027] Only set KVK branch sessionvar if branch is selected

### DIFF
--- a/src/eherkenning/tests/test_mock_views.py
+++ b/src/eherkenning/tests/test_mock_views.py
@@ -192,7 +192,7 @@ class PasswordLoginViewTests(eHerkenningMockTestCase):
         response = self.client.get(response["Location"], follow=True)
 
         # check company branch number in session
-        self.assertEqual(get_kvk_branch_number(self.client.session), "1234")
+        self.assertEqual(get_kvk_branch_number(self.client.session), None)
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     def test_redirect_flow_with_no_vestigingsnummer(self, mock_kvk):
@@ -229,7 +229,7 @@ class PasswordLoginViewTests(eHerkenningMockTestCase):
         response = self.client.get(response["Location"], follow=True)
 
         # check company branch number in session
-        self.assertEqual(get_kvk_branch_number(self.client.session), "29664887")
+        self.assertEqual(get_kvk_branch_number(self.client.session), None)
 
     def test_post_redirect_retains_acs_querystring_params(self):
         url = reverse("eherkenning-mock:password")

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -625,7 +625,7 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
         self.assertNotIn("invite_url", self.client.session.keys())
 
         # check company branch number in session
-        self.assertEqual(get_kvk_branch_number(self.client.session), "1234")
+        self.assertEqual(get_kvk_branch_number(self.client.session), None)
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
@@ -672,7 +672,7 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
         )
 
         # check company branch number in session
-        self.assertEqual(get_kvk_branch_number(self.client.session), "12345678")
+        self.assertEqual(get_kvk_branch_number(self.client.session), None)
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -725,7 +725,7 @@ class eHerkenningOIDCFlowTests(TestCase):
         session = self.client.session
         session["oidc_states"] = {"mock": {"nonce": "nonce"}}
         session["oidc_id_token"] = "foo"
-        session[KVK_BRANCH_SESSION_VARIABLE] = "1234"
+        session[KVK_BRANCH_SESSION_VARIABLE] = None
         session.save()
         logout_url = reverse("eherkenning_oidc:logout")
 

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -65,7 +65,7 @@ class InnerCaseListView(
             if config.fetch_eherkenning_zaken_with_rsin:
                 kvk_or_rsin = self.request.user.rsin
             vestigingsnummer = get_kvk_branch_number(self.request.session)
-            if vestigingsnummer and vestigingsnummer != self.request.user.kvk:
+            if vestigingsnummer:
                 raw_cases = fetch_cases_by_kvk_or_rsin(
                     kvk_or_rsin=kvk_or_rsin, vestigingsnummer=vestigingsnummer
                 )

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -83,12 +83,8 @@ class CaseAccessMixin(AccessMixin):
                     identifier = self.request.user.rsin
 
                 vestigingsnummer = get_kvk_branch_number(self.request.session)
-                if (
-                    vestigingsnummer
-                    and vestigingsnummer != self.request.user.kvk
-                    and not fetch_roles_for_case_and_vestigingsnummer(
-                        self.case.url, vestigingsnummer
-                    )
+                if vestigingsnummer and not fetch_roles_for_case_and_vestigingsnummer(
+                    self.case.url, vestigingsnummer
                 ):
                     logger.debug(
                         f"CaseAccessMixin - permission denied: no role for the case {self.case.url}"

--- a/src/open_inwoner/kvk/branches.py
+++ b/src/open_inwoner/kvk/branches.py
@@ -3,5 +3,9 @@ from typing import Optional
 KVK_BRANCH_SESSION_VARIABLE = "KVK_BRANCH_NUMBER"
 
 
+def kvk_branch_selected_done(session) -> bool:
+    return KVK_BRANCH_SESSION_VARIABLE in session
+
+
 def get_kvk_branch_number(session) -> Optional[str]:
     return session.get(KVK_BRANCH_SESSION_VARIABLE)

--- a/src/open_inwoner/kvk/forms.py
+++ b/src/open_inwoner/kvk/forms.py
@@ -2,4 +2,4 @@ from django import forms
 
 
 class CompanyBranchChoiceForm(forms.Form):
-    branch_number = forms.CharField(widget=forms.HiddenInput())
+    branch_number = forms.CharField(widget=forms.HiddenInput(), required=False)

--- a/src/open_inwoner/kvk/middleware.py
+++ b/src/open_inwoner/kvk/middleware.py
@@ -5,7 +5,7 @@ from django.urls import NoReverseMatch, reverse
 
 from furl import furl
 
-from open_inwoner.kvk.branches import get_kvk_branch_number
+from open_inwoner.kvk.branches import kvk_branch_selected_done
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class KvKLoginMiddleware:
         if (
             not user.is_authenticated
             or not user.is_eherkenning_user
-            or get_kvk_branch_number(request.session)
+            or kvk_branch_selected_done(request.session)
         ):
             return self.get_response(request)
 

--- a/src/open_inwoner/kvk/views.py
+++ b/src/open_inwoner/kvk/views.py
@@ -55,20 +55,18 @@ class CompanyBranchChoiceView(FormView):
         company_branches = context["company_branches"]
 
         if not company_branches:
-            request.session[KVK_BRANCH_SESSION_VARIABLE] = request.user.kvk
+            request.session[KVK_BRANCH_SESSION_VARIABLE] = None
             request.session.save()
             return HttpResponseRedirect(redirect.url)
 
         if len(company_branches) == 1:
-            request.session[KVK_BRANCH_SESSION_VARIABLE] = (
-                company_branches[0].get("vestigingsnummer") or request.user.kvk
-            )
+            request.session[KVK_BRANCH_SESSION_VARIABLE] = None
             request.session.save()
             return HttpResponseRedirect(redirect.url)
 
         # create pseudo-branch representing the company as a whole
         master_branch = {
-            "kvkNummer": request.user.kvk,
+            "vestigingsnummer": "",
             "handelsnaam": company_branches[0].get("handelsnaam", ""),
         }
         company_branches.insert(0, master_branch)
@@ -97,9 +95,8 @@ class CompanyBranchChoiceView(FormView):
             cleaned = form.cleaned_data
             branch_number = cleaned["branch_number"]
 
-            if not any(
-                branch["kvkNummer"] == branch_number
-                or branch.get("vestigingsnummer") == branch_number
+            if branch_number and not any(
+                branch.get("vestigingsnummer") == branch_number
                 for branch in context["company_branches"]
             ):
                 form.add_error(

--- a/src/open_inwoner/openklant/wrap.py
+++ b/src/open_inwoner/openklant/wrap.py
@@ -296,7 +296,7 @@ def get_fetch_parameters(request, use_vestigingsnummer: bool = False) -> dict:
         parameters = {"user_kvk_or_rsin": kvk_or_rsin}
         if use_vestigingsnummer:
             vestigingsnummer = get_kvk_branch_number(request.session)
-            if vestigingsnummer and vestigingsnummer != user.kvk:
+            if vestigingsnummer:
                 parameters.update({"vestigingsnummer": vestigingsnummer})
         return parameters
     return {}

--- a/src/open_inwoner/pdc/managers.py
+++ b/src/open_inwoner/pdc/managers.py
@@ -60,7 +60,7 @@ class CategoryPublishedQueryset(MP_NodeQuerySet):
             if config.fetch_eherkenning_zaken_with_rsin:
                 kvk_or_rsin = request.user.rsin
             vestigingsnummer = get_kvk_branch_number(request.session)
-            if vestigingsnummer and vestigingsnummer != request.user.kvk:
+            if vestigingsnummer:
                 cases = fetch_cases_by_kvk_or_rsin(
                     kvk_or_rsin=kvk_or_rsin, vestigingsnummer=vestigingsnummer
                 )

--- a/src/open_inwoner/templates/pages/kvk/branches.html
+++ b/src/open_inwoner/templates/pages/kvk/branches.html
@@ -12,7 +12,7 @@
             {% endif %}
             {% for branch in company_branches %}
                 {% render_card direction='horizontal' %}
-                    {% with company_id=branch.vestigingsnummer|default:branch.kvkNummer %}
+                    {% with company_id=branch.vestigingsnummer %}
                         <label class="left" for="branch-{{ company_id }}">
                             <p>{{ branch.handelsnaam }}</p>
                             {% if branch.straatnaam and branch.plaats %}


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/task/2027

previously, in case the user did not select a branch, the KVK_BRANCH_NUMBER would be set to the KVK, which meant that everywhere this sessionvariable was used, it had to be compared to the KVK number to see if it was an actual branch number or if it was set just to skip the branch selection screen