### PR TITLE
:lipstick: [#2272] Position indicator dot headings

### DIFF
--- a/src/open_inwoner/components/templates/components/File/File.html
+++ b/src/open_inwoner/components/templates/components/File/File.html
@@ -11,7 +11,7 @@
                 {% endif %}
             </p>
 
-            <p class="p file__data">
+            <p class="file__data">
                 {% if recently_added %}
                     <span class="file__file--recent">{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% trans "Nieuw" %}</span>
                 {% endif %}
@@ -37,7 +37,7 @@
                     </div>
                     {% if show_download %}
                         <div class="dropdown__item">
-                            {% button icon="file_download" text=_("Download") href=url icon_outlined=True transparent=True %}
+                            {% button icon="download" text=_("Download") href=url icon_outlined=True transparent=True %}
                         </div>
                     {% endif %}
                     <div class="dropdown__item">
@@ -50,7 +50,7 @@
                 {% enddropdown %}
             {% elif show_download %}
                 {% trans "Download" as download %}
-                {% link href=url text=download secondary=True download=True hide_text=True icon="file_download" icon_outlined=True icon_position="before" %}
+                {% link href=url text=download primary=True download=True hide_text=True extra_classes="file__download" icon="download" icon_outlined=True icon_position="before" %}
             {% endif %}
             {% if description %}<p class="p p--small">{{ description }}</p>{% endif %}
         </div>

--- a/src/open_inwoner/components/templates/components/File/FileTable.html
+++ b/src/open_inwoner/components/templates/components/File/FileTable.html
@@ -13,7 +13,7 @@
             <td class="table__item">{{ file.name }}</td>
             <td class="table__item">{{ file.owner.get_full_name }}</td>
             <td class="table__item">{{ file.created_on }}</td>
-            <td class="table__item">{% link icon="download" text=_("Download bestand") hide_text=True href=download_url|default:file.file.url download=True %}</td>
+            <td class="table__item">{% link icon="file_download" text=_("Download bestand") icon_outlined=True hide_text=True href=download_url|default:file.file.url download=True %}</td>
         </tr>
     {% endfor %}
 </table>

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -2,7 +2,7 @@
 
 <div class="form__control file-input" aria-live="polite">
     {% render_card direction="vertical" %}
-        {% icon icon="upload" icon_position="before" outlined=True %}
+        {% icon icon="upload" icon_position="before" outlined=True extra_classes="icon--large" %}
         <input class="file-input__input" id="{{ field.auto_id }}" name="file" type="file"{% if field.field.required %} required{% endif %}{% if multiple %} multiple{% endif %} data-max-size="{{ max_upload_size }}" data-file-types="{{ allowed_file_extensions }}">
         <label class="button button--primary file-input__label-empty" for="{{ field.auto_id }}">
             {% if multiple %}{% trans 'Sleep of selecteer bestanden' %}{% else %}{% trans 'Sleep of selecteer bestand' %}{% endif %}

--- a/src/open_inwoner/js/components/form/FileInput.js
+++ b/src/open_inwoner/js/components/form/FileInput.js
@@ -298,10 +298,10 @@ export class FileInput extends Component {
                 type.match('image') ? 'image' : 'description'
               }</span>
             </p>
-            <p class="p file__data">
+            <p class="file__data">
               <span class="file__name">${name} (${ext}, ${sizeMB}MB)</span>
             </p>
-            <a class="link link--primary" href="#document-upload" role="button" aria-label="${labelDelete}">
+            <a class="link link--primary file__download" href="#document-upload" role="button" aria-label="${labelDelete}">
               <span aria-hidden="true" class="material-icons-outlined">delete</span>
             </a>
         </div>

--- a/src/open_inwoner/scss/components/Cases/CaseDetail.scss
+++ b/src/open_inwoner/scss/components/Cases/CaseDetail.scss
@@ -1,4 +1,40 @@
-.cases__detail {
+.case-detail {
+  box-sizing: border-box;
+
+  &__documents {
+    .heading-2__indicator {
+      display: flex;
+      flex-direction: row;
+
+      // breaking-text fix
+      @media (min-width: 315px) {
+        display: grid;
+        grid-template-columns: 232px 10px;
+      }
+
+      @media (min-width: 440px) {
+        display: flex;
+        flex-direction: row;
+      }
+
+      @media (min-width: 768px) {
+        display: grid;
+        grid-template-columns: 232px 10px;
+      }
+
+      @media (min-width: 840px) {
+        display: flex;
+        flex-direction: row;
+      }
+    }
+
+    .h2.indicator {
+      display: inline;
+      font-size: var(--font-size-heading-2);
+      margin-bottom: var(--spacing-extra-large);
+    }
+  }
+
   .documents-upload__h3 {
     margin: var(--spacing-extra-large) 0;
   }
@@ -94,5 +130,14 @@
 
   #cases-contact-form-content > h2 {
     margin-top: var(--spacing-extra-large);
+  }
+
+  .contactmomenten {
+    margin: 0;
+  }
+
+  .textarea {
+    height: var(--header-height);
+    width: 100%;
   }
 }

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -16,8 +16,4 @@
     padding-top: var(--spacing-medium);
     padding-bottom: var(--spacing-extra-large);
   }
