### PR TITLE
[#2454] Add IPv6Address to JSONEncoderMixin

### DIFF
--- a/src/open_inwoner/utils/api.py
+++ b/src/open_inwoner/utils/api.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 
 import requests
@@ -41,6 +41,7 @@ class JSONEncoderMixin:
         json_encoders: dict = {
             datetime: lambda dt: dt.isoformat(sep=" "),
             IPv4Address: str,
+            IPv6Address: str,
             Url: str,
         }
         result = super().model_dump(**kwargs)

--- a/src/open_inwoner/utils/tests/test_api_utils.py
+++ b/src/open_inwoner/utils/tests/test_api_utils.py
@@ -1,0 +1,31 @@
+from ipaddress import IPv4Address, IPv6Address
+
+from django.test import TestCase
+
+from pydantic import BaseModel, HttpUrl
+
+from ..api import JSONEncoderMixin
+
+
+class TestDummy(JSONEncoderMixin, BaseModel):
+    ipv4: IPv4Address
+    ipv6: IPv6Address
+    url: HttpUrl
+
+
+class JSONEncoderTest(TestCase):
+    def test_encode(self):
+        user_data = TestDummy(
+            ipv4="127.0.0.1",
+            ipv6="2345:0425:2CA1:0:0:0567:5673:23b5",
+            url="http://source.url",
+        )
+
+        self.assertEqual(
+            user_data.model_dump(),
+            {
+                "ipv4": "127.0.0.1",
+                "ipv6": "2345:425:2ca1::567:5673:23b5",
+                "url": "http://source.url/",
+            },
+        )


### PR DESCRIPTION
Support for encoding IPv6 addresses was missing from the `JSONEncoderMixin` used for creating subscriptions

Taiga: [#2454](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2454)