### PR TITLE
:wheelchair: [#2346] Remove spans, correct list-items

### DIFF
--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -1257,12 +1257,11 @@ class UserAppointmentsTests(ClearCachesMixin, WebTest):
 
         passport_appointment = PQ(cards[0]).find("ul").children()
 
-        self.assertEqual(passport_appointment[0].text, "Aanvraag paspoort")
-        self.assertEqual(PQ(passport_appointment[1]).text(), "Datum\n1 januari 2020")
-        self.assertEqual(PQ(passport_appointment[2]).text(), "Tijd\n13:00 uur")
-        self.assertEqual(PQ(passport_appointment[3]).text(), "Locatie\nHoofdkantoor")
-        self.assertEqual(PQ(passport_appointment[4]).text(), "Dam 1")
-        self.assertEqual(PQ(passport_appointment[5]).text(), "1234 ZZ Amsterdam")
+        self.assertEqual(PQ(passport_appointment[0]).text(), "Datum\n1 januari 2020")
+        self.assertEqual(PQ(passport_appointment[1]).text(), "Tijd\n13:00 uur")
+        self.assertEqual(PQ(passport_appointment[2]).text(), "Locatie\nHoofdkantoor")
+        self.assertEqual(PQ(passport_appointment[3]).text(), "Dam 1")
+        self.assertEqual(PQ(passport_appointment[4]).text(), "1234 ZZ Amsterdam")
         self.assertEqual(
             PQ(cards[0]).find("a").attr("href"),
             f"{self.data.config.booking_base_url}{self.data.appointment_passport.publicId}",
@@ -1270,12 +1269,11 @@ class UserAppointmentsTests(ClearCachesMixin, WebTest):
 
         id_card_appointment = PQ(cards[1]).find("ul").children()
 
-        self.assertEqual(id_card_appointment[0].text, "Aanvraag ID kaart")
-        self.assertEqual(PQ(id_card_appointment[1]).text(), "Datum\n6 maart 2020")
-        self.assertEqual(PQ(id_card_appointment[2]).text(), "Tijd\n11:30 uur")
-        self.assertEqual(PQ(id_card_appointment[3]).text(), "Locatie\nHoofdkantoor")
-        self.assertEqual(PQ(id_card_appointment[4]).text(), "Wall Street 1")
-        self.assertEqual(PQ(id_card_appointment[5]).text(), "1111 AA New York")
+        self.assertEqual(PQ(id_card_appointment[0]).text(), "Datum\n6 maart 2020")
+        self.assertEqual(PQ(id_card_appointment[1]).text(), "Tijd\n11:30 uur")
+        self.assertEqual(PQ(id_card_appointment[2]).text(), "Locatie\nHoofdkantoor")
+        self.assertEqual(PQ(id_card_appointment[3]).text(), "Wall Street 1")
+        self.assertEqual(PQ(id_card_appointment[4]).text(), "1111 AA New York")
         self.assertEqual(
             PQ(cards[1]).find("a").attr("href"),
             f"{self.data.config.booking_base_url}{self.data.appointment_idcard.publicId}",

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -1255,6 +1255,10 @@ class UserAppointmentsTests(ClearCachesMixin, WebTest):
 
         self.assertEqual(len(cards), 2)
 
+        self.assertEqual(
+            PQ(cards[0]).find(".card__heading-2").text(), "Aanvraag paspoort"
+        )
+
         passport_appointment = PQ(cards[0]).find("ul").children()
 
         self.assertEqual(PQ(passport_appointment[0]).text(), "Datum\n1 januari 2020")
@@ -1265,6 +1269,10 @@ class UserAppointmentsTests(ClearCachesMixin, WebTest):
         self.assertEqual(
             PQ(cards[0]).find("a").attr("href"),
             f"{self.data.config.booking_base_url}{self.data.appointment_passport.publicId}",
+        )
+
+        self.assertEqual(
+            PQ(cards[1]).find(".card__heading-2").text(), "Aanvraag ID kaart"
         )
 
         id_card_appointment = PQ(cards[1]).find("ul").children()

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -193,6 +193,7 @@
   }
 
   &__text--small {
+    color: var(--color-body);
     font-size: var(--font-size-body-small);
   }
 
@@ -232,10 +233,24 @@
       text-decoration: none;
     }
 
-    .ellipsis .list-item p {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    .ellipsis {
+      .list-item p {
+        color: var(--color-body);
+        font-size: var(--font-size-body-small);
+        line-height: var(--font-line-height-body-small);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      &--none .list-item p {
+        color: var(--color-body);
+        font-size: var(--font-size-body-small);
+        line-height: var(--font-line-height-body-small);
+        overflow: initial;
+        text-overflow: initial;
+        white-space: normal;
+      }
     }
   }
 
@@ -259,6 +274,7 @@
     .p {
       margin-top: 4px;
     }
+
     .button {
       bottom: 0;
       right: 0;
@@ -367,7 +383,10 @@
   }
 
   &--stretch &__body .list:last-of-type {
-    padding-bottom: calc(var(--font-size-body) + var(--card-spacing) + 1em);
+    padding-bottom: calc(
+      var(--font-size-body-large) + var(--card-spacing) +
+        var(--font-size-body-large)
+    );
   }
 
   &--stretch .list + .link:first-of-type:last-of-type,

--- a/src/open_inwoner/scss/components/List/_List.scss
+++ b/src/open_inwoner/scss/components/List/_List.scss
@@ -4,12 +4,6 @@
   padding: 0;
   width: 100%;
   overflow-y: auto;
-
-  .case-list,
-  .contactmomenten-list,
-  .profile-list {
-    text-decoration: none;
-  }
 }
 
 .search + .list {

--- a/src/open_inwoner/scss/components/Profile/_personal-overview.scss
+++ b/src/open_inwoner/scss/components/Profile/_personal-overview.scss
@@ -19,7 +19,7 @@
     margin-top: 0;
   }
 
-  .profile-list {
+  .list {
     .list-item--compact {
       padding: var(--spacing-small) 0;
     }
@@ -31,8 +31,16 @@
     }
   }
 
-  .profile-cards .card {
-    min-height: 190px;
+  .profile-cards {
+    @media (min-width: 500px) and (max-width: 767px) {
+      &.card-container {
+        grid-template-columns: repeat(2, 1fr) !important;
+      }
+    }
+
+    .card {
+      min-height: 190px;
+    }
   }
 
   .form {

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -19,14 +19,12 @@
                     <a href="{{ case.vervolg_link }}" class="cases__link">
                     <h2 class="card__heading-2">{{ case.naam }}</h2>
                     {% render_list %}
-                    <span class="case-list">
                         <li class="list-item list-item--compact">
                             {% with end_date=case.eind_datum_geldigheid|default:"Geen" %}
                             <p class="card__caption card__text--small"><span>{% trans "Aanvraag verloopt op:" %}</span><span class="card__text--dark">{{ end_date|date }}</span></p>
                             {% endwith %}
                         </li>
                         {% list_item text="Openstaande aanvraag" caption=_("Status") compact=True strong=False %}
-                    </span>
                     {% endrender_list %}
                     <span class="link link--icon link--secondary">
                         <span class="link__text">{% trans "Aanvraag afronden" %}</span>
@@ -38,7 +36,6 @@
                     <a href="{% url 'cases:case_detail' object_id=case.uuid %}" class="cases__link">
                     <h2 class="card__heading-2">{{ case.description }}</h2>
                     {% render_list %}
-                        <span class="case-list">
                         <li class="list-item list-item--compact">
                             <p class="card__caption card__text--small"><span>{% trans "Aanvraag ingediend op:" %}</span><span class="card__text--dark">{{ case.start_date }}</span></p>
                         </li>
@@ -48,7 +45,6 @@
                             {% list_item "No status" caption=_("Status") compact=True strong=False %}
                         {% endif%}
                         {% list_item case.identification caption=_("Zaaknummer") compact=True strong=False %}
-                        </span>
                     {% endrender_list %}
 
                     <span class="link link--icon link--secondary">

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -40,9 +40,8 @@
                     {% endif %}
                     <div class="card__body">
                         <a href="{{ contactmoment.url }}" class="contactmomenten__link">
+                            <h2 class="card__heading-2">{{ contactmoment.onderwerp }}</h2>
                             {% render_list %}
-                                <span class="contactmomenten-list">
-                                <h2 class="card__heading-2">{{ contactmoment.onderwerp }}</h2>
                                 <li class="list-item list-item--compact">
                                     {% with register_date=contactmoment.registered_date|default:"" %}
                                     <p class="card__caption card__text--small"><span>{% trans "Vraag ingediend op:" %}</span><span class="card__text--dark">{{ register_date|date }}</span></p>
@@ -51,7 +50,6 @@
                                 {% list_item contactmoment.text compact=True strong=False %}
                                 {% list_item contactmoment.status caption=_("Status") compact=True strong=False %}
                                 {% list_item contactmoment.identificatie caption=_("Vraag nummer") compact=True strong=False %}
-                                </span>
                             {% endrender_list %}
 
                             <span class="link link--icon link--secondary" aria-label="{% trans "Bekijk vraag" %}" title="{% trans "Bekijk vraag" %}">

--- a/src/open_inwoner/templates/pages/profile/appointments.html
+++ b/src/open_inwoner/templates/pages/profile/appointments.html
@@ -14,9 +14,9 @@
             {% render_column start=forloop.counter_0|multiply:4 span=4 %}
                 <div class="card card--compact card--stretch appointment-info">
                     <div class="card__body">
+                    {% with branch=appointment.branch %}
+                        <h2 class="card__heading-2">{{ appointment.title }}</h2>
                         {% render_list %}
-                            {% with branch=appointment.branch %}
-                            <h2 class="card__heading-2">{{ appointment.title }}</h2>
                             {% timezone branch.timeZone %}
                                 {% list_item text=appointment.start|date:"j F Y" caption=_("Datum") compact=True strong=False %}
                                 {% list_item text=appointment.start|date:"H:i"|add:" "|add:_("uur") caption=_("Tijd") compact=True strong=False %}
@@ -24,8 +24,8 @@
                             {% list_item text=branch.addressLine1 caption=_("Locatie") extra_compact=True strong=False %}
                             {% list_item text=branch.addressLine2 extra_compact=True strong=False %}
                             {% list_item text=branch.addressZip|add:" "|add:branch.addressCity extra_compact=True strong=False %}
-                            {% endwith %}
                         {% endrender_list %}
+                    {% endwith %}
 
                         <a href="{{ appointment.url }}" class="link link--icon link--secondary"
                             title="{% trans "Wijzig of annuleer afspraak" %}">

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -165,10 +165,8 @@
                                 {% endfor %}
                             {% endrender_list %}
 
-                            <span class="link link--icon link--secondary"
-                                  aria-label="{% trans "Aanpassen" %}"
-                                  title="{% trans "Aanpassen" %}">
-                            <span class="link__text">{% trans "Aanpassen" %}</span>
+                            <span class="link link--icon link--secondary" title="{% trans "Aanpassen" %}">
+                                <span class="link__text">{% trans "Aanpassen" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
                         </div>
@@ -195,8 +193,8 @@
                                 {% endrender_list %}
 
                                 {% if inbox_page_is_published %}
-                                    <span class="link link--icon link--secondary" aria-label="{% trans "Stuur een bericht" %}" title="{% trans "Stuur een bericht" %}">
-                                    <span class="link__text">{% trans "Stuur een bericht" %}</span>
+                                    <span class="link link--icon link--secondary" title="{% trans "Stuur een bericht" %}">
+                                        <span class="link__text">{% trans "Stuur een bericht" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
                                 {% endif %}
@@ -218,10 +216,8 @@
                                     {% endfor %}
                                 {% endrender_list %}
 
-                                <span class="link link--icon link--secondary"
-                                      aria-label="{% trans "Beheer contacten" %}"
-                                      title="{% trans "Beheer contacten" %}">
-                                <span class="link__text">{% trans "Beheer contacten" %}</span>
+                                <span class="link link--icon link--secondary" title="{% trans "Beheer contacten" %}">
+                                    <span class="link__text">{% trans "Beheer contacten" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
                             </div>
@@ -238,7 +234,7 @@
                                 {% render_list %}
                                     {% list_item text=action_text compact=True strong=False %}
                                 {% endrender_list %}
-                                <span class="link link--icon link--secondary" aria-label="{% trans "Beheer acties" %}" title="{% trans "Beheer acties" %}">
+                                <span class="link link--icon link--secondary" title="{% trans "Beheer acties" %}">
                                     <span class="link__text">{% trans "Beheer acties" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
@@ -257,9 +253,7 @@
                                 {% list_item text="Jaaropgaven" compact=True strong=False active=False %}
                                 {% list_item text="Maandspecificaties" compact=True strong=False %}
                             {% endrender_list %}
-                            <span class="link link--icon link--secondary"
-                                  aria-label="{% trans "Bekijk uitkeringen" %}"
-                                  title="{% trans "Bekijk uitkeringen" %}">
+                            <span class="link link--icon link--secondary" title="{% trans "Bekijk uitkeringen" %}">
                                 <span class="link__text">{% trans "Bekijk uitkeringen" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -273,7 +267,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></h4>
-                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijken" %}" title="{% trans "Bekijken" %}">
+                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijken" %}">
                                 <span class="link__text">{% trans "Bekijken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -287,7 +281,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <h4 class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></h4>
-                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Start zelfdiagnose" %}" title="{% trans "Start zelfdiagnose" %}">
+                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Start zelfdiagnose" %}">
                                 <span class="link__text">{% trans "Start zelfdiagnose" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -300,7 +294,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span></h4>
-                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijk afspraken" %}" title="{% trans "Bekijk afspraken" %}">
+                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijk afspraken" %}">
                                 <span class="link__text">{% trans "Bekijk afspraken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -154,22 +154,20 @@
             {% if view.config.selected_categories %}
                 <a href="{% url 'profile:categories' %}" class="card card--compact card--stretch" id="profile-selected-categories">
                     <div class="card__body">
-                        <div class="profile__link">
+                        <div class="ellipsis--none">
                             <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn Interessegebieden" %}</span></h4>
 
                             {% render_list %}
-                                <span class="profile-list ellipsis">
-                                    {% for name in selected_categories %}
-                                        {% list_item text=name compact=True strong=False %}
-                                    {% empty %}
-                                        <p class="p list_paragraph">{% trans "U heeft geen interesses gekozen." %}</p>
-                                    {% endfor %}
-                                </span>
+                                {% for name in selected_categories %}
+                                    {% list_item text=name compact=True strong=False %}
+                                {% empty %}
+                                    <li class="card__text--small">{% trans "U heeft geen interesses gekozen." %}</li>
+                                {% endfor %}
                             {% endrender_list %}
 
                             <span class="link link--icon link--secondary"
-                                aria-label="{% trans "Aanpassen" %}"
-                                title="{% trans "Aanpassen" %}">
+                                  aria-label="{% trans "Aanpassen" %}"
+                                  title="{% trans "Aanpassen" %}">
                             <span class="link__text">{% trans "Aanpassen" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -186,24 +184,23 @@
                     <a href="#" class="card card--compact card--stretch" id="profile-section-mentors">
                 {% endif %}
                         <div class="card__body">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn begeleider" %}</span></h4>
-                            {% render_list %}
-                                <span class="profile-list ellipsis">
+                            <div class="ellipsis">
+                                <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn begeleider" %}</span></h4>
+                                {% render_list %}
                                     {% for name in mentor_contact_names %}
                                         {% list_item text=name compact=True strong=False %}
                                     {% empty %}
-                                        <p class="p list_paragraph">{% trans "U heeft geen gemeentelijke begeleider." %}</p>
+                                        <li class="card__text--small">{% trans "U heeft geen gemeentelijke begeleider." %}</li>
                                     {% endfor %}
-                                </span>
-                            {% endrender_list %}
+                                {% endrender_list %}
 
-                            {% if inbox_page_is_published %}
-                                <span class="link link--icon link--secondary" aria-label="{% trans "Stuur een bericht" %}" title="{% trans "Stuur een bericht" %}">
+                                {% if inbox_page_is_published %}
+                                    <span class="link link--icon link--secondary" aria-label="{% trans "Stuur een bericht" %}" title="{% trans "Stuur een bericht" %}">
                                     <span class="link__text">{% trans "Stuur een bericht" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
-                            {% endif %}
-
+                                {% endif %}
+                            </div>
                         </div>
                     </a>
             {% endif %}
@@ -211,16 +208,14 @@
             {% if view.config.my_contacts %}
                     <a href="{% url 'profile:contact_list' %}" class="card card--compact card--stretch" id="profile-section-contacts">
                         <div class="card__body">
-                            <div class="profile__link">
+                            <div class="ellipsis">
                                 <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn contacten" %}</span></h4>
                                 {% render_list %}
-                                    <span class="profile-list ellipsis">
                                     {% for name in contact_names %}
                                         {% list_item text=name compact=True strong=False %}
                                     {% empty %}
-                                        <p class="p list_paragraph">{% trans "U heeft nog geen contacten" %}</p>
+                                        <li class="card__text--small">{% trans "U heeft nog geen contacten" %}</li>
                                     {% endfor %}
-                                </span>
                                 {% endrender_list %}
 
                                 <span class="link link--icon link--secondary"
@@ -229,7 +224,6 @@
                                 <span class="link__text">{% trans "Beheer contacten" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
-
                             </div>
                         </div>
                     </a>
@@ -239,12 +233,10 @@
             {% if view.config.actions %}
                     <a href="{% url 'profile:action_list' %}" class="card card--compact card--stretch" id="profile-section-actions">
                         <div class="card__body">
-                            <div class="profile__link">
+                            <div class="ellipsis--none">
                                 <h4 class="card__heading-4"><span class="link link__text">{% trans "Acties" %}</span></h4>
                                 {% render_list %}
-                                    <span class="profile-list">
-                                        {% list_item text=action_text compact=True strong=False %}
-                                    </span>
+                                    {% list_item text=action_text compact=True strong=False %}
                                 {% endrender_list %}
                                 <span class="link link--icon link--secondary" aria-label="{% trans "Beheer acties" %}" title="{% trans "Beheer acties" %}">
                                     <span class="link__text">{% trans "Beheer acties" %}</span>
@@ -259,20 +251,19 @@
             {% if view.config.ssd %}
                 <a href="{% url 'ssd:uitkeringen' %}" class="card card--compact card--stretch" id="profile-section-ssd">
                     <div class="card__body">
-                        <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn uitkeringen" %}</span>
-                        </h4>
-                        {% render_list %}
-                            <span class="profile-list">
+                        <div class="ellipsis--none">
+                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn uitkeringen" %}</span></h4>
+                            {% render_list %}
                                 {% list_item text="Jaaropgaven" compact=True strong=False active=False %}
                                 {% list_item text="Maandspecificaties" compact=True strong=False %}
+                            {% endrender_list %}
+                            <span class="link link--icon link--secondary"
+                                  aria-label="{% trans "Bekijk uitkeringen" %}"
+                                  title="{% trans "Bekijk uitkeringen" %}">
+                                <span class="link__text">{% trans "Bekijk uitkeringen" %}</span>
+                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
-                        {% endrender_list %}
-                        <span class="link link--icon link--secondary"
-                              aria-label="{% trans "Bekijk uitkeringen" %}"
-                              title="{% trans "Bekijk uitkeringen" %}">
-                            <span class="link__text">{% trans "Bekijk uitkeringen" %}</span>
-                            {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-                        </span>
+                        </div>
                     </div>
                 </a>
             {% endif %}
@@ -280,11 +271,13 @@
             {% if view.config.questions %}
                 <a href="{% url 'cases:contactmoment_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
-                    <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></h4>
-                    <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijken" %}" title="{% trans "Bekijken" %}">
-                        <span class="link__text">{% trans "Bekijken" %}</span>
-                        {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-                    </span>
+                        <div class="ellipsis--none">
+                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></h4>
+                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijken" %}" title="{% trans "Bekijken" %}">
+                                <span class="link__text">{% trans "Bekijken" %}</span>
+                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                            </span>
+                        </div>
                     </div>
                 </a>
             {% endif %}
@@ -292,24 +285,26 @@
             {% if questionnaire_exists and view.config.selfdiagnose %}
                 <a href="{% url 'products:questionnaire_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
-                        <h4 class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></h4>
-                        <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Start zelfdiagnose" %}" title="{% trans "Start zelfdiagnose" %}">
-                            <span class="link__text">{% trans "Start zelfdiagnose" %}</span>
-                            {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-                        </span>
+                        <div class="ellipsis--none">
+                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></h4>
+                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Start zelfdiagnose" %}" title="{% trans "Start zelfdiagnose" %}">
+                                <span class="link__text">{% trans "Start zelfdiagnose" %}</span>
+                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                            </span>
+                        </div>
                     </div>
                 </a>
             {% endif %}
             {% if view.config.appointments %}
                 <a href="{% url 'profile:appointments' %}" class="card card--compact card--stretch" id="profile-section-appointments">
                     <div class="card__body">
-                        <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span>
-                        </h4>
-
-                        <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijk afspraken" %}" title="{% trans "Bekijk afspraken" %}">
-                            <span class="link__text">{% trans "Bekijk afspraken" %}</span>
-                            {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-                        </span>
+                        <div class="ellipsis--none">
+                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span></h4>
+                            <span class="link link--icon link--secondary profile-card__button" aria-label="{% trans "Bekijk afspraken" %}" title="{% trans "Bekijk afspraken" %}">
+                                <span class="link__text">{% trans "Bekijk afspraken" %}</span>
+                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                            </span>
+                        </div>
                     </div>
                 </a>
             {% endif %}

--- a/src/open_inwoner/templates/pages/questions/question.html
+++ b/src/open_inwoner/templates/pages/questions/question.html
@@ -7,7 +7,6 @@
     {% endif %}
     <div class="card__body">
         {% render_list %}
-        <span class="contactmomenten-list">
             <li class="list-item list-item--compact">
                 {% with register_date=contactmoment.registratiedatum|default:"" %}
                 <p class="card__caption card__text--small"><span>{% trans "Vraag ingediend op" %}:</span><span class="card__text--dark">{{ register_date|date }}</span></p>
@@ -19,7 +18,6 @@
                 <p class="card__caption card__text--small"><span>{% trans "Ingediend via" %}:</span><span class="card__text--dark">{{ channel }}</span></p>
                 {% endwith %}
             </li>
-        </span>
         {% endrender_list %}
         <span class="link link--icon link--primary" aria-label="{% trans "Bekijk vraag" %}" title="{% trans "Bekijk vraag" %}">
             <span class="link__text">{% trans "Bekijk vraag" %}</span>


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2346 

Turns out there were faulty Spans around LI's inside UL's in some Cards pages + also wrong use of paragraph tags in case of empty list-items. Also: Headings should not be a direct child inside UL's.