### PR TITLE
[#2187] WIP Untangling registration views, redirects and middleware

### DIFF
--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
@@ -148,7 +149,15 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
             },
         ),
     )
-    readonly_fields = ("bsn", "rsin", "is_prepopulated", "oidc_id", "uuid")
+    readonly_fields = (
+        "bsn",
+        "rsin",
+        "kvk",
+        "login_type",
+        "is_prepopulated",
+        "oidc_id",
+        "uuid",
+    )
     list_display = (
         "email",
         "first_name",
@@ -167,6 +176,32 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
         "groups",
         "user_permissions",
     )
+
+    debug_editable_fields = (
+        "bsn",
+        "kvk",
+        "rsin",
+        "login_type",
+        "oidc_id",
+        "is_prepopulated",
+    )
+
+    def get_fieldsets(self, request, obj=None):
+        fields = super().get_fieldsets(request, obj=obj)
+        if obj and settings.DEBUG:
+            fields += (
+                (
+                    _("Debug fields"),
+                    {"fields": self.debug_editable_fields},
+                ),
+            )
+        return fields
+
+    def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj=obj)
+        if obj and settings.DEBUG:
+            fields = tuple((f for f in fields if f not in self.debug_editable_fields))
+        return fields
 
 
 admin.site.unregister(Group)

--- a/src/open_inwoner/accounts/middleware.py
+++ b/src/open_inwoner/accounts/middleware.py
@@ -2,14 +2,18 @@ import logging
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.urls import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse, reverse_lazy
 
 from furl import furl
+
+from open_inwoner.cms.utils.page_display import profile_page_is_published
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.utils.middleware import BaseConditionalUserRedirectMiddleware
 
 logger = logging.getLogger(__name__)
 
 
-class NecessaryFieldsMiddleware:
+class NecessaryFieldsMiddleware___OLD:
     """
     Redirect the user to a view to fill in necessary fields
     """
@@ -62,3 +66,32 @@ class NecessaryFieldsMiddleware:
                 return HttpResponseRedirect(redirect.url)
 
         return self.get_response(request)
+
+
+class NecessaryFieldsMiddleware(BaseConditionalUserRedirectMiddleware):
+    """
+    Redirect the user to a view to fill in necessary fields
+    """
+
+    redirect_url = reverse_lazy("profile:registration_necessary")
+
+    def requires_redirect(self, request) -> bool:
+        user = request.user
+        return user.require_necessary_fields() and profile_page_is_published()
+
+
+class EmailVerificationMiddleware(BaseConditionalUserRedirectMiddleware):
+    """
+    Redirect the user to a view to verify email
+    """
+
+    redirect_url = reverse_lazy("profile:email_verification_user")
+    extra_pass_prefixes = (reverse_lazy("mail:verification"),)
+
+    def requires_redirect(self, request) -> bool:
+        user = request.user
+        return (
+            not user.has_verified_email()
+            and profile_page_is_published()
+            and SiteConfiguration.get_solo().email_verification_required
+        )

--- a/src/open_inwoner/accounts/query.py
+++ b/src/open_inwoner/accounts/query.py
@@ -114,4 +114,8 @@ class UserQuerySet(QuerySet):
         return self.filter(contacts_for_approval=user)
 
     def having_usable_email(self):
-        return self.exclude(Q(email="") | Q(email__endswith="@example.org"))
+        return self.exclude(
+            Q(email="")
+            | Q(email__endswith="@example.org")
+            | Q(email__endswith="@localhost")
+        )

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -77,6 +77,29 @@ class UserTests(TestCase):
         )
         self.assertTrue(user.require_necessary_fields())
 
+    def test_has_usable_email(self):
+        user_ok1 = UserFactory(email="foo@bar.baz")
+        self.assertTrue(user_ok1.has_usable_email())
+        self.assertTrue(User.is_usable_email("foo@bar.baz"))
+
+        user_ok2 = UserFactory(email="test@example.com")
+        self.assertTrue(user_ok2.has_usable_email())
+        self.assertTrue(User.is_usable_email("test@example.com"))
+
+        self.assertFalse(UserFactory(email="").has_usable_email())
+        self.assertFalse(User.is_usable_email(""))
+
+        # @example.org is used as placeholder
+        self.assertFalse(UserFactory(email="test@example.org").has_usable_email())
+        self.assertFalse(User.is_usable_email("test@example.org"))
+
+        # @localhost occurs in some old code
+        self.assertFalse(UserFactory(email="test@localhost").has_usable_email())
+        self.assertFalse(User.is_usable_email("test@localhost"))
+
+        actual = list(User.objects.having_usable_email())
+        self.assertEqual(actual, [user_ok1, user_ok2])
+
     def test_plan_contact_new_count_methods(self):
         owner = UserFactory()
         plan_1 = PlanFactory(created_by=owner)

