### PR TITLE
[#2404] Avoid redirect cycle for DigiD login with email required

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1140,7 +1140,7 @@ class DuplicateEmailRegistrationTest(WebTest):
         url = reverse("eherkenning-mock:password")
         params = {
             "acs": reverse("eherkenning:acs"),
-            "next": reverse("profile:registration_necessary"),
+            "next": reverse("kvk:branches"),
         }
         url = f"{url}?{urlencode(params)}"
 
@@ -1149,8 +1149,7 @@ class DuplicateEmailRegistrationTest(WebTest):
             "auth_name": "12345678",
             "auth_pass": "bar",
         }
-        # post our password to the IDP
-        response = self.app.post(url, data).follow().follow()
+        response = self.app.post(url, data).follow()
 
         # select company branch
         response = self.app.get(response["Location"])

--- a/src/open_inwoner/utils/middleware.py
+++ b/src/open_inwoner/utils/middleware.py
@@ -74,6 +74,8 @@ class BaseConditionalUserRedirectMiddleware(abc.ABC):
             for e in self.extra_pass_prefixes:
                 try:
                     prefixes.append(resolve_url(e))
+                    prefixes.append(reverse("profile:registration_necessary"))
+                    prefixes.append(reverse("profile:email_verification_user"))
                 except NoReverseMatch:
                     # support testing without cms app mounted
                     pass

--- a/src/open_inwoner/utils/middleware.py
+++ b/src/open_inwoner/utils/middleware.py
@@ -31,6 +31,27 @@ def get_always_pass_prefixes() -> tuple[str, ...]:
     )
 
 
+def get_app_pass_prefixes() -> tuple[str, ...]:
+    """
+    Urls for apps that may not be active
+    """
+    return (
+        "profile:registration_necessary",
+        "profile:email_verification_user",
+    )
+
+
+def resolve_urls(urls) -> tuple[str, ...]:
+    ret = list()
+    for url in urls:
+        try:
+            ret.append(resolve_url(url))
+        except NoReverseMatch:
+            # support testing without cms app mounted
+            pass
+    return tuple(ret)
+
+
 class BaseConditionalUserRedirectMiddleware(abc.ABC):
     """
     Base class for middleware that redirects users to another view based on conditions
@@ -64,6 +85,7 @@ class BaseConditionalUserRedirectMiddleware(abc.ABC):
         URL prefixes we're skipping without checking requires_redirect()
         """
         prefixes = get_always_pass_prefixes()
+        prefixes += resolve_urls(get_app_pass_prefixes())
         prefixes += (resolve_url(self.get_redirect_url(request)),)
         prefixes += self.get_extra_pass_prefixes()
         return prefixes
@@ -71,14 +93,7 @@ class BaseConditionalUserRedirectMiddleware(abc.ABC):
     def get_extra_pass_prefixes(self) -> tuple[str, ...]:
         prefixes = []
         if self.extra_pass_prefixes:
-            for e in self.extra_pass_prefixes:
-                try:
-                    prefixes.append(resolve_url(e))
-                    prefixes.append(reverse("profile:registration_necessary"))
-                    prefixes.append(reverse("profile:email_verification_user"))
-                except NoReverseMatch:
-                    # support testing without cms app mounted
-                    pass
+            return resolve_urls(self.extra_pass_prefixes)
         return tuple(prefixes)
 
     def __call__(self, request):


### PR DESCRIPTION
A redirect cycle occurs for DigiD login when email verification is required

Taiga: [#2404](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2404)