### PR TITLE
Fixed user save-signal issue with Haalcentraal BRP retrieval logging

### DIFF
--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -44,7 +44,7 @@ def log_user_login(sender, user, request, *args, **kwargs):
 
     if user.login_type == LoginTypeChoices.digid:
         if brp_config.service:
-            update_brp_data_in_db(user, initial=False)
+            update_brp_data_in_db(user)
 
     if user.login_type in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
         if oc_config.klanten_service:

--- a/src/open_inwoner/haalcentraal/signals.py
+++ b/src/open_inwoner/haalcentraal/signals.py
@@ -1,32 +1,26 @@
 import logging
 
-from django.db.models.signals import pre_save
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.models import User
-from open_inwoner.utils.logentry import system_action
 
 from .utils import update_brp_data_in_db
 
 logger = logging.getLogger(__name__)
 
 
-@receiver(pre_save, sender=User)
+@receiver(post_save, sender=User)
 def on_bsn_change(instance, **kwargs):
     if (
         instance.bsn
-        and instance.is_prepopulated is False
+        and not instance.is_prepopulated
         and instance.login_type == LoginTypeChoices.digid
+        and getattr(instance, "_process_on_bsn_change_post_save", True)
     ):
-        try:
-            system_action(
-                "Retrieving data for %s from haal centraal based on BSN",
-                content_object=instance,
-            )
-        except ValueError:
-            logger.info(
-                "Retrieving data for %s from haal centraal based on BSN", instance
-            )
+        # workaround to not have a post_save-signal loop if we save() again from within this handler
+        # note: this used to be a pre_save, but we need a saved user for the timeline log of the BRP access
+        instance._process_on_bsn_change_post_save = False
 
         update_brp_data_in_db(instance)

--- a/src/open_inwoner/haalcentraal/tests/test_signal.py
+++ b/src/open_inwoner/haalcentraal/tests/test_signal.py
@@ -1,9 +1,11 @@
 import logging
 
 from django.test import TestCase, override_settings
+from django.utils.translation import gettext as _
 
 import requests_mock
 from freezegun import freeze_time
+from timeline_logger.models import TimelineLog
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
@@ -279,6 +281,10 @@ class TestLogging(HaalCentraalMixin, AssertTimelineLogMixin, TestCase):
             "Retrieving data for %s from haal centraal based on BSN",
             level=logging.INFO,
         )
+        self.assertTimelineLog(
+            _("data was retrieved from haal centraal"),
+            level=logging.INFO,
+        )
 
     @requests_mock.Mocker()
     def test_single_entry_is_logged_when_there_is_an_error(self, m):
@@ -312,3 +318,4 @@ class TestLogging(HaalCentraalMixin, AssertTimelineLogMixin, TestCase):
             "Retrieving data for %s from haal centraal based on BSN",
             level=logging.INFO,
         )
+        self.assertEqual(TimelineLog.objects.count(), 1)


### PR DESCRIPTION
This was kind of gnarly:

1. We can't use `pre_save` signal because we need a saved user
2. Calling save() from either a `pre_save` or `post_save` handler creates a signal loop

Solution: use `post_save` so we have a saved user, and break the loop.

Downside is this will trigger any other `post_save` handler multiple times, which is a vote to centralize signal based user update stuff. Most of it is currently `user_logged_in` so not an issue.

Note this PR targets the open Django 4.x branch #1024
