### PR TITLE
Debugging playwright e2e tests

### DIFF
--- a/src/open_inwoner/accounts/tests/test_action_views.py
+++ b/src/open_inwoner/accounts/tests/test_action_views.py
@@ -344,7 +344,7 @@ class ActionsPlaywrightTests(PlaywrightSyncLiveServerTestCase):
 
         mock_solo.return_value.cookiebanner_enabled = False
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))

--- a/src/open_inwoner/accounts/tests/test_inbox_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_page.py
@@ -272,7 +272,7 @@ class InboxPagePlaywrightTests(PlaywrightSyncLiveServerTestCase):
         """
 
     def test_polling(self):
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.contact_1_conversation_url)

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -412,7 +412,7 @@ class CasesPlaywrightTests(
     def test_cases(self, m):
         self._setUpMocks(m)
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("cases:index"))
@@ -572,16 +572,20 @@ class CasesPlaywrightTests(
         ),
 
         # Setup.
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
         page = context.new_page()
         page.goto(
             self.live_reverse(
                 "cases:case_detail", kwargs={"object_id": self.zaak["uuid"]}
             )
         )
+        page.wait_for_load_state("load")
+        page.wait_for_load_state("networkidle")
 
         upload_form = page.locator("#document-upload")
-        file_input = upload_form.get_by_label("Sleep of selecteer bestanden")
+        expect(upload_form).to_be_visible()
+
+        file_input = upload_form.get_by_label(_("Sleep of selecteer bestanden"))
         submit_button = upload_form.get_by_role("button", name=_("Upload documenten"))
         notification_list = page.get_by_role("alert").get_by_role("list")
         notification_list_items = notification_list.get_by_role("listitem")
@@ -591,6 +595,7 @@ class CasesPlaywrightTests(
         # Check that the initial state does not have any uploaded documents.
         expect(notification_list_items).to_have_count(0)
         expect(file_list_items).to_have_count(0)
+        expect(file_input).to_be_visible()
 
         # Upload some files.
         file_input.set_input_files(

--- a/src/open_inwoner/configurations/tests/test_analytics.py
+++ b/src/open_inwoner/configurations/tests/test_analytics.py
@@ -133,10 +133,11 @@ class CookieBannerPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTest
     def test_cookie_accept(self):
         config = SiteConfiguration.get_solo()
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))
+        page.wait_for_load_state("load")
 
         cookie_banner = page.locator("#cookie-banner")
 
@@ -157,10 +158,11 @@ class CookieBannerPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTest
     def test_cookie_reject(self):
         config = SiteConfiguration.get_solo()
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.new_browser_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))
+        page.wait_for_load_state("load")
 
         cookie_banner = page.locator("#cookie-banner")
 

--- a/src/open_inwoner/pdc/tests/test_product.py
+++ b/src/open_inwoner/pdc/tests/test_product.py
@@ -381,7 +381,7 @@ class ProductPagePlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestC
             content="Some content [CTABUTTON]", link="http://www.example.com"
         )
 
-        context = self.browser.new_context()
+        context = self.new_browser_context()
         page = context.new_page()
 
         page.goto(

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -221,7 +221,7 @@ class SearchPagePlaywrightTests(
         config.save()
 
     def test_basic_search(self):
-        context = self.browser.new_context()
+        context = self.new_browser_context()
         page = context.new_page()
 
         # search to find both products
@@ -230,7 +230,7 @@ class SearchPagePlaywrightTests(
         expect(page.locator(".search-results__item")).to_have_count(2)
 
     def test_search_form_delegates_copy_query_value(self):
-        context = self.browser.new_context()
+        context = self.new_browser_context()
         page = context.new_page()
         page.goto(self.live_reverse("search:search", params={"query": "summary"}))
 
@@ -259,7 +259,7 @@ class SearchPagePlaywrightTests(
 
         for form_id, view_size, open_menu in self.form_delegates:
             with self.subTest(form_id):
-                context = self.browser.new_context(
+                context = self.new_browser_context(
                     viewport={"width": view_size, "height": 1024},
                 )
                 page = context.new_page()
@@ -277,7 +277,7 @@ class SearchPagePlaywrightTests(
                 context.close()
 
     def test_search_with_filters(self):
-        context = self.browser.new_context()
+        context = self.new_browser_context()
         page = context.new_page()
 
         # search to find both products
@@ -320,7 +320,7 @@ class SearchPagePlaywrightTests(
 
     def test_search_with_filter_combinations(self):
         # NOTE it isn't great to generate query-strings outside the form but we test the form above
-        context = self.browser.new_context()
+        context = self.new_browser_context()
         page = context.new_page()
 
         tests = [


### PR DESCRIPTION
Trying to find out why random e2e tests are failing on locator timeouts.

I've seen it happen on webkit, chromium and firefox, and either the cookie_accept test or the multifile upload.