### PR TITLE
[#2277] Use first OIP subject for questions as fallback

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -140,14 +140,6 @@ class KlantContactMomentBaseView(
             )
             return e_suite_subject_code
 
-        if not subject.subject:
-            logger.warning(
-                "Could not determine OIP subject for contactmoment %s; "
-                "falling back on e-suite subject code ('onderwerp')",
-                kcm.contactmoment.url,
-            )
-            return e_suite_subject_code
-
         return subject.subject
 
 

--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -114,22 +114,37 @@ class KlantContactMomentBaseView(
     ) -> str | None:
         """
         Determine the subject (`onderwerp`) of a `KlantContactMoment.contactmoment`:
-            1. replace e-suite subject code with OIP configured subject or
-            2. return e-suite subject code or
-            3. return an empty string as fallback
+            1. replace e-suite subject code with corresponding OIP configured subject or
+            2. return the first OIP subject if multiple subjects are mapped to the same
+               e-suite code or
+            3. return the the e-suite subject code if no mapping exists
         """
         e_suite_subject_code = getattr(kcm.contactmoment, "onderwerp", "")
 
         try:
             subject = ContactFormSubject.objects.get(subject_code=e_suite_subject_code)
-        except (
-            ContactFormSubject.DoesNotExist,
-            ContactFormSubject.MultipleObjectsReturned,
-        ) as exc:
+        except ContactFormSubject.MultipleObjectsReturned as exc:
             logger.warning(
-                "Could not determine subject ('onderwerp') for contactmoment %s",
+                "Multiple OIP subjects mapped to the same e-suite subject code for ",
+                "contactmoment %s; using the first one",
                 kcm.contactmoment.url,
                 exc_info=exc,
+            )
+            return ContactFormSubject.objects.first().subject
+        except ContactFormSubject.DoesNotExist as exc:
+            logger.warning(
+                "Could not determine OIP subject for contactmoment %s; "
+                "falling back on e-suite subject code ('onderwerp')",
+                kcm.contactmoment.url,
+                exc_info=exc,
+            )
+            return e_suite_subject_code
+
+        if not subject.subject:
+            logger.warning(
+                "Could not determine OIP subject for contactmoment %s; "
+                "falling back on e-suite subject code ('onderwerp')",
+                kcm.contactmoment.url,
             )
             return e_suite_subject_code
 

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -411,8 +411,7 @@ class ContactMomentViewsTestCase(ClearCachesMixin, DisableRequestLogMixin, WebTe
         """
         data = MockAPIReadData().install_mocks(m)
 
-        self.contactformsubject.subject = ""
-        self.contactformsubject.save()
+        self.contactformsubject.delete()
 
         detail_url = reverse(
             "cases:contactmoment_detail",

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -362,10 +362,19 @@ class ContactMomentViewsTestCase(ClearCachesMixin, DisableRequestLogMixin, WebTe
             ),
         )
 
-    def test_display_esuite_subject_code(self, m, mock_get_kcm_answer_mapping):
+    def test_display_contactmoment_subject_duplicate_esuite_codes(
+        self, m, mock_get_kcm_answer_mapping
+    ):
+        """
+        Assert that the first OIP subject is used if several are mapped to the same e-suite code
+        """
         data = MockAPIReadData().install_mocks(m)
 
-        ContactFormSubject.objects.first().delete()
+        ContactFormSubject.objects.create(
+            subject="control_subject_for_duplicate_code",
+            subject_code=self.contactformsubject.subject_code,
+            config=OpenKlantConfig.get_solo(),
+        )
 
         detail_url = reverse(
             "cases:contactmoment_detail",
@@ -384,7 +393,45 @@ class ContactMomentViewsTestCase(ClearCachesMixin, DisableRequestLogMixin, WebTe
                 "registered_date": datetime.fromisoformat(cm_data["registratiedatum"]),
                 "channel": cm_data["kanaal"].title(),
                 "text": cm_data["tekst"],
-                "onderwerp": "e_suite_subject_code",
+                "onderwerp": ContactFormSubject.objects.first().subject,
+                "antwoord": cm_data["antwoord"],
+                "identificatie": cm_data["identificatie"],
+                "type": cm_data["type"],
+                "status": Status.afgehandeld.label,
+                "url": detail_url,
+                "new_answer_available": False,
+            },
+        )
+
+    def test_display_contactmoment_subject_no_mapping_fallback(
+        self, m, mock_get_kcm_answer_mapping
+    ):
+        """
+        Assert that the e-suite subject code is displayed if no mapping is configured in OIP
+        """
+        data = MockAPIReadData().install_mocks(m)
+
+        self.contactformsubject.subject = ""
+        self.contactformsubject.save()
+
+        detail_url = reverse(
+            "cases:contactmoment_detail",
+            kwargs={"kcm_uuid": data.klant_contactmoment["uuid"]},
+        )
+        list_url = reverse("cases:contactmoment_list")
+        response = self.app.get(list_url, user=data.user)
+
+        kcms = response.context["contactmomenten"]
+        cm_data = data.contactmoment
+
+        self.assertEqual(len(kcms), 1)
+        self.assertEqual(
+            kcms[0],
+            {
+                "registered_date": datetime.fromisoformat(cm_data["registratiedatum"]),
+                "channel": cm_data["kanaal"].title(),
+                "text": cm_data["tekst"],
+                "onderwerp": self.contactformsubject.subject_code,
                 "antwoord": cm_data["antwoord"],
                 "identificatie": cm_data["identificatie"],
                 "type": cm_data["type"],


### PR DESCRIPTION
If no mapping exists for e-suite for a particular e-suite subject code (or if duplicate codes exist), we use the first OIP configured subject as fallback

Taiga: [#2277](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2277)