### PR TITLE
[#2521] Fix Open-Formulieren embedded form styling

### DIFF
--- a/src/open_inwoner/templates/pages/product/form.html
+++ b/src/open_inwoner/templates/pages/product/form.html
@@ -22,7 +22,9 @@
     {% include "components/Tag/Tag.html" with tags=object.tags.all only %}
 
     {% if object.form %}
+        <div class="openforms-theme">
         {% openforms_form object.form  csp_nonce=request.csp_nonce %}
+        </div>
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
BUG: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2521

quickfix for making the embedded form take open-forms's utrecht values,
instead of the utrecht values that are empty in our own NPM node-modules.