### PR TITLE
:bug: [#2544] Added quickfix for non-URL dependent tab panels

### DIFF
--- a/src/open_inwoner/scss/components/TabPanel/TabPanel.scss
+++ b/src/open_inwoner/scss/components/TabPanel/TabPanel.scss
@@ -109,7 +109,7 @@
 
     // Styling for Benefits reports/Mijn uitkeringen
     .form {
-      //max-width: var(--mobile-ms-width);
+      max-width: var(--mobile-ms-width);
 
       .form__actions {
         margin-top: 0;

--- a/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
+++ b/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
@@ -20,7 +20,10 @@
                     </ul>
                     {% if client.config.maandspecificatie_enabled is True %}
                         <div class="tabs__body">
-                            <div id="maandspecificaties" class="tab__content active">
+                        {# Note: Mijn uitkeringen tab-content styles need to be independent from the URL, unlike the Tabs of the Login page #}
+                        {# URL-dependent styles would be coming from src/open_inwoner/js/components/tab-panels #}
+                        {# Setting class to 'tab__contents' instead of 'tab__content' is a quick-fix #}
+                            <div id="maandspecificaties" class="tab__contents active">
                                 <p>
                                     {% blocktrans with display_text=client.config.maandspecificatie_display_text %}
                                         {{ display_text }}

--- a/src/open_inwoner/templates/pages/ssd/yearly_reports_list.html
+++ b/src/open_inwoner/templates/pages/ssd/yearly_reports_list.html
@@ -21,7 +21,10 @@
 
                     {% if client.config.jaaropgave_enabled is True %}
                     <div class="tabs__body">
-                        <div id="jaaropgaven" class="tab__content active">
+                    {# Note: Mijn uitkeringen tab-content styles need to be independent from the URL, unlike the Tabs of the Login page #}
+                    {# URL-dependent styles would be coming from src/open_inwoner/js/components/tab-panels #}
+                    {# Setting class to 'tab__contents' instead of 'tab__content' is a quick-fix #}
+                        <div id="maandspecificaties" class="tab__contents active">
                             <p>
                                 {% blocktrans with jaaropgave_text=client.config.jaaropgave_display_text %}
                                     {{ jaaropgave_text }}


### PR DESCRIPTION
quick-fix, because in future 'Mijn uitkeringen' will have a bigger design update, just like the login-page, and it needs to not respond to the URL-dependent javascript.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/2392 