### PR TITLE
Applied generate_oas_component_cached() where applicable

### DIFF
--- a/src/open_inwoner/cms/cases/tests/test_contactform.py
+++ b/src/open_inwoner/cms/cases/tests/test_contactform.py
@@ -27,6 +27,7 @@ from open_inwoner.openklant.tests.data import (
 )
 from open_inwoner.openzaak.models import CatalogusConfig, OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import ServiceFactory, ZaakTypeConfigFactory
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import (
     CATALOGI_ROOT,
     DOCUMENTEN_ROOT,
@@ -87,7 +88,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         )
         self.ok_config.save()
 
-        self.zaak = generate_oas_component(
+        self.zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             uuid="d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
@@ -101,7 +102,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             resultaat=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.user_role = generate_oas_component(
+        self.user_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/f33153aa-ad2c-4a07-ae75-15add5891",
@@ -114,7 +115,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
                 "geslachtsnaam": "Bazz",
             },
         )
-        self.eherkenning_user_role = generate_oas_component(
+        self.eherkenning_user_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/3ff7686f-db35-4181-8e48-57521220f887",
@@ -127,7 +128,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
                 "geslachtsnaam": "Bazz",
             },
         )
-        self.eherkenning_user_role_kvk = generate_oas_component(
+        self.eherkenning_user_role_kvk = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/5885531e-9b7f-46af-947e-f2278a2e72a8",
@@ -140,7 +141,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
                 "geslachtsnaam": "Bazz",
             },
         )
