### PR TITLE
:sparkles: [#2107] Implement contactmoment notifications webhook

### DIFF
--- a/src/open_inwoner/openklant/api/urls.py
+++ b/src/open_inwoner/openklant/api/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from open_inwoner.openklant.api.views import ContactmomentenNotificationsWebhookView
+
+app_name = "openklant"
+
+urlpatterns = [
+    path(
+        "notifications/webhook/contactmomenten",
+        ContactmomentenNotificationsWebhookView.as_view(),
+        name="notifications_webhook_contactmomenten",
+    ),
+]

--- a/src/open_inwoner/openklant/api/views.py
+++ b/src/open_inwoner/openklant/api/views.py
@@ -1,0 +1,20 @@
+import logging
+
+from notifications_api_common.models import Subscription
+
+from open_inwoner.openklant.notifications import handle_contactmomenten_notification
+from open_inwoner.openzaak.api.views import NotificationsWebhookBaseView
+from open_inwoner.openzaak.api_models import Notification
+
+logger = logging.getLogger(__name__)
+
+
+class ContactmomentenNotificationsWebhookView(NotificationsWebhookBaseView):
+    accept_channels = [
+        "zaken",
+    ]
+
+    def handle_notification(
+        self, subscription: Subscription, notification: Notification
+    ):
+        handle_contactmomenten_notification(notification)

--- a/src/open_inwoner/openklant/notifications.py
+++ b/src/open_inwoner/openklant/notifications.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Iterable, List
+
+from django.db.models import Q, QuerySet
+
+from open_inwoner.accounts.models import User
+from open_inwoner.openklant.api_models import Klant, KlantContactMoment
+from open_inwoner.openklant.clients import build_client
+from open_inwoner.openzaak.api_models import Notification
+from open_inwoner.utils.logentry import system_action as log_system_action
+
+logger = logging.getLogger(__name__)
+
+
+def handle_contactmomenten_notification(notification: Notification):
+    if notification.kanaal != "contactmomenten":
+        raise Exception(
+            f"handler expects kanaal 'contactmomenten' but received '{notification.kanaal}'"
+        )
+
+    if notification.resource == "contactmoment" and notification.actie in [
+        "update",
+        "partial_update",
+    ]:
+        handle_contactmoment_update(notification.resource_url)
+    else:
+        raise NotImplementedError("programmer error in earlier resource filter")
+
+
+def get_klant_data_from_contactmomenten(
+    client, klantcontactmomenten: List[KlantContactMoment]
+) -> Iterable[Klant]:
+    if not klantcontactmomenten:
+        return []
+
+    klanten = []
+    for kcm in klantcontactmomenten:
+        if kcm.klant not in klanten:
+            klanten.append(kcm.klant)
+
+    klanten = map(client.retrieve_klant_by_url, klanten)
+
+    return klanten
+
+
+def get_users_for_klanten(klanten: Iterable[Klant]) -> QuerySet[User]:
+    params = {"kvk__in": [], "rsin__in": [], "bsn__in": []}
+    for klant in klanten:
+        if klant.subject_type == "natuurlijk_persoon":
+            params["bsn__in"].append(klant.subject_identificatie["inp_bsn"])
+        elif klant.subject_type == "niet_natuurlijk_persoon":
+            params["kvk__in"].append(klant.subject_identificatie["inn_nnp_id"])
+            params["rsin__in"].append(klant.subject_identificatie["inn_nnp_id"])
+
+    query = Q()
+    for param, value in params.items():
+        query |= Q(**{param: value})
+
+    inform_users = User.objects.filter(query)
+
+    return inform_users
+
+
+def handle_contactmoment_update(contactmoment_url: str):
+    klanten_client = build_client("klanten")
+    contactmomenten_client = build_client("contactmomenten")
+
+    if not klanten_client or not contactmomenten_client:
+        log_system_action(
+            f"could not build client for klanten or contactmomenten API, ignoring notification "
+            f"for {contactmoment_url}",
+            log_level=logging.INFO,
+        )
+        return
+
+    contactmoment = contactmomenten_client.retrieve_contactmoment(contactmoment_url)
+    klantcontactmomenten = (
+        contactmomenten_client.retrieve_klantcontactmomenten_for_contactmoment(
+            contactmoment
+        )
+    )
+
+    log_system_action(
+        f"found klantcontactmomenten for {contactmoment_url}: {klantcontactmomenten}",
+        log_level=logging.INFO,
+    )
+
+    klanten = get_klant_data_from_contactmomenten(klanten_client, klantcontactmomenten)
+
+    inform_users = get_users_for_klanten(klanten)
+
+    log_system_action(
+        f"users found linked to {contactmoment_url}: {inform_users}",
+        log_level=logging.INFO,
+    )
+
+    # TODO send email #2105
+    # TODO userfeed hook? #2156

--- a/src/open_inwoner/openklant/tests/data.py
+++ b/src/open_inwoner/openklant/tests/data.py
@@ -118,6 +118,8 @@ class MockAPIReadData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
+            subjectType="natuurlijk_persoon",
+            subjectIdentificatie={"inp_bsn": self.user.bsn},
         )
         self.klant2 = generate_oas_component_cached(
             "kc",
@@ -126,6 +128,8 @@ class MockAPIReadData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-ffffffffffff",
             emailadres="foo@bar.com",
             telefoonnummer="0687654321",
+            subjectType="niet_natuurlijk_persoon",
+            subjectIdentificatie={"inn_nnp_id": self.eherkenning_user.kvk},
         )
         self.klant_vestiging = generate_oas_component_cached(
             "kc",
@@ -272,7 +276,15 @@ class MockAPIReadData(MockAPIData):
             json=paginated_response([self.klant_contactmoment]),
         )
         m.get(
+            f"{CONTACTMOMENTEN_ROOT}klantcontactmomenten?contactmoment={self.contactmoment['url']}",
+            json=paginated_response([self.klant_contactmoment]),
+        )
+        m.get(
             f"{CONTACTMOMENTEN_ROOT}klantcontactmomenten?klant={self.klant2['url']}",
+            json=paginated_response([self.klant_contactmoment2]),
+        )
+        m.get(
+            f"{CONTACTMOMENTEN_ROOT}klantcontactmomenten?contactmoment={self.contactmoment2['url']}",
             json=paginated_response([self.klant_contactmoment2]),
         )
         m.get(

--- a/src/open_inwoner/openklant/tests/test_notification_contactmoment.py
+++ b/src/open_inwoner/openklant/tests/test_notification_contactmoment.py
@@ -1,0 +1,87 @@
+import logging
+
+from django.test import TestCase
+
+import requests_mock
+from notifications_api_common.models import NotificationsConfig
+
+from open_inwoner.accounts.models import User
+from open_inwoner.openklant.notifications import handle_contactmomenten_notification
+from open_inwoner.openzaak.tests.factories import NotificationFactory
+from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
+
+from ..models import OpenKlantConfig
+from .data import MockAPIReadData
+
+
+@requests_mock.Mocker()
+class ContactmomentNotificationHandlerTestCase(
+    AssertTimelineLogMixin, ClearCachesMixin, TestCase
+):
+    maxDiff = None
+    config: OpenKlantConfig
+    note_config: NotificationsConfig
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        MockAPIReadData.setUpServices()
+
+    def test_status_handle_contactmoment_notification_digid_user(self, m):
+        """
+        happy-flow from valid data calls the (mocked) handle_status_update()
+        """
+        data = MockAPIReadData().install_mocks(m)
+
+        contactmoment_notification = NotificationFactory(
+            resource="contactmoment",
+            actie="update",
+            resource_url=data.contactmoment["url"],
+            hoofd_object=data.contactmoment["url"],
+            kanaal="contactmomenten",
+        )
+
+        handle_contactmomenten_notification(contactmoment_notification)
+
+        self.assertTimelineLog(
+            f"found klantcontactmomenten for {contactmoment_notification.resource_url}",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )
+
+        self.assertTimelineLog(
+            f"users found linked to {contactmoment_notification.resource_url}: "
+            f"{User.objects.filter(bsn=data.user.bsn)}",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )
+
+    def test_status_handle_contactmoment_notification_eherkenning_user(self, m):
+        """
+        happy-flow from valid data calls the (mocked) handle_status_update()
+        """
+        data = MockAPIReadData().install_mocks(m)
+
+        contactmoment_notification = NotificationFactory(
+            resource="contactmoment",
+            actie="update",
+            resource_url=data.contactmoment2["url"],
+            hoofd_object=data.contactmoment2["url"],
+            kanaal="contactmomenten",
+        )
+
+        handle_contactmomenten_notification(contactmoment_notification)
+
+        self.assertTimelineLog(
+            f"found klantcontactmomenten for {contactmoment_notification.resource_url}",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )
+
+        self.assertTimelineLog(
+            f"users found linked to {contactmoment_notification.resource_url}: "
+            f"{User.objects.filter(kvk=data.eherkenning_user.kvk)}",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )

--- a/src/open_inwoner/urls.py
+++ b/src/open_inwoner/urls.py
@@ -102,6 +102,10 @@ urlpatterns = [
         "api/openzaak/",
         include("open_inwoner.openzaak.api.urls", namespace="openzaak_api"),
     ),
+    path(
+        "api/openklant/",
+        include("open_inwoner.openklant.api.urls", namespace="openklant_api"),
+    ),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     # Views
     path("accounts/", include("open_inwoner.accounts.urls", namespace="accounts")),


### PR DESCRIPTION
task: https://taiga.maykinmedia.nl/project/open-inwoner/task/2107

TODO:
- [ ] implement handler
  - [x] retrieve contactmoment data
  - [x] find klantcontactmomenten -> cannot filter on contactmoment?
  - [x] retrieve klant data for all linked klanten
  - [x] search for users with matching bsn=inpBsn or kvk/rsin=innNnpId (no vestigingsnummer because those have a shared account)
  - [ ] ~~send email (depending on preference?)~~ separate task
  - [ ] ~~userfeed hook?~~ separate task
  - [ ] save locally in some model like UserCaseStatusNotification?
- [ ] how to ensure handler only triggers on contactmoment from gemeente side

issues:
- how to ensure handler only triggers on contactmoment from gemeente side? does contactmoment get an update when gemeente responds? updates dont seem to be defined in eSuite api spec
- eSuite doesn't implement a filter on klantcontactmoment by `contactmoment`