### PR TITLE
[#2473] Convert main buttons to NLDS

### DIFF
--- a/src/open_inwoner/accounts/tests/test_action_views.py
+++ b/src/open_inwoner/accounts/tests/test_action_views.py
@@ -361,6 +361,7 @@ class ActionsPlaywrightTests(PlaywrightSyncLiveServerTestCase):
 
         expect(dropdown_button).to_contain_text(open_label)
         # grab buttons
+        # remove role
         status_closed_button = dropdown_content.get_by_role("button", name=closed_label)
         status_approval_button = dropdown_content.get_by_role(
             "button", name=approval_label

--- a/src/open_inwoner/components/readme.md
+++ b/src/open_inwoner/components/readme.md
@@ -96,7 +96,7 @@ Given an example of a hyperlink with an icon:
 
 ```html
 {% load i18n %}
-<a class="utrecht-button button button--primary" href="{% url 'inbox:index' %}">
+<a class="utrecht-link-button button button--primary" href="{% url 'inbox:index' %}">
     <span class="material-icon">arrow_forward</span>
     {% trans 'My messages' %}
 </a>

--- a/src/open_inwoner/components/readme.md
+++ b/src/open_inwoner/components/readme.md
@@ -96,7 +96,7 @@ Given an example of a hyperlink with an icon:
 
 ```html
 {% load i18n %}
-<a class="button button--primary" href="{% url 'inbox:index' %}">
+<a class="utrecht-button button button--primary" href="{% url 'inbox:index' %}">
     <span class="material-icon">arrow_forward</span>
     {% trans 'My messages' %}
 </a>

--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -2,7 +2,7 @@
 
 {% if href %}
     <a
-        class="{{ classes }}"
+        class="utrecht-button {{ classes }}"
         href="{{ href }}"
         title="{% firstof title text %}"
         aria-label="{% firstof text title %}"
@@ -23,7 +23,7 @@
     </a>
 {% else %}
     <button
-        class="{{ classes }}"
+        class="utrecht-button {{ classes }}"
         type="{{ type }}"
         name="{{ name }}"
         value="{{ value }}"

--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -2,7 +2,7 @@
 
 {% if href %}
     <a
-        class="utrecht-button {{ classes }}"
+        class="utrecht-link-button {{ classes }}"
         href="{{ href }}"
         title="{% firstof title text %}"
         aria-label="{% firstof text title %}"

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -19,7 +19,7 @@
         {% endif %}
 
         <span class="spacer"></span>
-        <span class="button button--icon-before button--transparent button--secondary">
+        <span class="utrecht-button button button--icon-before button--transparent button--secondary">
         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
         </span>
     </div>

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -26,7 +26,7 @@
             {% endif %}
 
             <span class="spacer"></span>
-            <span class="button button--icon-before button--transparent button--secondary">
+            <span class="utrecht-button button button--icon-before button--transparent button--secondary">
             {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
             </span>
 

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -7,7 +7,7 @@
         <label class="button button--primary file-input__label-empty" for="{{ field.auto_id }}">
             {% if multiple %}{% trans 'Sleep of selecteer bestanden' %}{% else %}{% trans 'Sleep of selecteer bestand' %}{% endif %}
         </label>
-        <label class="button button--borderless file-input__label-selected" for="{{ field.auto_id }}">
+        <label class="utrecht-button button button--borderless file-input__label-selected" for="{{ field.auto_id }}">
         {% icon icon="add_circle_outlined" icon_position="before" outlined=True %}
             {% if multiple %}{% trans 'Selecteer meer bestanden' %}{% else %}{% trans 'Selecteer ander bestand' %}{% endif %}
         </label>

--- a/src/open_inwoner/components/templates/components/Modal/Modal.html
+++ b/src/open_inwoner/components/templates/components/Modal/Modal.html
@@ -8,8 +8,8 @@
         <h2 class="modal__title" id="modal__title"></h2>
         <div class="modal__text" id="modal__text"></div>
         <div class="modal__actions" id="modal__actions">
-            <button class="button modal__button button--error-confirm button-icon__confirm modal__confirm" type="submit" name="" value="" aria-label=""><span class="inner-text">Bevestig </span>{% icon icon="delete" icon_position="after" extra_classes="modal__visible-icon" outlined=True %}</button>
-            <button class="button modal__button modal__close button--primary button-icon--primary" type="button" name="" value="" aria-label=""><span class="inner-text">Sluiten </span>{% icon icon="cancel" icon_position="after" extra_classes="modal__visible-icon" outlined=True %}</button>
+            <button class="utrecht-button button modal__button button--error-confirm button-icon__confirm modal__confirm" type="submit" name="" value="" aria-label=""><span class="inner-text">Bevestig </span>{% icon icon="delete" icon_position="after" extra_classes="modal__visible-icon" outlined=True %}</button>
+            <button class="utrecht-button button modal__button modal__close button--primary button-icon--primary" type="button" name="" value="" aria-label=""><span class="inner-text">Sluiten </span>{% icon icon="cancel" icon_position="after" extra_classes="modal__visible-icon" outlined=True %}</button>
         </div>
     </div>
 </div>

--- a/src/open_inwoner/components/templatetags/button_tags.py
+++ b/src/open_inwoner/components/templatetags/button_tags.py
@@ -93,19 +93,19 @@ def button(text, **kwargs):
             classnames += " button--bordered"
 
         if kwargs.get("primary"):
-            classnames += " button--primary"
+            classnames += " utrecht-button--primary-action button--primary"
 
         if kwargs.get("danger"):
             classnames += " button--danger"
 
         if kwargs.get("secondary"):
-            classnames += " button--secondary"
+            classnames += " utrecht-button--secondary-action button--secondary"
 
         if kwargs.get("transparent"):
             classnames += " button--transparent"
 
         if kwargs.get("disabled"):
-            classnames += " button--disabled"
+            classnames += " utrecht-button-disabled button--disabled"
 
         if kwargs.get("pill"):
             classnames += " button--pill"

--- a/src/open_inwoner/components/templatetags/button_tags.py
+++ b/src/open_inwoner/components/templatetags/button_tags.py
@@ -68,7 +68,7 @@ def button(text, **kwargs):
 
     def get_classes():
         extra_classes = kwargs.get("extra_classes")
-        classnames = "button"
+        classnames = "utrecht-button"
 
         if extra_classes:
             classnames += f" {extra_classes}"

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -1,6 +1,6 @@
 @import '~@utrecht/components/dist/button/css/index.css';
 
-.button {
+.utrecht-button {
   align-items: center;
   border-radius: var(--border-radius);
   box-sizing: border-box;

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -1,6 +1,7 @@
 @import '~@utrecht/components/dist/button/css/index.css';
 
-.utrecht-button {
+.utrecht-button,
+.button {
   align-items: center;
   border-radius: var(--border-radius);
   box-sizing: border-box;
@@ -84,9 +85,9 @@
   }
 
   &#{&}--primary {
-    background-color: var(--color-primary);
-    border: 1px solid var(--color-primary);
-    color: var(--color-font-primary);
+    background-color: var(--utrecht-button-primary-action-background-color);
+    border: 1px solid var(--utrecht-button-primary-action-background-color);
+    color: var(--utrecht-button-secondary-color);
 
     &:focus,
     &:hover {
@@ -95,9 +96,9 @@
   }
 
   &--secondary {
-    background-color: var(--color-secondary);
-    border: 1px solid var(--color-secondary);
-    color: var(--color-white);
+    background-color: var(--utrecht-button-secondary-action-background-color);
+    border: 1px solid var(--utrecht-button-secondary-action-background-color);
+    color: var(--utrecht-button-secondary-action-color);
 
     &:focus,
     &:hover {

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -1,3 +1,5 @@
+@import '~@utrecht/components/dist/button/css/index.css';
+
 .button {
   align-items: center;
   border-radius: var(--border-radius);
@@ -16,12 +18,21 @@
   text-align: center;
   text-decoration: none;
   transition: transform 300ms, background-color 300ms;
-  font-weight: normal;
+  font-weight: var(--font-weight-body);
   // modified outline for accessibility focus
   outline-width: 1px;
   outline-offset: 1px;
   border: 0;
   white-space: nowrap;
+  // values from NLDS components that need to be unset
+  block-size: initial;
+  inline-size: initial;
+  justify-content: center;
+  max-inline-size: initial;
+  min-block-size: initial;
+  min-inline-size: initial;
+  scale: 1;
+  text-transform: none;
 
   &:focus,
   &:hover {

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -148,6 +148,7 @@
     calc(var(--color-error-l) + 50%)
   );
 
+  // From color picker
   --color-info-h: 2010;
   --color-info-s: 64%;
   --color-info-l: 80%;
@@ -168,6 +169,12 @@
     calc(var(--color-info-l) - 40%)
   );
 
+  // From design-tokens
+  --oip-color-primary: var(--color-primary);
+  --oip-color-secondary: var(--color-secondary);
+  --oip-color-primary-darker: var(--color-primary-darker);
+  --oip-color-secondary-darker: var(--color-secondary-darker);
+
   --color-success-h: 115;
   --color-success-s: 26%;
   --color-success-l: 37%;
@@ -183,8 +190,8 @@
   );
   // color-success-l was +50% but +57% is needed for 4.5:1 contrast
 
-  --color-font-primary: var(--color-white);
-  --color-font-secondary: var(--color-white);
+  //--color-font-primary: var(--color-white);
+  //--color-font-secondary: var(--color-white);
   --color-font-accent: var(--color-gray-dark);
 
   --color-body: var(--color-gray-dark);

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -199,6 +199,7 @@
   // Font-family = 'Heading' coming from both NLDS and/or the font-upload functionality
   --font-family-heading: var(--utrecht-heading-font-family);
   --font-weight-heading: bold;
+  --font-weight-body: normal;
 
   --font-color-heading-1: var(--font-color-heading);
   --font-family-heading-1: var(--font-family-heading);

--- a/src/open_inwoner/scss/views/_nl-design-system-community.scss
+++ b/src/open_inwoner/scss/views/_nl-design-system-community.scss
@@ -1,0 +1,9 @@
+@import '@utrecht/components/dist/document/css/index.css';
+@import '~@utrecht/components/dist/heading-1/css/index.css';
+@import '~@utrecht/components/dist/heading-2/css/index';
+@import '~@utrecht/components/dist/heading-3/css/index';
+@import '~@utrecht/components/dist/heading-4/css/index';
+@import '~@utrecht/components/dist/heading-5/css/index';
+@import '@utrecht/components/dist/button/css/index.css';
+@import '@utrecht/components/dist/link-button/css/index.css';
+@import '@utrecht/components/dist/paragraph/css/index.css';

--- a/src/open_inwoner/scss/views/_nl-design-system-oip-theme.scss
+++ b/src/open_inwoner/scss/views/_nl-design-system-oip-theme.scss
@@ -1,0 +1,6 @@
+.openinwoner-theme {
+  --oip-color-primary: var(--color-primary);
+  --oip-color-secondary: var(--color-secondary);
+  --oip-color-primary-darker: var(--color-primary-darker);
+  --oip-color-secondary-darker: var(--color-secondary-darker);
+}

--- a/src/open_inwoner/scss/views/_nl-design-system-oip-theme.scss
+++ b/src/open_inwoner/scss/views/_nl-design-system-oip-theme.scss
@@ -1,5 +1,5 @@
 .openinwoner-theme {
-  --oip-color-primary: var(--color-primary);
+  //--oip-color-primary: var(--color-primary);
   --oip-color-secondary: var(--color-secondary);
   --oip-color-primary-darker: var(--color-primary-darker);
   --oip-color-secondary-darker: var(--color-secondary-darker);

--- a/src/open_inwoner/templates/500.html
+++ b/src/open_inwoner/templates/500.html
@@ -133,7 +133,7 @@ p.lead {
   <h1 class="utrecht-heading-1">Sorry, a server error has occurred (500)</h1>
   <p class="lead">We have been automatically notified about the problem and will investigate as soon as possible.</p>
   <p class="lead">
-    <a href="/" class="utrecht-button button">Back to home</a>
+    <a href="/" class="button">Back to home</a>
   </p>
 </body>
 

--- a/src/open_inwoner/templates/500.html
+++ b/src/open_inwoner/templates/500.html
@@ -133,7 +133,7 @@ p.lead {
   <h1 class="utrecht-heading-1">Sorry, a server error has occurred (500)</h1>
   <p class="lead">We have been automatically notified about the problem and will investigate as soon as possible.</p>
   <p class="lead">
-    <a href="/" class="button">Back to home</a>
+    <a href="/" class="utrecht-button button">Back to home</a>
   </p>
 </body>
 

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -14,7 +14,7 @@
                     <p class="utrecht-paragraph">{{ plan.goal|truncatewords:20 }}</p>
                     <p class="utrecht-paragraph">{{ plan.description|truncatewords:20 }}</p>
                     <span class="spacer"></span>
-                    <span class="button button--icon-before button--transparent button--secondary">
+                    <span class="utrecht-button button button--icon-before button--transparent button--secondary">
                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
                 </div>

--- a/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
+++ b/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
@@ -14,7 +14,7 @@
                     <h2 class="plugin-card__heading">
                         <span class="status">{{ appointment.services.0.name|default:appointment.title }}</span>
                     </h2>
-                    <span class="button button--icon-before button--transparent">
+                    <span class="utrecht-button button button--icon-before button--transparent">
                         {% icon icon="east" icon_position="after" primary=True outlined=True %}
                     </span>
                 </div>

--- a/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
+++ b/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
@@ -33,7 +33,7 @@
                     <p class="userfeed-card__description">
                         <span class="status">{{ item.message }}</span>
                     </p>
-                    <span class="button button--icon-before button--transparent">
+                    <span class="utrecht-button button button--icon-before button--transparent">
                     {% icon icon="east" icon_position="after" primary=True outlined=True %}
                     </span>
                 </div>

--- a/src/open_inwoner/templates/djangocms_link/arrow/link.html
+++ b/src/open_inwoner/templates/djangocms_link/arrow/link.html
@@ -1,4 +1,4 @@
 {% load cms_tags button_tags icon_tags i18n %}{% spaceless %}
 {# copied and modified from 'default' #}
 {# this needs to be in one line for rendering purpose #}
-{% endspaceless %}<a class="utrecht-button button button--textless button--icon button--icon-before button--transparent"  href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% icon icon="arrow_forward" %}{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a>
+{% endspaceless %}<a class="utrecht-link-button button button--textless button--icon button--icon-before button--transparent"  href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% icon icon="arrow_forward" %}{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a>

--- a/src/open_inwoner/templates/djangocms_link/arrow/link.html
+++ b/src/open_inwoner/templates/djangocms_link/arrow/link.html
@@ -1,4 +1,4 @@
 {% load cms_tags button_tags icon_tags i18n %}{% spaceless %}
 {# copied and modified from 'default' #}
 {# this needs to be in one line for rendering purpose #}
-{% endspaceless %}<a class="button button--textless button--icon button--icon-before button--transparent"  href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% icon icon="arrow_forward" %}{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a>
+{% endspaceless %}<a class="utrecht-button button button--textless button--icon button--icon-before button--transparent"  href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% icon icon="arrow_forward" %}{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a>

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -74,7 +74,7 @@
                 {% include "pages/partials/questions.html" with questions=case.questions only %}
                 {% if case.questions|length > 3 %}
                     <div class="expand">
-                        <a id="toggle-hide-elements" class="utrecht-button button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ case.questions|length }} aria-expanded=false>
+                        <a id="toggle-hide-elements" class="utrecht-link-button button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ case.questions|length }} aria-expanded=false>
                             {% icon extra_classes="expand-icon" icon="expand_more" icon_position="after" icon_outlined=True %}
                         </a>
                     </div>

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -74,7 +74,7 @@
                 {% include "pages/partials/questions.html" with questions=case.questions only %}
                 {% if case.questions|length > 3 %}
                     <div class="expand">
-                        <a id="toggle-hide-elements" class="button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ case.questions|length }} aria-expanded=false>
+                        <a id="toggle-hide-elements" class="utrecht-button button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ case.questions|length }} aria-expanded=false>
                             {% icon extra_classes="expand-icon" icon="expand_more" icon_position="after" icon_outlined=True %}
                         </a>
                     </div>

--- a/src/open_inwoner/templates/pages/contactmoment/detail.html
+++ b/src/open_inwoner/templates/pages/contactmoment/detail.html
@@ -26,13 +26,13 @@
                         {% endif %}
                     </div>
                     <div>
-                        <a href="{{ origin.url }}" id="origin_link" class="utrecht-button button button--primary contactmoment__actions">
+                        <a href="{{ origin.url }}" id="origin_link" class="utrecht-link-button button button--primary contactmoment__actions">
                             {% icon "arrow_backward" %}{{ origin.label }}
                         </a>
                     </div>
                     {% if destination %}
                         <div>
-                            <a href="{{ destination.url }}" id="destination_link" class="utrecht-button button button--transparent contactmoment__actions">
+                            <a href="{{ destination.url }}" id="destination_link" class="utrecht-link-button button button--transparent contactmoment__actions">
                                 <span>{{ destination.label }}</span>{% icon "arrow_forward" %}
                             </a>
                         </div>

--- a/src/open_inwoner/templates/pages/contactmoment/detail.html
+++ b/src/open_inwoner/templates/pages/contactmoment/detail.html
@@ -26,13 +26,13 @@
                         {% endif %}
                     </div>
                     <div>
-                        <a href="{{ origin.url }}" id="origin_link" class="button button--primary contactmoment__actions">
+                        <a href="{{ origin.url }}" id="origin_link" class="utrecht-button button button--primary contactmoment__actions">
                             {% icon "arrow_backward" %}{{ origin.label }}
                         </a>
                     </div>
                     {% if destination %}
                         <div>
-                            <a href="{{ destination.url }}" id="destination_link" class="button button--transparent contactmoment__actions">
+                            <a href="{{ destination.url }}" id="destination_link" class="utrecht-button button button--transparent contactmoment__actions">
                                 <span>{{ destination.label }}</span>{% icon "arrow_forward" %}
                             </a>
                         </div>


### PR DESCRIPTION
First read: https://adamsilver.io/blog/but-sometimes-buttons-look-like-links/ 

issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2473

This PR works with this NPM version from [PR nr. 8 in our design-token package](https://github.com/maykinmedia/open-inwoner-design-tokens/pull/8).

Buttons are complex, information-heavy little atomic components, and in the case of NLDS we don't just style Inputs and true Button tags but also `< a href...>` anchor tags and make them look like buttons.

Documentation on Utrecht true buttons: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css-button-appearance--docs
Documentation on Utrecht link-that-looks-like button: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-button-link--docs

In future users need to be able to change the colors and fonts of OIP buttons where they are similar to NL/Utrecht/Denhaag buttons. But all our other styling like the 'textless', 'pill', 'small', and 'big' buttons (etcetera, etcetera) just have differences in spacing so that is why we are replacing the 'button' class with --oip here so we can still use all of the unique spacing values like `&--icon-after`.

Unique modifiers in OIP that Utrecht doesn't have:

1. &--small, 
2. &--big, 
3. &--fullwidth, 
4. &--spaceless, 
5. &--transparent, 
6. &--open, 
7. &--bordered, 
8. &--pill, 
9. &--disabled, 
10. &--danger, 
11. &--danger-borderless , 
12. &--error, 
13. &--primary-close, 
14. &--error-confirm, 
15. &--borderless, 
16. &__text-wrapper