### PR TITLE
[#1808] Use long month names consistently in ssd templates

### DIFF
--- a/src/open_inwoner/ssd/templates/maandspecificatie.html
+++ b/src/open_inwoner/ssd/templates/maandspecificatie.html
@@ -156,7 +156,7 @@
         <div class="section extra-margin">
             <p class="monthly-report__p extra-margin">Op de 25e van de maand krijgt u het bedrag ad. &euro; {% format_currency last.bedrag.waarde_bedrag %} uitbetaald.</p>
         </div>
-        {% endif %}  
+        {% endif %}
 	</div>
 	</body>
 	<p style="page-break-after: always;">&nbsp;</p>

--- a/src/open_inwoner/ssd/tests/test_views.py
+++ b/src/open_inwoner/ssd/tests/test_views.py
@@ -87,7 +87,7 @@ class TestMonthlyBenefitsFormView(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertContains(
-            response, "Geen uitkeringsspecificatie gevonden voor Dec 1985"
+            response, "Geen uitkeringsspecificatie gevonden voor december 1985"
         )
 
     @patch(

--- a/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
+++ b/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
@@ -33,7 +33,7 @@
                                 {% endrender_form %}
                                 <div>
                                     {% if report_not_found %}
-                                        {% blocktrans with time_period=report_not_found|date:"M Y" %}
+                                        {% blocktrans with time_period=report_not_found|date:"F Y" %}
                                             Geen uitkeringsspecificatie gevonden voor {{ time_period }}.
                                         {% endblocktrans %}
                                     {% endif %}


### PR DESCRIPTION
Taiga: [#1808](https://taiga.maykinmedia.nl/project/open-inwoner/issue/1808)

- set empty title in PDF templates to prevent duplication of report name in tab
- use long month name in case no reports are found