--- a/src/open_inwoner/kvk/middleware.py
+++ b/src/open_inwoner/kvk/middleware.py
@@ -7,11 +7,12 @@ from django.urls import NoReverseMatch, reverse
 from furl import furl
 
 from open_inwoner.kvk.branches import kvk_branch_selected_done
+from open_inwoner.utils.middleware import BaseConditionalUserRedirectMiddleware
 
 logger = logging.getLogger(__name__)
 
 
-class KvKLoginMiddleware:
+class KvKLoginMiddleware__X:
     """Redirect authenticated eHerkenning users to select a company branch"""
 
     def __init__(self, get_response):
@@ -50,3 +51,21 @@ class KvKLoginMiddleware:
         redirect.args.update(request.GET)
 
         return HttpResponseRedirect(redirect.url)
+
+
+class KvKLoginMiddleware(BaseConditionalUserRedirectMiddleware):
+    """Redirect authenticated eHerkenning users to select a company branch"""
+
+    def requires_redirect(self, request):
+        user = request.user
+        return user.is_eherkenning_user and not kvk_branch_selected_done(
+            request.session
+        )
+
+    def get_redirect_url(self, request):
+        try:
+            return reverse("kvk:branches")
+        except NoReverseMatch:
+            # TODO do we need this?
+            # temporary fallback for tests
+            return "/kvk/branches/"

--- a/src/open_inwoner/utils/middleware.py
+++ b/src/open_inwoner/utils/middleware.py
@@ -1,0 +1,105 @@
+import abc
+
+from django.conf import settings
+from django.shortcuts import redirect, resolve_url
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
+
+from furl import furl
+
+
+def get_always_pass_prefixes() -> tuple[str, ...]:
+    return (
+        settings.MEDIA_URL,
+        settings.PRIVATE_MEDIA_URL,
+        settings.STATIC_URL,
+        reverse("login"),
+        # TODO is kvk always here?
+        reverse("kvk:branches"),
+        # prefixes from urls.py
+        "/admin/",
+        "/csp/",
+        "/reset/",
+        "/api/",
+        "/digid/",
+        "/eherkenning/",
+        "/oidc/",
+        "/digid-oidc/",
+        "/eherkenning-oidc/",
+        "/cms_login/",
+        "/cms_wizard/",
+    )
+
+
+class BaseConditionalUserRedirectMiddleware(abc.ABC):
+    """
+    Base class for middleware that redirects users to another view based on conditions
+
+    Typical use case is forced registration, verification
+    """
+
+    redirect_url: str = None
+    extra_pass_prefixes: tuple[str, ...] = None
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    @abc.abstractmethod
+    def requires_redirect(self, request) -> bool:
+        return False
+
+    def get_redirect_url(self, request) -> str:
+        # redirect_url could be reverse_lazy
+        if self.redirect_url is None:
+            n = self.__class__.__name__
+            raise ValueError(
+                f"configure {n}.redirect_url or override {n}.get_redirect_url()"
+            )
+        return self.redirect_url
+
+    def get_pass_prefixes(self, request) -> tuple[str, ...]:
+        prefixes = get_always_pass_prefixes()
+        prefixes += (resolve_url(self.get_redirect_url(request)),)
+        prefixes += self.get_extra_pass_prefixes()
+        return prefixes
+
+    def get_extra_pass_prefixes(self) -> tuple[str, ...]:
+        prefixes = []
+        if self.extra_pass_prefixes:
+            for e in self.extra_pass_prefixes:
+                try:
+                    prefixes.append(resolve_url(e))
+                except NoReverseMatch:
+                    # support testing without cms app mounted
+                    pass
+        return tuple(prefixes)
+
+    def __call__(self, request):
+        # # we could filter on method for safety but it's kludgy
+        # if request.method not in ("GET", "HEAD", "OPTIONS"):
+        #     return self.get_response(request)
+
+        # we only trigger for authenticated users
+        if not request.user.is_authenticated:
+            return self.get_response(request)
+
+        try:
+            # str() to resolve lazy reverses
+            target = str(self.get_redirect_url(request))
+        except NoReverseMatch:
+            # TODO log this or raise (raise problematic if cms-app gets unmounted)
+            return self.get_response(request)
+
+        if request.path.startswith(self.get_pass_prefixes(request)):
+            return self.get_response(request)
+
+        if target and self.requires_redirect(request):
+            url = furl(target)
+            # NOTE: this looks odd but exising code could depend on it
+            if request.path != settings.LOGIN_REDIRECT_URL:
+                url.set({"next": request.path})
+            url.args.update(request.GET)
+            return redirect(str(url))
+
+        # fallthrough
+        return self.get_response(request)