-
-  &__detail {
-    box-sizing: border-box;
-  }
 }

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -31,7 +31,6 @@
   &__data {
     display: flex;
     flex-direction: column;
-    adding: var(--spacing-large);
     font-family: var(--font-family-body);
     line-height: var(--spacing-extra-large);
     padding: var(--spacing-large);

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -31,8 +31,18 @@
   &__data {
     display: flex;
     flex-direction: column;
+    adding: var(--spacing-large);
+    font-family: var(--font-family-body);
+    line-height: var(--spacing-extra-large);
+    padding: var(--spacing-large);
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
 
-    > * {
+    .file__name {
+      margin: 0;
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
@@ -45,17 +55,13 @@
     box-sizing: border-box;
   }
 
+  .file__download {
+    margin-left: auto;
+  }
+
   &__file .link:hover {
     color: var(--font-color-body);
     text-decoration: none;
-  }
-
-  &__file .file__data {
-    width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: var(--spacing-extra-large);
   }
 
   &__file .link__text {
@@ -75,6 +81,7 @@
   }
 
   &__file + .file__data {
+    background-color: greenyellow;
     margin-top: var(--spacing-small);
   }
 

--- a/src/open_inwoner/scss/components/File/FileList.scss
+++ b/src/open_inwoner/scss/components/File/FileList.scss
@@ -18,6 +18,10 @@
       margin-bottom: 0;
     }
   }
+
+  &__heading {
+    display: flex;
+  }
 }
 
 ///

--- a/src/open_inwoner/scss/components/Form/FileInput.scss
+++ b/src/open_inwoner/scss/components/Form/FileInput.scss
@@ -16,6 +16,10 @@
     pointer-events: none;
   }
 
