### PR TITLE
Add support for resolving instance attributes in the cache decorator

### DIFF
--- a/src/open_inwoner/utils/decorators.py
+++ b/src/open_inwoner/utils/decorators.py
@@ -1,5 +1,8 @@
 import inspect
 import logging
+import random
+import re
+import string
 from collections.abc import Callable
 from functools import wraps
 from typing import TypeVar
@@ -12,7 +15,43 @@ logger = logging.getLogger(__name__)
 RT = TypeVar("RT")
 
 
-def cache(key: str, alias: str = "default", *, timeout: int = 60):
+def _generate_attr_placeholder_id(length=12):
+    valid_chars = string.ascii_letters + string.digits + "_"
+    identifier = "".join(random.choice(valid_chars) for _ in range(length))
+    return identifier if not identifier[0].isdigit() else f"_{identifier[1:]}"
+
+
+def _map_cache_key_instance_attrs_to_placeholders(key):
+    identifiers = {}
+
+    # Match `attr` in "{self.attr}:foo:bar:{baz}". Also matches arbitrarily
+    # deeply nested attrs, but simply as a guard to warn the caller that nested
+    # lookups are currently unsupported (and probably a bad idea for this use-case).
+    pattern = r"\{self\.([a-zA-Z_][a-zA-Z0-9_]*)(?:\.([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*))?\}"
+    mapped_key = key
+    mapped_attr_base = _generate_attr_placeholder_id()
+
+    for i, match in enumerate(re.finditer(pattern, key)):
+        if match.group(2) is not None:
+            raise ValueError("Nested lookups on `self` are not supported")
+
+        original_identifier = match.group(1)
+        original = "{self." + original_identifier + "}"
+
+        mapped_identifier = f"{mapped_attr_base}_{i}"
+        replacement = "attribute_" + mapped_identifier
+        identifiers[replacement] = original_identifier
+        mapped_key = mapped_key.replace(original, "{" + replacement + "}")
+
+    return mapped_key, identifiers
+
+
+def cache(
+    key: str,
+    alias: str = "default",
+    *,
+    timeout: int = 60,
+):
     """
     Decorator factory for updating the django low-level cache.
 
@@ -20,7 +59,8 @@ def cache(key: str, alias: str = "default", *, timeout: int = 60):
     or creates it if doesn't exist.
 
     :param key: the caching key to use. Can contain any named positional and keyword argument
-                of the wrapped function as interpolation placeholders.
+    of the wrapped function as interpolation placeholders. When deocarating a method,
+    you can also include instance attributes using the `"cache:{self.attr}"` syntax.
     :param alias: the Django cache to use, defaults to "default"
     :param timeout: the timeout for the cache in seconds. Defaults to 60
     """
@@ -48,17 +88,36 @@ def cache(key: str, alias: str = "default", *, timeout: int = 60):
                 }
                 key_kwargs[argspec.varkw] = var_kwargs
 
-            cache_key = key.format(**key_kwargs)
+            cache_key_with_attr_placeholders, attr_mapping = (
+                _map_cache_key_instance_attrs_to_placeholders(key)
+            )
+            if attr_mapping:
+                if len(args) == 0:
+                    raise ValueError(
+                        "You can only access attributes on `self` when decorating a method"
+                    )
 
+                bound_instance = args[0]
+                for mapped_attr, original_attr in attr_mapping.items():
+                    try:
+                        key_kwargs[mapped_attr] = getattr(bound_instance, original_attr)
+                    except AttributeError:
+                        raise AttributeError(
+                            f"Attribute `{original_attr}` does not exist on bound instance"
+                        )
+
+            cache_key = cache_key_with_attr_placeholders.format(**key_kwargs)
+            logger.debug("Resolved cache_key `%s` to `%s`", key, cache_key)
             _cache: BaseCache = caches[alias]
             result = _cache.get(cache_key)
 
             # The key exists in cache so we return the already cached data
             if result is not None:
-                logger.debug("Cache key '%s' hit", cache_key)
+                logger.debug("Cache hit: '%s'", cache_key)
                 return result
 
             # The key does not exist so we call the decorated function and set the cache
+            logger.debug("Cache miss: '%s'", cache_key)
             result = func(*args, **kwargs)
             _cache.set(cache_key, result, timeout=timeout)
 

