### PR TITLE
Updated flake8 dependency, added autoflake

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -36,6 +36,8 @@ attrs==21.2.0
     #   -r requirements/base.txt
     #   glom
     #   jsonschema
+autoflake==2.3.0
+    # via -r requirements/test-tools.in
 beautifulsoup4==4.10.0
     # via webtest
 billiard==3.6.4.0
@@ -518,7 +520,7 @@ factory-boy==3.2.0
     # via -r requirements/test-tools.in
 faker==9.9.0
     # via factory-boy
-flake8==3.9.2
+flake8==7.0.0
     # via -r requirements/test-tools.in
 fonttools[woff]==4.43.0
     # via
@@ -647,7 +649,7 @@ maykin-python3-saml==1.14.0.post0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   flake8
     #   pylint
@@ -732,7 +734,7 @@ psycopg2==2.9.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-pycodestyle==2.7.0
+pycodestyle==2.11.1
     # via flake8
 pycparser==2.20
     # via
@@ -749,8 +751,10 @@ pyee==11.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   playwright
-pyflakes==2.3.1
-    # via flake8
+pyflakes==3.2.0
+    # via
+    #   autoflake
+    #   flake8
 pyjwt==2.8.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,6 +41,10 @@ attrs==21.2.0
     #   -r requirements/ci.txt
     #   glom
     #   jsonschema
+autoflake==2.3.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 autopep8==1.5.7
     # via django-silk
 babel==2.9.1
@@ -575,7 +579,7 @@ faker==9.9.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   factory-boy
-flake8==3.9.2
+flake8==7.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -748,7 +752,7 @@ maykin-python3-saml==1.14.0.post0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -857,7 +861,7 @@ psycopg2==2.9.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-pycodestyle==2.7.0
+pycodestyle==2.11.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -878,10 +882,11 @@ pyee==11.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   playwright
-pyflakes==2.3.1
+pyflakes==3.2.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   autoflake
     #   flake8
 pygments==2.12.0
     # via sphinx

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -15,6 +15,7 @@ tblib
 black
 isort
 flake8
+autoflake
 
 # DigidLocal
 pyopenssl

--- a/src/open_inwoner/accounts/gateways.py
+++ b/src/open_inwoner/accounts/gateways.py
@@ -15,8 +15,6 @@ class GatewayError(Exception):
     text message.
     """
 
-    pass
-
 
 class Gateway(object):
     def get_message(self, token):

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -167,18 +167,18 @@ def autorender_field(form_object, field_name, **kwargs):
     fn = input
     tmplt = WIDGET_TEMPLATES["INPUT"]
 
-    if type(field) == forms.fields.DateField:
+    if type(field) is forms.fields.DateField:
         tmplt = WIDGET_TEMPLATES["DATE"]
-    elif type(field) == forms.models.ModelMultipleChoiceField:
+    elif type(field) is forms.models.ModelMultipleChoiceField:
         tmplt = WIDGET_TEMPLATES["MULTIPLECHECKBOX"]
-    elif type(field) == forms.fields.BooleanField:
+    elif type(field) is forms.fields.BooleanField:
         fn = checkbox
         tmplt = WIDGET_TEMPLATES["CHECKBOX"]
-    elif type(field.widget) == forms.fields.HiddenInput:
+    elif type(field.widget) is forms.fields.HiddenInput:
         tmplt = WIDGET_TEMPLATES["HIDDEN"]
-    elif type(field.widget) == forms.widgets.RadioSelect:
+    elif type(field.widget) is forms.widgets.RadioSelect:
         tmplt = WIDGET_TEMPLATES["RADIO"]
-    elif type(field.widget) == forms.fields.Textarea:
+    elif type(field.widget) is forms.fields.Textarea:
         tmplt = WIDGET_TEMPLATES["TEXTAREA"]
 
     context = fn(bound_field, **kwargs)

--- a/src/open_inwoner/media/admin/__init__.py
+++ b/src/open_inwoner/media/admin/__init__.py
@@ -1,1 +1,1 @@
-from .video import VideoAdmin
+from .video import VideoAdmin  # noqa


### PR DESCRIPTION
The flake8 dependency was ancient and needed to update so we can use autoflake

With autoflake you can automatically fix some flake8 issues, so it works similar to black and isort.

I use this mostly for unused imports, because I always forget:

````
autoflake --in-place --remove-all-unused-imports
````

(also fixed some issues from new tooling)
