### PR TITLE
[#2137] Show disabled pseudo-checkbox for actions

### DIFF
--- a/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
+++ b/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
@@ -20,8 +20,8 @@
                         {# pseudo checkbox for notifications that cannot be disabled #}
                         <div class="checkbox">
                             <span role="checkbox" aria-disabled="true" aria-checked="true" class="checkbox__input checkbox__pseudo checkbox__input--disabled" aria-labelledby="id_cases_notifications_action_required" tabindex="0"></span>
-                            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - action required" %}</span>
-                            <p class="p">{% trans "E-mail notifications for case updates that require action (cannot be disabled)" %}</p>
+                            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - actie is nodig" %}</span>
+                            <p class="p">{% trans "E-mailnotificaties wanneer er actie nodig is voor een zaak (kan niet uitgeschakeld worden)" %}</p>
                         </div>
                     </div>
 

--- a/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
+++ b/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
@@ -16,12 +16,14 @@
                     {% autorender_field form field %}
                 {% endfor %}
 
-                {# pseudo checkbox for notifications that cannot be disabled #}
-                <div class="checkbox">
-                    <input type="checkbox" name="cases_notifications_action_required" disabled="" class="checkbox__input checkbox__input--disabled" checked="">
-                    <label class="checkbox__label" for="id_cases_notifications_action_required">{% trans "Zaaknotificaties - action required" %}</label>
-                    <p class="p">{% trans "E-mail notifications for case updates that require action (cannot be disabled)" %}</p>
-                </div>
+                    <div class="form__control">
+                        {# pseudo checkbox for notifications that cannot be disabled #}
+                        <div class="checkbox">
+                            <span role="checkbox" aria-disabled="true" aria-checked="true" class="checkbox__input checkbox__pseudo checkbox__input--disabled" aria-labelledby="id_cases_notifications_action_required" tabindex="0"></span>
+                            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - action required" %}</span>
+                            <p class="p">{% trans "E-mail notifications for case updates that require action (cannot be disabled)" %}</p>
+                        </div>
+                    </div>
 
                 {% form_actions primary_icon='arrow_forward' primary_text="Verzenden" %}
             </form>

--- a/src/open_inwoner/scss/components/Form/Checkbox.scss
+++ b/src/open_inwoner/scss/components/Form/Checkbox.scss
@@ -35,6 +35,10 @@
       border-radius: 1px; // intended-var-change.
       background-color: var(--color-white);
     }
+
+    &.checkbox__pseudo-label {
+      padding-left: calc(var(--gutter-width) + 4px);
+    }
   }
 
   .checkbox__input:checked ~ .checkbox__label:before {
@@ -49,6 +53,25 @@
     background-color: var(--color-gray);
     color: var(--color-white);
     font-family: 'Material Icons';
+    content: '\e876';
+  }
+
+  /// Mimic checked-styles for pseudo checkboxes
+
+  &__pseudo ~ .checkbox__label:before {
+    background-color: var(--color-secondary);
+    color: var(--color-font-secondary);
+    font-family: 'Material Icons';
+    left: 4px;
+    content: '\e876';
+  }
+
+  &__pseudo.checkbox__input--disabled ~ .checkbox__label:before {
+    border-color: var(--color-gray) !important;
+    background-color: var(--color-gray);
+    color: var(--color-white);
+    font-family: 'Material Icons';
+    left: 3px;
     content: '\e876';
   }
 }

--- a/src/open_inwoner/templates/pages/profile/notifications.html
+++ b/src/open_inwoner/templates/pages/profile/notifications.html
@@ -20,8 +20,8 @@
         {# pseudo checkbox for notifications that cannot be disabled #}
         <div class="checkbox">
             <span role="checkbox" aria-disabled="true" aria-checked="true" class="checkbox__input checkbox__pseudo checkbox__input--disabled" aria-labelledby="id_cases_notifications_action_required" tabindex="0"></span>
-            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - action required" %}</span>
-            <p class="p">{% trans "E-mail notifications for case updates that require action (cannot be disabled)" %}</p>
+            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - actie is nodig" %}</span>
+            <p class="p">{% trans "E-mailnotificaties wanneer er actie nodig is voor een zaak (kan niet uitgeschakeld worden)" %}</p>
         </div>
     </div>
 

--- a/src/open_inwoner/templates/pages/profile/notifications.html
+++ b/src/open_inwoner/templates/pages/profile/notifications.html
@@ -9,6 +9,23 @@
     {% trans "Kies voor welk onderwerp je meldingen wilt ontvangen" %}
 </p>
 
-{% form form_object=form method="POST" id="change-notifications" submit_text=_("Opslaan") secondary_href='profile:detail' secondary_text=_('Terug') secondary_icon='arrow_backward' secondary_icon_position="before" %}
+<form method="POST" id="change-notifications" action="{% url 'profile:notifications' %}" class="form" novalidate>
+    {% csrf_token %}
+
+    {% for field in form.fields %}
+        {% autorender_field form field %}
+    {% endfor %}
+
+    <div class="form__control">
+        {# pseudo checkbox for notifications that cannot be disabled #}
+        <div class="checkbox">
+            <span role="checkbox" aria-disabled="true" aria-checked="true" class="checkbox__input checkbox__pseudo checkbox__input--disabled" aria-labelledby="id_cases_notifications_action_required" tabindex="0"></span>
+            <span class="checkbox__label checkbox__pseudo-label" id="id_cases_notifications_action_required">{% trans "Zaaknotificaties - action required" %}</span>
+            <p class="p">{% trans "E-mail notifications for case updates that require action (cannot be disabled)" %}</p>
+        </div>
+    </div>
+
+    {% form_actions primary_text=_("Opslaan") primary_icon="arrow_forward" secondary_href='profile:detail' secondary_text=_('Terug') secondary_icon_position="before" secondary_icon='arrow_backward' %}
+</form>
 
 {% endblock content %}


### PR DESCRIPTION
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2137 
To explicitly show required-actions notifications cannot be turned off (on http://localhost:8000/mijn-profiel/notificaties/).

➕ also making the pseudo checkbox accessible (⚠️ ordinary **disabled** inputs are **_not_** detected by screenreaders and are not read + cannot be focussed, so making a _visual_ fake checkbox here that actually gets detected).
A disabled input that cannot be enabled by the user in any way is a violation of accessibility.