### PR TITLE
[#2175] Fix rounded corners for mail-templates

### DIFF
--- a/src/open_inwoner/conf/parts/case_document_notification.html
+++ b/src/open_inwoner/conf/parts/case_document_notification.html
@@ -26,16 +26,16 @@
         </td>
     </tr>
 
-    <!-- Table with different column-widths -->
+    <!-- Contains Table with different column-widths -->
     <tr>
-        <td class="td-mail td-mail__bg-info td__padding-all" colspan="6">
-            <div class="td-mail__bg-white">
+        <td class="td-mail td-mail__bg-info cell--rounded-padding" colspan="6">
+            <div class="td-mail__bg-white mail-cell--rounded">
                 <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%">
                     <tr>
-                        <td width="35" class="td-mail td__padding-left align-center">
+                        <td width="35" class="td-mail mail--transparent td__padding-left align-center">
                             <img src="/static/img/mail/info_info-blue.png" width="20" height="20" alt="" class="mail__icon">
                         </td>
-                        <td class="td__padding-top td__padding-right td__padding-bottom align-center">
+                        <td class="td-mail mail--transparent td__padding-top td__padding-right td__padding-bottom align-center">
                             <p class="text-color__info">Een of meer documenten zijn aan uw aanvraag toegevoegd.</p>
                         </td>
                     </tr>

--- a/src/open_inwoner/conf/parts/case_status_notification.html
+++ b/src/open_inwoner/conf/parts/case_status_notification.html
@@ -26,16 +26,16 @@
         </td>
     </tr>
 
-    <!-- Table with different column-widths -->
-    <tr>
-        <td class="td-mail td-mail__bg-info td__padding-all" colspan="6">
-            <div class="td-mail__bg-white">
-                <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%">
+    <!-- Contains Table with different column-widths -->
+    <tr class="mail--transparent">
+        <td class="td-mail td-mail__bg-info cell--rounded-padding" colspan="6">
+            <div class="td-mail__bg-white mail-cell--rounded">
+                <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" class="mail--transparent">
                     <tr>
-                        <td width="35" class="td-mail td__padding-left align-center">
+                        <td width="35" class="td-mail mail--transparent td__padding-left align-center">
                             <img src="/static/img/mail/info_info-blue.png" width="20" height="20" alt="" class="mail__icon">
                         </td>
-                        <td class="td__padding-top td__padding-right td__padding-bottom align-center">
+                        <td class="td-mail mail--transparent td__padding-top td__padding-right td__padding-bottom align-center">
                             <p class="text-color__info">De status is gewijzigd naar <span class="status_current"><strong><a href="{{ case_link }}" class="text-color__info">{{ status_description }}</a></strong></span>.</p>
                         </td>
                     </tr>

--- a/src/open_inwoner/conf/parts/case_status_notification_action_required.html
+++ b/src/open_inwoner/conf/parts/case_status_notification_action_required.html
@@ -25,15 +25,17 @@
             <p><span class="text-color__small-gray-900">Zaaknummer: </span><br/>{{ identification }}</p>
         </td>
     </tr>
+
+    <!-- Contains Table with different column-widths -->
     <tr>
-        <td class="td-mail td-mail__bg-danger td__padding-all" colspan="6">
-            <div class="td-mail__bg-white">
-                <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%">
+        <td class="td-mail td-mail__bg-danger cell--rounded-padding" colspan="6">
+            <div class="td-mail__bg-white mail-cell--rounded">
+                <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" class="mail--transparent">
                     <tr>
-                        <td width="35" class="td-mail td__padding-left align-center">
+                        <td width="35" class="td-mail mail--transparent td__padding-left align-center">
                             <img src="/static/img/mail/alarm_danger-orange.png" width="20" height="18" alt="" class="mail__icon">
                         </td>
-                        <td class="td__padding-top td__padding-right td__padding-bottom align-center">
+                        <td class="td-mail mail--transparent td__padding-top td__padding-right td__padding-bottom align-center">
                             <p class="text-color__danger"><strong>Wij hebben documenten van u nodig</strong><br>
                                 Upload de documenten tot {{ end_date }}</p>
                         </td>
@@ -42,6 +44,8 @@
             </div>
         </td>
     </tr>
+    <!-- end of Table with differing column-widths -->
+
     <tr>
         <td class="td-mail td-mail__bg-danger td__padding-all" colspan="6">
             <p>Log in om de documenten te uploaden.</p>

--- a/src/open_inwoner/static/mailcss/email.css
+++ b/src/open_inwoner/static/mailcss/email.css
@@ -109,16 +109,25 @@ td.align-center {
 
 .td-mail__bg-white {
     background-color: #ffffff;
-    border: 1px solid #ffffff;
-    border-radius: 6px;
-    color: #704000;
-    display: inline-block;
+    color: #4B4B4B;
     font-family: Lato, Helvetica, Arial, sans-serif;
     font-size: 16px;
     line-height: 24px;
     text-decoration: none;
     width: 100%;
     -webkit-text-size-adjust: none;
+}
+
+.mail-cell--rounded {
+    border: 1px solid #ffffff;
+    border-radius: 3px;
+    display: inline-block;
+    margin: 3px;
+    padding: 3px;
+}
+
+.mail--transparent {
+    background-color: transparent;
 }
 
 .td__padding-top {
@@ -139,6 +148,10 @@ td.align-center {
 
 .td__padding-all {
     padding: 20px 24px 20px 24px;
+}
+
+.cell--rounded-padding {
+    padding: 20px 30px 20px 20px;
 }
 
 .td__padding-zero {
@@ -163,7 +176,7 @@ td.align-center {
 
 .button--primary {
     border: 1px solid;
-    border-radius: 6px;
+    border-radius: 3px;
     color: #ffffff;
     display: inline-block;
     font-family: sans-serif;

--- a/src/open_inwoner/templates/mail/_base.html
+++ b/src/open_inwoner/templates/mail/_base.html
@@ -102,8 +102,8 @@
             display: block;
         }
 
-        .td__alignright {
-            text-align: left;
+        .td__alignright, .td__rightcell {
+            text-align: left !important;
         }
     }
 </style>


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2175

- check rounded corners for Gmail on Android

This fix does not use fallbacks, instead the issue was that the Table with rounded area got a white background, which cut through the rounded corners and made it seem not-rounded.
PS: the border-radiuses in the design are only 3px so not dramatically visible.