### PR TITLE
[#2480] Add NLDS paragraph components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@emotion/styled": "^11.3.0",
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@joeattardi/emoji-button": "^4.6.4",
-        "@open-inwoner/design-tokens": "^0.0.5-alpha.4",
+        "@open-inwoner/design-tokens": "^0.0.5-alpha.5",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "bem.js": "^1.0.10",
         "emojibase-data": "^7.0.1",
@@ -4140,9 +4140,9 @@
       }
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.5-alpha.4",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.4.tgz",
-      "integrity": "sha512-8DhJ1Tg/Hd/WFFzxn5TriX/3Lc9UC4j8wlJSGsfpRUKLsKNSvx5YKUQLqqMPYzJTeNXNebWJ5p3Km35Bu3wUdQ=="
+      "version": "0.0.5-alpha.5",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.5.tgz",
+      "integrity": "sha512-oPTrpY/OA0oOMjgKauqEAzXJuggbb1+m3LvHFzLYZhiLPfqgJV+B6KcOT+gD2sHsiP74e8A8EgiC0rZBa16l1A=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.5",
@@ -22718,9 +22718,9 @@
       }
     },
     "@open-inwoner/design-tokens": {
-      "version": "0.0.5-alpha.4",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.4.tgz",
-      "integrity": "sha512-8DhJ1Tg/Hd/WFFzxn5TriX/3Lc9UC4j8wlJSGsfpRUKLsKNSvx5YKUQLqqMPYzJTeNXNebWJ5p3Km35Bu3wUdQ=="
+      "version": "0.0.5-alpha.5",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.5.tgz",
+      "integrity": "sha512-oPTrpY/OA0oOMjgKauqEAzXJuggbb1+m3LvHFzLYZhiLPfqgJV+B6KcOT+gD2sHsiP74e8A8EgiC0rZBa16l1A=="
     },
     "@popperjs/core": {
       "version": "2.11.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@emotion/styled": "^11.3.0",
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@joeattardi/emoji-button": "^4.6.4",
-        "@open-inwoner/design-tokens": "^0.0.3-alpha.0",
+        "@open-inwoner/design-tokens": "^0.0.5-alpha.4",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "bem.js": "^1.0.10",
         "emojibase-data": "^7.0.1",
@@ -4140,9 +4140,9 @@
       }
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-UXS6KK2onthn6+mWw7/DxzUvNHq5iGDaoKE2hLll3/O8EvsygTXm3PiTkxcsEpHQN6m9QLSY/GGSqg47Fg/Sdw=="
+      "version": "0.0.5-alpha.4",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.4.tgz",
+      "integrity": "sha512-8DhJ1Tg/Hd/WFFzxn5TriX/3Lc9UC4j8wlJSGsfpRUKLsKNSvx5YKUQLqqMPYzJTeNXNebWJ5p3Km35Bu3wUdQ=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.5",
@@ -22718,9 +22718,9 @@
       }
     },
     "@open-inwoner/design-tokens": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-UXS6KK2onthn6+mWw7/DxzUvNHq5iGDaoKE2hLll3/O8EvsygTXm3PiTkxcsEpHQN6m9QLSY/GGSqg47Fg/Sdw=="
+      "version": "0.0.5-alpha.4",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.4.tgz",
+      "integrity": "sha512-8DhJ1Tg/Hd/WFFzxn5TriX/3Lc9UC4j8wlJSGsfpRUKLsKNSvx5YKUQLqqMPYzJTeNXNebWJ5p3Km35Bu3wUdQ=="
     },
     "@popperjs/core": {
       "version": "2.11.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@joeattardi/emoji-button": "^4.6.4",
-    "@open-inwoner/design-tokens": "^0.0.3-alpha.0",
+    "@open-inwoner/design-tokens": "^0.0.5-alpha.4",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "bem.js": "^1.0.10",
     "emojibase-data": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@joeattardi/emoji-button": "^4.6.4",
-    "@open-inwoner/design-tokens": "^0.0.5-alpha.4",
+    "@open-inwoner/design-tokens": "^0.0.5-alpha.5",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "bem.js": "^1.0.10",
     "emojibase-data": "^7.0.1",

--- a/src/open_inwoner/accounts/templates/accounts/email_verification.html
+++ b/src/open_inwoner/accounts/templates/accounts/email_verification.html
@@ -8,7 +8,7 @@
         {% render_card tinted=True  %}
             {% get_solo 'configurations.SiteConfiguration' as config %}
             <h1 class="utrecht-heading-1">{% trans "E-mailadres bevestigen" %}</h1><br>
-            {% if verification_text %}<p class="p">{{ verification_text|linebreaksbr }}</p><br>{% endif %}
+            {% if verification_text %}<p class="utrecht-paragraph">{{ verification_text|linebreaksbr }}</p><br>{% endif %}
             <form method="POST" id="email-verification-form" action="{{ request.get_full_path }}" class="form" novalidate>
                 {% csrf_token %}
                 {% form_actions primary_icon='arrow_forward' primary_text=button_text %}

--- a/src/open_inwoner/accounts/templates/accounts/inbox.html
+++ b/src/open_inwoner/accounts/templates/accounts/inbox.html
@@ -22,9 +22,9 @@
             {% for conv in conversations.page_obj %}
                 {% with conv_thread_url=conv.thread_url|qs_page:conversations.page_obj.number %}
                     {% if other_user.uuid == conv.other_user_uuid %}
-                        {% list_item conv.other_user_full_name|truncatechars:25 conv.content|truncatechars:25 conv_thread_url active=True %}
+                        {% list_item conv.other_user_full_name|truncatechars:25 conv.content|truncatechars:25 conv_thread_url active=True strong=True %}
                     {% else %}
-                        {% list_item conv.other_user_full_name|truncatechars:25 conv.content|truncatechars:25 conv_thread_url %}
+                        {% list_item conv.other_user_full_name|truncatechars:25 conv.content|truncatechars:25 conv_thread_url strong=True %}
                     {% endif %}
                 {% endwith %}
             {% endfor %}

--- a/src/open_inwoner/accounts/templates/accounts/invite_accept.html
+++ b/src/open_inwoner/accounts/templates/accounts/invite_accept.html
@@ -6,7 +6,7 @@
 <h1 class="utrecht-heading-1">
     {% trans "Accept an invitation" %}
 </h1>
-<p class="p">
+<p class="utrecht-paragraph">
     {% blocktranslate with inviter_name=object.inviter.get_full_name %}Accept invitation from {{ inviter_name }} and join Open Inwoner Platform {% endblocktranslate %}
 </p>
 

--- a/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
+++ b/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
@@ -7,7 +7,7 @@
         {% render_column start=5 span=5 %}
             {% get_solo 'configurations.SiteConfiguration' as config %}
             <h1 class="utrecht-heading-1">{% trans "Registratie voltooien" %}</h1><br>
-            {% if config.registration_text %}<p class="p">{{ config.registration_text|urlize|linebreaksbr }}</p>{% endif %}
+            {% if config.registration_text %}<p class="utrecht-paragraph">{{ config.registration_text|urlize|linebreaksbr }}</p>{% endif %}
             <form method="POST" id="necessary-form" action="{{ request.get_full_path }}" class="form" novalidate>
                 {% csrf_token %}
 

--- a/src/open_inwoner/accounts/templates/django_registration/registration_complete.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_complete.html
@@ -3,5 +3,5 @@
 
 {% block content %}
 <h1 class="utrecht-heading-1">{% trans "Succes" %}</h1>
-<p class="p">{% trans "U bent nu geregistreerd" %}</p>
+<p class="utrecht-paragraph">{% trans "U bent nu geregistreerd" %}</p>
 {% endblock content %}

--- a/src/open_inwoner/accounts/templates/registration/add_phone_number_1.html
+++ b/src/open_inwoner/accounts/templates/registration/add_phone_number_1.html
@@ -4,7 +4,7 @@
 {% block content %}
     {{ block.super }}
 
-    <p class="p">
+    <p class="utrecht-paragraph">
         {% blocktrans trimmed %}
             Het nummer van uw mobiele telefoon is nog niet bij de Open Inwoner Platform bekend
             en is nodig voor toegang tot deze website.

--- a/src/open_inwoner/accounts/templates/registration/add_phone_number_2.html
+++ b/src/open_inwoner/accounts/templates/registration/add_phone_number_2.html
@@ -4,7 +4,7 @@
 {% block content %}
     {{ block.super }}
 
-    <p class="p">
+    <p class="utrecht-paragraph">
         {% trans 'U ontvangt een SMS bericht op uw mobiele telefoon nummer met daarin een code. ' %}
         {% trans 'Vul hieronder de code in. Geen bericht ontvangen? ' %}
         {% trans 'Kies <em>Vorige</em> om uw telefoon nummer te controleren en eventueel aan te passen.' %}

--- a/src/open_inwoner/accounts/templates/registration/verify_token.html
+++ b/src/open_inwoner/accounts/templates/registration/verify_token.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <h2 class="utrecht-heading-2">{% trans 'Account verificatie' %}</h2>
-    <p class="p">
+    <p class="utrecht-paragraph">
         {% blocktrans trimmed %}
             U ontvangt binnen 1 minuut een sms-bericht op uw mobiele telefoon.
             Vul de code die in het bericht staat hieronder in en klik op

--- a/src/open_inwoner/cms/banner/tests/test_plugin_banner.py
+++ b/src/open_inwoner/cms/banner/tests/test_plugin_banner.py
@@ -49,4 +49,4 @@ class TestBannerText(TestCase):
         )
 
         self.assertIn(f'<h1 class="utrecht-heading-1">{title} </h1>', html)
-        self.assertIn(f'<p class="p">{description}</p>', html)
+        self.assertIn(f'<p class="utrecht-paragraph">{description}</p>', html)

--- a/src/open_inwoner/components/templates/components/Action/Actions.html
+++ b/src/open_inwoner/components/templates/components/Action/Actions.html
@@ -7,7 +7,7 @@
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
         <div class="actions__filter-container filter__container">
-            <p class="p">{% trans "Filter op:" %}</p>
+            <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
             {% date_field action_form.end_date no_label=True no_help=True icon="today" %}
             {% input action_form.is_for no_label=True no_help=True icon="person" %}
             {% input action_form.status no_label=True no_help=True icon="expand_more" %}
@@ -89,7 +89,7 @@
                 </div>
             </div>
         {% empty %}
-            <div class="table__item" colspan="4"><p class="p">{% trans "er zijn geen acties gevonden met de huidige filters of er zijn geen acties" %}</p></div>
+            <div class="table__item" colspan="4"><p class="utrecht-paragraph">{% trans "er zijn geen acties gevonden met de huidige filters of er zijn geen acties" %}</p></div>
         {% endfor %}
     </div>
 </div>

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -8,7 +8,7 @@
                 <span class="link link__text">{{ title }}</span>
             </h2>
         {% endif %}
-        <p class="p">{{ description }}</p>
+        <p class="utrecht-paragraph">{{ description }}</p>
         {% if object.end_date %}
             <div class="card__tabled">
                 <div>{% trans "Einddatum" %}:</div>

--- a/src/open_inwoner/components/templates/components/Card/LocationCard.html
+++ b/src/open_inwoner/components/templates/components/Card/LocationCard.html
@@ -4,9 +4,9 @@
     {% if location_name %}
         <h3 class="utrecht-heading-3 card__heading-3">{% link href=location.get_absolute_url primary=True text=location_name %}</h3>
     {% endif %}
-        <div class="card__body--flex p--no-margin">
-            <p class="p">{{ address_line_1 }}</p>
-            <p class="p">{{ address_line_2 }}</p>
+        <div class="card__body--flex container--no-margin">
+            <p class="utrecht-paragraph">{{ address_line_1 }}</p>
+            <p class="utrecht-paragraph">{{ address_line_2 }}</p>
             {% if phonenumber %}
                 {% link href='tel:'|addstr:phonenumber secondary=True text=phonenumber %}
             {% endif %}

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -15,7 +15,7 @@
             <div class="card__content">
             <h2 class="card__heading-2"><span class="link link__text">{{ title }}</span></h2>
     {% endif %}