--- a/src/open_inwoner/utils/tests/test_url.py
+++ b/src/open_inwoner/utils/tests/test_url.py
@@ -1,0 +1,100 @@
+from django.test import TestCase, override_settings
+
+from open_inwoner.utils.url import (
+    get_next_url_from,
+    get_next_url_param,
+    prepend_next_url_param,
+)
+
+
+class MockRequest:
+    def __init__(self, GET=None):
+        self.GET = GET or dict()
+
+    def get_host(self):
+        return "testserver"
+
+
+class URLTest(TestCase):
+    @override_settings(IS_HTTPS=True)
+    def test_get_next_url_from(self):
+        request = MockRequest()
+
+        with self.subTest("defaults"):
+            self.assertEqual(get_next_url_from(request), "")
+            self.assertEqual(get_next_url_from(request, default="/foo"), "/foo")
+
+        with self.subTest("normal"):
+            request.GET["next"] = "/bar"
+            self.assertEqual(
+                get_next_url_from(
+                    request,
+                ),
+                "/bar",
+            )
+
+        with self.subTest("http same host not valid"):
+            request.GET["next"] = "http://testserver/bar"
+            self.assertEqual(
+                get_next_url_from(
+                    request,
+                ),
+                "",
+            )
+        with self.subTest("https same host is valid"):
+            request.GET["next"] = "https://testserver/bar"
+            self.assertEqual(
+                get_next_url_from(
+                    request,
+                ),
+                "https://testserver/bar",
+            )
+
+        with self.subTest("http bad host not valid"):
+            request.GET["next"] = "http://bazz/bar"
+            self.assertEqual(
+                get_next_url_from(
+                    request,
+                ),
+                "",
+            )
+        with self.subTest("https bad host not valid"):
+            request.GET["next"] = "https://bazz/bar"
+            self.assertEqual(
+                get_next_url_from(
+                    request,
+                ),
+                "",
+            )
+
+    def test_get_next_url_param(self):
+        self.assertEqual(get_next_url_param("http://testserver/"), "")
+        self.assertEqual(get_next_url_param("http://testserver/?next="), "")
+        self.assertEqual(get_next_url_param("http://testserver/?next=%2Ffoo"), "/foo")
+        self.assertEqual(
+            get_next_url_param("http://testserver/?next=%2Fbar%3Fnext%3D%252Ffoo"),
+            "/bar?next=%2Ffoo",
+        )
+
+    def test_prepend_next_url_param(self):
+        url = prepend_next_url_param("http://testserver/", "/foo")
+        self.assertEqual(url, "http://testserver/?next=%2Ffoo")
+
+        url = prepend_next_url_param(url, "/bar")
+        self.assertEqual(url, "http://testserver/?next=%2Fbar%3Fnext%3D%252Ffoo")
+
+        url = prepend_next_url_param(url, "/bazz")
+        self.assertEqual(
+            url,
+            "http://testserver/?next=%2Fbazz%3Fnext%3D%252Fbar%253Fnext%253D%25252Ffoo",
+        )
+
+        # now let's go in reverse
+        param = get_next_url_param(url)
+        self.assertEqual(param, "/bazz?next=%2Fbar%3Fnext%3D%252Ffoo")
+
+        param = get_next_url_param(param)
+        self.assertEqual(param, "/bar?next=%2Ffoo")
+
+        param = get_next_url_param(param)
+        self.assertEqual(param, "/foo")

--- a/src/open_inwoner/utils/url.py
+++ b/src/open_inwoner/utils/url.py
@@ -1,8 +1,52 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.utils.encoding import iri_to_uri
+from django.utils.http import url_has_allowed_host_and_scheme
+
+from furl.furl import furl
 
 
 def build_absolute_url(path: str) -> str:
     domain = Site.objects.get_current().domain
     protocol = "https" if settings.IS_HTTPS else "http"
     return f"{protocol}://{domain}{path}"
+
+
+def get_next_url_from(request, *, default: str = "") -> str:
+    # possibly add parameter to prioritize get/post, override parameter name
+    next_url = request.GET.get("next")
+    if next_url and url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts=[
+            request.get_host(),
+        ],
+        require_https=settings.IS_HTTPS,
+    ):
+        return iri_to_uri(next_url)
+    return default
+
+
+def get_next_url_param(url: str) -> str:
+    return furl(url).args.get("next", "")
+
+
+def prepend_next_url_param(url: str, next_url: str) -> str:
+    """
+    set next parameter on url,
+        if parameter already exists prepend it to the new next_url (recursively in case it already exists)
+
+    prepend_next_url_param('/foo', '/bar')
+    (url encoded) '/foo?next=/bar'
+
+    prepend_next_url_param('/foo?next=/bar', '/bazz')
+    (url encoded) '/foo?next=/bazz?next=/bar'
+    """
+    if not next_url:
+        return url
+
+    u = furl(url)
+    current_next = u.args.get("next", "")
+    if current_next:
+        next_url = prepend_next_url_param(next_url, current_next)
+    u.args.set("next", next_url)
+    return u.url


### PR DESCRIPTION
This started in the email-verification task but is spiraling a little bit because of how entangled the user-upfix redirects are with various views and login flows.