### PR TITLE
[#2170] Fixed issue with profile_page_is_published() & get_active_app_names() CMS helpers

### DIFF
--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -7,12 +7,13 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from cms import api
 from django_webtest import WebTest
 
 from open_inwoner.accounts.models import User
 from open_inwoner.utils.tests.helpers import create_image_bytes
 
+from ...cms.inbox.cms_apps import InboxApphook
+from ...cms.tests import cms_tools
 from ..choices import ContactTypeChoices
 from .factories import DigidUserFactory, UserFactory
 
@@ -98,14 +99,7 @@ class ContactViewTests(WebTest):
         self.assertNotContains(response, _("Stuur bericht"))
 
         # case 2: unpublished message page
-        page = api.create_page(
-            "Mijn Berichten",
-            "cms/fullwidth.html",
-            "nl",
-            slug="berichten",
-        )
-        page.application_namespace = "inbox"
-        page.save()
+        page = cms_tools.create_apphook_page(InboxApphook, publish=False)
 
         response = self.app.get(self.list_url, user=self.user)
 

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 import requests_mock
-from cms import api
 from django_webtest import WebTest
 from pyquery import PyQuery as PQ
 from webtest import Upload
@@ -30,6 +29,9 @@ from open_inwoner.utils.logentry import LOG_ACTIONS
 from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, create_image_bytes
 
+from ...cms.cases.cms_apps import CasesApphook
+from ...cms.collaborate.cms_apps import CollaborateApphook
+from ...cms.inbox.cms_apps import InboxApphook
 from ...cms.profile.cms_apps import ProfileApphook
 from ...cms.tests import cms_tools
 from ...haalcentraal.api_models import BRPData
@@ -265,14 +267,7 @@ class ProfileViewTests(WebTest):
         self.assertNotContains(response, _("Stuur een bericht"))
 
         # case 2: unpublished message page
-        page = api.create_page(
-            "Mijn Berichten",
-            "cms/fullwidth.html",
-            "nl",
-            slug="berichten",
-        )
-        page.application_namespace = "inbox"
-        page.save()
+        page = cms_tools.create_apphook_page(InboxApphook, publish=False)
 
         response = self.app.get(self.url, user=self.user)
 
@@ -975,14 +970,7 @@ class NotificationsDisplayTests(WebTest):
         self.assertNotIn("messages_notifications", form.fields)
 
         # inbox page created but not published
-        page = api.create_page(
-            "Mijn Berichten",
-            "cms/fullwidth.html",
-            "nl",
-            slug="berichten",
-        )
-        page.application_namespace = "inbox"
-        page.save()
+        page = cms_tools.create_apphook_page(InboxApphook, publish=False)
 
         response = self.app.get(self.url, user=self.user)
         form = response.forms["change-notifications"]
@@ -1006,15 +994,7 @@ class NotificationsDisplayTests(WebTest):
         self.assertNotIn("cases_notifications", form.fields)
 
         # cases page created but not published
-        page = api.create_page(
-            "Mijn Aanvragen",
-            "cms/fullwidth.html",
-            "nl",
-            slug="aanvragen",
-        )
-        page.application_namespace = "cases"
-        page.save()
-
+        page = cms_tools.create_apphook_page(CasesApphook, publish=False)
         response = self.app.get(self.url, user=self.user)
         form = response.forms["change-notifications"]
 
@@ -1035,14 +1015,7 @@ class NotificationsDisplayTests(WebTest):
         self.assertNotIn("plans_notifications", form.fields)
 
         # collaborate page created but not published
-        page = api.create_page(
-            "Samenwerken",
-            "cms/fullwidth.html",
-            "nl",
-            slug="samenwerken",
-        )
-        page.application_namespace = "collaborate"
-        page.save()
+        page = cms_tools.create_apphook_page(CollaborateApphook, publish=False)
 
         response = self.app.get(self.url, user=self.user)
         form = response.forms["change-notifications"]

--- a/src/open_inwoner/cms/tests/cms_tools.py
+++ b/src/open_inwoner/cms/tests/cms_tools.py
@@ -104,6 +104,7 @@ def create_apphook_page(
     extension_args: dict = None,
     config_args: dict = None,
     parent_page=None,
+    publish=True,
 ):
     p = api.create_page(
         (title or hook_class.name),
@@ -129,7 +130,7 @@ def create_apphook_page(
     #     config_args["namespace"] = hook_class.app_name
     #     p.app_config = hook_class.app_config.objects.create(**config_args)
 
-    if not p.publish("nl"):
+    if publish and not p.publish("nl"):
         raise Exception("failed to publish page")
 
     return p

--- a/src/open_inwoner/cms/tests/test_page_display.py
+++ b/src/open_inwoner/cms/tests/test_page_display.py
@@ -1,0 +1,63 @@
+from django_webtest import WebTest
+
+from open_inwoner.cms.benefits.cms_apps import SSDApphook
+from open_inwoner.cms.cases.cms_apps import CasesApphook
+from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
+from open_inwoner.cms.inbox.cms_apps import InboxApphook
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests.cms_tools import create_apphook_page
+from open_inwoner.cms.utils.page_display import (
+    benefits_page_is_published,
+    case_page_is_published,
+    collaborate_page_is_published,
+    get_active_app_names,
+    inbox_page_is_published,
+    profile_page_is_published,
+)
+
+
+class CMSPageDisplayTests(WebTest):
+    def test_published_pages_helpers(self):
+        # check blank
+        names = get_active_app_names()
+        self.assertEqual(names, list())
+
+        self.assertFalse(inbox_page_is_published())
+        self.assertFalse(case_page_is_published())
+        self.assertFalse(collaborate_page_is_published())
+        self.assertFalse(benefits_page_is_published())
+        self.assertFalse(profile_page_is_published())
+
+        # check apps
+        inbox = create_apphook_page(InboxApphook)
+        self.assertTrue(inbox_page_is_published())
+        self.assertEqual(set(get_active_app_names()), {"inbox"})
+
+        create_apphook_page(CasesApphook)
+        self.assertTrue(case_page_is_published())
+        self.assertEqual(set(get_active_app_names()), {"inbox", "cases"})
+
+        create_apphook_page(CollaborateApphook)
+        self.assertTrue(collaborate_page_is_published())
+        self.assertEqual(set(get_active_app_names()), {"inbox", "cases", "collaborate"})
+
+        create_apphook_page(SSDApphook)
+        self.assertTrue(benefits_page_is_published())
+        self.assertEqual(
+            set(get_active_app_names()), {"inbox", "cases", "collaborate", "ssd"}
+        )
+
+        create_apphook_page(ProfileApphook)
+        self.assertTrue(benefits_page_is_published())
+        self.assertEqual(
+            set(get_active_app_names()),
+            {"inbox", "cases", "collaborate", "ssd", "profile"},
+        )
+
+        # check unpublishing
+        inbox.unpublish("nl")
+        self.assertFalse(inbox_page_is_published())
+        self.assertEqual(
+            set(get_active_app_names()),
+            {"cases", "collaborate", "ssd", "profile"},
+        )


### PR DESCRIPTION
Also added tests for page_display helpers

The problem was `Page.application_namespace` is not always the clean 'app_name' but gets postfixed with `-app-config` if the app-hook has an app-config. I fixed it by relying on the other field but it needs a little processing.