+  .icon--large[class*='icon'] {
+    font-size: 40px;
+  }
+
   .card__body {
     box-sizing: border-box;
     padding: var(--row-height);
@@ -82,10 +86,6 @@
 
   & .file-list {
     margin-bottom: var(--spacing-large) !important;
-
-    &__list-item {
-    }
-    margin-bottom: var(--spacing-large);
 
     // upload-error styles
     .file__file.error {

--- a/src/open_inwoner/scss/components/Grid/Grid.scss
+++ b/src/open_inwoner/scss/components/Grid/Grid.scss
@@ -10,7 +10,11 @@
   }
 
   &__main {
-    display: grid;
+    display: block;
+
+    @media (min-width: 768px) {
+      display: grid;
+    }
 
     /// Home grid
 

--- a/src/open_inwoner/scss/components/Typography/H2.scss
+++ b/src/open_inwoner/scss/components/Typography/H2.scss
@@ -37,21 +37,15 @@
 
   &.indicator {
     display: inline-block;
+    justify-content: flex-start;
     overflow: visible;
     position: relative;
-
-    &:after {
-      content: '';
-      background-color: var(--color-red-notification);
-      border-radius: 100px;
-      display: inline-block;
-      height: 8px;
-      position: absolute;
-      right: -12px;
-      top: 6px;
-      width: 8px;
-    }
   }
+}
+
+.heading-2__indicator {
+  display: flex;
+  flex-direction: row;
 }
 
 ///

--- a/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
+++ b/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
@@ -26,10 +26,14 @@
       &:after {
         content: ' ';
         position: absolute;
-        border-right: 1px solid var(--color-red-notification);
+        border-right: none;
         right: -4px;
         top: 2px;
         height: 16px;
+
+        @media (min-width: 768px) {
+          border-right: 1px solid var(--color-red-notification);
+        }
       }
 
       &:first-child {

--- a/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
+++ b/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
@@ -2,9 +2,13 @@
 
 {% if userfeed %}
 <section class="plugin userfeed">
-    <h2 class="h2 {% if userfeed.action_required %}indicator{% endif %}">
-        {{ instance.title }}
-    </h2>
+    <div class="heading-2__indicator">
+        <h2 class="h2 {% if userfeed.action_required %}indicator{% endif %}">
+            {{ instance.title }}
+        </h2>
+        {% if userfeed.action_required %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
+    </div>
+
     <div class="userfeed__summary">
         <ul class="userfeed__list">
             {% for line in userfeed.summary %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -60,8 +60,13 @@
 
             {#  Documents #}
             {% if case.documents %}
-                <h2 class="h2 {% if case.new_docs %}indicator{% endif %}" id="documents">{% trans 'Eerder toegevoegde documenten' %}</h2>
-                {% case_document_list case.documents %}
+                <section class="case-detail__documents">
+                    <div class="heading-2__indicator">
+                        <h2 class="h2 {% if case.new_docs %}indicator{% endif %}" id="documents">{% trans 'Eerder toegevoegde documenten' %}</h2>
+                        {% if case.new_docs %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
+                    </div>
+                    {% case_document_list case.documents %}
+                </section>
             {% endif %}
 
             {# Questions/contactmomenten #}

--- a/src/open_inwoner/templates/pages/cases/status_outer.html
+++ b/src/open_inwoner/templates/pages/cases/status_outer.html
@@ -6,7 +6,7 @@
 {% endblock notifications %}
 
 {% block content %}
-    <div class="cases__detail" id="cases-detail-content"><div>
+    <div class="case-detail" id="cases-detail-content"><div>
 
     <div class="loader-container" id="spinner-container">
         <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-detail-content">

--- a/src/open_inwoner/templates/pages/cases/statuses.html
+++ b/src/open_inwoner/templates/pages/cases/statuses.html
@@ -1,9 +1,7 @@
 {% load i18n button_tags icon_tags %}
 
-{# WILL BE UPDATED WHEN status_inner IS FINISHED #}
-
 {% if case.statuses %}
-<h2 class="h3 h2-statuses" id="statuses">{% trans 'Status' %}</h2>
+<h2 class="h2 h2-statuses" id="statuses">{% trans 'Status' %}</h2>
 
 <aside class="status-list" aria-label="{% trans "Status lijst" %}">
     <ul class="status-list__list">


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2272

The nature of 'shrinking' a breaking text [where the wrap-width is unknown](https://stackoverflow.com/questions/37406353/make-container-shrink-to-fit-child-elements-as-they-wrap) turned out quite difficult; therefor I am using a  rather unique grid in order to make the indicator appear as close to the breaking text as possible with media-queries.

In this PR I am also fixing the ellipsis for long file-names 
➕ minor improvements of the case-detail page.

To test dot for file-list, increase default value of `DOCUMENT_RECENT_DAYS = config("DOCUMENT_RECENT_DAYS", default=1)`