### PR TITLE
:wheelchair: [#2345] A11y replace disallowed heading tags in Cards

### DIFF
--- a/src/open_inwoner/components/templates/components/Card/CategoryCard.html
+++ b/src/open_inwoner/components/templates/components/Card/CategoryCard.html
@@ -22,12 +22,13 @@
 </div>
 
 {% else %}
+{# If this card has no content section #}
     <a href="{{ category.slug }}" class="card">
         <div class="card__body">
             {% if category %}
-                <h3 class="utrecht-heading-3 card__heading-3">
+                <p class="utrecht-heading-3 card__heading-3">
                     <span class="link link__text">{{ category }}</span>
-                </h3>
+                </p>
             {% endif %}
         </div>
     </a>

--- a/src/open_inwoner/components/templates/components/Card/RenderCard.html
+++ b/src/open_inwoner/components/templates/components/Card/RenderCard.html
@@ -13,13 +13,13 @@
     <div class="card__body{% if compact %}--compact{% endif %} {% if direction %} card__body--direction-{{ direction }}{% endif %}{% if grid %} card__body--grid{% endif %}">
         {% if title %}
             {% if compact %}
-            <h3 class="utrecht-heading-3 card__heading-3">
+            <p class="utrecht-heading-3 card__heading-3">
                 <span class="link link__text">{{ title }}</span>
-            </h3>
+            </p>
             {% else %}
-            <h4 class="card__heading-4">
+            <p class="utrecht-heading-4 card__heading-4">
                 <span class="link link__text">{{ title }}</span>
-            </h4>
+            </p>
             {% endif %}
         {% endif %}
         {{ contents }}

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -322,6 +322,7 @@
   &__heading-3 .link,
   &__heading-4 .link {
     color: var(--oip-color-fg-heading);
+    font-family: var(--utrecht-heading-font-family);
     font-size: var(--font-size-heading-card);
     line-height: var(--utrecht-heading-4-line-height);
     margin: 0;

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -157,7 +157,7 @@
                 <a href="{% url 'profile:categories' %}" class="card card--compact card--stretch" id="profile-selected-categories">
                     <div class="card__body">
                         <div class="ellipsis--none">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn Interessegebieden" %}</span></h4>
+                            <p class="card__heading-4"><span class="link link__text">{% trans "Mijn Interessegebieden" %}</span></p>
 
                             {% render_list %}
                                 {% for name in selected_categories %}
@@ -185,7 +185,7 @@
                 {% endif %}
                         <div class="card__body">
                             <div class="ellipsis">
-                                <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn begeleider" %}</span></h4>
+                                <p class="card__heading-4"><span class="link link__text">{% trans "Mijn begeleider" %}</span></p>
                                 {% render_list %}
                                     {% for name in mentor_contact_names %}
                                         {% list_item text=name compact=True strong=False %}
@@ -209,7 +209,7 @@
                     <a href="{% url 'profile:contact_list' %}" class="card card--compact card--stretch" id="profile-section-contacts">
                         <div class="card__body">
                             <div class="ellipsis">
-                                <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn contacten" %}</span></h4>
+                                <p class="card__heading-4"><span class="link link__text">{% trans "Mijn contacten" %}</span></p>
                                 {% render_list %}
                                     {% for name in contact_names %}
                                         {% list_item text=name compact=True strong=False %}
@@ -232,7 +232,7 @@
                     <a href="{% url 'profile:action_list' %}" class="card card--compact card--stretch" id="profile-section-actions">
                         <div class="card__body">
                             <div class="ellipsis--none">
-                                <h4 class="card__heading-4"><span class="link link__text">{% trans "Acties" %}</span></h4>
+                                <p class="card__heading-4"><span class="link link__text">{% trans "Acties" %}</span></p>
                                 {% render_list %}
                                     {% list_item text=action_text compact=True strong=False %}
                                 {% endrender_list %}
@@ -250,7 +250,7 @@
                 <a href="{% url 'ssd:uitkeringen' %}" class="card card--compact card--stretch" id="profile-section-ssd">
                     <div class="card__body">
                         <div class="ellipsis--none">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn uitkeringen" %}</span></h4>
+                            <p class="card__heading-4"><span class="link link__text">{% trans "Mijn uitkeringen" %}</span></p>
                             {% render_list %}
                                 {% list_item text="Jaaropgaven" compact=True strong=False active=False %}
                                 {% list_item text="Maandspecificaties" compact=True strong=False %}
@@ -268,7 +268,7 @@
                 <a href="{% url 'cases:contactmoment_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
                         <div class="ellipsis--none">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></h4>
+                            <p class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></p>
                             <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijken" %}">
                                 <span class="link__text">{% trans "Bekijken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
@@ -282,7 +282,7 @@
                 <a href="{% url 'products:questionnaire_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
                         <div class="ellipsis--none">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></h4>
+                            <p class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></p>
                             <span class="link link--icon link--secondary profile-card__button" title="{% trans "Start zelfdiagnose" %}">
                                 <span class="link__text">{% trans "Start zelfdiagnose" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
@@ -295,7 +295,7 @@
                 <a href="{% url 'profile:appointments' %}" class="card card--compact card--stretch" id="profile-section-appointments">
                     <div class="card__body">
                         <div class="ellipsis--none">
-                            <h4 class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span></h4>
+                            <p class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span></p>
                             <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijk afspraken" %}">
                                 <span class="link__text">{% trans "Bekijk afspraken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}


### PR DESCRIPTION
issue: if there is no content, then there should not be any headings.
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2345 

Cards that only have an image and no text content at all, should use a paragraph that may visually look like a Heading.
A real Heading is an HTML tag that should summarize/pin-point the section below it, but in case of an image it does not make sense in accessibility/meaningfulness.

Also screen-readers will read out headings as a list with hierarchy, so there better be something meaningful there.

Note : it is **outside of the scope** of this issue but some of the other cards are incorrect as well - in case a card has only a title, it's again not really a heading. Example: the sub-category card here: https://open-inwoner-test.maykin.nl/onderwerpen/vervoer/ 
And on the Profile page it is better to just consistently use paragraphs, since many of the 'Overzicht' cards do not have 'meaningful' content when read by a screenreader as a hierarchical list.

Perhaps none of the cards need a true Heading tag, but at least our 'Aanvragen/Vragen/Samenwerkingen' cards have a lot more content that may benefit from having a heading.

Also note: NL Design System has its own Card component, which we are not using yet in OIP.