### PR TITLE
[#2507] Fixed and added test for 'django-admin-index' fixture

### DIFF
--- a/src/open_inwoner/conf/fixtures/django-admin-index.json
+++ b/src/open_inwoner/conf/fixtures/django-admin-index.json
@@ -337,10 +337,6 @@
             ],
             [
                 "openzaak",
-                "statustranslation"
-            ],
-            [
-                "openzaak",
                 "usercaseinfoobjectnotification"
             ],
             [

--- a/src/open_inwoner/conf/tests/test_fixtures.py
+++ b/src/open_inwoner/conf/tests/test_fixtures.py
@@ -1,0 +1,25 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from open_inwoner.accounts.apps import update_admin_index
+
+
+class FixtureTests(TestCase):
+    def test_admin_index(self):
+        self.assertTrue(update_admin_index())
+
+    def test_cms_pages(self):
+        # pass if this doesn't raise anything
+        call_command("loaddata", "cms-pages")
+
+    def test_custom_csp(self):
+        # pass if this doesn't raise anything
+        call_command("loaddata", "custom_csp")
+
+    def test_mail_editor(self):
+        # pass if this doesn't raise anything
+        call_command("loaddata", "mail-editor")
+
+    def test_profile_apphook_config(self):
+        # pass if this doesn't raise anything
+        call_command("loaddata", "profile_apphook_config")


### PR DESCRIPTION
I think the mechanism wasn't broken, it just errored on bad data (there was a content-type in there that was removed).

Note it listens to the post-migrate signal (eg: not application startup). If we runt this on application start it would run for every test and management command as well (and it deletes and re-creates all the records)

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/2482