### PR TITLE
:wheelchair: [#2370] Enable equal text-alternative for Header and Footer logo

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -16,7 +16,7 @@
             </button>
         {% endif %}
         {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
-        {% include "components/Logo/Logo.html" with src=config.logo.file.url alt="Homepage "|add:logo_alt_text svg_height=75 only %}
+        {% include "components/Logo/Logo.html" with src=config.logo.file.url alt=logo_alt_text svg_height=75 only %}
 
         {% if request.user.is_authenticated %}
             <span class="nav-login--icon">{% icon icon="how_to_reg" icon_position="before" outlined=True %}</span>
@@ -104,7 +104,7 @@
             {# end of submenu items #}
 
     {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
-        <div class="logo__desktop">{% include "components/Logo/Logo.html" with src=config.logo.file.url alt="Homepage "|add:logo_alt_text svg_height=75 only %}</div>
+        <div class="logo__desktop">{% include "components/Logo/Logo.html" with src=config.logo.file.url alt=logo_alt_text svg_height=75 only %}</div>
 
         {% include "components/Header/PrimaryNavigation.html" %}
 


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2370
de tekstuele inhoud van de Alt/Aria/Title tekstalternatieven is een taak voor redacteuren maar de hardcoded 'homepage' tekst in het Header logo moet worden verwijderd zodat het tekstalternatief volledig door de redacteur kan worden bepaald.

En: het tekstalternatief moet ook eigenlijk **starten** met de labeltekst, dus dan zou Homepage pas op het eind gezet mogen worden, maar het kan hier beter verwijderd worden,
(i.p.v. Homepage wil men bijvoorbeeld misschien "inlogpagina" gebruiken).