### PR TITLE
:wheelchair: [#2373] Make aria-labels same as (hidden) texts

### DIFF
--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -3,9 +3,9 @@
 {% if href %}
     <a
         class="{{ classes }}"
-        href="{{href}}"
+        href="{{ href }}"
         title="{% firstof title text %}"
-        aria-label="{% firstof title text %}"
+        aria-label="{% firstof text title %}"
         {% if href|startswith:"http" %}target="_blank"{% endif %}
         {% as_attributes extra_attributes %}
         {% if ariaExpanded %} aria-expanded="{{ ariaExpanded }}" {% endif %}
@@ -14,20 +14,20 @@
         {% if text_icon %}
             <span class="button__text-wrapper">
             {% icon icon=text_icon outlined=icon_outlined %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
             </span>
         {% else %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
         {% endif %}
     </a>
 {% else %}
     <button
         class="{{ classes }}"
-        type="{{type}}"
+        type="{{ type }}"
         name="{{ name }}"
         value="{{ value }}"
         title="{% firstof title text %}"
-        aria-label="{% firstof title text %}"
+        aria-label="{% firstof text title %}"
         {% as_attributes extra_attributes %}
         {% if id %} id="{{ id }}" {% endif %}
         {% if form_id %} form="{{ form_id }}"{% endif %}
@@ -37,10 +37,10 @@
         {% if text_icon %}
             <span class="button__text-wrapper">
             {% icon icon=text_icon outlined=icon_outlined %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
             </span>
         {% else %}
-            {% if not hide_text %}{{text}}{% endif %}
+            {% if not hide_text %}{{ text }}{% endif %}
         {% endif %}
     </button>
 {% endif %}


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2373

 
A small change with big effects.
aria-labels only work on interactive elements and need to at least 'contain' keywords that are inside the visible or invisible text of the component.
 

Side note: title attributes are not meant for accessibility, and should **actually** contain different, more meaningful text than the readable text of an interactive element. But this has not been addressed as an issue anywhere in the report - so we're only changing the aria-label here, as per request.

TL;DR: I changed the order of `{% firstof title text %}`