### PR TITLE
Remove celery-once test

### DIFF
--- a/src/open_inwoner/celery.py
+++ b/src/open_inwoner/celery.py
@@ -2,7 +2,6 @@ from django.conf import settings
 
 from celery import Celery
 from celery.signals import setup_logging
-from celery_once import QueueOnce  # noqa
 
 from .setup import setup_env
 

--- a/src/open_inwoner/openzaak/tasks.py
+++ b/src/open_inwoner/openzaak/tasks.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management import call_command
 from django.utils.translation import gettext as _
 
-from open_inwoner.celery import QueueOnce, app
+from open_inwoner.celery import app
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports_task.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports_task.py
@@ -1,9 +1,6 @@
-import uuid
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
-
-from celery_once.tasks import AlreadyQueued
 
 from open_inwoner.celery import app as celery_app
 from open_inwoner.openzaak.tasks import import_zgw_data
@@ -27,26 +24,3 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
     def test_task_calls_command(self, mock_call: Mock):
         import_zgw_data()
         mock_call.assert_called_once_with("zgw_import_data")
-
-    @patch("open_inwoner.celery.app.send_task")
-    def test_task_runs_once(self, mock_send: Mock):
-        # manually patch the task because it is not a normal class/method
-        key = str(uuid.uuid4())
-
-        def get_key(self, args=None, kwargs=None):
-            return key
-
-        import_zgw_data.get_key = get_key
-
-        # add manual cleanup so we don't litter locks
-        def cleanup():
-            import_zgw_data.once_backend.clear_lock(key)
-
-        self.addCleanup(cleanup)
-
-        # actual test
-        import_zgw_data.apply_async()
-        with self.assertRaises(AlreadyQueued):
-            import_zgw_data.apply_async()
-
-        mock_send.assert_called_once()

--- a/src/open_inwoner/utils/admin.py
+++ b/src/open_inwoner/utils/admin.py
@@ -1,7 +1,7 @@
-import logging
 import json
+import logging
 
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, redirect
@@ -9,7 +9,6 @@ from django.urls import NoReverseMatch, path, reverse
 from django.utils.html import escape, format_html
 from django.utils.translation import gettext as _
 
-from celery_once import AlreadyQueued
 from django_celery_beat.admin import PeriodicTaskAdmin as _PeriodicTaskAdmin
 from django_celery_beat.models import PeriodicTask
 from import_export.admin import ExportMixin
@@ -20,7 +19,6 @@ from timeline_logger.resources import TimelineLogResource
 
 from open_inwoner.celery import app
 from open_inwoner.utils.logentry import LOG_ACTIONS
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The test specific to celery-once has to be removed after converting the zgw import task to a regular celery task