-        self.zaaktype = generate_oas_component(
+        self.zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="0caa29cb-0167-426f-8dc1-88bebd7c8804",
@@ -154,7 +155,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         #
         # statuses
         #
-        self.status_new = generate_oas_component(
+        self.status_new = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
@@ -163,7 +164,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
-        self.status_finish = generate_oas_component(
+        self.status_finish = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
@@ -175,7 +176,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         #
         # status types
         #
-        self.status_type_new = generate_oas_component(
+        self.status_type_new = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=self.status_new["statustype"],
@@ -188,7 +189,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             isEindstatus=False,
         )
         # no associated status (for testing `add_second_status_preview`)
-        self.status_type_in_behandeling = generate_oas_component(
+        self.status_type_in_behandeling = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/167cb935-ac8a-428e-8cca-5abda0da47c7",
@@ -200,7 +201,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             volgnummer=3,
             isEindstatus=False,
         )
-        self.status_type_finish = generate_oas_component(
+        self.status_type_finish = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=self.status_finish["statustype"],
@@ -212,7 +213,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             volgnummer=1,
             isEindstatus=True,
         )
-        self.result = generate_oas_component(
+        self.result = generate_oas_component_cached(
             "zrc",
             "schemas/Resultaat",
             uuid="a44153aa-ad2c-6a07-be75-15add5113",
@@ -221,7 +222,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             zaak=self.zaak["url"],
             toelichting="resultaat toelichting",
         )
-        self.klant = generate_oas_component(
+        self.klant = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -296,7 +297,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         ]
 
     def _setUpExtraMocks(self, m):
-        self.contactmoment = generate_oas_component(
+        self.contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-bbbbbbbbbbbb",
@@ -305,7 +306,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
             antwoord="",
             text="hey!\n\nwaddup?",
         )
-        self.klant_contactmoment = generate_oas_component(
+        self.klant_contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-cccccccccccc",

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -12,7 +12,7 @@ from zgw_consumers.api_models.constants import (
     VertrouwelijkheidsAanduidingen,
 )
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.accounts.tests.factories import DigidUserFactory
 from open_inwoner.cms.tests import cms_tools
@@ -31,6 +31,7 @@ from open_inwoner.openzaak.tests.factories import (
     ZaakTypeInformatieObjectTypeConfigFactory,
     ZaakTypeStatusTypeConfigFactory,
 )
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import (
     CATALOGI_ROOT,
     DOCUMENTEN_ROOT,
@@ -101,7 +102,7 @@ class CasesPlaywrightTests(
         )
         self.ok_config.save()
 
-        self.zaak = generate_oas_component(
+        self.zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             uuid="d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
@@ -115,7 +116,7 @@ class CasesPlaywrightTests(
             resultaat=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        self.zaaktype = generate_oas_component(
+        self.zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="0caa29cb-0167-426f-8dc1-88bebd7c8804",
@@ -129,7 +130,7 @@ class CasesPlaywrightTests(
         #
         # statuses
         #
-        self.status_new = generate_oas_component(
+        self.status_new = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
@@ -138,7 +139,7 @@ class CasesPlaywrightTests(
             datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
-        self.status_finish = generate_oas_component(
+        self.status_finish = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
@@ -150,7 +151,7 @@ class CasesPlaywrightTests(
         #
         # status types
         #
-        self.status_type_new = generate_oas_component(
+        self.status_type_new = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=self.status_new["statustype"],
@@ -162,7 +163,7 @@ class CasesPlaywrightTests(
             volgnummer=1,
             isEindstatus=False,
         )
-        self.status_type_finish = generate_oas_component(
+        self.status_type_finish = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=self.status_finish["statustype"],
@@ -174,7 +175,7 @@ class CasesPlaywrightTests(
             volgnummer=1,
             isEindstatus=True,
         )
-        self.user_role = generate_oas_component(
+        self.user_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/f33153aa-ad2c-4a07-ae75-15add5891",
@@ -187,7 +188,7 @@ class CasesPlaywrightTests(
                 "geslachtsnaam": "Bazz",
             },
         )
-        self.result = generate_oas_component(
+        self.result = generate_oas_component_cached(
             "zrc",
             "schemas/Resultaat",
             uuid="a44153aa-ad2c-6a07-be75-15add5113",
@@ -196,7 +197,7 @@ class CasesPlaywrightTests(
             zaak=self.zaak["url"],
             toelichting="resultaat toelichting",
         )
-        self.zaak_informatie_object = generate_oas_component(
+        self.zaak_informatie_object = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
@@ -204,14 +205,14 @@ class CasesPlaywrightTests(
             zaak=self.zaak["url"],
             registratiedatum="2021-01-12",
         )
-        self.informatie_object_type = generate_oas_component(
+        self.informatie_object_type = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
             omschrijving="Some content",
         )
-        self.zaaktype_informatie_object_type = generate_oas_component(
+        self.zaaktype_informatie_object_type = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakTypeInformatieObjectType",
             uuid="3fb03882-f6f9-4e0d-ad92-f810e24b9abb",
@@ -223,7 +224,7 @@ class CasesPlaywrightTests(
             richting="inkomend",
             statustype=self.status_type_finish,
         )
-        self.informatie_object = generate_oas_component(
+        self.informatie_object = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="014c38fe-b010-4412-881c-3000032fb812",
@@ -238,7 +239,7 @@ class CasesPlaywrightTests(
         )
 
         # for upload testing
-        self.uploaded_zaak_informatie_object = generate_oas_component(
+        self.uploaded_zaak_informatie_object = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/48599f76-b524-48e8-be5a-6fc47288c9bf",
@@ -247,7 +248,7 @@ class CasesPlaywrightTests(
             registratiedatum="2022-01-12",
         )
         self.uploaded_zaak_informatie_object_content = "test56789".encode("utf8")
-        self.uploaded_informatie_object = generate_oas_component(
+        self.uploaded_informatie_object = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="48599f76-b524-48e8-be5a-6fc47288c9bf",
@@ -260,7 +261,7 @@ class CasesPlaywrightTests(
             titel="uploaded_test_file.txt",
             bestandsomvang=len(self.uploaded_zaak_informatie_object_content),
         )
-        self.klant = generate_oas_component(
+        self.klant = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -271,7 +272,7 @@ class CasesPlaywrightTests(
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
         )
-        self.contactmoment = generate_oas_component(
+        self.contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-bbbbbbbbbbbb",
@@ -280,7 +281,7 @@ class CasesPlaywrightTests(
             antwoord="",
             text="hey!\n\nwaddup?",
         )
-        self.klant_contactmoment = generate_oas_component(
+        self.klant_contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-cccccccccccc",
@@ -521,7 +522,7 @@ class CasesPlaywrightTests(
             Creates schemas/ZaakInformatieObject dict for each item in uploads.
             """
             items = [
-                generate_oas_component(
+                generate_oas_component_cached(
                     "zrc",
                     "schemas/ZaakInformatieObject",
                     url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
@@ -553,7 +554,7 @@ class CasesPlaywrightTests(
             seed = file_name.ljust(16, "0").encode("utf-8")
             uuid = UUID(bytes=seed)
 
-            uploaded_informatie_object = generate_oas_component(
+            uploaded_informatie_object = generate_oas_component_cached(
                 "drc",
                 "schemas/EnkelvoudigInformatieObject",
                 uuid=str(uuid),

--- a/src/open_inwoner/openklant/tests/data.py
+++ b/src/open_inwoner/openklant/tests/data.py
@@ -1,5 +1,5 @@
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.accounts.tests.factories import (
     DigidUserFactory,
@@ -8,6 +8,7 @@ from open_inwoner.accounts.tests.factories import (
 from open_inwoner.openklant.constants import Status
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.openzaak.tests.factories import ServiceFactory
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.utils.test import paginated_response
 
 KLANTEN_ROOT = "https://klanten.nl/api/v1/"
@@ -44,7 +45,7 @@ class MockAPIReadPatchData(MockAPIData):
             rsin="000000000",
         )
 
-        self.klant_old = generate_oas_component(
+        self.klant_old = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -52,7 +53,7 @@ class MockAPIReadPatchData(MockAPIData):
             emailadres="bad@example.com",
             telefoonnummer="",
         )
-        self.klant_updated = generate_oas_component(
+        self.klant_updated = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -109,7 +110,7 @@ class MockAPIReadData(MockAPIData):
             rsin="000000000",
         )
 
-        self.klant = generate_oas_component(
+        self.klant = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -117,7 +118,7 @@ class MockAPIReadData(MockAPIData):
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
         )
-        self.klant2 = generate_oas_component(
+        self.klant2 = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-ffffffffffff",
@@ -125,7 +126,7 @@ class MockAPIReadData(MockAPIData):
             emailadres="foo@bar.com",
             telefoonnummer="0687654321",
         )
-        self.klant_vestiging = generate_oas_component(
+        self.klant_vestiging = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -133,7 +134,7 @@ class MockAPIReadData(MockAPIData):
             emailadres="foo@bar.com",
             telefoonnummer="0612345678",
         )
-        self.contactmoment = generate_oas_component(
+        self.contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-bbbbbbbbbbbb",
@@ -145,7 +146,7 @@ class MockAPIReadData(MockAPIData):
             antwoord="",
             onderwerp="e_suite_subject_code",
         )
-        self.contactmoment2 = generate_oas_component(
+        self.contactmoment2 = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-dddddddddddd",
@@ -157,7 +158,7 @@ class MockAPIReadData(MockAPIData):
             antwoord="",
             onderwerp="e_suite_subject_code",
         )
-        self.contactmoment_vestiging = generate_oas_component(
+        self.contactmoment_vestiging = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-eeeeeeeeeeee",
@@ -169,7 +170,7 @@ class MockAPIReadData(MockAPIData):
             antwoord="",
             onderwerp="e_suite_subject_code",
         )
-        self.klant_contactmoment = generate_oas_component(
+        self.klant_contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-cccccccccccc",
@@ -177,7 +178,7 @@ class MockAPIReadData(MockAPIData):
             klant=self.klant["url"],
             contactmoment=self.contactmoment["url"],
         )
-        self.klant_contactmoment2 = generate_oas_component(
+        self.klant_contactmoment2 = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-eeeeeeeeeeee",
@@ -185,7 +186,7 @@ class MockAPIReadData(MockAPIData):
             klant=self.klant2["url"],
             contactmoment=self.contactmoment2["url"],
         )
-        self.klant_contactmoment3 = generate_oas_component(
+        self.klant_contactmoment3 = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-dddddddddddd",
@@ -193,7 +194,7 @@ class MockAPIReadData(MockAPIData):
             klant=self.klant["url"],
             contactmoment=self.contactmoment_vestiging["url"],
         )
-        self.klant_contactmoment4 = generate_oas_component(
+        self.klant_contactmoment4 = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-ffffffffffff",
@@ -265,7 +266,7 @@ class MockAPICreateData(MockAPIData):
             kvk="12345678",
             rsin="000000000",
         )
-        self.klant = generate_oas_component(
+        self.klant = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -276,7 +277,7 @@ class MockAPICreateData(MockAPIData):
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
         )
-        self.klant_no_contact_info = generate_oas_component(
+        self.klant_no_contact_info = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -287,7 +288,7 @@ class MockAPICreateData(MockAPIData):
             emailadres="",
             telefoonnummer="",
         )
-        self.contactmoment = generate_oas_component(
+        self.contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/ContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-bbbbbbbbbbbb",
@@ -299,7 +300,7 @@ class MockAPICreateData(MockAPIData):
             antwoord="",
             text="hey!\n\nwaddup?",
         )
-        self.klant_contactmoment = generate_oas_component(
+        self.klant_contactmoment = generate_oas_component_cached(
             "cmc",
             "schemas/KlantContactMoment",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-cccccccccccc",

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -10,6 +10,7 @@ from open_inwoner.accounts.models import User
 from open_inwoner.accounts.tests.factories import UserFactory, eHerkenningUserFactory
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.openklant.tests.data import KLANTEN_ROOT, MockAPIReadData
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.utils.test import (
     ClearCachesMixin,
     DisableRequestLogMixin,
@@ -27,10 +28,10 @@ class UpdateUserFromLoginSignalAPITestCase(
         super().setUpTestData()
         MockAPIReadData.setUpServices()
 
-    def test_update_user_after_login(self, m):
-        MockAPIReadData.setUpOASMocks(m)
+    def setUp(self) -> None:
+        super().setUp()
 
-        self.klant = generate_oas_component(
+        self.klant = generate_oas_component_cached(
             "kc",
             "schemas/Klant",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -38,6 +39,10 @@ class UpdateUserFromLoginSignalAPITestCase(
             emailadres="new@example.com",
             telefoonnummer="0612345678",
         )
+
+    def test_update_user_after_login(self, m):
+        MockAPIReadData.setUpOASMocks(m)
+
         m.get(
             f"{KLANTEN_ROOT}klanten?subjectNatuurlijkPersoon__inpBsn=999993847",
             json=paginated_response([self.klant]),
@@ -67,14 +72,6 @@ class UpdateUserFromLoginSignalAPITestCase(
     def test_update_eherkenning_user_after_login(self, m):
         MockAPIReadData.setUpOASMocks(m)
 
-        self.klant = generate_oas_component(
-            "kc",
-            "schemas/Klant",
-            uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            emailadres="new@example.com",
-            telefoonnummer="0612345678",
-        )
         user = eHerkenningUserFactory(
             phonenumber="0123456789",
             email="old@example.com",
@@ -122,14 +119,6 @@ class UpdateUserFromLoginSignalAPITestCase(
     def test_update_user_after_login_skips_existing_email(self, m):
         MockAPIReadData.setUpOASMocks(m)
 
-        self.klant = generate_oas_component(
-            "kc",
-            "schemas/Klant",
-            uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            emailadres="foo@example.com",
-            telefoonnummer="0612345678",
-        )
         m.get(
             f"{KLANTEN_ROOT}klanten?subjectNatuurlijkPersoon__inpBsn=999993847",
             json=paginated_response([self.klant]),
@@ -144,7 +133,7 @@ class UpdateUserFromLoginSignalAPITestCase(
         other_user = UserFactory(
             phonenumber="0101010101",
             # uses same email as klant resource
-            email="foo@example.com",
+            email="new@example.com",
         )
 
         request = RequestFactory().get("/dummy")

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -585,6 +585,12 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             ),
         )
 
+        # extra mock for fetching single status (#2037)
+        m.get(
+            f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
+            json=self.status_new,
+        )
+
     @patch("open_inwoner.userfeed.hooks.case_status_seen")
     @patch("open_inwoner.userfeed.hooks.case_documents_seen")
     def test_status_is_retrieved_when_user_logged_in_via_digid(

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -21,7 +21,7 @@ from zgw_consumers.api_models.constants import (
     VertrouwelijkheidsAanduidingen,
 )
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory, eHerkenningUserFactory
@@ -43,6 +43,7 @@ from ...utils.tests.helpers import AssertRedirectsMixin
 from ..api_models import Status, StatusType
 from ..models import OpenZaakConfig
 from .factories import CatalogusConfigFactory, ServiceFactory
+from .helpers import generate_oas_component_cached
 from .shared import CATALOGI_ROOT, DOCUMENTEN_ROOT, ZAKEN_ROOT
 
 PATCHED_MIDDLEWARE = [
@@ -58,44 +59,43 @@ PATCHED_MIDDLEWARE = [
     MIDDLEWARE=PATCHED_MIDDLEWARE,
 )
 class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
+    def setUp(self):
+        super().setUp()
 
-        cls.user = UserFactory(
+        self.user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="johm@smith.nl"
         )
-        cls.eherkenning_user = eHerkenningUserFactory.create(
+        self.eherkenning_user = eHerkenningUserFactory.create(
             kvk="12345678",
             rsin="123456789",
             login_type=LoginTypeChoices.eherkenning,
         )
         # services
-        cls.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
-        cls.catalogi_service = ServiceFactory(
+        self.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
+        self.catalogi_service = ServiceFactory(
             api_root=CATALOGI_ROOT, api_type=APITypes.ztc
         )
-        cls.document_service = ServiceFactory(
+        self.document_service = ServiceFactory(
             api_root=DOCUMENTEN_ROOT, api_type=APITypes.drc
         )
         # openzaak config
-        cls.config = OpenZaakConfig.get_solo()
-        cls.config.zaak_service = cls.zaak_service
-        cls.config.catalogi_service = cls.catalogi_service
-        cls.config.document_service = cls.document_service
-        cls.config.document_max_confidentiality = (
+        self.config = OpenZaakConfig.get_solo()
+        self.config.zaak_service = self.zaak_service
+        self.config.catalogi_service = self.catalogi_service
+        self.config.document_service = self.document_service
+        self.config.document_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
-        cls.config.zaak_max_confidentiality = (
+        self.config.zaak_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
-        cls.config.save()
+        self.config.save()
 
-        cls.case_detail_url = reverse(
+        self.case_detail_url = reverse(
             "cases:case_detail_content",
             kwargs={"object_id": "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"},
         )
-        cls.eherkenning_case_detail_url = reverse(
+        self.eherkenning_case_detail_url = reverse(
             "cases:case_detail_content",
             kwargs={"object_id": "3b751e7e-cf17-4200-9ee4-4a42d801ea21"},
         )
@@ -103,7 +103,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
         #
         # zaken
         #
-        cls.zaak = generate_oas_component(
+        self.zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             uuid="d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
@@ -118,7 +118,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             resultaat=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        cls.zaak_eherkenning = generate_oas_component(
+        self.zaak_eherkenning = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             uuid="3b751e7e-cf17-4200-9ee4-4a42d801ea21",
@@ -133,22 +133,22 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             resultaat=f"{ZAKEN_ROOT}resultaten/a44153aa-ad2c-6a07-be75-15add5113",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        cls.zaak_invisible = generate_oas_component(
+        self.zaak_invisible = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             uuid="213b0a04-fcbc-4fee-8d11-cf950a0a0bbb",
             url=f"{ZAKEN_ROOT}zaken/213b0a04-fcbc-4fee-8d11-cf950a0a0bbb",
-            zaaktype=cls.zaak["zaaktype"],
+            zaaktype=self.zaak["zaaktype"],
             identificatie="ZAAK-2022-invisible",
             omschrijving="Zaak invisible",
             startdatum="2022-01-02",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.geheim,
         )
-        cls.zaaktype = generate_oas_component(
+        self.zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="0caa29cb-0167-426f-8dc1-88bebd7c8804",
-            url=cls.zaak["zaaktype"],
+            url=self.zaak["zaaktype"],
             identificatie="ZAAKTYPE-2020-0000000001",
             omschrijving="Coffee zaaktype",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
@@ -166,26 +166,26 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             beginGeldigheid="2020-09-25",
             versiedatum="2020-09-25",
         )
-        cls.zaaktype_config = ZaakTypeConfigFactory.create(
-            identificatie=cls.zaaktype["identificatie"],
+        self.zaaktype_config = ZaakTypeConfigFactory.create(
+            identificatie=self.zaaktype["identificatie"],
         )
         #
         # statuses
         #
-        cls.status_new = generate_oas_component(
+        self.status_new = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
-            url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
-            zaak=cls.zaak["url"],
+            url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
+            zaak=self.zaak["url"],
             statustype=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-777yu878km09",
             datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
-        cls.status_finish = generate_oas_component(
+        self.status_finish = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
             url=f"{ZAKEN_ROOT}statussen/29ag1264-c4he-249j-bc24-jip862tle833",
-            zaak=cls.zaak["url"],
+            zaak=self.zaak["url"],
             statustype=f"{CATALOGI_ROOT}statustypen/d4839012-gh35-3a8d-866h-444uy935acv7",
             datumStatusGezet="2021-03-12",
             statustoelichting="",
@@ -193,11 +193,11 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
         #
         # status types
         #
-        cls.status_type_new = generate_oas_component(
+        self.status_type_new = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
-            url=cls.status_new["statustype"],
-            zaaktype=cls.zaaktype["url"],
+            url=self.status_new["statustype"],
+            zaaktype=self.zaaktype["url"],
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
             omschrijving="Initial request",
             omschrijvingGeneriek="some content",
@@ -206,11 +206,11 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             isEindstatus=False,
         )
         # no associated status (for testing `add_second_status_preview`)
-        cls.status_type_in_behandeling = generate_oas_component(
+        self.status_type_in_behandeling = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/167cb935-ac8a-428e-8cca-5abda0da47c7",
-            zaaktype=cls.zaaktype["url"],
+            zaaktype=self.zaaktype["url"],
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
             omschrijving="In behandeling",
             omschrijvingGeneriek="some content",
@@ -219,23 +219,23 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             isEindstatus=False,
         )
         # we need to use a `StatusType` object, not the oas_component (a `dict`)
-        cls.second_status_preview = StatusType(
-            url=cls.status_type_in_behandeling["url"],
-            zaaktype=cls.status_type_in_behandeling["zaaktype"],
+        self.second_status_preview = StatusType(
+            url=self.status_type_in_behandeling["url"],
+            zaaktype=self.status_type_in_behandeling["zaaktype"],
             omschrijving="In behandeling",
-            omschrijving_generiek=cls.status_type_in_behandeling[
+            omschrijving_generiek=self.status_type_in_behandeling[
                 "omschrijvingGeneriek"
             ],
-            statustekst=cls.status_type_in_behandeling["statustekst"],
+            statustekst=self.status_type_in_behandeling["statustekst"],
             volgnummer=3,
-            is_eindstatus=cls.status_type_in_behandeling["isEindstatus"],
-            informeren=cls.status_type_in_behandeling["informeren"],
+            is_eindstatus=self.status_type_in_behandeling["isEindstatus"],
+            informeren=self.status_type_in_behandeling["informeren"],
         )
-        cls.status_type_finish = generate_oas_component(
+        self.status_type_finish = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
-            url=cls.status_finish["statustype"],
-            zaaktype=cls.zaaktype["url"],
+            url=self.status_finish["statustype"],
+            zaaktype=self.zaaktype["url"],
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
             omschrijving="Finish",
             omschrijvingGeneriek="some content",
@@ -243,7 +243,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             volgnummer=4,
             isEindstatus=True,
         )
-        cls.user_role = generate_oas_component(
+        self.user_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/f33153aa-ad2c-4a07-ae75-15add5891",
@@ -256,7 +256,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
                 "geslachtsnaam": "Bazz",
             },
         )
-        cls.eherkenning_user_role_rsin = generate_oas_component(
+        self.eherkenning_user_role_rsin = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/ff4a3ae8-bf31-40cd-9db1-7ca9a0c8aea9",
@@ -269,7 +269,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
                 "geslachtsnaam": "Bazz",
             },
         )
-        cls.eherkenning_user_role_kvk = generate_oas_component(
+        self.eherkenning_user_role_kvk = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/ff4a3ae8-bf31-40cd-9db1-7ca9a0c8aea9",
@@ -282,7 +282,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
                 "geslachtsnaam": "Bazz",
             },
         )
-        cls.eherkenning_user_role_kvk_vestiging = generate_oas_component(
+        self.eherkenning_user_role_kvk_vestiging = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/58ff6286-893f-45cb-a074-9c9c97ec876e",
@@ -295,7 +295,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
                 "kvkNummer": "Bazz",
             },
         )
-        cls.not_initiator_role = generate_oas_component(
+        self.not_initiator_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aa353aa-ad2c-4a07-ae75-15add5822",
@@ -307,113 +307,113 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
                 "geslachtsnaam": "Else",
             },
         )
-        cls.result = generate_oas_component(
+        self.result = generate_oas_component_cached(
             "zrc",
             "schemas/Resultaat",
             uuid="a44153aa-ad2c-6a07-be75-15add5113",
-            url=cls.zaak["resultaat"],
+            url=self.zaak["resultaat"],
             resultaattype=f"{CATALOGI_ROOT}resultaattypen/b1a268dd-4322-47bb-a930-b83066b4a32c",
-            zaak=cls.zaak["url"],
+            zaak=self.zaak["url"],
             toelichting="resultaat toelichting",
         )
-        cls.zaak_informatie_object = generate_oas_component(
+        self.zaak_informatie_object = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812",
-            zaak=cls.zaak["url"],
+            zaak=self.zaak["url"],
             aardRelatieWeergave="some content",
             titel="info object 1",
             beschrijving="",
             registratiedatum="2021-01-12",
         )
-        cls.zaak_informatie_object_2 = generate_oas_component(
+        self.zaak_informatie_object_2 = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d7",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/015c38fe-b010-4412-881c-3000032fb812",
-            zaak=cls.zaak["url"],
+            zaak=self.zaak["url"],
             aardRelatieWeergave="some content",
             titel="info object 2",
             beschrijving="",
             registratiedatum="2021-02-12",
         )
         # informatie_object without registratiedatum
-        cls.zaak_informatie_object_no_date = generate_oas_component(
+        self.zaak_informatie_object_no_date = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d7",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/016c38fe-b010-4412-881c-3000032fb812",
-            zaak=cls.zaak["url"],
+            zaak=self.zaak["url"],
             aardRelatieWeergave="some content",
             titel="info object 3",
             beschrijving="",
         )
-        cls.informatie_object_type = generate_oas_component(
+        self.informatie_object_type = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
             omschrijving="Some content",
         )
-        cls.zaaktype_informatie_object_type = generate_oas_component(
+        self.zaaktype_informatie_object_type = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakTypeInformatieObjectType",
             uuid="3fb03882-f6f9-4e0d-ad92-f810e24b9abb",
             url=f"{CATALOGI_ROOT}zaaktype-informatieobjecttypen/93250e6d-ef92-4474-acca-a6dbdcd61b7e",
             catalogus=f"{CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
-            zaaktype=cls.zaaktype["url"],
-            informatieobjecttype=cls.informatie_object_type["url"],
+            zaaktype=self.zaaktype["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             volgnummer=1,
             richting="inkomend",
-            statustype=cls.status_type_finish,
+            statustype=self.status_type_finish,
         )
-        cls.informatie_object = generate_oas_component(
+        self.informatie_object = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="014c38fe-b010-4412-881c-3000032fb812",
-            url=cls.zaak_informatie_object["informatieobject"],
+            url=self.zaak_informatie_object["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/014c38fe-b010-4412-881c-3000032fb812/download",
-            informatieobjecttype=cls.informatie_object_type["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
             titel="uploaded_document_title.txt",
             bestandsomvang=123,
         )
-        cls.informatie_object_2 = generate_oas_component(
+        self.informatie_object_2 = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="015c38fe-b010-4412-881c-3000032fb812",
-            url=cls.zaak_informatie_object_2["informatieobject"],
+            url=self.zaak_informatie_object_2["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/015c38fe-b010-4412-881c-3000032fb812/download",
-            informatieobjecttype=cls.informatie_object_type["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
             titel="another_document_title.txt",
             bestandsomvang=123,
         )
-        cls.informatie_object_no_date = generate_oas_component(
+        self.informatie_object_no_date = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="015c38fe-b010-4412-881c-3000032fb812",
-            url=cls.zaak_informatie_object_no_date["informatieobject"],
+            url=self.zaak_informatie_object_no_date["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/016c38fe-b010-4412-881c-3000032fb812/download",
-            informatieobjecttype=cls.informatie_object_type["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
             titel="yet_another_document_title.txt",
             bestandsomvang=123,
         )
-        cls.uploaded_informatie_object = generate_oas_component(
+        self.uploaded_informatie_object = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="85079ba3-554a-450f-b963-2ce20b176c90",
-            url=cls.zaak_informatie_object["informatieobject"],
+            url=self.zaak_informatie_object["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/85079ba3-554a-450f-b963-2ce20b176c90/download",
-            informatieobjecttype=cls.informatie_object_type["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="upload.txt",
@@ -421,62 +421,62 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             titel="uploaded file",
         )
 
-        cls.zaak_informatie_object_invisible = generate_oas_component(
+        self.zaak_informatie_object_invisible = generate_oas_component_cached(
             "zrc",
             "schemas/ZaakInformatieObject",
             url=f"{ZAKEN_ROOT}zaakinformatieobjecten/fa5153aa-ad2c-4a07-ae75-15add57ee",
             informatieobject=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123",
-            zaak=cls.zaak_invisible["url"],
+            zaak=self.zaak_invisible["url"],
             aardRelatieWeergave="some invisible content",
             titel="",
             beschrijving="",
             registratiedatum="2021-01-12",
         )
-        cls.informatie_object_invisible = generate_oas_component(
+        self.informatie_object_invisible = generate_oas_component_cached(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
             uuid="994c38fe-b010-4412-881c-3000032fb123",
-            url=cls.zaak_informatie_object_invisible["informatieobject"],
+            url=self.zaak_informatie_object_invisible["informatieobject"],
             inhoud=f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/994c38fe-b010-4412-881c-3000032fb123/download",
-            informatieobjecttype=cls.informatie_object_type["url"],
+            informatieobjecttype=self.informatie_object_type["url"],
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.geheim,
             bestandsnaam="geheim-document.txt",
             bestandsomvang=123,
         )
 
-        cls.informatie_object_file = SimpleFile(
+        self.informatie_object_file = SimpleFile(
             name="uploaded_document_title.txt",
             size=123,
             url=reverse(
                 "cases:document_download",
                 kwargs={
-                    "object_id": cls.zaak["uuid"],
-                    "info_id": cls.informatie_object["uuid"],
+                    "object_id": self.zaak["uuid"],
+                    "info_id": self.informatie_object["uuid"],
                 },
             ),
             created=datetime.datetime(2021, 1, 12, 0, 0, 0),
         )
-        cls.informatie_object_file_2 = SimpleFile(
+        self.informatie_object_file_2 = SimpleFile(
             name="another_document_title.txt",
             size=123,
             url=reverse(
                 "cases:document_download",
                 kwargs={
-                    "object_id": cls.zaak["uuid"],
-                    "info_id": cls.informatie_object_2["uuid"],
+                    "object_id": self.zaak["uuid"],
+                    "info_id": self.informatie_object_2["uuid"],
                 },
             ),
             created=datetime.datetime(2021, 2, 12, 0, 0, 0),
         )
-        cls.informatie_object_file_no_date = SimpleFile(
+        self.informatie_object_file_no_date = SimpleFile(
             name="yet_another_document_title.txt",
             size=123,
             url=reverse(
                 "cases:document_download",
                 kwargs={
-                    "object_id": cls.zaak["uuid"],
-                    "info_id": cls.informatie_object_no_date["uuid"],
+                    "object_id": self.zaak["uuid"],
+                    "info_id": self.informatie_object_no_date["uuid"],
                 },
             ),
         )
@@ -507,7 +507,6 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             self.status_type_new,
             self.status_type_in_behandeling,
             self.status_type_finish,
-            self.status_new,
         ]:
             m.get(resource["url"], json=resource)
 
@@ -1057,7 +1056,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
     def test_no_access_when_no_roles_are_found_for_user_kvk_or_rsin(self, m):
         self._setUpOASMocks(m)
 
-        not_initiator_role = generate_oas_component(
+        not_initiator_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aa353aa-ad2c-4a07-ae75-15add5822",
@@ -1173,7 +1172,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
     ):
         self._setUpOASMocks(m)
 
-        not_initiator_role = generate_oas_component(
+        not_initiator_role = generate_oas_component_cached(
             "zrc",
             "schemas/Rol",
             url=f"{ZAKEN_ROOT}rollen/aa353aa-ad2c-4a07-ae75-15add5822",
@@ -1216,7 +1215,7 @@ class TestCaseDetailView(AssertRedirectsMixin, ClearCachesMixin, WebTest):
             # no roles for our user found
             json=paginated_response([self.user_role]),
         )
-        zaaktype_intern = generate_oas_component(
+        zaaktype_intern = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             url=self.zaak["zaaktype"],

--- a/src/open_inwoner/openzaak/tests/test_case_request.py
+++ b/src/open_inwoner/openzaak/tests/test_case_request.py
@@ -2,26 +2,28 @@ from django.test import TestCase
 
 import requests_mock
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.openzaak.cases import fetch_single_case
 
 from ...utils.test import ClearCachesMixin
 from ..models import OpenZaakConfig
 from .factories import ServiceFactory
+from .helpers import generate_oas_component_cached
 from .shared import ZAKEN_ROOT
 
 
 @requests_mock.Mocker()
 class TestFetchSpecificCase(ClearCachesMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
-        cls.config = OpenZaakConfig.get_solo()
-        cls.config.zaak_service = cls.zaak_service
-        cls.config.save()
+    def setUp(self):
+        super().setUp()
 
-        cls.zaak = generate_oas_component(
+        self.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
+        self.config = OpenZaakConfig.get_solo()
+        self.config.zaak_service = self.zaak_service
+        self.config.save()
+
+        self.zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 from furl import furl
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
@@ -18,6 +18,7 @@ from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 from ..models import OpenZaakConfig
 from .factories import ServiceFactory
+from .helpers import generate_oas_component_cached
 from .shared import CATALOGI_ROOT, ZAKEN_ROOT
 
 
@@ -26,28 +27,27 @@ from .shared import CATALOGI_ROOT, ZAKEN_ROOT
 class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
     inner_url = reverse_lazy("cases:cases_content")
 
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
+    def setUp(self):
+        super().setUp()
 
-        cls.user = UserFactory(
+        self.user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="johm@smith.nl"
         )
         # services
-        cls.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
-        cls.catalogi_service = ServiceFactory(
+        self.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
+        self.catalogi_service = ServiceFactory(
             api_root=CATALOGI_ROOT, api_type=APITypes.ztc
         )
         # openzaak config
-        cls.config = OpenZaakConfig.get_solo()
-        cls.config.zaak_service = cls.zaak_service
-        cls.config.catalogi_service = cls.catalogi_service
-        cls.config.zaak_max_confidentiality = (
+        self.config = OpenZaakConfig.get_solo()
+        self.config.zaak_service = self.zaak_service
+        self.config.catalogi_service = self.catalogi_service
+        self.config.zaak_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
-        cls.config.save()
+        self.config.save()
 
-        cls.zaaktype = generate_oas_component(
+        self.zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             url=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f",
@@ -56,29 +56,29 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             indicatieInternOfExtern="extern",
         )
-        cls.status_type1 = generate_oas_component(
+        self.status_type1 = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-777yu878km09",
-            zaaktype=cls.zaaktype["url"],
+            zaaktype=self.zaaktype["url"],
             omschrijving="Initial request",
             volgnummer=1,
             isEindstatus=False,
         )
-        cls.status_type2 = generate_oas_component(
+        self.status_type2 = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-744516671fe4",
-            zaaktype=cls.zaaktype["url"],
+            zaaktype=self.zaaktype["url"],
             omschrijving="Finish",
             volgnummer=2,
             isEindstatus=True,
         )
-        cls.zaak1 = generate_oas_component(
+        self.zaak1 = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
-            zaaktype=cls.zaaktype["url"],
+            zaaktype=self.zaaktype["url"],
             identificatie="ZAAK-2022-0000000001",
             omschrijving="Coffee zaak1",
             startdatum="2022-01-02",
@@ -86,20 +86,20 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             status=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        cls.status1 = generate_oas_component(
+        self.status1 = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
-            zaak=cls.zaak1["url"],
-            statustype=cls.status_type1["url"],
+            zaak=self.zaak1["url"],
+            statustype=self.status_type1["url"],
             datumStatusGezet="2021-01-12",
             statustoelichting="",
         )
-        cls.zaak2 = generate_oas_component(
+        self.zaak2 = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/e4d469b9-6666-4bdd-bf42-b53445298102",
-            zaaktype=cls.zaaktype["url"],
+            zaaktype=self.zaaktype["url"],
             identificatie="ZAAK-2022-0008800002",
             omschrijving="Coffee zaak2",
             startdatum="2022-01-12",
@@ -107,18 +107,18 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             status=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-beu760sle929",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        cls.status2 = generate_oas_component(
+        self.status2 = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
-            zaak=cls.zaak2["url"],
-            statustype=cls.status_type2["url"],
+            zaak=self.zaak2["url"],
+            statustype=self.status_type2["url"],
             datumStatusGezet="2021-03-12",
             statustoelichting="",
         )
 
         # objects needed to test how the cache is updated
-        cls.new_zaaktype = generate_oas_component(
+        self.new_zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             url=f"{CATALOGI_ROOT}zaaktypen/53340e34-7581-4b04-884f-98ui7y87i876",
@@ -127,20 +127,20 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             indicatieInternOfExtern="extern",
         )
-        cls.new_status_type = generate_oas_component(
+        self.new_status_type = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/e3798107-ab27-4c3c-977d-984yr8887rhe",
-            zaaktype=cls.new_zaaktype["url"],
+            zaaktype=self.new_zaaktype["url"],
             omschrijving="Process",
             volgnummer=1,
             isEindstatus=False,
         )
-        cls.new_zaak = generate_oas_component(
+        self.new_zaak = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}zaken/a25b2dce-1cae-4fc9-b9e9-141b0ad5189f",
-            zaaktype=cls.new_zaaktype["url"],
+            zaaktype=self.new_zaaktype["url"],
             identificatie="ZAAK-2022-0000000003",
             omschrijving="Tea zaak",
             startdatum="2022-01-02",
@@ -148,12 +148,12 @@ class OpenCaseListCacheTests(ClearCachesMixin, WebTest):
             status=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-oie8u899923g",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
-        cls.new_status = generate_oas_component(
+        self.new_status = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
             url=f"{ZAKEN_ROOT}statussen/3da81560-c7fc-476a-ad13-oie8u899923g",
-            zaak=cls.new_zaak["url"],
-            statustype=cls.new_status_type["url"],
+            zaak=self.new_zaak["url"],
+            statustype=self.new_status_type["url"],
             datumStatusGezet="2021-01-12",
             statustoelichting="",
         )

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports.py
@@ -6,6 +6,7 @@ from zgw_consumers.test import generate_oas_component, mock_service_oas_get
 
 from open_inwoner.openzaak.models import CatalogusConfig, OpenZaakConfig, ZaakTypeConfig
 from open_inwoner.openzaak.tests.factories import CatalogusConfigFactory, ServiceFactory
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import CATALOGI_ROOT
 from open_inwoner.openzaak.zgw_imports import (
     import_catalog_configs,
@@ -17,14 +18,14 @@ from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 class CatalogMockData:
     def __init__(self):
         self.catalogs = [
-            generate_oas_component(
+            generate_oas_component_cached(
                 "ztc",
                 "schemas/Catalogus",
                 url=f"{CATALOGI_ROOT}catalogussen/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 domein="aaaaa",
                 rsin="123456789",
             ),
-            generate_oas_component(
+            generate_oas_component_cached(
                 "ztc",
                 "schemas/Catalogus",
                 url=f"{CATALOGI_ROOT}catalogussen/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -32,7 +33,7 @@ class CatalogMockData:
                 rsin="123456789",
             ),
         ]
-        self.extra_catalog = generate_oas_component(
+        self.extra_catalog = generate_oas_component_cached(
             "ztc",
             "schemas/Catalogus",
             url=f"{CATALOGI_ROOT}catalogussen/cccccccc-cccc-cccc-cccc-cccccccccccc",
@@ -55,7 +56,7 @@ class CatalogMockData:
 class ZaakTypeMockData:
     def __init__(self):
 
-        self.zaaktype_aaa_1 = generate_oas_component(
+        self.zaaktype_aaa_1 = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
@@ -65,7 +66,7 @@ class ZaakTypeMockData:
             omschrijving="zaaktype-aaa",
             indicatieInternOfExtern="extern",
         )
-        self.zaaktype_bbb = generate_oas_component(
+        self.zaaktype_bbb = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
@@ -76,7 +77,7 @@ class ZaakTypeMockData:
             omschrijving="zaaktype-bbb",
             indicatieInternOfExtern="extern",
         )
-        self.zaaktype_aaa_2 = generate_oas_component(
+        self.zaaktype_aaa_2 = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-333333333333",
@@ -87,7 +88,7 @@ class ZaakTypeMockData:
             omschrijving="zaaktype-aaa",
             indicatieInternOfExtern="extern",
         )
-        self.zaaktype_intern = generate_oas_component(
+        self.zaaktype_intern = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-444444444444",
@@ -104,7 +105,7 @@ class ZaakTypeMockData:
             self.zaaktype_aaa_2,
             self.zaaktype_intern,
         ]
-        self.extra_zaaktype = generate_oas_component(
+        self.extra_zaaktype = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-555555555555",

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports_iotypes.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports_iotypes.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 import requests_mock
 from zgw_consumers.constants import APITypes
-from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+from zgw_consumers.test import mock_service_oas_get
 
 from open_inwoner.openzaak.models import (
     OpenZaakConfig,
@@ -15,6 +15,7 @@ from open_inwoner.openzaak.tests.factories import (
     ServiceFactory,
     ZaakTypeConfigFactory,
 )
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import CATALOGI_ROOT
 from open_inwoner.openzaak.zgw_imports import (
     import_zaaktype_informatieobjecttype_configs,
@@ -25,21 +26,21 @@ from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 class InformationObjectTypeMockData:
     def __init__(self):
 
-        self.info_type_aaa_1 = generate_oas_component(
+        self.info_type_aaa_1 = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttypen/aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
             catalogus=f"{CATALOGI_ROOT}catalogussen/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             omschrijving="info-aaa-1",
         )
-        self.info_type_aaa_2 = generate_oas_component(
+        self.info_type_aaa_2 = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttypen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
             catalogus=f"{CATALOGI_ROOT}catalogussen/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             omschrijving="info-aaa-2",
         )
-        self.extra_info_type_aaa_3 = generate_oas_component(
+        self.extra_info_type_aaa_3 = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttypen/aaaaaaaa-aaaa-aaaa-aaaa-333333333333",
@@ -47,7 +48,7 @@ class InformationObjectTypeMockData:
             omschrijving="info-aaa-3",
         )
 
-        self.info_type_bbb = generate_oas_component(
+        self.info_type_bbb = generate_oas_component_cached(
             "ztc",
             "schemas/InformatieObjectType",
             url=f"{CATALOGI_ROOT}informatieobjecttypen/bbbbbbbb-bbbb-bbbb-bbbb-111111111111",
@@ -56,7 +57,7 @@ class InformationObjectTypeMockData:
             omschrijving="info-bbb",
         )
 
-        self.statustype_aaa_1 = generate_oas_component(
+        self.statustype_aaa_1 = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
@@ -64,7 +65,7 @@ class InformationObjectTypeMockData:
             # zaaktype=self.zaaktype_aaa_1,
             omschrijving="status-aaa-1",
         )
-        self.statustype_aaa_2 = generate_oas_component(
+        self.statustype_aaa_2 = generate_oas_component_cached(
             "ztc",
             "schemas/StatusType",
             url=f"{CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
@@ -73,7 +74,7 @@ class InformationObjectTypeMockData:
             omschrijving="status-aaa-2",
         )
 
-        self.zaaktype_aaa_1 = generate_oas_component(
+        self.zaaktype_aaa_1 = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
@@ -92,7 +93,7 @@ class InformationObjectTypeMockData:
                 f"{CATALOGI_ROOT}resultaatypen/b1a268dd-4322-47bb-a930-b83066b4a32c"
             ],
         )
-        self.resultaat_type_1 = generate_oas_component(
+        self.resultaat_type_1 = generate_oas_component_cached(
             "ztc",
             "schemas/ResultaatType",
             url=f"{CATALOGI_ROOT}resultaatypen/b1a268dd-4322-47bb-a930-b83066b4a32c",
@@ -101,7 +102,7 @@ class InformationObjectTypeMockData:
             resultaattypeomschrijving="test1",
             selectielijstklasse="ABC",
         )
-        self.zaaktype_bbb = generate_oas_component(
+        self.zaaktype_bbb = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="bbbbbbbb-bbbb-bbbb-bbbb-111111111111",
@@ -119,7 +120,7 @@ class InformationObjectTypeMockData:
                 f"{CATALOGI_ROOT}resultaatypen/b1a268dd-4322-47bb-a930-b83066b4a32c"
             ],
         )
-        self.zaaktype_aaa_2 = generate_oas_component(
+        self.zaaktype_aaa_2 = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
@@ -140,7 +141,7 @@ class InformationObjectTypeMockData:
                 f"{CATALOGI_ROOT}resultaatypen/b1a268dd-4322-47bb-a930-b83066b4a32c",
             ],
         )
-        self.zaaktype_aaa_intern = generate_oas_component(
+        self.zaaktype_aaa_intern = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-444444444444",
@@ -157,7 +158,7 @@ class InformationObjectTypeMockData:
             statustypen=[],
             resultaattypen=[],
         )
-        self.extra_zaaktype_aaa = generate_oas_component(
+        self.extra_zaaktype_aaa = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
             uuid="aaaaaaaa-aaaa-aaaa-aaaa-555555555555",


### PR DESCRIPTION
Let's use `generate_oas_component_cached()` in all the relevant setUp()'s and see what it does for test runtime.

I also refactored/restored some ZGW tests that earlier sacrificed test-isolation for performance, by using the setupTestData class-method, but this is no longer needed. This is slightly slower because the normal factories run for every tests but it is safer and more correct.