### PR TITLE
[#2513] Refactor generic ZGW client factories to concrete equivalents

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -25,7 +25,7 @@ from open_inwoner.openklant.wrap import (
     get_fetch_parameters,
     get_kcm_answer_mapping,
 )
-from open_inwoner.openzaak.clients import build_client as build_client_openzaak
+from open_inwoner.openzaak.clients import build_zaken_client
 from open_inwoner.utils.mixins import PaginationMixin
 from open_inwoner.utils.views import CommonPageMixin
 
@@ -219,7 +219,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
             local_kcm.save()
 
         if client := build_client("contactmomenten"):
-            zaken_client = build_client_openzaak("zaak")
+            zaken_client = build_zaken_client()
             ocm = client.retrieve_objectcontactmoment(
                 kcm.contactmoment, "zaak", zaken_client
             )

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -7,7 +7,7 @@ from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.htmx.mixins import RequiresHtmxMixin
 from open_inwoner.openzaak.cases import preprocess_data
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_zaken_client
 from open_inwoner.openzaak.formapi import fetch_open_submissions
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.types import UniformCase
@@ -56,7 +56,7 @@ class InnerCaseListView(
         return _("Mijn aanvragen")
 
     def get_cases(self):
-        client = build_client("zaak")
+        client = build_zaken_client()
 
         if client is None:
             return []

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from open_inwoner.kvk.branches import get_kvk_branch_number
 from open_inwoner.openzaak.api_models import Zaak
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_catalogi_client, build_zaken_client
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.types import UniformCase
 from open_inwoner.openzaak.utils import is_zaak_visible
@@ -60,7 +60,7 @@ class CaseAccessMixin(AccessMixin):
             )
             return self.handle_no_permission()
 
-        client = build_client("zaak")
+        client = build_zaken_client()
         if client is None:
             return super().dispatch(request, *args, **kwargs)
 
@@ -102,7 +102,7 @@ class CaseAccessMixin(AccessMixin):
                     return self.handle_no_permission()
 
             # resolve case-type
-            if catalogi_client := build_client("catalogi"):
+            if catalogi_client := build_catalogi_client():
                 self.case.zaaktype = catalogi_client.fetch_single_case_type(
                     self.case.zaaktype
                 )

--- a/src/open_inwoner/configurations/bootstrap/zgw.py
+++ b/src/open_inwoner/configurations/bootstrap/zgw.py
@@ -7,7 +7,12 @@ from simple_certmanager.models import Certificate
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import (
+    build_catalogi_client,
+    build_documenten_client,
+    build_forms_client,
+    build_zaken_client,
+)
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.api import ClientError
 
@@ -361,10 +366,10 @@ class ZGWAPIsConfigurationStep(BaseConfigurationStep):
         """
         make requests to each API and verify that a connection can be made
         """
-        zaken_client = build_client("zaak")
-        catalogi_client = build_client("catalogi")
-        documenten_client = build_client("document")
-        forms_client = build_client("form")
+        zaken_client = build_zaken_client()
+        catalogi_client = build_catalogi_client()
+        documenten_client = build_documenten_client()
+        forms_client = build_forms_client()
 
         try:
             response = zaken_client.get("statussen")

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -11,7 +11,7 @@ from requests import HTTPError, RequestException, Response
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.catalogi import Catalogus
 from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
-from zgw_consumers.client import build_client as _build_client
+from zgw_consumers.client import build_client
 from zgw_consumers.service import pagination_helper
 
 from open_inwoner.openzaak.api_models import InformatieObject
@@ -670,7 +670,7 @@ class FormClient(APIClient):
         return results
 
 
-def build_client(type_) -> APIClient | None:
+def _build_zgw_client(type_) -> APIClient | None:
     config = OpenZaakConfig.get_solo()
     services_to_client_mapping = {
         "zaak": ZakenClient,
@@ -681,8 +681,24 @@ def build_client(type_) -> APIClient | None:
     if client_class := services_to_client_mapping.get(type_):
         service = getattr(config, f"{type_}_service")
         if service:
-            client = _build_client(service, client_factory=client_class)
+            client = build_client(service, client_factory=client_class)
             return client
 
     logger.warning("no service defined for %s", type_)
     return None
+
+
+def build_zaken_client() -> ZakenClient | None:
+    return _build_zgw_client("zaak")
+
+
+def build_catalogi_client() -> CatalogiClient | None:
+    return _build_zgw_client("catalogi")
+
+
+def build_documenten_client() -> DocumentenClient | None:
+    return _build_zgw_client("document")
+
+
+def build_forms_client() -> FormClient | None:
+    return _build_zgw_client("form")

--- a/src/open_inwoner/openzaak/documents.py
+++ b/src/open_inwoner/openzaak/documents.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 
 from open_inwoner.openzaak.api_models import InformatieObject
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_documenten_client
 
 from ..utils.decorators import cache as cache_result
 
@@ -12,11 +12,11 @@ logger = logging.getLogger(__name__)
 
 @cache_result("information_object_url:{url}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT)
 def fetch_single_information_object_url(url: str) -> InformatieObject | None:
-    if client := build_client("document"):
+    if client := build_documenten_client():
         return client._fetch_single_information_object(url=url)
 
 
 # not cached because currently only used in info-object download view
 def fetch_single_information_object_uuid(uuid: str) -> InformatieObject | None:
-    if client := build_client("document"):
+    if client := build_documenten_client():
         return client._fetch_single_information_object(uuid=uuid)

--- a/src/open_inwoner/openzaak/formapi.py
+++ b/src/open_inwoner/openzaak/formapi.py
@@ -1,6 +1,6 @@
 import logging
 
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_forms_client
 
 from .api_models import OpenSubmission
 
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def fetch_open_submissions(bsn: str) -> list[OpenSubmission]:
-    client = build_client("form")
+    client = build_forms_client()
 
     if client is None:
         return []

--- a/src/open_inwoner/openzaak/management/commands/zgw_dev_status.py
+++ b/src/open_inwoner/openzaak/management/commands/zgw_dev_status.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from open_inwoner.accounts.models import User
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_catalogi_client, build_zaken_client
 from open_inwoner.openzaak.utils import get_zaak_type_config, is_zaak_visible
 
 logger = logging.getLogger(__name__)
@@ -41,11 +41,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.silence()
 
-        zaken_client = build_client("zaak")
+        zaken_client = build_zaken_client()
         if zaken_client is None:
             self.die(self.style.ERROR("Could not build Zaken API client"))
 
-        catalogi_client = build_client("catalogi")
+        catalogi_client = build_catalogi_client()
         if catalogi_client is None:
             self.die(self.style.ERROR("Could not build Catalogi API client"))
 

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -18,7 +18,12 @@ from open_inwoner.openzaak.api_models import (
     ZaakType,
 )
 from open_inwoner.openzaak.cases import resolve_status
-from open_inwoner.openzaak.clients import CatalogiClient, ZakenClient, build_client
+from open_inwoner.openzaak.clients import (
+    CatalogiClient,
+    ZakenClient,
+    build_catalogi_client,
+    build_zaken_client,
+)
 from open_inwoner.openzaak.documents import fetch_single_information_object_url
 from open_inwoner.openzaak.models import (
     OpenZaakConfig,
@@ -68,7 +73,7 @@ def handle_zaken_notification(notification: Notification):
     resources = ("status", "zaakinformatieobject")
     r = notification.resource  # short alias for logging
 
-    client = build_client("zaak")
+    client = build_zaken_client()
     if not client:
         log_system_action(
             f"ignored {r} notification: cannot build Zaken API client for case {case_url}",
@@ -111,7 +116,7 @@ def handle_zaken_notification(notification: Notification):
         return
 
     case_type = None
-    if catalogi_client := build_client("catalogi"):
+    if catalogi_client := build_catalogi_client():
         case_type = catalogi_client.fetch_single_case_type(case.zaaktype)
 
     if not case_type:
@@ -144,7 +149,7 @@ def _handle_zaakinformatieobject_notification(
     oz_config = OpenZaakConfig.get_solo()
     r = notification.resource  # short alias for logging
 
-    client = build_client("zaak")
+    client = build_zaken_client()
     if not client:
         log_system_action(
             f"ignored {r} notification: cannot build Zaken API client for case {case.url}",
@@ -466,7 +471,7 @@ def handle_status_notification(
     """
     oz_config = OpenZaakConfig.get_solo()
 
-    catalogi_client = build_client("catalogi")
+    catalogi_client = build_catalogi_client()
     if not catalogi_client:
         log_system_action(
             f"ignored {notification.resource} notification for {case.url}: cannot create Catalogi API client",
@@ -474,7 +479,7 @@ def handle_status_notification(
         )
         return None
 
-    zaken_client = build_client("zaak")
+    zaken_client = build_zaken_client()
     if not zaken_client:
         log_system_action(
             f"ignored {notification.resource} notification for {case.url}: cannot create Zaken API client",

--- a/src/open_inwoner/openzaak/tests/test_case_request.py
+++ b/src/open_inwoner/openzaak/tests/test_case_request.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 import requests_mock
 from zgw_consumers.constants import APITypes
 
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_zaken_client
 
 from ...utils.test import ClearCachesMixin
 from ..models import OpenZaakConfig
@@ -32,7 +32,7 @@ class TestFetchSpecificCase(ClearCachesMixin, TestCase):
             einddatum=None,
         )
 
-        self.client = build_client("zaak")
+        self.client = build_zaken_client()
 
     def test_case_is_retrieved(self, m):
         m.get(self.zaak["url"], json=self.zaak)

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -21,7 +21,7 @@ from zgw_consumers.constants import APITypes, AuthTypes
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.cms.cases.views.status import SimpleFile
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_documenten_client, build_zaken_client
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 from ..models import OpenZaakConfig
@@ -58,7 +58,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         self.zaak_service = ServiceFactory(api_root=ZAKEN_ROOT, api_type=APITypes.zrc)
         self.config.zaak_service = self.zaak_service
         self.config.save()
-        self.zaken_client = build_client("zaak")
+        self.zaken_client = build_zaken_client()
 
         self.config.zaak_service = self.zaak_service
         self.catalogi_service = ServiceFactory(
@@ -387,7 +387,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
 
         m.get(self.informatie_object["inhoud"], content=self.informatie_object_content)
 
-        document_client = build_client("document")
+        document_client = build_documenten_client()
         document_client.download_document(self.informatie_object["inhoud"])
 
         req = m.request_history[0]
@@ -411,7 +411,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         file = get_temporary_text_file()
         title = "my_document"
 
-        documenten_client = build_client("document")
+        documenten_client = build_documenten_client()
         created_document = documenten_client.upload_document(
             self.user, file, title, zaak_type_iotc.id, self.zaak["bronorganisatie"]
         )
@@ -434,7 +434,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         title = "my_document"
 
         m.post(f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten", status_code=404)
-        documenten_client = build_client("document")
+        documenten_client = build_documenten_client()
         created_document = documenten_client.upload_document(
             self.user, file, title, zaak_type_iotc.id, self.zaak["bronorganisatie"]
         )
@@ -457,7 +457,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, WebTest):
         title = "my_document"
 
         m.post(f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten", status_code=500)
-        documenten_client = build_client("document")
+        documenten_client = build_documenten_client()
         created_document = documenten_client.upload_document(
             self.user, file, title, zaak_type_iotc.id, self.zaak["bronorganisatie"]
         )

--- a/src/open_inwoner/openzaak/zgw_imports.py
+++ b/src/open_inwoner/openzaak/zgw_imports.py
@@ -10,7 +10,7 @@ from zgw_consumers.api_models.catalogi import (
 )
 
 from open_inwoner.openzaak.api_models import ZaakType
-from open_inwoner.openzaak.clients import CatalogiClient, build_client
+from open_inwoner.openzaak.clients import CatalogiClient, build_catalogi_client
 from open_inwoner.openzaak.models import (
     CatalogusConfig,
     ZaakTypeConfig,
@@ -48,7 +48,7 @@ def import_catalog_configs() -> list[CatalogusConfig]:
 
     note this doesn't generate anything on eSuite
     """
-    client = build_client("catalogi")
+    client = build_catalogi_client()
     if not client:
         logger.warning(
             "Not importing catalogus configs: could not build Catalogi API client"
@@ -86,7 +86,7 @@ def import_zaaktype_configs() -> list[ZaakTypeConfig]:
 
     this collapses individual ZaakType versions on their identificatie and catalog
     """
-    client = build_client("catalogi")
+    client = build_catalogi_client()
     if not client:
         logger.warning(
             "Not importing zaaktype configs: could not build Catalogi API client"
@@ -138,9 +138,9 @@ def import_zaaktype_configs() -> list[ZaakTypeConfig]:
     return list((create or {}).values())
 
 
-def import_zaaktype_informatieobjecttype_configs() -> list[
-    tuple[ZaakTypeConfig, InformatieObjectType]
-]:
+def import_zaaktype_informatieobjecttype_configs() -> (
+    list[tuple[ZaakTypeConfig, InformatieObjectType]]
+):
     """
     generate ZaakTypeInformatieObjectTypeConfigs for all ZaakTypeConfig
     """
@@ -164,9 +164,9 @@ def import_zaaktype_statustype_configs() -> list[tuple[ZaakTypeConfig, StatusTyp
     return created
 
 
-def import_zaaktype_resultaattype_configs() -> list[
-    tuple[ZaakTypeConfig, ResultaatType]
-]:
+def import_zaaktype_resultaattype_configs() -> (
+    list[tuple[ZaakTypeConfig, ResultaatType]]
+):
     """
     generate ZaakTypeResultaatTypeConfigs for all ZaakTypeConfig
     """
@@ -186,7 +186,7 @@ def import_zaaktype_informatieobjecttype_configs_for_type(
 
     this is a bit complicated because one ZaakTypeConfig can represent multiple ZaakTypes
     """
-    client = build_client("catalogi")
+    client = build_catalogi_client()
     if not client:
         logger.warning(
             "Not importing zaaktype-informatieobjecttype configs: could not build Catalogi API client"
@@ -260,7 +260,7 @@ def import_statustype_configs_for_type(
 
     this is a bit complicated because one ZaakTypeConfig can represent multiple ZaakTypes
     """
-    client = build_client("catalogi")
+    client = build_catalogi_client()
     if not client:
         logger.warning(
             "Not importing statustype configs: could not build Catalogi API client"
@@ -336,7 +336,7 @@ def import_resultaattype_configs_for_type(
 
     this is a bit complicated because one ZaakTypeConfig can represent multiple ZaakTypes
     """
-    client = build_client("catalogi")
+    client = build_catalogi_client()
     if not client:
         logger.warning(
             "Not importing resultaattype configs: could not build Catalogi API client"

--- a/src/open_inwoner/pdc/managers.py
+++ b/src/open_inwoner/pdc/managers.py
@@ -9,7 +9,7 @@ from treebeard.mp_tree import MP_NodeQuerySet
 from open_inwoner.accounts.models import User
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.api_models import Zaak
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_zaken_client
 from open_inwoner.openzaak.models import ZaakTypeConfig
 from open_inwoner.openzaak.utils import get_user_fetch_parameters
 
@@ -54,7 +54,7 @@ class CategoryPublishedQueryset(MP_NodeQuerySet):
         if not request.user.bsn and not request.user.kvk:
             return self
 
-        client = build_client("zaak")
+        client = build_zaken_client()
         if client is None:
             return self.none()
 

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -9,7 +9,7 @@ from django.views.generic import FormView
 from furl import furl
 
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_zaken_client
 from open_inwoner.openzaak.utils import get_user_fetch_parameters
 from open_inwoner.utils.mixins import PaginationMixin
 from open_inwoner.utils.views import CommonPageMixin, LoginMaybeRequiredMixin, LogMixin
@@ -64,7 +64,7 @@ class SearchView(
 
         # Check if the query exactly matches with a case that belongs to the user
         if search_params := get_user_fetch_parameters(self.request):
-            if client := build_client("zaak"):
+            if client := build_zaken_client():
                 cases = client.fetch_cases(**search_params, identificatie=query)
                 if cases and len(cases) == 1:
                     return HttpResponseRedirect(

--- a/src/open_inwoner/userfeed/hooks/external_task.py
+++ b/src/open_inwoner/userfeed/hooks/external_task.py
@@ -7,7 +7,7 @@ from requests import RequestException
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.models import User
 from open_inwoner.openzaak.api_models import OpenTask
-from open_inwoner.openzaak.clients import build_client
+from open_inwoner.openzaak.clients import build_forms_client
 from open_inwoner.userfeed.adapter import FeedItem
 from open_inwoner.userfeed.choices import FeedItemType
 from open_inwoner.userfeed.models import FeedItemData
@@ -83,7 +83,7 @@ def update_external_task_items(user: User, openstaande_taken: list[OpenTask]):
 
 def update_user_tasks(user: User):
     if user.login_type == LoginTypeChoices.digid:
-        if client := build_client("form"):
+        if client := build_forms_client():
             try:
                 tasks = client.fetch_open_tasks(user.bsn)
             except (RequestException, ClientError):


### PR DESCRIPTION
The generic ZGW client factory has the drawback of both typing ambiguity (generic `APIClient` versus concrete `ZakenClient`), but also makes it harder to do code analysis for the purposes of migrating to a multi-ZGW-backend approach. This refactor will address both concerns.

[Taiga #2513](https://taiga.maykinmedia.nl/project/open-inwoner/us/2485)