### PR TITLE
Add init volume to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .vscode/
 .sass-cache/
 *.db
+docker-init-db.sql/*
 *.pyc
 __pycache__
 *~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: '3'
 services:
   db:
     image: postgis/postgis:12-2.5
+    container_name: open-inwoner-db
     environment:
       - POSTGRES_USER=${DB_USER:-open_inwoner}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-open_inwoner}
@@ -21,13 +22,14 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
     ports:
-      - 9201:9201
+      - ${ES_PORTS:-9201:9201}
 
   redis:
     image: redis
 
   web:
     build: .
+    container_name: open-inwoner-web
     environment:
       - DJANGO_SETTINGS_MODULE=open_inwoner.conf.docker
       - SECRET_KEY=${SECRET_KEY:-7bk)w=_%lnm#68rc!c)h@gy&5+%^fl=okq17bv!)yv!l0udu2y}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - POSTGRES_USER=${DB_USER:-open_inwoner}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-open_inwoner}
     volumes:
+      - ./docker-init-db.sql:/docker-entrypoint-initdb.d
       - db_data:/var/lib/postgresql/data
 
   elasticsearch:
@@ -20,7 +21,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
     ports:
-      - 9200:9200
+      - 9201:9201
 
   redis:
     image: redis

--- a/docs/install/docker-compose.rst
+++ b/docs/install/docker-compose.rst
@@ -1,0 +1,62 @@
+.. _install_docker_compose:
+
+============================
+Install using Docker Compose
+============================
+
+We include a compose stack for development purposes and for trying out OIP on
+your own machine.
+
+The `docker_compose.yml` defines 'convenience' settings, meaning that that no
+additional configuration is needed to run the app. It is **not** suitable
+for production.
+
+
+Getting started
+===============
+
+1. Clone the repository
+
+   .. code:: bash
+
+        git clone git@github.com:maykinmedia/open-inwoner.git
+
+2. Optionally, you you can initialize the database on first startup with an SQL dump
+   by adding it to ``docker-init-db.sql/``. In order to create a user for the database,
+   add a ``.sql`` script in the same directory with the following content:
+
+   .. code:: bash
+
+        DO
+        $do$
+        BEGIN
+            IF NOT EXISTS ( SELECT FROM pg_roles WHERE rolname = 'open_inwoner') THEN
+                CREATE USER open_inwoner;
+            END IF;
+        END
+        $do$;
+
+    Choose the rolname/user name depending on the owner of the database in the dump
+    you're loading in.
+
+    Make sure you get the quotes right: ``rolname`` requires single quotes. If you
+    happen to have a ``USER`` name containing dashes, it must be referenced in double
+    quotes (``"open-inwoner-test"``).
+
+3. Start the docker containers with ``docker compose up``. If you want to run the
+   containers in the background, add the ``-d`` option.
+
+4. Create a super-user:
+
+   .. code:: bash
+
+        sudo docker exec -it open-inwoner-web src/manage.py createsuperuser
+
+5. Navigate to ``http://127.0.0.1:8000/admin/`` and use the credentials created
+   above to log in.
+
+6. To stop the containers, press *CTRL-C* or if you used the ``-d`` option:
+
+   .. code:: bash
+
+        docker compose stop


### PR DESCRIPTION
The PR:
- adds an init volume to docker-compose so we can initialize containers with SQL dumps
- changes the port for Elasticsearch to `9201` so the Docker container can run alongside the system installation of ES without blocking the default port