### PR TITLE
Swapping around migrations due to InconsistentMigrationHistory on acc…

### DIFF
--- a/src/open_inwoner/openzaak/migrations/0047_delete_statustranslation.py
+++ b/src/open_inwoner/openzaak/migrations/0047_delete_statustranslation.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("openzaak", "0046_alter_openzaakconfig_fetch_eherkenning_zaken_with_rsin"),
+        ("openzaak", "0048_alter_zaaktyperesultaattypeconfig_omschrijving"),
     ]
 
     operations = [

--- a/src/open_inwoner/openzaak/migrations/0048_alter_zaaktyperesultaattypeconfig_omschrijving.py
+++ b/src/open_inwoner/openzaak/migrations/0048_alter_zaaktyperesultaattypeconfig_omschrijving.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("openzaak", "0047_delete_statustranslation"),
+        ("openzaak", "0046_alter_openzaakconfig_fetch_eherkenning_zaken_with_rsin"),
     ]
 
     operations = [


### PR DESCRIPTION
Problem that occurred on acceptance environments with v1.17.0 which I switched around on v1.17.1. This was most likely due to the fact that we delayed removing the statustranslation table to 1.17