### PR TITLE
[#2287] Fix mailtemplate background colors

### DIFF
--- a/src/open_inwoner/static/mailcss/email.css
+++ b/src/open_inwoner/static/mailcss/email.css
@@ -104,15 +104,15 @@ td.align-center {
 }
 
 .td-mail__bg-info {
-    background-color: #D5E6F6;
+    background-color: #eef5fc;
 }
 
 .td-mail__bg-success {
-    background-color: #ECF4EC;
+    background-color: #edf6ef;
 }
 
 .td-mail__bg-danger {
-    background-color: #FFEDDF;
+    background-color: #fef8f1;
 }
 
 .td-mail__bg-white {


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2287

Note: opacity does not work in Gmail, so I converted the opacity colors to static binhex.

Preview: 
http://127.0.0.1:8000/admin/mail_editor/mailtemplate/ >> Voorbeeld >> Open.