### PR TITLE
[#2514] Refactor generic openklant client factories to concrete equivalents

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -14,7 +14,10 @@ from django.views.generic import TemplateView
 from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.openklant.api_models import KlantContactMoment
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import (
+    build_contactmomenten_client,
+    build_klanten_client,
+)
 from open_inwoner.openklant.constants import Status
 from open_inwoner.openklant.models import ContactFormSubject, KlantContactMomentAnswer
 from open_inwoner.openklant.views.contactform import ContactFormView
@@ -218,7 +221,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
             local_kcm.is_seen = True
             local_kcm.save()
 
-        if client := build_client("contactmomenten"):
+        if client := build_contactmomenten_client():
             zaken_client = build_zaken_client()
             ocm = client.retrieve_objectcontactmoment(
                 kcm.contactmoment, "zaak", zaken_client
@@ -281,8 +284,8 @@ class KlantContactMomentRedirectView(KlantContactMomentAccessMixin, View):
     """
 
     def get(self, request, *args, **kwargs):
-        klanten_client = build_client("klanten")
-        contactmoment_client = build_client("contactmomenten")
+        klanten_client = build_klanten_client()
+        contactmoment_client = build_contactmomenten_client()
 
         klant = klanten_client.retrieve_klant(**get_fetch_parameters(self.request))
         kcms = contactmoment_client.retrieve_klantcontactmomenten_for_klant(klant)

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -27,7 +27,7 @@ from open_inwoner.cms.utils.page_display import (
 from open_inwoner.haalcentraal.utils import fetch_brp
 from open_inwoner.laposta.forms import NewsletterSubscriptionForm
 from open_inwoner.laposta.models import LapostaConfig
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import build_klanten_client
 from open_inwoner.openklant.wrap import get_fetch_parameters
 from open_inwoner.plans.models import Plan
 from open_inwoner.qmatic.client import NoServiceConfigured, QmaticClient
@@ -239,7 +239,7 @@ class EditProfileView(
             if user_form_data.get(local_name)
         }
         if update_data:
-            if client := build_client("klanten"):
+            if client := build_klanten_client():
                 klant = client.retrieve_klant(**get_fetch_parameters(self.request))
 
                 if klant:

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -20,7 +20,10 @@ from view_breadcrumbs import BaseBreadcrumbMixin
 from zgw_consumers.api_models.constants import RolOmschrijving
 
 from open_inwoner.mail.service import send_contact_confirmation_mail
-from open_inwoner.openklant.clients import build_client as build_client_openklant
+from open_inwoner.openklant.clients import (
+    build_contactmomenten_client,
+    build_klanten_client,
+)
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.openklant.wrap import (
     contactmoment_has_new_answer,
@@ -150,7 +153,7 @@ class InnerCaseDetailView(
             self.store_resulttype_mapping(self.case.zaaktype.identificatie)
 
             objectcontactmomenten = []
-            if contactmoment_client := build_client_openklant("contactmomenten"):
+            if contactmoment_client := build_contactmomenten_client():
                 objectcontactmomenten = (
                     contactmoment_client.retrieve_objectcontactmomenten_for_zaak(
                         self.case
@@ -911,7 +914,7 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
         except ObjectDoesNotExist:
             ztc = None
 
-        if klanten_client := build_client_openklant("klanten"):
+        if klanten_client := build_klanten_client():
             klant = klanten_client.retrieve_klant(**get_fetch_parameters(self.request))
 
             if klant:
@@ -959,7 +962,7 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
         if ztc and ztc.contact_subject_code:
             data["onderwerp"] = ztc.contact_subject_code
 
-        if contactmoment_client := build_client_openklant("contactmomenten"):
+        if contactmoment_client := build_contactmomenten_client():
             contactmoment = contactmoment_client.create_contactmoment(data, klant=klant)
             if contactmoment:
                 self.log_system_action(

--- a/src/open_inwoner/configurations/bootstrap/kic.py
+++ b/src/open_inwoner/configurations/bootstrap/kic.py
@@ -7,7 +7,10 @@ from simple_certmanager.models import Certificate
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import (
+    build_contactmomenten_client,
+    build_klanten_client,
+)
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.utils.api import ClientError
 
@@ -200,8 +203,8 @@ class KICAPIsConfigurationStep(BaseConfigurationStep):
         """
         make requests to the APIs and verify that a connection can be made
         """
-        klanten_client = build_client("klanten")
-        contactmoment_client = build_client("contactmomenten")
+        klanten_client = build_klanten_client()
+        contactmoment_client = build_contactmomenten_client()
 
         try:
             response = klanten_client.get(

--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -3,7 +3,7 @@ import logging
 from ape_pie.client import APIClient
 from requests.exceptions import RequestException
 from zgw_consumers.api_models.base import factory
-from zgw_consumers.client import build_client as _build_client
+from zgw_consumers.client import build_client
 from zgw_consumers.utils import pagination_helper
 
 from open_inwoner.openzaak.api_models import Zaak
@@ -311,7 +311,7 @@ class ContactmomentenClient(APIClient):
             return ocms[0]
 
 
-def build_client(type_) -> APIClient | None:
+def _build_open_klant_client(type_) -> APIClient | None:
     config = OpenKlantConfig.get_solo()
     services_to_client_mapping = {
         "klanten": KlantenClient,
@@ -320,8 +320,16 @@ def build_client(type_) -> APIClient | None:
     if client_class := services_to_client_mapping.get(type_):
         service = getattr(config, f"{type_}_service")
         if service:
-            client = _build_client(service, client_factory=client_class)
+            client = build_client(service, client_factory=client_class)
             return client
 
     logger.warning("no service defined for %s", type_)
     return None
+
+
+def build_contactmomenten_client() -> ContactmomentenClient | None:
+    return _build_open_klant_client("contactmomenten")
+
+
+def build_klanten_client() -> KlantenClient | None:
+    return _build_open_klant_client("klanten")

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1,5 +1,5 @@
 from open_inwoner.accounts.models import User
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import build_klanten_client
 from open_inwoner.utils.logentry import system_action
 
 from .wrap import get_fetch_parameters
@@ -11,7 +11,7 @@ def update_user_from_klant(request):
 
     user: User = request.user
 
-    client = build_client("klanten")
+    client = build_klanten_client()
     if not client:
         return
 

--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -11,7 +11,10 @@ from mail_editor.helpers import find_template
 from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.mail.service import send_contact_confirmation_mail
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import (
+    build_contactmomenten_client,
+    build_klanten_client,
+)
 from open_inwoner.openklant.forms import ContactForm
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.openklant.wrap import get_fetch_parameters
@@ -149,7 +152,7 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
 
         # fetch/update/create klant
         klant = None
-        if klanten_client := build_client("klanten"):
+        if klanten_client := build_klanten_client():
             if self.request.user.is_authenticated and (
                 self.request.user.bsn or self.request.user.kvk
             ):
@@ -245,7 +248,7 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
             data["medewerkerIdentificatie"] = {"identificatie": employee_id}
 
         contactmoment = None
-        if contactmoment_client := build_client("contactmomenten"):
+        if contactmoment_client := build_contactmomenten_client():
             contactmoment = contactmoment_client.create_contactmoment(data, klant=klant)
 
         if contactmoment:

--- a/src/open_inwoner/openklant/wrap.py
+++ b/src/open_inwoner/openklant/wrap.py
@@ -6,7 +6,10 @@ from django.conf import settings
 from open_inwoner.accounts.models import User
 from open_inwoner.kvk.branches import get_kvk_branch_number
 from open_inwoner.openklant.api_models import ContactMoment, KlantContactMoment
-from open_inwoner.openklant.clients import build_client
+from open_inwoner.openklant.clients import (
+    build_contactmomenten_client,
+    build_klanten_client,
+)
 from open_inwoner.openklant.models import KlantContactMomentAnswer, OpenKlantConfig
 from open_inwoner.utils.time import instance_is_new
 
@@ -21,7 +24,7 @@ def fetch_klantcontactmomenten(
     if not user_bsn and not user_kvk_or_rsin:
         return []
 
-    client = build_client("klanten")
+    client = build_klanten_client()
     if client is None:
         return []
 
@@ -35,7 +38,7 @@ def fetch_klantcontactmomenten(
     if klanten is None:
         return []
 
-    client = build_client("contactmomenten")
+    client = build_contactmomenten_client()
     if client is None:
         return []
 


### PR DESCRIPTION
The generic client factory has the drawback of both typing ambiguity (generic APIClient versus concrete KlantenClient) and poor static code analysis. This refactor will address both concerns. 

This also achieves consistency with #1226. 