--- a/src/open_inwoner/utils/tests/test_utils.py
+++ b/src/open_inwoner/utils/tests/test_utils.py
@@ -1,0 +1,207 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.core.cache import caches
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase as DjangoTestCase, override_settings
+
+import freezegun
+
+from open_inwoner.utils.decorators import cache
+
+MockCache = mock.create_autospec(DummyCache)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "open_inwoner.utils.tests.test_utils.MockCache"}}
+)
+class DynamicCacheKeyTests(DjangoTestCase):
+
+    def setUp(self):
+        self.cache = caches["default"]
+        self.cache.reset_mock()
+
+    def test_method_key_accepts_permutations_of_attr_and_kwarg_keys(self):
+        class TestClass:
+
+            foo = "bar"
+            bar = "baz"
+
+            @cache("alpha:{self.foo}:bravo:{baz}")
+            def with_kwarg_and_attr(self, baz: int):
+                pass
+
+            @cache("alpha:{bar}:bravo:{baz}")
+            def with_kwargs_only(self, bar: str, baz: int):
+                pass
+
+            @cache("alpha:{self.foo}:bravo:{self.bar}")
+            def with_attrs_only(self):
+                pass
+
+            @cache("alpha:{self.foo}:bravo:{self.bar}:{bar}:charlie:{baz}")
+            def with_multiple_attrs_and_kwargs(self, bar, baz):
+                pass
+
+            @cache("static")
+            def with_static_key(self):
+                pass
+
+        instance = TestClass()
+        instance.with_kwargs_only("charlie", 42)
+        instance.with_attrs_only()
+        instance.with_kwarg_and_attr(baz=5)
+        instance.with_multiple_attrs_and_kwargs("charlie", 42)
+        instance.with_static_key()
+
+        self.cache.get.assert_has_calls(
+            [
+                mock.call("alpha:charlie:bravo:42"),
+                mock.call("alpha:bar:bravo:baz"),
+                mock.call("alpha:bar:bravo:5"),
+                mock.call("alpha:bar:bravo:baz:charlie:charlie:42"),
+                mock.call("static"),
+            ]
+        )
+
+    def test_non_existent_attr_key_raises(self):
+        class TestInstance:
+            @cache("alpha:{self.non_existent_attr}")
+            def missing_attr(self):
+                pass
+
+        instance = TestInstance()
+
+        with self.assertRaises(AttributeError):
+            instance.missing_attr()
+
+    def test_nested_attr_key_raises(self):
+        m = mock.Mock()
+        m.nested_foo = "Nested foo"
+
+        class TestInstance:
+            foo = m
+
+            @cache("alpha:{self.foo.nested_foo}")
+            def nested_attr(self):
+                pass
+
+            @cache("alpha:{self.foo.nested_foo.nested_again.and_again}")
+            def deeply_nested_attr(self):
+                pass
+
+        instance = TestInstance()
+
+        with self.assertRaises(ValueError):
+            instance.nested_attr()
+
+        with self.assertRaises(ValueError):
+            instance.deeply_nested_attr()
+
+    def test_attr_key_on_plain_function_raises(self):
+        @cache("{self.foo}:bar:baz")
+        def foo():
+            pass
+
+        with self.assertRaises(ValueError):
+            foo()
+
+        self.cache.get.assert_not_called()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+)
+class CacheBehaviorTests(DjangoTestCase):
+
+    def setUp(self):
+        caches["default"].clear()
+
+    def test_static_cache_key_caches_value(self):
+        m = mock.MagicMock()
+        m.return_value = 42
+
+        @cache("static")
+        def func():
+            return m()
+
+        results = [
+            # miss
+            func(),
+            # hit
+            func(),
+        ]
+        m.assert_called_once()
+        self.assertEqual(results, [42, 42])
+
+    @freezegun.freeze_time("2024-05-31 12:00:00", as_kwarg="frozen_time")
+    def test_timeout_expires_value(self, frozen_time):
+        m = mock.Mock(side_effect=lambda x: x)
+
+        @cache("dynamic:{x}", timeout=1)
+        def func(x):
+            return m(x)
+
+        results = [
+            # miss
+            func(42),
+            # hit
+            func(42),
+        ]
+
+        frozen_time.tick(delta=timedelta(seconds=2))
+        results.extend(
+            [
+                # miss due to expiry
+                func(42),
+                # hit
+                func(42),
+            ]
+        )
+
+        self.assertEqual(m.call_count, 2)
+        self.assertEqual(results, [42, 42, 42, 42])
+
+    def test_dynamic_cache_key_varies_value(self):
+        m = mock.Mock(side_effect=lambda x: x)
+
+        @cache("dynamic:{a}")
+        def func(a: int):
+            return m(a)
+
+        results = [func(n) for n in [5, 5, 6]]  # 1 hit
+
+        self.assertEqual(m.call_count, 2)
+        self.assertEqual(results, [5, 5, 6])
+
+    def test_method_cache_key_varies_by_value_and_attr(self):
+        m = mock.Mock(side_effect=lambda x: x)
+
+        class TestClass:
+            foo = "bar"
+
+            @cache("alpha:{self.foo}:bravo:{baz}")
+            def with_kwarg_and_attr(self, baz: int):
+                return m(baz)
+
+        class DifferentAttrTestClass(TestClass):
+            foo = "fubar"
+
+        instance1, instance2 = TestClass(), DifferentAttrTestClass()
+        results = []
+        for instance in instance1, instance2:
+            results.extend(
+                [
+                    instance.with_kwarg_and_attr(5),  # miss
+                    instance.with_kwarg_and_attr(5),  # hit
+                    instance.with_kwarg_and_attr(6),  # miss
+                    instance.with_kwarg_and_attr(6),  # hit
+                ]
+            )
+
+        self.assertEqual(
+            m.call_count,
+            4,
+            msg="Same calls with varying instance attrs should lead to cache separation",
+        )
+        self.assertEqual(results, [5, 5, 6, 6, 5, 5, 6, 6])


### PR DESCRIPTION
Taiga issue [#2516](https://taiga.maykinmedia.nl/project/open-inwoner/task/2516).

This will be followed by a PR to actually use this in the ZGW clients (and will probably also remove a few tests that were really just testing the underlying caching logic, which I've included here in a more isolated form by testing the cache behavior directly).