### PR TITLE
:lipstick: [#2194] Correct use of Sections and other gaps

### DIFF
--- a/src/open_inwoner/scss/components/Card/CardGrid.scss
+++ b/src/open_inwoner/scss/components/Card/CardGrid.scss
@@ -1,6 +1,5 @@
 .card__grid {
   & .grid {
-    grid-row-gap: var(--spacing-medium);
     grid-column-gap: var(--spacing-extra-large);
 
     // Tablets

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -1,6 +1,4 @@
 .cases {
-  margin-top: var(--spacing-giant);
-
   /// cards on cases list
   .card {
     .cases__link {

--- a/src/open_inwoner/scss/components/Contactmomenten/Contactmomenten.scss
+++ b/src/open_inwoner/scss/components/Contactmomenten/Contactmomenten.scss
@@ -44,8 +44,7 @@
   }
 
   & .grid {
-    grid-row-gap: var(--spacing-medium);
-    grid-column-gap: var(--spacing-extra-large);
+    grid-gap: var(--spacing-extra-large);
 
     // Tablets
     @media (min-width: 500px) and (max-width: 767px) {
@@ -98,16 +97,4 @@
   .button--transparent {
     padding: var(--spacing-medium) 0 0 0;
   }
-}
-
-// overrides of elements outside of components
-section {
-  display: block;
-  padding-bottom: 2em;
-}
-
-.pagination {
-  display: table !important;
-  margin: 0 auto !important;
-  padding-top: 1em !important;
 }

--- a/src/open_inwoner/scss/components/Pagination/Pagination.scss
+++ b/src/open_inwoner/scss/components/Pagination/Pagination.scss
@@ -1,7 +1,7 @@
 .pagination {
   display: flex;
-  margin-top: 34px;
-  justify-content: space-between;
+  margin: var(--spacing-giant) auto 0 auto;
+  justify-content: center;
 
   &__pages {
     display: flex;

--- a/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
+++ b/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
@@ -118,4 +118,9 @@
       }
     }
   }
+
+  .card-container.plugin-card {
+    grid-row-gap: var(--spacing-medium);
+    grid-column-gap: var(--spacing-giant);
+  }
 }


### PR DESCRIPTION
This PR solves wrong section styles and some other faulty gaps/margins/paddings here and there.
issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2194 

the main issue is a bit of a ['blame' because some styles were put inside 'contactmomenten' that did not belong there](https://github.com/maykinmedia/open-inwoner/pull/1045/files#diff-715ac754308c4741d154fa5bad16a14a6a78c544ac23aaff2571b33a8cd0e2a2R120)  + all Section tags in the entire project were styled wrong because of the CSS that was targeting all Section Tags instead of a `.[componentname]-section` class (we need to target components instead of everything everywhere all at once 🙂)

inside scope of this issue:

- [x] remove margins from section tags, check to see if section styling doesn't break everywhere

outside scope of this issue so did is as an extra

- [x] delete pagination styling from wrong file - move to .pagination component and remove table display
- [x] improve card spacing for Userfeed and other Cards
- [x] remove unnecessary margin on Mijn Aanvragen page