### PR TITLE
[#2416] Scope ZGW clients cache keys by the underlying service endpoint

### DIFF
--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -66,7 +66,7 @@ class ZakenClient(APIClient):
         return []
 
     @cache_result(
-        "cases:{user_bsn}:{max_requests}:{identificatie}",
+        "{self.base_url}:cases:{user_bsn}:{max_requests}:{identificatie}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_cases_by_bsn(
@@ -114,7 +114,7 @@ class ZakenClient(APIClient):
         return cases
 
     @cache_result(
-        "cases:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}",
+        "{self.base_url}:cases:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_cases_by_kvk_or_rsin(
@@ -174,7 +174,10 @@ class ZakenClient(APIClient):
 
         return cases
 
-    @cache_result("single_case:{case_uuid}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT)
+    @cache_result(
+        "{self.base_url}:single_case:{case_uuid}",
+        timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
+    )
     def fetch_single_case(self, case_uuid: str) -> Zaak | None:
         try:
             response = self.get(f"zaken/{case_uuid}", headers=CRS_HEADERS)
@@ -200,7 +203,8 @@ class ZakenClient(APIClient):
         return case
 
     @cache_result(
-        "single_case_information_object:{url}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT
+        "{self.base_url}:single_case_information_object:{url}",
+        timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_single_case_information_object(
         self, url: str
@@ -246,11 +250,14 @@ class ZakenClient(APIClient):
 
         return statuses
 
-    @cache_result("status_history:{case_url}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT)
+    @cache_result(
+        "{self.base_url}:status_history:{case_url}",
+        timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
+    )
     def fetch_status_history(self, case_url: str) -> list[Status]:
         return self.fetch_status_history_no_cache(case_url)
 
-    @cache_result("status:{status_url}", timeout=60 * 60)
+    @cache_result("{self.base_url}:status:{status_url}", timeout=60 * 60)
     def fetch_single_status(self, status_url: str) -> Status | None:
         try:
             response = self.get(url=status_url)
@@ -264,7 +271,7 @@ class ZakenClient(APIClient):
         return status
 
     @cache_result(
-        "case_roles:{case_url}:{role_desc_generic}",
+        "{self.base_url}:case_roles:{case_url}:{role_desc_generic}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_case_roles(
@@ -385,7 +392,8 @@ class ZakenClient(APIClient):
         return case_info_objects
 
     @cache_result(
-        "single_result:{result_url}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT
+        "{self.base_url}:single_result:{result_url}",
+        timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_single_result(self, result_url: str) -> Resultaat | None:
         try:
@@ -453,7 +461,8 @@ class CatalogiClient(APIClient):
         return result_types
 
     @cache_result(
-        "status_type:{status_type_url}", timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT
+        "{self.base_url}:status_type:{status_type_url}",
+        timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT,
     )
     def fetch_single_status_type(self, status_type_url: str) -> StatusType | None:
         try:
@@ -468,7 +477,7 @@ class CatalogiClient(APIClient):
         return status_type
 
     @cache_result(
-        "resultaat_type:{resultaat_type_url}",
+        "{self.base_url}:resultaat_type:{resultaat_type_url}",
         timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT,
     )
     def fetch_single_resultaat_type(
@@ -522,7 +531,8 @@ class CatalogiClient(APIClient):
         return zaak_types
 
     @cache_result(
-        "case_type:{case_type_url}", timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT
+        "{self.base_url}:case_type:{case_type_url}",
+        timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT,
     )
     def fetch_single_case_type(self, case_type_url: str) -> ZaakType | None:
         try:
@@ -553,7 +563,7 @@ class CatalogiClient(APIClient):
         return catalogs
 
     @cache_result(
-        "information_object_type:{information_object_type_url}",
+        "{self.base_url}:information_object_type:{information_object_type_url}",
         timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT,
     )
     def fetch_single_information_object_type(

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -196,13 +196,17 @@ class OpenCaseListCacheTests(ClearCachesMixin, TransactionTestCase):
         self._setUpMocks(m)
 
         # Cache is empty before the request
-        self.assertIsNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+        self.assertIsNone(
+            cache.get(f"{CATALOGI_ROOT}:case_type:{self.zaaktype['url']}")
+        )
 
         self.client.force_login(user=self.user)
         self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
         # Case type is cached after the request
-        self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+        self.assertIsNotNone(
+            cache.get(f"{CATALOGI_ROOT}:case_type:{self.zaaktype['url']}")
+        )
 
     def test_cached_case_types_are_deleted_after_one_day(self, m):
         self._setUpMocks(m)
@@ -213,30 +217,42 @@ class OpenCaseListCacheTests(ClearCachesMixin, TransactionTestCase):
 
             # After one day the results should be deleted
             frozen_time.tick(delta=datetime.timedelta(days=1))
-            self.assertIsNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+            self.assertIsNone(
+                cache.get(f"{ZAKEN_ROOT}:case_type:{self.zaaktype['url']}")
+            )
 
     def test_cached_case_types_in_combination_with_new_ones(self, m):
         self._setUpMocks(m)
 
         with freeze_time("2022-01-01 12:00") as frozen_time:
             # First attempt
-            self.assertIsNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+            self.assertIsNone(
+                cache.get(f"{CATALOGI_ROOT}:case_type:{self.zaaktype['url']}")
+            )
 
             self.client.force_login(user=self.user)
             self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-            self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
+            self.assertIsNotNone(
+                cache.get(f"{CATALOGI_ROOT}:case_type:{self.zaaktype['url']}")
+            )
 
             # Second attempt with new case and case type
             self._setUpNewMock(m)
             # Wait 3 minutes for the list cases cache to expire
             frozen_time.tick(delta=datetime.timedelta(minutes=3))
-            self.assertIsNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
+            self.assertIsNone(
+                cache.get(f"{CATALOGI_ROOT}:case_type:{self.new_zaaktype['url']}")
+            )
 
             self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-            self.assertIsNotNone(cache.get(f"case_type:{self.zaaktype['url']}"))
-            self.assertIsNotNone(cache.get(f"case_type:{self.new_zaaktype['url']}"))
+            self.assertIsNotNone(
+                cache.get(f"{CATALOGI_ROOT}:case_type:{self.zaaktype['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"{CATALOGI_ROOT}:case_type:{self.new_zaaktype['url']}")
+            )
 
     def test_cached_status_types_are_deleted_after_one_day(self, m):
         self._setUpMocks(m)
@@ -248,25 +264,29 @@ class OpenCaseListCacheTests(ClearCachesMixin, TransactionTestCase):
             # After one day the results should be deleted
             frozen_time.tick(delta=datetime.timedelta(hours=24))
             self.assertIsNone(
-                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+                cache.get(
+                    f"{ZAKEN_ROOT}:status_types_for_case_type:{self.zaaktype['url']}"
+                )
             )
             self.assertIsNone(
-                cache.get(f"status_types_for_case_type:{self.zaaktype['url']}")
+                cache.get(
+                    f"{ZAKEN_ROOT}:status_types_for_case_type:{self.zaaktype['url']}"
+                )
             )
 
     def test_statuses_are_cached(self, m):
         self._setUpMocks(m)
 
         # Cache is empty before the request
-        self.assertIsNone(cache.get(f"status:{self.status1['url']}"))
-        self.assertIsNone(cache.get(f"status:{self.status2['url']}"))
+        self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}"))
+        self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}"))
 
         self.client.force_login(user=self.user)
         self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
         # Status is cached after the request
-        self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
-        self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
+        self.assertIsNotNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}"))
+        self.assertIsNotNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}"))
 
     def test_cached_statuses_are_deleted_after_one_hour(self, m):
         self._setUpMocks(m)
@@ -277,22 +297,26 @@ class OpenCaseListCacheTests(ClearCachesMixin, TransactionTestCase):
 
             # After one hour the results should be deleted
             frozen_time.tick(delta=datetime.timedelta(hours=1))
-            self.assertIsNone(cache.get(f"status:{self.status1['url']}"))
-            self.assertIsNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}"))
+            self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}"))
 
     def test_cached_statuses_in_combination_with_new_ones(self, m):
         self._setUpMocks(m)
 
         with freeze_time("2022-01-01 12:00") as frozen_time:
             # First attempt
-            self.assertIsNone(cache.get(f"status:{self.status1['url']}"))
-            self.assertIsNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}"))
+            self.assertIsNone(cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}"))
 
             self.client.force_login(user=self.user)
             self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-            self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
-            self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNotNone(
+                cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}")
+            )
 
             # Second attempt with new case and status type
             self._setUpNewMock(m)
@@ -302,6 +326,12 @@ class OpenCaseListCacheTests(ClearCachesMixin, TransactionTestCase):
 
             self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-            self.assertIsNotNone(cache.get(f"status:{self.new_status['url']}"))
-            self.assertIsNotNone(cache.get(f"status:{self.status1['url']}"))
-            self.assertIsNotNone(cache.get(f"status:{self.status2['url']}"))
+            self.assertIsNotNone(
+                cache.get(f"{ZAKEN_ROOT}:status:{self.new_status['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"{ZAKEN_ROOT}:status:{self.status1['url']}")
+            )
+            self.assertIsNotNone(
+                cache.get(f"{ZAKEN_ROOT}:status:{self.status2['url']}")
+            )


### PR DESCRIPTION
Taiga [#2516](https://taiga.maykinmedia.nl/project/open-inwoner/task/2516).