### PR TITLE
Implemented cached version of `generate_oas_component()`

### DIFF
--- a/src/open_inwoner/openzaak/tests/helpers.py
+++ b/src/open_inwoner/openzaak/tests/helpers.py
@@ -2,6 +2,10 @@ import re
 from copy import deepcopy
 from uuid import uuid4
 
+from zgw_consumers.test import generate_oas_component
+
+from open_inwoner.utils.hash import pyhash_value
+
 
 def copy_with_new_uuid(oas_resource: dict) -> dict:
     oas_resource = deepcopy(oas_resource)
@@ -10,3 +14,29 @@ def copy_with_new_uuid(oas_resource: dict) -> dict:
     if "uuid" in oas_resource:
         oas_resource["uuid"] = new_uuid
     return oas_resource
+
+
+_oas_component_cache = dict()
+
+
+def generate_oas_component_cached(
+    service: str,
+    component: str,
+    **properties,
+) -> dict[str, any]:
+    """
+    Cached version of generate_oas_component() for reused TestCase.setup()-style generation
+
+    Uses pyhash_value() to calculate cache key so properties must be somewhat hashable
+    Uses deepcopy() to isolate output values between tests
+
+    """
+    key = pyhash_value((service, component, properties))
+
+    try:
+        res = _oas_component_cache[key]
+    except KeyError:
+        res = generate_oas_component(service, component, **properties)
+        _oas_component_cache[key] = res
+
+    return deepcopy(res)

--- a/src/open_inwoner/openzaak/tests/test_notification_data.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_data.py
@@ -21,6 +21,7 @@ from open_inwoner.openzaak.tests.factories import (
 from open_inwoner.utils.test import paginated_response
 
 from ..models import OpenZaakConfig
+from .helpers import generate_oas_component_cached
 from .shared import CATALOGI_ROOT, DOCUMENTEN_ROOT, ZAKEN_ROOT
 
 
@@ -62,7 +63,7 @@ class MockAPIData:
             rsin="000000000",
             email="initiator_kvk@example.com",
         )
-        self.zaak_type = generate_oas_component(
+        self.zaak_type = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -72,7 +73,7 @@ class MockAPIData:
             indicatieInternOfExtern="extern",
             omschrijving="My Zaaktype omschrijving",
         )
-        self.status_type_initial = generate_oas_component(
+        self.status_type_initial = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
@@ -82,7 +83,7 @@ class MockAPIData:
             omschrijving="initial",
             isEindStatus=False,
         )
-        self.status_type_final = generate_oas_component(
+        self.status_type_final = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
@@ -92,7 +93,7 @@ class MockAPIData:
             omschrijving="final",
             isEindStatus=True,
         )
-        self.zaak = generate_oas_component(
+        self.zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -101,7 +102,7 @@ class MockAPIData:
             resultaat=f"{ZAKEN_ROOT}resultaten/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.zaak2 = generate_oas_component(
+        self.zaak2 = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -110,14 +111,14 @@ class MockAPIData:
             resultaat=f"{ZAKEN_ROOT}resultaten/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.status_initial = generate_oas_component(
+        self.status_initial = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
             zaak=self.zaak["url"],
             statustype=self.status_type_initial["url"],
         )
-        self.status_final = generate_oas_component(
+        self.status_final = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
@@ -125,7 +126,7 @@ class MockAPIData:
             statustype=self.status_type_final["url"],
         )
 