-            <p class="p">{{ description }}</p>
+            <p class="utrecht-paragraph">{{ description }}</p>
             {% if object.end_date %}
             <div class="card__tabled">
                 <div>{% trans "Einddatum" %}:</div>

--- a/src/open_inwoner/components/templates/components/Contact/ContactForm.html
+++ b/src/open_inwoner/components/templates/components/Contact/ContactForm.html
@@ -28,7 +28,7 @@
             {% endrender_form %}
 
         {% else %}
-            <p class="p">{% trans "Contact formulier niet geconfigureerd." %}</p>
+            <p class="utrecht-paragraph">{% trans "Contact formulier niet geconfigureerd." %}</p>
         {% endif %}
         </div>
     {% endrender_column %}

--- a/src/open_inwoner/components/templates/components/Dashboard/Dashboard.html
+++ b/src/open_inwoner/components/templates/components/Dashboard/Dashboard.html
@@ -4,7 +4,7 @@
     <ul class="dashboard__list">
         {% for metric in metrics %}
             <li class="dashboard__list-item">
-                <p class="p p--compact"><span class="dashboard__item-label">{{ metric.label }}</span> {{ metric.value|default:'-' }}</p>
+                <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact"><span class="dashboard__item-label">{{ metric.label }}</span> {{ metric.value|default:'-' }}</p>
             </li>
         {% endfor %}
     </ul>

--- a/src/open_inwoner/components/templates/components/Faq/Faq.html
+++ b/src/open_inwoner/components/templates/components/Faq/Faq.html
@@ -14,7 +14,7 @@
                     {% firstof 'question-'|add:id|add:'-answer' as answer_id %}
                     {% link bold=True href='#'|add:answer_id icon='keyboard_arrow_down' secondary=True text=question.question toggle="open"  %}
                 </h3>
-                <div id="{{ answer_id }}" class="p faq__answer">{{ question.answer|ckeditor_content|safe }}</div>
+                <div id="{{ answer_id }}" class="faq__answer">{{ question.answer|ckeditor_content|safe }}</div>
             </li>
         {% endfor %}
     </ul>

--- a/src/open_inwoner/components/templates/components/File/File.html
+++ b/src/open_inwoner/components/templates/components/File/File.html
@@ -3,15 +3,15 @@
 <aside class="file">
     <div class="file__container {% if recently_added %}file__container--recent{% endif %}">
         <div class="file__file">
-            <p class="file__symbol">
+            <div class="file__symbol">
                 {% if is_image %}
                     {% icon icon="image" outlined=True %}
                 {% else %}
                     {% icon icon="insert_drive_file" outlined=True %}
                 {% endif %}
-            </p>
+            </div>
 
-            <p class="file__data">
+            <div class="file__data">
                 {% if recently_added %}
                     <span class="file__file--recent">{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% trans "Nieuw" %}</span>
                 {% endif %}
@@ -26,7 +26,7 @@
                     {% endif %}
                 </span>
                 <span class="file__date">{{ created|date:'j F Y' }}</span>
-            </p>
+            </div>
             {% if allow_delete %}
                 {% dropdown icon="more_horiz" %}
                     <div class="dropdown__item">
@@ -52,7 +52,7 @@
                 {% trans "Download" as download %}
                 {% link href=url text=download primary=True download=True hide_text=True extra_classes="file__download" icon="download" icon_outlined=True icon_position="before" %}
             {% endif %}
