### PR TITLE
:wrench: [#2101] Add OIDC admin config to admin index fixture

### DIFF
--- a/src/open_inwoner/accounts/backends.py
+++ b/src/open_inwoner/accounts/backends.py
@@ -119,6 +119,9 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
             self.update_user(user, claims)
             # TODO verify we want unusable_password
             user.set_unusable_password()
+            # Saving after using `set_unusable_password` is required, otherwise the user
+            # will not actually be authenticated, see: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2101
+            user.save()
 
             return user
 

--- a/src/open_inwoner/conf/fixtures/django-admin-index.json
+++ b/src/open_inwoner/conf/fixtures/django-admin-index.json
@@ -27,6 +27,10 @@
                 "user"
             ],
             [
+                "mozilla_django_oidc_db",
+                "openidconnectconfig"
+            ],
+            [
                 "userfeed",
                 "feeditemdata"
             ]

--- a/src/open_inwoner/configurations/tests/test_oidc.py
+++ b/src/open_inwoner/configurations/tests/test_oidc.py
@@ -41,7 +41,10 @@ class OIDCConfigTest(ClearCachesMixin, WebTest):
 
         oidc_login_option = response.pyquery.find(".admin-login-option")
 
-        self.assertEqual(oidc_login_option.text(), _("Login with organization account"))
+        self.assertEqual(
+            oidc_login_option.text(),
+            "{} {}".format(_("or"), _("Login with organization account")),
+        )
 
     def test_admin_only_disabled(self):
         """Assert that the OIDC login option is only displayed for regular users"""

--- a/src/open_inwoner/scss/admin/_app_overrides.scss
+++ b/src/open_inwoner/scss/admin/_app_overrides.scss
@@ -104,3 +104,10 @@ $djai-border-width: 8px;
     }
   }
 }
+
+/* Extra login links in admin login screen */
+.admin-login-option {
+  text-align: center;
+  clear: both;
+  padding-top: 1em;
+}

--- a/src/open_inwoner/templates/admin/login.html
+++ b/src/open_inwoner/templates/admin/login.html
@@ -1,0 +1,17 @@
+{% extends "admin/login.html" %}
+{% load solo_tags i18n %}
+
+
+{% block content %}
+{{ block.super }}
+
+{% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
+{% get_solo 'configurations.SiteConfiguration' as site_config %}
+{% if oidc_config.enabled and site_config.openid_enabled_for_admin %}
+<div class="admin-login-option">{% trans "or" %}</div>
+<div class="admin-login-option">
+    <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/src/open_inwoner/templates/maykin_2fa/login.html
+++ b/src/open_inwoner/templates/maykin_2fa/login.html
@@ -6,6 +6,7 @@
     {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
     {% get_solo 'configurations.SiteConfiguration' as site_config %}
     {% if oidc_config.enabled and site_config.openid_enabled_for_admin %}
+        <div class="admin-login-option">{% trans "or" %}</div>
         <div class="admin-login-option">
             <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
         </div>


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2101

Fixes two issues:
- If an OIDC user logs in for the first time, they are now actually authenticated (previously they had to log in twice)
- If OIDC is enabled for admins, the `is_staff` attribute is set for those users (according to the OIDC config) and they are redirected to the admin interface