### PR TITLE
:arrow_up: [#2066] Upgrade psycopg2 to 2.9.9 and pip-tools to 7.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -394,7 +394,7 @@ polib==1.1.1
     # via django-rosetta
 prompt-toolkit==3.0.36
     # via click-repl
-psycopg2==2.9.5
+psycopg2==2.9.9
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -705,7 +705,7 @@ prompt-toolkit==3.0.36
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   click-repl
-psycopg2==2.9.5
+psycopg2==2.9.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -802,7 +802,7 @@ pillow==10.1.0
     #   easy-thumbnails
     #   reportlab
     #   weasyprint
-pip-tools==6.8.0
+pip-tools==7.3.0
     # via -r requirements/dev.in
 platformdirs==2.4.0
     # via
@@ -826,7 +826,7 @@ prompt-toolkit==3.0.36
     #   click-repl
 psutil==5.9.7
     # via locust
-psycopg2==2.9.5
+psycopg2==2.9.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2066

pip-tools was stuck on a version that doesn't work properly for python3.11