-            {% if description %}<p class="p p--small">{{ description }}</p>{% endif %}
+            {% if description %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small">{{ description }}</p>{% endif %}
         </div>
     </div>
 </aside>

--- a/src/open_inwoner/components/templates/components/File/File.html
+++ b/src/open_inwoner/components/templates/components/File/File.html
@@ -52,7 +52,7 @@
                 {% trans "Download" as download %}
                 {% link href=url text=download primary=True download=True hide_text=True extra_classes="file__download" icon="download" icon_outlined=True icon_position="before" %}
             {% endif %}
-            {% if description %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small">{{ description }}</p>{% endif %}
+            {% if description %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--small">{{ description }}</p>{% endif %}
         </div>
     </div>
 </aside>

--- a/src/open_inwoner/components/templates/components/File/FileList.html
+++ b/src/open_inwoner/components/templates/components/File/FileList.html
@@ -15,7 +15,7 @@
                 {% file file=file.file created=created name=file.name uuid=file.uuid allow_delete=allow_delete download_url=download_url show_download=show_download %}
             </li>
         {% empty %}
-            <li><p class="p">{% trans "Er zijn nog geen bestanden geüpload" %}</p></li>
+            <li><p class="utrecht-paragraph">{% trans "Er zijn nog geen bestanden geüpload" %}</p></li>
         {% endfor %}
     </ul>
 </div>

--- a/src/open_inwoner/components/templates/components/Form/Autocomplete.html
+++ b/src/open_inwoner/components/templates/components/Form/Autocomplete.html
@@ -10,7 +10,7 @@
         <input id="{{ field.auto_id }}-autocomplete" name="{{ field.name }}-autocomplete" class="input" type="search" spellcheck=false autocomplete="off" autocapitalize="off" {% include "django/forms/widgets/attrs.html" with widget=field.field.widget %}>
 
         {% if field.help_text %}
-            <p class="p">{{ field.help_text }}</p>
+            <p class="utrecht-paragraph">{{ field.help_text }}</p>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/DateField.html
+++ b/src/open_inwoner/components/templates/components/Form/DateField.html
@@ -6,7 +6,7 @@
         {% if not no_label %}{{ field.label }}{% endif %}
         {{ field|addclass:"input datefield" }}
         {% if field.help_text and not no_help %}
-            <p class="p">{{ field.help_text }}</p>
+            <p class="utrecht-paragraph">{{ field.help_text }}</p>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Error.html
+++ b/src/open_inwoner/components/templates/components/Form/Error.html
@@ -5,7 +5,7 @@
         <div class="notification notification--warning">
             {% icon icon="warning_amber" icon_position="before" outlined=True %}
             <div class="notification__content">
-                <p class="p p--compact">{{ message.message }}</p>
+                <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ message.message }}</p>
             </div>
         </div>
     </div>

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -13,7 +13,7 @@
         </label>
     {% endrender_card %}
 
-    {% if field.help_text %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small utrecht-paragraph--oip-centered">{{ field.help_text }}</p>{% endif %}
+    {% if field.help_text %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--small utrecht-paragraph--oip-centered">{{ field.help_text }}</p>{% endif %}
     {% if field.errors %}{% errors errors=field.errors %}{% endif %}
 
     <div class="file-list" aria-live="polite">

--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -13,7 +13,7 @@
         </label>
     {% endrender_card %}
 
-    {% if field.help_text %}<p class="p p--small p--centered">{{ field.help_text }}</p>{% endif %}
+    {% if field.help_text %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small utrecht-paragraph--oip-centered">{{ field.help_text }}</p>{% endif %}
     {% if field.errors %}{% errors errors=field.errors %}{% endif %}
 
     <div class="file-list" aria-live="polite">

--- a/src/open_inwoner/components/templates/components/Form/ImageCrop.html
+++ b/src/open_inwoner/components/templates/components/Form/ImageCrop.html
@@ -5,7 +5,7 @@
         {{ field.label }}
         {{ field|addclass:"image-ratio" }}
         {% if field.help_text and not no_help %}
-            <p class="p">{{ field.help_text }}</p>
+            <p class="utrecht-paragraph">{{ field.help_text }}</p>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Input.html
+++ b/src/open_inwoner/components/templates/components/Form/Input.html
@@ -9,7 +9,7 @@
         </span>
         {% field_as_widget field "input" form_id %}
         {% if field.help_text and not no_help %}
-            <p class="p">{{ field.help_text }}</p>
+            <p class="utrecht-paragraph">{{ field.help_text }}</p>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/MultipleCheckbox.html
+++ b/src/open_inwoner/components/templates/components/Form/MultipleCheckbox.html
@@ -8,7 +8,7 @@
     </div>
 
     {% if field.help_text %}
-        <p class="p">{{ field.help_text }}</p>
+        <p class="utrecht-paragraph">{{ field.help_text }}</p>
     {% endif %}
 
     {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/MultipleRadio.html
+++ b/src/open_inwoner/components/templates/components/Form/MultipleRadio.html
@@ -15,7 +15,7 @@
     </fieldset>
 
     {% if field.help_text %}
-        <p class="p">{{ field.help_text }}</p>
+        <p class="utrecht-paragraph">{{ field.help_text }}</p>
     {% endif %}
 
     {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Textarea.html
+++ b/src/open_inwoner/components/templates/components/Form/Textarea.html
@@ -5,7 +5,7 @@
         {% firstof field.label label %}
         {{ field|addclass:"textarea" }}
         {% if field.help_text %}
-            <p class="p">{{ field.help_text }}</p>
+            <p class="utrecht-paragraph">{{ field.help_text }}</p>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -85,7 +85,7 @@
                     <div class="header__text-actions">
 
                         {% if request.user.is_authenticated %}
-                            <p class="p">
+                            <p class="utrecht-paragraph">
                                 {% icon icon="person" icon_position="before" outlined=True %}{% trans "Ingelogd als" %} {{ request.user.get_short_name }}
                             </p>
                             <ul class="header__list">

--- a/src/open_inwoner/components/templates/components/List/ListItem.html
+++ b/src/open_inwoner/components/templates/components/List/ListItem.html
@@ -1,12 +1,12 @@
 {% load link_tags %}
 <li class="list-item{% if active %} list-item--active{% endif %}{% if compact %} list-item--compact{% endif %}{% if extra_compact %} list-item--extra-compact{% endif %}">
     {% if href %}<a class="link" href="{{ href }}">{% endif %}
-    {% if caption %}<p class="p list-item__caption">{{ caption }}</p>{% endif %}
+    {% if caption %}<p class="utrecht-paragraph list-item__caption">{{ caption }}</p>{% endif %}
     {% if strong %}
         <h4 class="utrecht-heading-4">{{ text }}</h4>
     {% else %}
-        <p class="p">{{ text }}</p>
+        <p class="utrecht-paragraph">{{ text }}</p>
     {% endif %}
-    {% if description %}<p class="p p--muted">{{ description }}</p>{% endif %}
+    {% if description %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted">{{ description }}</p>{% endif %}
     {% if href %}</a>{% endif %}
 </li>

--- a/src/open_inwoner/components/templates/components/List/ListItem.html
+++ b/src/open_inwoner/components/templates/components/List/ListItem.html
@@ -3,7 +3,7 @@
     {% if href %}<a class="link" href="{{ href }}">{% endif %}
     {% if caption %}<p class="utrecht-paragraph list-item__caption">{{ caption }}</p>{% endif %}
     {% if strong %}
-        <h4 class="utrecht-heading-4">{{ text }}</h4>
+        <p class="utrecht-heading-4">{{ text }}</p>
     {% else %}
         <p class="utrecht-paragraph">{{ text }}</p>
     {% endif %}

--- a/src/open_inwoner/components/templates/components/Messages/Message.html
+++ b/src/open_inwoner/components/templates/components/Messages/Message.html
@@ -7,11 +7,11 @@
             {% url "inbox:download" uuid=message.uuid as download_url %}
             {% link href=download_url text=message.file secondary=True download=True %}
         {% else %}
-            <p class="p">{{ message.content|linebreaksbr }}</p>
+            <p class="utrecht-paragraph">{{ message.content|linebreaksbr }}</p>
         {% endif %}
     </div>
 
     <footer class="message__footer">
-        <p class="p p--muted p--small" title="{{ message.created_on }}">{{ message.created_on|time }}</p>
+        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted utrecht-paragraph--oip-small" title="{{ message.created_on }}">{{ message.created_on|time }}</p>
     </footer>
 </aside>

--- a/src/open_inwoner/components/templates/components/Messages/Message.html
+++ b/src/open_inwoner/components/templates/components/Messages/Message.html
@@ -12,6 +12,6 @@
     </div>
 
     <footer class="message__footer">
-        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted utrecht-paragraph--oip-small" title="{{ message.created_on }}">{{ message.created_on|time }}</p>
+        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted utrecht-paragraph--small" title="{{ message.created_on }}">{{ message.created_on|time }}</p>
     </footer>
 </aside>

--- a/src/open_inwoner/components/templates/components/Messages/Messages.html
+++ b/src/open_inwoner/components/templates/components/Messages/Messages.html
@@ -2,8 +2,8 @@
 
 <section class="messages">
     <header class="messages__header">
-        <h4 class="utrecht-heading-4">{{ subject }}</h4>
-        <p class="p p--muted">{{ status }}</p>
+        <h3 class="utrecht-heading-4">{{ subject }}</h3>
+        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted">{{ status }}</p>
     </header>
 
 
@@ -17,7 +17,7 @@
             {% for day in days %}
                 <li class="messages__day">
                     <header class="messages__day-header">
-                        <h4 class="p p--muted">{{ day.text }}</h4>
+                        <p class="utrecht-paragraph utrecht-paragraph--oip-paragraph-muted">{{ day.text }}</p>
                     </header>
 
                     <ol class="messages__list">
@@ -68,7 +68,7 @@
                 {% form_actions primary_text=_("Verzenden") primary_icon='arrow_forward' %}
             {% endrender_form %}
         {% else %}
-            <p class="p p--muted">{% trans "De gebruiker is inactief. Het is niet mogelijk een bericht te sturen." %}</p>
+            <p class="utrecht-paragraph utrecht-paragraph--oip-paragraph-muted">{% trans "De gebruiker is inactief. Het is niet mogelijk een bericht te sturen." %}</p>
         {% endif %}
     </div>
 </section>

--- a/src/open_inwoner/components/templates/components/Messages/Messages.html
+++ b/src/open_inwoner/components/templates/components/Messages/Messages.html
@@ -2,7 +2,7 @@
 
 <section class="messages">
     <header class="messages__header">
-        <h3 class="utrecht-heading-4">{{ subject }}</h3>
+        <h2 class="utrecht-heading-4">{{ subject }}</h2>
         <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted">{{ status }}</p>
     </header>
 
@@ -17,7 +17,7 @@
             {% for day in days %}
                 <li class="messages__day">
                     <header class="messages__day-header">
-                        <p class="utrecht-paragraph utrecht-paragraph--oip-paragraph-muted">{{ day.text }}</p>
+                        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-paragraph-muted">{{ day.text }}</p>
                     </header>
 
                     <ol class="messages__list">
@@ -68,7 +68,7 @@
                 {% form_actions primary_text=_("Verzenden") primary_icon='arrow_forward' %}
             {% endrender_form %}
         {% else %}
-            <p class="utrecht-paragraph utrecht-paragraph--oip-paragraph-muted">{% trans "De gebruiker is inactief. Het is niet mogelijk een bericht te sturen." %}</p>
+            <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-paragraph-muted">{% trans "De gebruiker is inactief. Het is niet mogelijk een bericht te sturen." %}</p>
         {% endif %}
     </div>
 </section>

--- a/src/open_inwoner/components/templates/components/Notification/Notification.html
+++ b/src/open_inwoner/components/templates/components/Notification/Notification.html
@@ -8,7 +8,7 @@
 
     <div class="notification__content">
         {% if title %}<h2 class="utrecht-heading-2">{{ title }}</h2>{% endif %}
-        {% if notification %}<p class="p">{{ notification }}</p>{% endif %}
+        {% if notification %}<p class="utrecht-paragraph">{{ notification }}</p>{% endif %}
         {% if action %}{% button href=action text=action_text %}{% endif %}
         {% if contents %}
             {{ contents }}
@@ -16,7 +16,7 @@
             {% if as_markdown %}
                 {{ message|markdown|safe }}
             {% else %}
-                <p class="p p--compact">{{ message }}</p>
+                <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ message }}</p>
             {% endif %}
         {% endif %}
     </div>

--- a/src/open_inwoner/components/templates/components/Product/finder.html
+++ b/src/open_inwoner/components/templates/components/Product/finder.html
@@ -2,13 +2,13 @@
 
 {% render_column span=6 compact=True extra_classes="product-finder" %}
     <h2 class="utrecht-heading-2">{{configurable_text.home_page.home_product_finder_title}}</h2>
-    <p class="p">{{configurable_text.home_page.home_product_finder_intro|linebreaksbr}}</p>
+    <p class="utrecht-paragraph">{{configurable_text.home_page.home_product_finder_intro|linebreaksbr}}</p>
 
     <div class="product-finder__form">
         {% if not conditions_done %}
             <h3 class="utrecht-heading-3">{{ condition.question }}</h3>
             {% if condition.rule %}
-            <p class="p p--compact">{{ condition.rule }}</p>
+            <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ condition.rule }}</p>
             {% endif %}
 
             {% if show_previous %}
@@ -17,7 +17,7 @@
                 {% form id="product-finder" spaceless=True form_object=form method="POST" submit_text=primary_text %}
             {% endif %}
         {% else %}
-            <p class="p p--compact">
+            <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact">
                 {% trans "Er zijn geen extra vragen meer. Bekijk de producten hiernaast." %}
             </p>
             {% render_form id="product-finder" method="POST" form=form %}

--- a/src/open_inwoner/components/templatetags/string_tags.py
+++ b/src/open_inwoner/components/templatetags/string_tags.py
@@ -25,7 +25,7 @@ def optional_paragraph(optional_text: str) -> str:
     if not optional_text:
         return ""
     return format_html(
-        '<p class="p">{optional_text}</p>'.format(
+        '<p class="utrecht-paragraph">{optional_text}</p>'.format(
             optional_text=linebreaksbr(optional_text)
         )
     )

--- a/src/open_inwoner/components/tests/test_list.py
+++ b/src/open_inwoner/components/tests/test_list.py
@@ -21,11 +21,11 @@ class TestListItem(InclusionTagWebTest):
         self.assertRender({"text": "Lorem ipsum"})
 
     def test_text(self):
-        self.assertTextContent("h4", "Lorem ipsum", {"text": "Lorem ipsum"})
+        self.assertTextContent("p", "Lorem ipsum", {"text": "Lorem ipsum"})
 
     def test_description(self):
         self.assertTextContent(
-            "p", "Dolor sit", {"text": "Lorem ipsum", "description": "Dolor sit"}
+            "p", "Lorem ipsum", {"text": "Lorem ipsum", "description": "Dolor sit"}
         )
 
     def test_href(self):

--- a/src/open_inwoner/components/tests/test_messages.py
+++ b/src/open_inwoner/components/tests/test_messages.py
@@ -143,4 +143,6 @@ class TestListItem(InclusionTagWebTest):
         Tests that:
             - Header renders the correct status.
         """
-        self.assertTextContent(".messages__header .p", "Dolor sit amet.", self.config)
+        self.assertTextContent(
+            ".messages__header .utrecht-paragraph", "Dolor sit amet.", self.config
+        )

--- a/src/open_inwoner/js/components/form/FileInput.js
+++ b/src/open_inwoner/js/components/form/FileInput.js
@@ -293,14 +293,14 @@ export class FileInput extends Component {
       <aside class="file">
         <div class="file__container">
           <div class="file__file ${typeError || sizeError ? 'error' : ''}">
-            <p class="file__symbol">
+            <div class="file__symbol">
               <span aria-hidden="true" class="material-icons-outlined">${
                 type.match('image') ? 'image' : 'description'
               }</span>
-            </p>
-            <p class="file__data">
+            </div>
+            <div class="file__data">
               <span class="file__name">${name} (${ext}, ${sizeMB}MB)</span>
-            </p>
+            </div>
             <a class="link link--primary file__download" href="#document-upload" role="button" aria-label="${labelDelete}">
               <span aria-hidden="true" class="material-icons-outlined">delete</span>
             </a>
@@ -308,13 +308,13 @@ export class FileInput extends Component {
           ${
             typeError && sizeError
               ? `
-              <p class="p p--small error">
+              <p class="utrecht-paragraph utrecht-paragraph--oip-small error">
                 <span aria-hidden="true" class="material-icons-outlined">warning_amber</span>
                 <span class="file-error__content">Dit type bestand (${ext}) is ongeldig en te groot. Geldige bestandstypen zijn: ${uploadFileTypes}</span>
               </p>`
               : typeError || sizeError
               ? `
-              <p class="p p--small error">
+              <p class="utrecht-paragraph utrecht-paragraph--oip-small error">
                 <span aria-hidden="true" class="material-icons-outlined">warning_amber</span>
                 ${
                   typeError

--- a/src/open_inwoner/js/components/form/FileInput.js
+++ b/src/open_inwoner/js/components/form/FileInput.js
@@ -308,13 +308,13 @@ export class FileInput extends Component {
           ${
             typeError && sizeError
               ? `
-              <p class="utrecht-paragraph utrecht-paragraph--oip-small error">
+              <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small error">
                 <span aria-hidden="true" class="material-icons-outlined">warning_amber</span>
                 <span class="file-error__content">Dit type bestand (${ext}) is ongeldig en te groot. Geldige bestandstypen zijn: ${uploadFileTypes}</span>
               </p>`
               : typeError || sizeError
               ? `
-              <p class="utrecht-paragraph utrecht-paragraph--oip-small error">
+              <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small error">
                 <span aria-hidden="true" class="material-icons-outlined">warning_amber</span>
                 ${
                   typeError

--- a/src/open_inwoner/js/components/map/index.js
+++ b/src/open_inwoner/js/components/map/index.js
@@ -121,9 +121,9 @@ class Map {
           ${title}
         </h4>
       </div>
-      <div class="leaflet-content-details p--no-margin">
-        <p class="p">${displayAddress1}</p>
-        <p class="p">${displayAddress2}</p>
+      <div class="leaflet-content-details container--no-margin">
+        <p class="utrecht-paragraph">${displayAddress1}</p>
+        <p class="utrecht-paragraph">${displayAddress2}</p>
         <a href="tel:${displayPhonenumber}" class="link link--secondary" aria-label=${displayPhonenumber} title=${displayPhonenumber}>
           <span class="link__text">${displayPhonenumber}</span>
         </a>

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -212,14 +212,22 @@
   }
 }
 
-.h2 + .button,
-.h4 + .button,
-.p + .button,
 .utrecht-heading-2 + .button,
-.utrecht-heading-4 + .button {
+.utrecht-heading-4 + .button,
+.utrecht-paragraph + .button {
   margin-top: var(--spacing-large);
 }
 
 .cta-button {
   margin-bottom: var(--spacing-large);
+}
+
+///
+/// Legacy styling
+///
+
+.h2 + .button,
+.h4 + .button,
+.p + .button {
+  margin-top: var(--spacing-large);
 }

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -271,7 +271,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
 
-    .p {
+    .utrecht-paragraph {
       margin-top: 4px;
     }
 
@@ -335,7 +335,7 @@
       width: 100%;
     }
 
-    .p {
+    .utrecht-paragraph {
       width: 100%;
     }
   }

--- a/src/open_inwoner/scss/components/Card/LocationCardList.scss
+++ b/src/open_inwoner/scss/components/Card/LocationCardList.scss
@@ -1,9 +1,4 @@
 .location-card-list {
-  .h4,
-  .utrecht-heading-4 {
-    margin-bottom: var(--spacing-large);
-  }
-
   &__list {
     grid-template-columns: repeat(2, 1fr);
     display: grid;
@@ -19,5 +14,13 @@
 
   .card {
     height: 100%;
+  }
+
+  ///
+  /// Legacy styling
+  ///
+
+  .h4 {
+    margin-bottom: var(--spacing-large);
   }
 }

--- a/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
+++ b/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
@@ -41,8 +41,8 @@
 
 .card-container + .card-container,
 .map + .card-container,
-.p + .card-container,
-.card-container + h2 {
+.card-container + .utrecht-heading-2,
+.utrecht-paragraph + .card-container {
   margin-top: var(--gutter-width);
 }
 
@@ -63,4 +63,13 @@
       }
     }
   }
+}
+
+///
+/// Legacy styling
+///
+
+.p + .card-container,
+.card-container + .h2 {
+  margin-top: var(--gutter-width);
 }

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -10,8 +10,8 @@
     cursor: pointer;
   }
 
-  &__title_text {
-    padding-top: var(--spacing-medium);
-    padding-bottom: var(--spacing-extra-large);
+  > .utrecht-paragraph--oip-title-text {
+    padding-top: var(--spacing-large);
+    padding-bottom: var(--spacing-giant);
   }
 }

--- a/src/open_inwoner/scss/components/File/File.scss
+++ b/src/open_inwoner/scss/components/File/File.scss
@@ -49,7 +49,7 @@
   }
 
   &__file .link,
-  &__file .p {
+  &__file .utrecht-paragraph {
     padding: var(--spacing-large);
     box-sizing: border-box;
   }

--- a/src/open_inwoner/scss/components/File/FileList.scss
+++ b/src/open_inwoner/scss/components/File/FileList.scss
@@ -34,11 +34,20 @@
 /// Contextual
 ///
 
-.file-list + .p,
-.file-list + .utrecht-heading-2 {
+.file-list + .utrecht-heading-2,
+.file-list + .utrecht-paragraph {
   margin-top: var(--spacing-large);
 }
 
 .utrecht-heading-2 + .file-list {
   margin-top: var(--spacing-extra-large);
+}
+
+///
+/// Legacy styling
+///
+
+.file-list + .h2,
+.file-list + .p {
+  margin-top: var(--spacing-large);
 }

--- a/src/open_inwoner/scss/components/Form/FileInput.scss
+++ b/src/open_inwoner/scss/components/Form/FileInput.scss
@@ -73,7 +73,7 @@
     height: var(--row-height-giant);
   }
 
-  > .p {
+  > .utrecht-paragraph {
     margin: calc(0.5 * var(--gutter-width)) 0;
     display: block;
     text-align: center;
@@ -91,7 +91,7 @@
     .file__file.error {
       border-color: var(--color-red-notification);
 
-      .p {
+      .utrecht-paragraph {
         color: var(--color-gray-dark-900);
       }
 
@@ -116,7 +116,7 @@
       }
     }
 
-    .p--small {
+    .utrecht-paragraph--oip-small {
       margin-top: var(--spacing-small);
       margin-bottom: var(--spacing-small);
 

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -91,11 +91,11 @@
     transform: translateY(-5px);
   }
 
-  &__control > .label .p:last-child {
+  &__control > .label .utrecht-paragraph:last-child {
     font-size: var(--font-size-body-small);
   }
 
-  &__control > .label .p.p--compact {
+  &__control > .label .utrecht-paragraph.utrecht-paragraph--oip-compact {
     font-size: var(--font-size-body);
   }
 

--- a/src/open_inwoner/scss/components/Header/AnchorMenu.scss
+++ b/src/open_inwoner/scss/components/Header/AnchorMenu.scss
@@ -1,9 +1,3 @@
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6,
 .utrecht-heading-1,
 .utrecht-heading-2,
 .utrecht-heading-3,
@@ -156,5 +150,22 @@
       top: 0;
       right: var(--spacing-large);
     }
+  }
+}
+
+///
+/// Legacy scroll styling
+///
+
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  scroll-margin-top: 122px;
+
+  @media (min-width: 768px) {
+    scroll-margin-top: var(--spacing-medium);
   }
 }

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -345,8 +345,8 @@ $vm: var(--spacing-large);
     width: 100%;
 
     // Cut text and display dots if username is very long
-    > .p {
-      display: inline-block !important;
+    > .utrecht-paragraph {
+      display: flex !important;
       max-width: 250px;
       overflow: hidden;
       white-space: nowrap;
@@ -366,7 +366,7 @@ $vm: var(--spacing-large);
     @media (min-width: 768px) {
       justify-content: flex-end;
 
-      > .p {
+      > .utrecht-paragraph {
         display: flex;
         max-width: initial;
         overflow: initial;
@@ -491,7 +491,7 @@ $vm: var(--spacing-large);
             margin: var(--spacing-large) 0 0 0;
             width: calc(100% - (var(--spacing-extra-large)));
 
-            .p {
+            .utrecht-paragraph {
               display: flex;
               align-items: center;
               justify-content: space-between;

--- a/src/open_inwoner/scss/components/List/_ListItem.scss
+++ b/src/open_inwoner/scss/components/List/_ListItem.scss
@@ -46,11 +46,19 @@
     margin: 0;
   }
 
-  .p + .p {
+  .utrecht-paragraph + .utrecht-paragraph {
     margin-top: 0;
   }
 
   & + & {
     border-top: none;
+  }
+
+  ///
+  /// Legacy styling
+  ///
+
+  .p + .p {
+    margin-top: 0;
   }
 }

--- a/src/open_inwoner/scss/components/Map/_Map.scss
+++ b/src/open_inwoner/scss/components/Map/_Map.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.p + .map {
+.utrecht-paragraph + .map {
   margin-top: var(--spacing-large);
 }
 
@@ -28,4 +28,25 @@
   flex-direction: column;
   row-gap: var(--spacing-small);
   flex-wrap: wrap;
+
+  &.container--no-margin {
+    margin-top: var(--spacing-small);
+
+    & > .utrecht-paragraph {
+      margin: 0 !important;
+    }
+
+    /// leaflet reset
+    .link {
+      text-decoration: underline;
+    }
+  }
+}
+
+///
+/// Legacy styling
+///
+
+.p + .map {
+  margin-top: var(--spacing-large);
 }

--- a/src/open_inwoner/scss/components/Messages/_Messages.scss
+++ b/src/open_inwoner/scss/components/Messages/_Messages.scss
@@ -17,7 +17,7 @@
     overflow-y: auto;
   }
 
-  &__header .p {
+  &__header .utrecht-paragraph {
     margin-top: 0 !important;
   }
 
@@ -33,7 +33,7 @@
     justify-content: center;
   }
 
-  &__day-header > .p:first-child {
+  &__day-header > .utrecht-paragraph:first-child {
     display: flex;
     align-items: center;
     width: 100%;
@@ -42,19 +42,19 @@
     white-space: nowrap;
   }
 
-  &__day-header > .p:first-child:before,
-  &__day-header > .p:first-child:after {
+  &__day-header > .utrecht-paragraph:first-child:before,
+  &__day-header > .utrecht-paragraph:first-child:after {
     border-top: 1px solid var(--color-gray-lightest);
     content: '';
     margin: var(--spacing-large);
     width: 100%;
   }
 
-  &__day-header > .p:first-child:before {
+  &__day-header > .utrecht-paragraph:first-child:before {
     margin-left: 0;
   }
 
-  &__day-header > .p:first-child:after {
+  &__day-header > .utrecht-paragraph:first-child:after {
     margin-right: 0;
   }
 
@@ -85,7 +85,7 @@
     .message__body {
       border: 1px solid transparent;
 
-      .p::before {
+      .utrecht-paragraph::before {
         background-color: var(--color-primary);
         border-radius: var(--border-radius);
         bottom: 21px;

--- a/src/open_inwoner/scss/components/Notification/_Notification.scss
+++ b/src/open_inwoner/scss/components/Notification/_Notification.scss
@@ -19,7 +19,7 @@
 
   [class*='icon'],
   [class*='Icon'] {
-    line-height: 1.3;
+    line-height: var(--spacing-giant);
   }
 
   /// Individual errors.
@@ -67,7 +67,7 @@
     color: var(--notification-color-text);
   }
 
-  &:not(#{&}--contents) .p {
+  &:not(#{&}--contents) .utrecht-paragraph {
     color: var(--notification-color-text);
   }
 
@@ -99,7 +99,7 @@
   }
 
   & &__content {
-    margin-top: 0.15em;
+    margin-top: var(--spacing-tiny);
 
     & * {
       margin: 0;

--- a/src/open_inwoner/scss/components/Product/product-detail.scss
+++ b/src/open_inwoner/scss/components/Product/product-detail.scss
@@ -42,6 +42,12 @@
   }
 }
 
+.utrecht-paragraph--oip-summary {
+  margin-bottom: var(--gutter-width);
+}
+
+/// Legacy style
+
 p.p-summary {
   margin-bottom: var(--gutter-width);
 }

--- a/src/open_inwoner/scss/components/Product/product-detail.scss
+++ b/src/open_inwoner/scss/components/Product/product-detail.scss
@@ -43,7 +43,7 @@
 }
 
 .utrecht-paragraph--oip-summary {
-  margin-bottom: var(--gutter-width);
+  margin-bottom: var(--gutter-width) !important;
 }
 
 /// Legacy style

--- a/src/open_inwoner/scss/components/Profile/_personal-overview.scss
+++ b/src/open_inwoner/scss/components/Profile/_personal-overview.scss
@@ -63,6 +63,12 @@
   }
 
   &.profile-section__newsletters {
+    .form {
+      gap: var(--spacing-large);
+    }
+    .checkbox__p.newsletter-remarks {
+      line-height: var(--font-line-height-body);
+    }
     .button {
       padding: var(--spacing-medium) var(--spacing-giant);
     }

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -1,10 +1,20 @@
 .questionnaire {
   &__fieldset {
     border: 0 solid transparent;
+
     legend {
       padding: 0;
     }
+
+    *[class^='utrecht-heading'] + .utrecht-paragraph--oip-compact {
+      margin-top: 0;
+    }
+
+    .utrecht-paragraph + .form {
+      margin-top: 0;
+    }
   }
+
   &__list {
     list-style: none;
     margin: 0;

--- a/src/open_inwoner/scss/components/Status/_StatusList.scss
+++ b/src/open_inwoner/scss/components/Status/_StatusList.scss
@@ -54,18 +54,18 @@
       color: var(--color-gray-dark-900);
     }
 
-    .p-date {
+    .status-list__date {
       font-size: var(--font-size-body-small);
     }
 
-    .p-text {
+    .status-list__text {
       display: flex;
       flex-direction: column;
     }
 
-    .p__upload {
+    .status-list__upload {
       display: none;
-      &.p__upload--enabled {
+      &.status-list__upload--enabled {
         //hide when final status is reached
         display: block;
       }

--- a/src/open_inwoner/scss/components/Typography/H1.scss
+++ b/src/open_inwoner/scss/components/Typography/H1.scss
@@ -17,6 +17,14 @@
   }
 }
 
+.utrecht-heading-1 + .card-container {
+  margin-top: var(--gutter-width);
+}
+
+///
+/// Legacy styling
+///
+
 .h1 {
   color: var(--utrecht-heading-1-color);
   font-family: var(--utrecht-heading-1-font-family);
@@ -37,8 +45,4 @@
   &:first-of-type {
     margin: 0;
   }
-}
-
-.utrecht-heading-1 + .card-container {
-  margin-top: var(--gutter-width);
 }

--- a/src/open_inwoner/scss/components/Typography/H2.scss
+++ b/src/open_inwoner/scss/components/Typography/H2.scss
@@ -27,6 +27,30 @@
   }
 }
 
+.heading-2__indicator {
+  display: flex;
+  flex-direction: row;
+}
+
+///
+/// Contextual.
+///
+
+.card + .utrecht-heading-2,
+.dashboard + .utrecht-heading-2,
+.status-list + .utrecht-heading-2,
+.table + .utrecht-heading-2 {
+  margin-top: var(--row-height);
+}
+
+.utrecht-paragraph + .utrecht-heading-2 {
+  margin-top: var(--spacing-large);
+}
+
+///
+/// Legacy styling
+///
+
 .h2 {
   color: var(--utrecht-heading-2-color);
   font-family: var(--utrecht-heading-2-font-family);
@@ -55,24 +79,10 @@
   }
 }
 
-.heading-2__indicator {
-  display: flex;
-  flex-direction: row;
-}
-
-///
-/// Contextual.
-///
-
-.table + .h2,
-.card + .utrecht-heading-2,
-.dashboard + .utrecht-heading-2,
-.status-list + .utrecht-heading-2,
-.table + .utrecht-heading-2 {
+.table + .h2 {
   margin-top: var(--row-height);
 }
 
-.p + .h2,
-.p + .utrecht-heading-2 {
+.p + .h2 {
   margin-top: var(--spacing-large);
 }

--- a/src/open_inwoner/scss/components/Typography/H3.scss
+++ b/src/open_inwoner/scss/components/Typography/H3.scss
@@ -1,6 +1,14 @@
 @import '~@utrecht/components/dist/heading-3/css/index.css';
 @import '~microscope-sass/lib/responsive';
 
+.utrecht-paragraph + .utrecht-heading-3 {
+  margin-top: var(--spacing-large);
+}
+
+///
+/// Legacy styling
+///
+
 .h3 {
   color: var(--utrecht-heading-3-color);
   font-family: var(--utrecht-heading-3-font-family);
@@ -17,7 +25,6 @@
   }
 }
 
-.p + .utrecht-heading-3,
 .p + .h3 {
   margin-top: var(--spacing-large);
 }

--- a/src/open_inwoner/scss/components/Typography/H4.scss
+++ b/src/open_inwoner/scss/components/Typography/H4.scss
@@ -1,6 +1,10 @@
 @import '~@utrecht/components/dist/heading-4/css/index.css';
 @import '~microscope-sass/lib/responsive';
 
+///
+/// Legacy styling - other styling comes from NLDS
+///
+
 .h4 {
   color: var(--utrecht-heading-4-color);
   font-family: var(--utrecht-heading-4-font-family);

--- a/src/open_inwoner/scss/components/Typography/Link.scss
+++ b/src/open_inwoner/scss/components/Typography/Link.scss
@@ -43,7 +43,6 @@
     color: var(--color-secondary);
   }
 
-  .leaflet-container .h4 &--primary,
   .leaflet-container .utrecht-heading-4 &--primary {
     color: var(--color-black);
   }
@@ -93,5 +92,13 @@
   *[class*='icon']:first-child,
   *[class*='Icon']:first-child {
     transform: scale(1);
+  }
+
+  ///
+  /// Legacy styling
+  ///
+
+  .leaflet-container .h4 &--primary {
+    color: var(--color-black);
   }
 }

--- a/src/open_inwoner/scss/components/Typography/LinkList.scss
+++ b/src/open_inwoner/scss/components/Typography/LinkList.scss
@@ -1,5 +1,4 @@
 .link-list {
-  .h4,
   .utrecht-heading-4 {
     margin-bottom: var(--spacing-large);
   }
@@ -27,5 +26,13 @@
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  ///
+  /// Legacy styling
+  ///
+
+  .h4 {
+    margin-bottom: var(--spacing-large);
   }
 }

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -7,11 +7,7 @@
     // Takes style values from our own design-tokens NPM package
     margin: 0;
 
-    &-small {
-      font-size: var(--oip-utrecht-paragraph-small-font-size);
-      line-height: var(--oip-utrecht-paragraph-small-line-height);
-    }
-
+    // Extensions of the utrecht-paragraph component with OIP-specific styles.
     &-muted {
       color: var(--oip-utrecht-paragraph-muted-color);
     }
@@ -21,8 +17,8 @@
     }
 
     &-compact {
-      margin-top: 0 !important;
-      margin-bottom: 0 !important;
+      margin-top: var(--oip-utrecht-paragraph-compact-margin-top);
+      margin-bottom: var(--oip-utrecht-paragraph-compact-margin-bottom);
     }
 
     &:empty {
@@ -62,11 +58,14 @@
   .content {
     text-decoration: underline;
   }
+
   &:hover {
     text-decoration: none;
   }
+
   .material-icons {
     text-decoration: none;
+
     &:hover {
       text-decoration: none;
     }
@@ -120,11 +119,14 @@
   .content {
     text-decoration: underline;
   }
+
   &:hover {
     text-decoration: none;
   }
+
   .material-icons {
     text-decoration: none;
+
     &:hover {
       text-decoration: none;
     }

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -1,27 +1,33 @@
-.p {
-  color: var(--font-color-body);
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-body);
-  line-height: var(--font-line-height-body);
-  font-weight: normal;
-  margin: 0;
+@import '~@utrecht/components/dist/paragraph/css/index.css';
 
-  &#{&}--compact {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-  }
+.utrecht-paragraph {
+  // Takes style values from NLDS community
 
-  &--small {
-    font-size: var(--font-size-body-small);
-    line-height: var(--font-line-height-body-small);
-  }
+  &--oip {
+    // Takes style values from our own design-tokens NPM package
+    margin: 0;
 
-  &--muted {
-    color: var(--color-mute);
-  }
+    &-small {
+      font-size: var(--oip-utrecht-paragraph-small-font-size);
+      line-height: var(--oip-utrecht-paragraph-small-line-height);
+    }
 
-  &--centered {
-    text-align: center;
+    &-muted {
+      color: var(--oip-utrecht-paragraph-muted-color);
+    }
+
+    &-centered {
+      text-align: var(--oip-utrecht-paragraph-centered-text-align);
+    }
+
+    &-compact {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+
+    &:empty {
+      margin: 0 !important;
+    }
   }
 
   &:empty {
@@ -29,35 +35,30 @@
   }
 }
 
-*[class^='h'] + .p,
-*[class^='utrecht-heading'] + .p {
+*[class^='utrecht-heading'] + .utrecht-paragraph {
   margin-top: var(--spacing-small);
 }
 
-.p + .h1,
-.p + .h2,
-.p + .h3,
-.p + .utrecht-heading-1,
-.p + .utrecht-heading-2,
-.p + .utrecht-heading-3 {
+.utrecht-paragraph + .utrecht-heading-1,
+.utrecht-paragraph + .utrecht-heading-2,
+.utrecht-paragraph + .utrecht-heading-3 {
   margin-top: var(--gutter-width);
 }
 
-.p + .h4,
-.p + .utrecht-heading-4 {
+.utrecht-paragraph + .utrecht-heading-4 {
   margin-top: var(--row-height-small);
 }
 
-.p + .p {
+.utrecht-paragraph + .utrecht-paragraph {
   margin-top: var(--font-line-height-body);
 }
 
-.tag-list + .p {
+.tag-list + .utrecht-paragraph,
+.utrecht-paragraph + .form {
   margin-top: var(--spacing-extra-large);
 }
 
-.p .link {
-  //text-decoration: underline;
+.utrecht-paragraph .link {
   .content {
     text-decoration: underline;
   }
@@ -72,15 +73,60 @@
   }
 }
 
-.p--no-margin {
-  margin-top: var(--spacing-small);
+///
+/// Legacy styling
+///
 
-  & > .p {
+.p {
+  color: var(--utrecht-paragraph-color);
+  font-family: var(--utrecht-paragraph-font-family);
+  font-size: var(--utrecht-paragraph-font-size);
+  line-height: var(--utrecht-paragraph-line-height);
+  font-weight: normal;
+  margin: 0;
+
+  &:empty {
     margin: 0 !important;
   }
+}
 
-  /// leaflet reset
-  .link {
+*[class^='h1'] + .p,
+*[class^='h2'] + .p,
+*[class^='h3'] + .p,
+*[class^='h4'] + .p {
+  margin-top: var(--spacing-small);
+}
+
+.p + .h1,
+.p + .h2,
+.p + .h3 {
+  margin-top: var(--gutter-width);
+}
+
+.p + .h4 {
+  margin-top: var(--row-height-small);
+}
+
+.p + .p {
+  margin-top: var(--font-line-height-body);
+}
+
+.tag-list + .p,
+.p + .form {
+  margin-top: var(--spacing-extra-large);
+}
+
+.p .link {
+  .content {
     text-decoration: underline;
+  }
+  &:hover {
+    text-decoration: none;
+  }
+  .material-icons {
+    text-decoration: none;
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/src/open_inwoner/scss/components/Typography/wysiwyg.scss
+++ b/src/open_inwoner/scss/components/Typography/wysiwyg.scss
@@ -1,16 +1,15 @@
 .wysiwyg {
-  font-family: var(--font-family-body);
+  font-family: var(--utrecht-document-font-family);
 
   a {
     display: inline-flex;
     flex-direction: row;
     align-items: center;
-    font-size: var(--font-size-body);
-    line-height: var(--font-line-height-body);
+    font-size: var(--utrecht-document-font-size);
+    line-height: var(--utrecht-document-line-height);
     text-decoration: none;
     gap: var(--spacing-small);
     color: var(--color-secondary);
-
     word-wrap: break-word;
   }
 
@@ -20,11 +19,11 @@
   h4,
   h5,
   h6 {
-    font-family: var(--font-family-heading);
+    font-family: var(--utrecht-heading-font-family);
   }
 
   ul {
     margin: 0;
-    padding: 0 0 0 var(--font-size-body);
+    padding: 0 0 0 var(--utrecht-document-font-size);
   }
 }

--- a/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
+++ b/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
@@ -14,7 +14,7 @@
     background-color: var(--color-white);
     color: var(--color-red-notification);
     display: block;
-    line-height: var(--font-line-height-body);
+    line-height: var(--utrecht-document-line-height);
     position: relative;
 
     & * {
@@ -71,6 +71,7 @@
     }
   }
 
+  /// Cards in userfeed
   .card {
     justify-content: flex-start;
 
@@ -101,6 +102,7 @@
         font-family: var(--font-family-body);
         font-size: var(--font-size-body-small);
         font-weight: normal;
+        line-height: var(--utrecht-document-line-height);
         overflow-wrap: break-word;
         word-break: normal;
         padding: var(--font-size-body-small) var(--card-spacing) 0
@@ -113,7 +115,7 @@
       color: var(--utrecht-heading-color);
       font-family: var(--utrecht-heading-font-family);
       font-size: var(--font-size-body);
-      line-height: var(--font-line-height-body);
+      line-height: var(--utrecht-document-line-height);
       margin: 0;
       padding: var(--spacing-medium) var(--row-height-big) var(--card-spacing)
         var(--card-spacing);

--- a/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
+++ b/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
@@ -16,6 +16,10 @@
     display: block;
     line-height: var(--font-line-height-body);
     position: relative;
+
+    & * {
+      color: var(--color-red-notification);
+    }
   }
 
   &__list {
@@ -106,8 +110,8 @@
     }
 
     .userfeed-card__description {
-      color: var(--font-color-heading);
-      font-family: var(--font-family-heading);
+      color: var(--utrecht-heading-color);
+      font-family: var(--utrecht-heading-font-family);
       font-size: var(--font-size-body);
       line-height: var(--font-line-height-body);
       margin: 0;

--- a/src/open_inwoner/scss/overwrites/_ckeditor.scss
+++ b/src/open_inwoner/scss/overwrites/_ckeditor.scss
@@ -1,10 +1,26 @@
 .li .link,
-.p .link {
+.utrecht-paragraph .link {
   text-decoration: underline;
   display: inline;
 }
 
 // Style icons separately
+.utrecht-paragraph .link *[class*='icon'] {
+  text-decoration: none;
+  transform: scale(0.75);
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+///
+/// Legacy styling
+///
+
+.p .link {
+  text-decoration: underline;
+  display: inline;
+}
+
 .p .link *[class*='icon'] {
   text-decoration: none;
   transform: scale(0.75);

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -36,7 +36,7 @@
   --color-green: #d5e7d4;
   --color-green-dark: #248641;
   --color-red: #e50026;
-  --color-red-notification: #d94100;
+  --color-red-notification: var(--oip-color-red-notification);
   --color-white: #fff;
   --color-yellow: #f8d62d;
   --color-yellow-dark: #cca000;

--- a/src/open_inwoner/scss/views/_product_detail.scss
+++ b/src/open_inwoner/scss/views/_product_detail.scss
@@ -1,5 +1,4 @@
 .view--products-category_product_detail {
-  .h4,
   .utrecht-heading-4 {
     margin: 21px 0;
   }
@@ -9,5 +8,13 @@
     text-overflow: ellipsis;
     width: 99%;
     display: block;
+  }
+
+  ///
+  /// Legacy styling
+  ///
+
+  .h4 {
+    margin: 21px 0;
   }
 }

--- a/src/open_inwoner/templates/404.html
+++ b/src/open_inwoner/templates/404.html
@@ -3,5 +3,5 @@
 
 {% block content %}
 <h1 class="utrecht-heading-1">{% trans "Sorry, the requested page could not be found (404)" %}</h1>
-<p class="p">{% link href="/" text=_("Ga naar de home pagina") %}</p>
+<p class="utrecht-paragraph">{% link href="/" text=_("Ga naar de home pagina") %}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/cms/banner/banner_text_plugin.html
+++ b/src/open_inwoner/templates/cms/banner/banner_text_plugin.html
@@ -3,7 +3,7 @@
         <h1 class="utrecht-heading-1">{{ instance.title }} {{ request.user.get_full_name }}</h1>
 
         {% if instance.description %}
-            <p class="p">{{ instance.description|linebreaksbr }}</p>
+            <p class="utrecht-paragraph">{{ instance.description|linebreaksbr }}</p>
         {% endif %}
     </div>
 </section>

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -11,8 +11,8 @@
                 {% render_card image_object_fit="cover" href=plan.get_absolute_url %}
                 <div class="card__content">
                     <h3 class="utrecht-heading-3 card__heading-3 plan-list">{{ plan.title }}</h3>
-                    <p class="p">{{ plan.goal|truncatewords:20 }}</p>
-                    <p class="p">{{ plan.description|truncatewords:20 }}</p>
+                    <p class="utrecht-paragraph">{{ plan.goal|truncatewords:20 }}</p>
+                    <p class="utrecht-paragraph">{{ plan.description|truncatewords:20 }}</p>
                     <span class="spacer"></span>
                     <span class="button button--icon-before button--transparent button--secondary">
                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
         {% else %}
-            <p class="p">{{ configurable_text.plans_page.plans_no_plans_message }}</p>
+            <p class="utrecht-paragraph">{{ configurable_text.plans_page.plans_no_plans_message }}</p>
         {% endif %}
     </section>
 {% endif %}

--- a/src/open_inwoner/templates/cms/fullwidth.html
+++ b/src/open_inwoner/templates/cms/fullwidth.html
@@ -25,7 +25,7 @@
     {% if not request.user.is_authenticated %}
         <section class="plugin grid__welcome">
             <h1 class="utrecht-heading-1">{{configurable_text.home_page.home_welcome_title}}</h1>
-            <p class="p">{{configurable_text.home_page.home_welcome_intro|linebreaksbr}}</p>
+            <p class="utrecht-paragraph">{{configurable_text.home_page.home_welcome_intro|linebreaksbr}}</p>
         </section>
     {% else %}
         {% placeholder 'banner_text' %}

--- a/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
+++ b/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
@@ -9,7 +9,7 @@
             <a href="{{ appointment_list_url }}" class="card">
                 <div class="card__body card__body--tabled">
                     {% timezone appointment.branch.timeZone %}
-                        <p class="p tabled__value">{{ appointment.start|date:"j F Y" }} {% trans "om" %} {{ appointment.start|date:"H:i"|add:" "|add:_("uur") }}</p>
+                        <p class="utrecht-paragraph tabled__value">{{ appointment.start|date:"j F Y" }} {% trans "om" %} {{ appointment.start|date:"H:i"|add:" "|add:_("uur") }}</p>
                     {% endtimezone %}
                     <h2 class="plugin-card__heading">
                         <span class="status">{{ appointment.title }}</span>

--- a/src/open_inwoner/templates/cms/products/categories_plugin.html
+++ b/src/open_inwoner/templates/cms/products/categories_plugin.html
@@ -7,7 +7,7 @@
             <span class="spacer"></span>
             {% button href='products:category_list' text=button_text icon="arrow_forward" icon_position="after" %}
         </h2>
-        <p class="p">{{ configurable_text.home_page.home_theme_intro|linebreaksbr }}</p>
+        <p class="utrecht-paragraph">{{ configurable_text.home_page.home_theme_intro|linebreaksbr }}</p>
 
         {% include "components/Card/CardContainer.html" with categories=categories columns=4 image_object_fit="cover" only %}
     </section>

--- a/src/open_inwoner/templates/cms/products/product_location_plugin.html
+++ b/src/open_inwoner/templates/cms/products/product_location_plugin.html
@@ -2,7 +2,7 @@
 
 <section class="plugin plugin__locations">
     <h2 class="utrecht-heading-2">{{ configurable_text.home_page.home_map_title }}</h2>
-    <p class="p">{{ configurable_text.home_page.home_map_intro|linebreaksbr }}</p>
+    <p class="utrecht-paragraph">{{ configurable_text.home_page.home_map_intro|linebreaksbr }}</p>
 
     {% with centroid=product_locations.get_centroid %}
         {% map centroid.lat centroid.lng geojson_feature_collection=product_locations.get_geojson_feature_collection %}

--- a/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
+++ b/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
@@ -8,9 +8,9 @@
             {% for step in steps %}
             <li>
                 <h4>{% trans "Question:" %}</h4>
-                <p class="p">{{ step.question }}</p>
+                <p class="utrecht-paragraph">{{ step.question }}</p>
                 <h4>{% trans "Answer:" %}</h4>
-                <p class="p">{{ step.answer }}</p>
+                <p class="utrecht-paragraph">{{ step.answer }}</p>
             </li>
             {% endfor %}
         </ol>
@@ -18,14 +18,14 @@
 
     <div class="qa_results">
         <h4 class="utrecht-heading-4">{{ last_step.question }}</h4>
-        <p class="p">{{ last_step.content|ckeditor_content|safe}}</p>
+        <p class="utrecht-paragraph">{{ last_step.content|ckeditor_content|safe}}</p>
         {% if related_products.exists %}
             <h4>{% trans "Related products:" %}</h4>
             <ol>
                 {% for product in related_products %}
                 <li>
                     <h4>{{ product.name }}</h4>
-                    <p class="p">{{ product.summary }}</p>
+                    <p class="utrecht-paragraph">{{ product.summary }}</p>
                 </li>
                 {% endfor %}
             </ol>

--- a/src/open_inwoner/templates/flatpages/default.html
+++ b/src/open_inwoner/templates/flatpages/default.html
@@ -3,5 +3,5 @@
 
 {% block content %}
   <h1 class="utrecht-heading-1">{{ flatpage.title }}</h1>
-  <p class="p">{{ flatpage.content|ckeditor_content|safe }}</p>
+  <p class="utrecht-paragraph">{{ flatpage.content|ckeditor_content|safe }}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -1,5 +1,5 @@
 {% load static i18n card_tags button_tags link_tags notification_tags anchor_menu_tags view_breadcrumbs utils solo_tags session_tags django_htmx cms_tags menu_tags sekizai_tags %}<!DOCTYPE html>
-<html lang="nl" class="view openinwoner-theme {% block view_class %}view--{{ request.resolver_match.namespaces|join:'-' }}-{{ request.resolver_match.url_name }}{% endblock %}">
+<html lang="nl" class="view utrecht-document openinwoner-theme {% block view_class %}view--{{ request.resolver_match.namespaces|join:'-' }}-{{ request.resolver_match.url_name }}{% endblock %}">
     <head>
         <meta charset="utf-8">
         <title>{% block title %}{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}{% endblock %}</title>
@@ -61,7 +61,7 @@
 	{% endif %}
     </head>
 
-    <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+    <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="utrecht-page">
 
         {% if cookiebanner_enabled %}
         {# render cookiebanner first #}
@@ -144,7 +144,7 @@
             <div class="footer__header">
                 {% if footer.logo_title %}
                     <div class="footer__logo-text">
-                        <p class="p">{{ footer.logo_title|linebreaksbr }}</p>
+                        <p class="utrecht-paragraph">{{ footer.logo_title|linebreaksbr }}</p>
                     </div>
                 {% endif %}
                 {% if footer.logo %}

--- a/src/open_inwoner/templates/pages/cases/403.html
+++ b/src/open_inwoner/templates/pages/cases/403.html
@@ -1,4 +1,4 @@
 {% load i18n link_tags %}
 
 <h1 class="utrecht-heading-1">{% trans "Sorry, you don't have access to this page (403)" %}</h1>
-<p class="p">{% link href="pages-root" text=_("Ga naar de home pagina") %}</p>
+<p class="utrecht-paragraph">{% link href="pages-root" text=_("Ga naar de home pagina") %}</p>

--- a/src/open_inwoner/templates/pages/cases/contact_form.html
+++ b/src/open_inwoner/templates/pages/cases/contact_form.html
@@ -1,7 +1,7 @@
 {% load i18n form_tags button_tags icon_tags %}
 
 <h2 class="utrecht-heading-2" id="contact">{% trans 'Stel een vraag' %}</h2>
-<p class="p">
+<p class="utrecht-paragraph">
     {% blocktrans trimmed %}
     Door middel van dit formulier kunt u een vraag stellen over deze zaak.
     U dient ten minste uw telefoonnummer of uw e-mailadres in te vullen.

--- a/src/open_inwoner/templates/pages/cases/document_form.html
+++ b/src/open_inwoner/templates/pages/cases/document_form.html
@@ -8,6 +8,6 @@
     {% file_input form.files max_upload_size=openzaak_config.max_upload_size allowed_file_extensions=openzaak_config.allowed_file_extensions %}
     {% form_actions primary_text=_("Upload documenten") enctype="multipart/form-data" fullwidth=True %}
     <div class="non-field-error" hidden>
-        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small utrecht-paragraph--oip-centered">{% trans "Verwijder eerst bestanden die niet voldoen aan de voorwaarden" %}</p>
+        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--small utrecht-paragraph--oip-centered">{% trans "Verwijder eerst bestanden die niet voldoen aan de voorwaarden" %}</p>
     </div>
 {% endrender_form %}

--- a/src/open_inwoner/templates/pages/cases/document_form.html
+++ b/src/open_inwoner/templates/pages/cases/document_form.html
@@ -8,6 +8,6 @@
     {% file_input form.files max_upload_size=openzaak_config.max_upload_size allowed_file_extensions=openzaak_config.allowed_file_extensions %}
     {% form_actions primary_text=_("Upload documenten") enctype="multipart/form-data" fullwidth=True %}
     <div class="non-field-error" hidden>
-        <p class="p p--small p--centered">{% trans "Verwijder eerst bestanden die niet voldoen aan de voorwaarden" %}</p>
+        <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-small utrecht-paragraph--oip-centered">{% trans "Verwijder eerst bestanden die niet voldoen aan de voorwaarden" %}</p>
     </div>
 {% endrender_form %}

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -1,7 +1,7 @@
 {% load link_tags button_tags i18n grid_tags icon_tags list_tags pagination_tags utils %}
 
 <h1 class="utrecht-heading-1" id="cases">{{ page_title }} ({{ paginator.count }})</h1>
-<p class="utrecht-paragraph utrecht-paragraph--oip-title-text">{{ title_text }}</p>
+<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-title-text">{{ title_text }}</p>
 
 <div class="card__grid">
 {% render_grid %}

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -1,7 +1,7 @@
 {% load link_tags button_tags i18n grid_tags icon_tags list_tags pagination_tags utils %}
 
 <h1 class="utrecht-heading-1" id="cases">{{ page_title }} ({{ paginator.count }})</h1>
-<p class="cases__title_text">{{ title_text }}</p>
+<p class="utrecht-paragraph utrecht-paragraph--oip-title-text">{{ title_text }}</p>
 
 <div class="card__grid">
 {% render_grid %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -36,7 +36,7 @@
                     <div class="card__body document-upload-description">
                         {% icon icon="info" icon_position="after" extra_classes="icon--info" outlined=True %}
 
-                        <div class="document-upload-description__text">{{ case.case_type_document_upload_description|markdown|safe }}</div>
+                        <div class="document-upload-description__text wysiwyg">{{ case.case_type_document_upload_description|markdown|safe }}</div>
                     </div>
                 </div>
                 {% endif %}
@@ -49,9 +49,9 @@
             {% elif case.external_upload_enabled %}
                 <h2 class="utrecht-heading-2" id="documents-upload">{% trans "Document toevoegen" %}</h2>
                 {% if case.case_type_config_description %}
-                    <p class="p">{{ case.case_type_config_description }}</p>
+                    <p class="utrecht-paragraph">{{ case.case_type_config_description }}</p>
                 {% else %}
-                    <p class="p">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
+                    <p class="utrecht-paragraph">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
                 {% endif %}
                 {% button_row %}
                     {% button href=case.external_upload_url text=_("Document uploaden") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}

--- a/src/open_inwoner/templates/pages/cases/statuses.html
+++ b/src/open_inwoner/templates/pages/cases/statuses.html
@@ -18,16 +18,16 @@
                             <span class="link link--bold">{{ status.label }}</span>
                             {% if case.end_statustype_data %}{% icon icon="expand_more" icon_position="after" outlined=True %}{% endif %} </button>
                         <div class="status-list__notification-content {% if case.end_statustype_data %}status-content--open{% endif %} {% if not case.end_statustype_data %}status-content--open{% endif %}" id="{{ content_id }}">
-                            <p class="p p-text p--compact">
+                            <p class="utrecht-paragraph status-list__text utrecht-paragraph--oip utrecht-paragraph--oip-compact">
                                 {# Configurable texts #}
                                 {% if case.end_statustype_data %}<span>{{ status.description|default:"" }}</span>{% endif %}
                                 {% if not case.end_statustype_data %}<span class="status--result">{{ case.result_description|default:"" }}</span>{% endif %}
                             </p>
-                            <p class="p p-date p--compact">{{ status.date|date }}</p>
+                            <p class="utrecht-paragraph status-list__date utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ status.date|date }}</p>
 			    {% if status.call_to_action_url %}
                                 {% button href=status.call_to_action_url text=status.call_to_action_text title=status.call_to_action_text primary=True icon="arrow_forward" icon_position="after" %}
                             {% else %}
-                                <p class="p p__upload {% if case.end_statustype_data %}p__upload--enabled{% endif %}">
+                                <p class="utrecht-paragraph status-list__upload {% if case.end_statustype_data %}status-list__upload--enabled{% endif %}">
                                 {% if case.internal_upload_enabled or case.external_upload_enabled %}
                                     {% button href="#documents-upload" text=_("Scroll omlaag") title=_("Ga direct naar document upload sectie.") primary=True icon="arrow_downward" icon_position="after" %}
                                 {% endif %}
@@ -46,11 +46,11 @@
                     <div class="status-list__notification">
                         <button class="status-list__button button--borderless" aria-controls="{{ completed_id }}" aria-expanded="false" id="{{ id }}"><a href="#" class="link link-success">{{ status.label }}</a>{% icon icon="expand_more" icon_position="after" outlined=True %}</button>
                         <div class="status-list__notification-content" id="{{ completed_id }}">
-                            <p class="p p-text p--compact">
+                            <p class="utrecht-paragraph status-list__text utrecht-paragraph--oip utrecht-paragraph--oip-compact">
                                 {# Configurable texts #}
                                 <span>{{ status.description|default:"" }}</span>
                             </p>
-                            <p class="p p-date p--compact">{{ status.date|date }}</p>
+                            <p class="utrecht-paragraph status-list__date utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ status.date|date }}</p>
                         </div>
                     </div>
                 </li>

--- a/src/open_inwoner/templates/pages/category/list.html
+++ b/src/open_inwoner/templates/pages/category/list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="categories__content">
     <h1 class="utrecht-heading-1">{{configurable_text.theme_page.theme_title}}</h1>
-    <p class="p">{{configurable_text.theme_page.theme_intro|linebreaksbr}}</p>
+    <p class="utrecht-paragraph">{{configurable_text.theme_page.theme_intro|linebreaksbr}}</p>
 
     {% include "components/Card/CardContainer.html" with categories=object_list only %}
 </div>

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -9,7 +9,7 @@
         <div class="form-container">
             <div class="form-heading">
                 <h2 class="utrecht-heading-2">{% trans "Stel een vraag" %}</h2>
-                <p class="p">
+                <p class="utrecht-paragraph">
                 {% blocktrans trimmed %}
                     Heeft u een vraag? Dan kunt u deze hier stellen.
                     Een van onze medewerkers beantwoord uw vraag z.s.m.
@@ -72,7 +72,7 @@
         <div class="form-container">
             <div class="form-heading">
                 <h2 class="utrecht-heading-2">{% trans "Stel een vraag" %}</h2>
-                <p class="p">
+                <p class="utrecht-paragraph">
                 {% blocktrans trimmed %}
                     Heeft u een vraag? Dan kunt u deze hier stellen.
                     Een van onze medewerkers beantwoord uw vraag z.s.m.

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -71,7 +71,7 @@
             {% form_actions primary_text=_("Verzenden") primary_icon="arrow_forward" %}
         {% endrender_form %}
         {% else %}
-            <div class="p">
+            <div class="utrecht-paragraph">
                 {% url 'profile:contact_create' as contact_create %}
                 {% link href=contact_create text=_("Maak je eerste contact aan voordat je een samenwerking start") icon="arrow_forward" icon_position="after" primary=True %}
             </div>

--- a/src/open_inwoner/templates/pages/plans/detail.html
+++ b/src/open_inwoner/templates/pages/plans/detail.html
@@ -56,11 +56,11 @@
     </div>
 
     <h2 class="utrecht-heading-2" id="goals">{% trans "Doel" %}</h2>
-    <p class="p">{{ object.goal|linebreaksbr }}</p>
+    <p class="utrecht-paragraph">{{ object.goal|linebreaksbr }}</p>
 
     {% if object.description %}
     <h2 class="utrecht-heading-2" id="description">{% trans "Description" %}</h2>
-    <p class="p">{{ object.description|linebreaksbr }}</p>
+    <p class="utrecht-paragraph">{{ object.description|linebreaksbr }}</p>
     {% endif %}
 
     {% button href="collaborate:plan_edit_goal" uuid=object.uuid text=_("Doel en omschrijving bewerken") primary=True %}

--- a/src/open_inwoner/templates/pages/plans/goal_edit.html
+++ b/src/open_inwoner/templates/pages/plans/goal_edit.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Doel en omschrijving aanpassen" %}</h1>
-    <p class="p">
+    <p class="utrecht-paragraph">
         {{configurable_text.plans_page.plans_edit_message}}
     </p>
 

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -19,7 +19,7 @@
                 {% button text=_("Filter") type="button" bordered=True %}
             </div>
             <div class="plan-filter__container filter__container">
-                <p class="p">{% trans "Filter op:" %}</p>
+                <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
                 {% input plan_filter_form.plan_contacts no_label=True no_help=True icon="person" %}
                 {% input plan_filter_form.status no_label=True no_help=True icon="expand_more" %}
                 <div class="plan-filter__search-container">

--- a/src/open_inwoner/templates/pages/product/detail.html
+++ b/src/open_inwoner/templates/pages/product/detail.html
@@ -33,7 +33,7 @@
         {% endif %}
     </h1>
     {% include "components/Tag/Tag.html" with tags=object.tags.all only %}
-    <p class="utrecht-paragraph utrecht-paragraph--oip-summary">{{ object.summary }}</p>
+    <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-summary">{{ object.summary }}</p>
 
     {# Collapsable content #}
     <div class="readmore">

--- a/src/open_inwoner/templates/pages/product/detail.html
+++ b/src/open_inwoner/templates/pages/product/detail.html
@@ -33,7 +33,7 @@
         {% endif %}
     </h1>
     {% include "components/Tag/Tag.html" with tags=object.tags.all only %}
-    <p class="p p-summary">{{ object.summary }}</p>
+    <p class="utrecht-paragraph utrecht-paragraph--oip-summary">{{ object.summary }}</p>
 
     {# Collapsable content #}
     <div class="readmore">
@@ -140,7 +140,7 @@
 
                                 {% if contact.phonenumber %}
                                     {% render_column span=6 %}
-                                        <span class="p">{{ contact.role|default:_('Telefoonnummer') }}</span>
+                                        <span class="utrecht-paragraph">{{ contact.role|default:_('Telefoonnummer') }}</span>
                                     {% endrender_column %}
 
                                     {% render_column start=7 span=6 %}
@@ -150,7 +150,7 @@
 
                                 {% if contact.email %}
                                     {% render_column span=6 %}
-                                        <p class="p">{{ contact.organization|default:_('E-mail')}}</p>
+                                        <p class="utrecht-paragraph">{{ contact.organization|default:_('E-mail')}}</p>
                                     {% endrender_column %}
 
                                     {% render_column start=7 span=6 %}

--- a/src/open_inwoner/templates/pages/product/finder.html
+++ b/src/open_inwoner/templates/pages/product/finder.html
@@ -17,7 +17,7 @@
                     </li>
 		{% empty %}
 		<li class="product-filter__item">
-		  <p class="p">{% trans "Geen producten gevonden" %}</p>
+		  <p class="utrecht-paragraph">{% trans "Geen producten gevonden" %}</p>
 		</li>
                 {% endfor %}
             </ul>

--- a/src/open_inwoner/templates/pages/product/location_detail.html
+++ b/src/open_inwoner/templates/pages/product/location_detail.html
@@ -9,16 +9,16 @@
         <div class="location__details">
             <div class="location__address">
                 {% if object.address_line_1 %}
-                    <p class="p">{{ object.address_line_1 }}</p>
+                    <p class="utrecht-paragraph">{{ object.address_line_1 }}</p>
                 {% endif %}
-                <p class="p">{{ object.address_line_2 }}</p>
+                <p class="utrecht-paragraph">{{ object.address_line_2 }}</p>
             </div>
             <div class="location__contact">
                 {% if object.phonenumber %}
-                    <p class="p">{{ object.phonenumber }}</p>
+                    <p class="utrecht-paragraph">{{ object.phonenumber }}</p>
                 {% endif %}
                 {% if object.email %}
-                    <p class="p">{{ object.email }}</p>
+                    <p class="utrecht-paragraph">{{ object.email }}</p>
                 {% endif %}
             </div>
         </div>

--- a/src/open_inwoner/templates/pages/profile/categories.html
+++ b/src/open_inwoner/templates/pages/profile/categories.html
@@ -5,7 +5,7 @@
 <h1 class="utrecht-heading-1" id="title">
     {% trans "Mijn Interessegebieden" %}
 </h1>
-<p class="p">
+<p class="utrecht-paragraph">
     {% trans "Selecteer hier welke onderwerpen u interesseren, om op maat gemaakte inhoud voorgeschoteld te krijgen en nog beter te kunnen zoeken en vinden" %}
 </p>
 

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -15,12 +15,12 @@
         <div class="approval">
             <div class="approval__header">
                 <h2 class="utrecht-heading-2">{% trans "U bent toegevoegd als contactpersoon" %}</h2>
-                <p class="p">{% trans "By accepting you agree on sharing your personal data (first name, last name and phonenumber)." %}</p>
+                <p class="utrecht-paragraph">{% trans "By accepting you agree on sharing your personal data (first name, last name and phonenumber)." %}</p>
             </div>
             {% if approvals_count == 1 %}
                 {% with pending_approvals.get as pending_approval %}
                 <div class="approval__single">
-                    <p class="p">
+                    <p class="utrecht-paragraph">
                         {% blocktrans with full_name=pending_approval.get_full_name %}{{ full_name }} wil u toevoegen als contactpersoon.{% endblocktrans %}
                     </p>
                     {% url 'profile:contact_approval' uuid=pending_approval.uuid as approval_url %}
@@ -37,7 +37,7 @@
                 <ul class="approval__list">
                     {% for approval in pending_approvals %}
                         <li class="approval__list-item">
-                            <p class="p">{{approval.get_full_name}}</p>
+                            <p class="utrecht-paragraph">{{approval.get_full_name}}</p>
                             {% url 'profile:contact_approval' uuid=approval.uuid as approval_url %}
                             {% render_form form=None method="POST" form_action=approval_url id="approval_form" spaceless=True show_notifications=True %}
                                 {% csrf_token %}
@@ -71,7 +71,7 @@
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
         <div class="contacts__filter-container filter__container">
-            <p class="p">{% trans "Filter op:" %}</p>
+            <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
             {% input form.type no_label=True no_help=True icon="expand_more" class="label input" id="id_type" %}
         </div>
     </div>

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -119,7 +119,7 @@
         <div class="tabled__section">
             <h2 class="utrecht-heading-2 title" id="newsletters">{% trans "Nieuwsbrieven" %}</h2>
         </div>
-            <p class="p">{% trans "Vink de nieuwsbrieven aan die u wilt ontvangen. Wilt u een nieuwsbrief niet meer ontvangen? Haal het vinkje dan weg. Sla daarna uw keuze op." %}</p>
+            <p class="utrecht-paragraph">{% trans "Vink de nieuwsbrieven aan die u wilt ontvangen. Wilt u een nieuwsbrief niet meer ontvangen? Haal het vinkje dan weg. Sla daarna uw keuze op." %}</p>
             <form method="POST" id="newsletter-form" class="form" novalidate>
                 {% csrf_token %}
                 {% with form.fields.newsletters.remarks_mapping as remarks_mapping %}
@@ -312,7 +312,7 @@
         <div class="tabled__section">
             <h2 class="utrecht-heading-2 title" id="profile-remove">{% trans "Profiel verwijderen" %}</h2></div>
             <div class="tabled">
-                <p class="p">
+                <p class="utrecht-paragraph">
                     {% trans "Hiermee worden alleen uw persoonlijke voorkeuren verwijderd. U krijgt dan bijvoorbeeld geen e-mail meer van ons over wijzigingen van uw lopende zaken. Uw persoonsgegevens en uw lopende zaken zelf worden hiermee niet verwijderd." %}
                 </p>
             </div>

--- a/src/open_inwoner/templates/pages/profile/mydata.html
+++ b/src/open_inwoner/templates/pages/profile/mydata.html
@@ -12,7 +12,7 @@
             {% trans "Persoonlijke gegevens" %}
         </h1>
 
-        <p class="p">
+        <p class="utrecht-paragraph">
             {% trans "Hier ziet u een beperkte set van gegevens die van u zijn opgeslagen in de Basisregistratie Personen (BRP). Al uw persoonlijke gegevens kunt u vinden op " %}
             {% link href="https://mijn.overheid.nl" text="mijn.overheid.nl" primary=True %}
         </p>

--- a/src/open_inwoner/templates/pages/profile/notifications.html
+++ b/src/open_inwoner/templates/pages/profile/notifications.html
@@ -7,7 +7,7 @@
         <h1 class="utrecht-heading-1" id="title">
             {% trans "Ontvang berichten over" %}
         </h1>
-        <p class="p">
+        <p class="utrecht-paragraph">
             {% trans "Kies voor welk onderwerp je meldingen wilt ontvangen" %}
         </p>
 

--- a/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
+++ b/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
@@ -12,7 +12,7 @@
             </h1>
 
             {% if form.instance.get_description %}
-                <p class="p">{{ form.instance.get_description }}</p>
+                <p class="utrecht-paragraph">{{ form.instance.get_description }}</p>
             {% endif %}
 
             {% step_indicator form.instance.depth form.instance.depth object_list=form.instance.get_tree_path object_list_str='question_subject' %}
@@ -21,7 +21,7 @@
             <legend class="utrecht-heading-4" id="question">{{ form.instance.question }}</legend>
 
             {% if form.instance.help_text %}
-                <p class="p p--compact">{{ form.instance.help_text }}</p>
+                <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ form.instance.help_text }}</p>
             {% endif %}
 
             {% firstof form.instance.get_parent.get_absolute_url as secondary_href %}

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -52,7 +52,7 @@
                 {% if paginator.count and not messages %}
                     <section class="feedback" aria-label="{% trans "Pagina feedback" %}">
                         <h4 class="utrecht-heading-4">{% trans "Feedback" %}</h4>
-                        <p class="p">{% trans "Heeft u gevonden wat u zocht?" %}</p>
+                        <p class="utrecht-paragraph">{% trans "Heeft u gevonden wat u zocht?" %}</p>
                         {% render_form form=feedback_form method="POST" form_action=request.get_full_path id="feedback_form" show_notifications=True %}
                             {% csrf_token %}
                             {{ feedback_form.errors }}
@@ -83,7 +83,7 @@
                     <h2 class="utrecht-heading-2 search-results__title">
                         {% trans "Geen zoekresultaten" %}
                     </h2>
-                    <p class="p">{% trans "Helaas, wij vonden geen resultaten voor jouw zoekopdracht." %}</p>
+                    <p class="utrecht-paragraph">{% trans "Helaas, wij vonden geen resultaten voor jouw zoekopdracht." %}</p>
                 </div>
                 <ul class="ul">
                    <li class="li">{% trans "Controleer de spelling van je zoekopdracht." %}</li>

--- a/src/open_inwoner/templates/registration/password_change_done.html
+++ b/src/open_inwoner/templates/registration/password_change_done.html
@@ -3,5 +3,5 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset was successful" %}</h1>
-    <p class="p">{% trans "Your password has been changed." %}</p>
+    <p class="utrecht-paragraph">{% trans "Your password has been changed." %}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_change_form.html
+++ b/src/open_inwoner/templates/registration/password_change_form.html
@@ -11,7 +11,7 @@
         {% render_column start=0 span=8 %}
 
             <h1 class="utrecht-heading-1">{% trans "Password reset" %}</h1>
-            <p class="p">{% trans "For security reasons, please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
+            <p class="utrecht-paragraph">{% trans "For security reasons, please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
 
             {% render_form id="password-change-form" method="POST" form=form %}
                 {% csrf_token %}

--- a/src/open_inwoner/templates/registration/password_reset_complete.html
+++ b/src/open_inwoner/templates/registration/password_reset_complete.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset complete" %}</h1>
-    <p class="p">{% trans "Your password has been set. You can now continue and log in." %}</p>
+    <p class="utrecht-paragraph">{% trans "Your password has been set. You can now continue and log in." %}</p>
 
     {% with login_url as login_url %}
-        <p class="p">{% button href=login_url text=_("Log in") primary=True %}</p>
+        <p class="utrecht-paragraph">{% button href=login_url text=_("Log in") primary=True %}</p>
     {% endwith %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_confirm.html
+++ b/src/open_inwoner/templates/registration/password_reset_confirm.html
@@ -4,10 +4,10 @@
 {% block content %}
     {% if validlink %}
         <h1 class="utrecht-heading-1">{% trans "Enter new password" %}</h1>
-        <p class="p">{% trans "Please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
+        <p class="utrecht-paragraph">{% trans "Please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
         {% form form_object=form method="POST" submit_text=_('Change my password') id="password-reset-confirm" %}
     {% else %}
         <h1 class="utrecht-heading-1">{% trans "Password reset failed" %}</h1>
-        <p class="p">{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>
+        <p class="utrecht-paragraph">{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>
     {% endif %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_done.html
+++ b/src/open_inwoner/templates/registration/password_reset_done.html
@@ -3,6 +3,6 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset email sent" %}</h1>
-    <p class="p">{% trans "We have sent you instructions on how to set your password, if an account exists with the email address you entered. You should receive this shortly." %}</p>
-    <p class="p">{% trans "If you did not receive an email, please make sure you entered the email address you registered with and check your spam folder." %}</p>
+    <p class="utrecht-paragraph">{% trans "We have sent you instructions on how to set your password, if an account exists with the email address you entered. You should receive this shortly." %}</p>
+    <p class="utrecht-paragraph">{% trans "If you did not receive an email, please make sure you entered the email address you registered with and check your spam folder." %}</p>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_form.html
+++ b/src/open_inwoner/templates/registration/password_reset_form.html
@@ -6,8 +6,8 @@
     {% render_grid %}
         {% render_column start=0 span=6 %}
             <h1 class="utrecht-heading-1">{% trans "Reset password" %}</h1>
-            <p class="p">{% trans "Forgot your password? Enter your email address below. Then you will receive an email with instructions to set a new password." %}</p>
-            <p class="p">{% trans "Please note: this only works if you do are not using DigiD to log in." %}</p>
+            <p class="utrecht-paragraph">{% trans "Forgot your password? Enter your email address below. Then you will receive an email with instructions to set a new password." %}</p>
+            <p class="utrecht-paragraph">{% trans "Please note: this only works if you do are not using DigiD to log in." %}</p>
 
             {% render_form id="password-reset-form" method="POST" form=form %}
                 {% csrf_token %}


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2480

paragraph modifiers that Utrecht doesn't have are: `--compact`, `--small`, `--muted`, `--centered`
This means we will have to make "`--oip`" modifiers with our own designtokens, so that municipalities that do not wish to use our design-tokens can use either their own or add custom-styling themselves.

HTML example of the proper way of working: 
This is what it looked/looks like in the past/legacy code:
`<p class="p p--small">…..` 

But now this should become:
`<p class="utrecht-paragraph  utrecht-paragraph--oip  utrecht-paragraph--oip-small">.....`

We will not yet be implementing this for **_ALL_** `<p>` tags because we have them in our own components that do not exist in NLDS at all. (Like the paragraphs inside the '**Mijn profiel**' tabled sections for example).

Also: in future I would love to completely remove all "legacy styling" that's meant to keep things backwards compatible for now. Plus it seems we have unused code, like `location-card-list` which might be safe to delete but not sure. So 'clean-up' will need to become a separate issue.

This PR relies on changes in our [NLDS token package PR nr.9](https://github.com/maykinmedia/open-inwoner-design-tokens/pull/9) so to view and check to see if all styles look the same, do an NPM ci --legacy-peer-deps install and rebuild.

Note to self: the two unique classes `utrecht-paragraph--oip-title-text` and `utrecht-paragraph--oip-summary` are not in design tokens becasue they should probably be defined by their parent component (like "readmore" component.