### PR TITLE
:lipstick: [#2117] Tag styles for wysiwyg in footer

### DIFF
--- a/src/open_inwoner/scss/components/Typography/wysiwyg.scss
+++ b/src/open_inwoner/scss/components/Typography/wysiwyg.scss
@@ -1,16 +1,30 @@
 .wysiwyg {
+  font-family: var(--font-family-body);
+
   a {
     display: inline-flex;
     flex-direction: row;
     align-items: center;
-    font-family: var(--font-family-body);
     font-size: var(--font-size-body);
     line-height: var(--font-line-height-body);
     text-decoration: none;
     gap: var(--spacing-small);
-
     color: var(--color-secondary);
 
     word-wrap: break-word;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-family-heading);
+  }
+
+  ul {
+    margin: 0;
+    padding: 0 0 0 var(--font-size-body);
   }
 }

--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -152,9 +152,9 @@
                 {% endif %}
             </div>
             {% endif %}
-            <div class="footer__left">{% static_placeholder "footer_left" %}</div>
-            <div class="footer__center">{% static_placeholder "footer_center" %}</div>
-            <div class="footer__right">{% static_placeholder "footer_right" %}</div>
+            <div class="footer__left wysiwyg">{% static_placeholder "footer_left" %}</div>
+            <div class="footer__center wysiwyg">{% static_placeholder "footer_center" %}</div>
+            <div class="footer__right wysiwyg">{% static_placeholder "footer_right" %}</div>
         </footer>
         {% endif %}
 


### PR DESCRIPTION
issue https://taiga.maykinmedia.nl/project/open-inwoner/task/2117

This is for situations where we have CKeditor elements/tags that do not have project style-classes.

I moved this into a higher priority because I see Enschede is experimenting with the footer: https://mijn-acceptatie.enschede.nl/accounts/login/ (scroll down to see footer)