-        self.informatie_object = generate_oas_component(
+        self.informatie_object = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             url=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/aaaaaaaa-0001-bbbb-aaaa-aaaaaaaaaaaa",
@@ -133,14 +134,14 @@ class MockAPIData:
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.zaak_informatie_object = generate_oas_component(
+        self.zaak_informatie_object = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0001-aaaa-aaaa-aaaaaaaaaaaa",
             informatieobject=self.informatie_object["url"],
             zaak=self.zaak["url"],
         )
-        self.zaak_informatie_object2 = generate_oas_component(
+        self.zaak_informatie_object2 = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0002-aaaa-aaaa-aaaaaaaaaaaa",
@@ -148,7 +149,7 @@ class MockAPIData:
             zaak=self.zaak2["url"],
         )
 
-        self.informatie_object_extra = generate_oas_component(
+        self.informatie_object_extra = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             url=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/aaaaaaaa-0002-bbbb-aaaa-aaaaaaaaaaaa",
@@ -156,7 +157,7 @@ class MockAPIData:
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.zaak_informatie_object_extra = generate_oas_component(
+        self.zaak_informatie_object_extra = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0003-aaaa-aaaa-aaaaaaaaaaaa",
@@ -164,7 +165,7 @@ class MockAPIData:
             zaak=self.zaak["url"],
         )
 
-        self.role_initiator = generate_oas_component(
+        self.role_initiator = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aaaaaaaa-0001-aaaa-aaaa-aaaaaaaaaaaa",
@@ -174,7 +175,7 @@ class MockAPIData:
                 "inpBsn": self.user_initiator.bsn,
             },
         )
-        self.eherkenning_role_initiator = generate_oas_component(
+        self.eherkenning_role_initiator = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aaaaaaaa-0002-aaaa-aaaa-aaaaaaaaaaaa",
@@ -184,7 +185,7 @@ class MockAPIData:
                 "innNnpId": self.eherkenning_user_initiator.kvk,
             },
         )
-        self.eherkenning_role_initiator2 = generate_oas_component(
+        self.eherkenning_role_initiator2 = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aaaaaaaa-0003-aaaa-aaaa-aaaaaaaaaaaa",

--- a/src/open_inwoner/utils/tests/test_hash.py
+++ b/src/open_inwoner/utils/tests/test_hash.py
@@ -1,0 +1,62 @@
+from collections import deque
+from datetime import date, datetime
+from uuid import UUID, uuid4
+
+from django.test import TestCase
+
+from open_inwoner.utils.hash import pyhash_value
+
+
+class PyHashTest(TestCase):
+    def test_pyhash_value(self):
+        self.assertEqual(pyhash_value(123), pyhash_value(123))
+        self.assertEqual(pyhash_value("123"), pyhash_value("123"))
+        self.assertEqual(pyhash_value(True), pyhash_value(True))
+
+        self.assertEqual(
+            # list
+            pyhash_value([1, 2, 3]),
+            pyhash_value([1, 2, 3]),
+        )
+        self.assertEqual(
+            # tuple
+            pyhash_value((1, 2, 3)),
+            pyhash_value((1, 2, 3)),
+        )
+        self.assertEqual(
+            # set
+            pyhash_value({1, 2, 3}),
+            pyhash_value({3, 2, 1}),
+        )
+        self.assertEqual(
+            # mixed list/tuple
+            pyhash_value((1, 2, 3)),
+            pyhash_value([1, 2, 3]),
+        )
+        self.assertEqual(
+            pyhash_value(date(2022, 1, 1)),
+            pyhash_value(date(2022, 1, 1)),
+        )
+        self.assertEqual(
+            pyhash_value(datetime(2022, 1, 1)),
+            pyhash_value(datetime(2022, 1, 1)),
+        )
+        self.assertEqual(
+            # mixed ordering
+            pyhash_value({"a": (1, 2, 3), "b": "xyz"}),
+            pyhash_value({"b": "xyz", "a": (1, 2, 3)}),
+        )
+        uuid = str(uuid4())
+        self.assertEqual(
+            # any hashable
+            pyhash_value(UUID(uuid)),
+            pyhash_value(UUID(uuid)),
+        )
+        self.assertEqual(
+            # nested kitchensink
+            pyhash_value({"a": {"b": (1, date(2022, 1, 1), UUID(uuid))}}),
+            pyhash_value({"a": {"b": (1, date(2022, 1, 1), UUID(uuid))}}),
+        )
+        with self.assertRaises(TypeError):
+            # try an unsupported un-hashable
+            pyhash_value(deque([1, 2, 3]))


### PR DESCRIPTION
I tried this after-hours and it works surprisingly well so I cleaned it up and put it here:

It caches `generate_oas_component()` calls that are repeated multiple times, like when they are part of a `TestCase.setup()` or some other often re-used code like the `MockAPIData` class.

It works by using some funky python `hash()` code to get a cache key and `deepcopy()` to isolate each usage.

Also it's obviously a memory hole, but memory and `deepcopy()` are a lot cheaper then CPU cycles running the OAS/faker stack.