### PR TITLE
♿ [#2344] Add text alternatives for meaningful status-icons

### DIFF
--- a/src/open_inwoner/templates/pages/cases/statuses.html
+++ b/src/open_inwoner/templates/pages/cases/statuses.html
@@ -13,6 +13,7 @@
                 {% firstof case.id|slugify as id %}
                 {% firstof 'content-'|add:id|add:'-id' as content_id %}
                     {% icon icon="circle" extra_classes="status-step" %}
+                    <span class="sr-only">{% trans 'Niet voltooid' %}</span>
                     <div class="status-list__notification status-list__notification--{{ status.status_indicator }}">
                         <h3 class="utrecht-heading-3 utrecht-accordion__header">
                             <button class="button--borderless {% if case.end_statustype_data %}status-list__button{% endif %} {# Final status class #}{% if not case.end_statustype_data %}status-list__open-button{% endif %}" aria-controls="{{ content_id }}" aria-expanded="true" id="{{ id }}">
@@ -47,6 +48,7 @@
                 {% firstof case.id|slugify as id %}
                 {% firstof 'completed-'|add:id|add:'-id' as completed_id %}
                     {% icon icon="task_alt" %}
+                    <span class="sr-only">{% trans 'Voltooid' %}</span>
                     <div class="status-list__notification">
                         <h3 class="utrecht-heading-3 utrecht-accordion__header">
                             <button class="status-list__button button--borderless" aria-controls="{{ completed_id }}" aria-expanded="false" id="{{ id }}"><a href="#" class="link link-success">{{ status.label }}</a>{% icon icon="expand_more" icon_position="after" outlined=True %}</button>
@@ -67,6 +69,7 @@
         {% if case.second_status_preview %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
+                <span class="sr-only">{% trans 'Toekomstige status' %}</span>
                 <div class="status-list__notification status-list__notification">
                     <div class="status-list__open"><span class="link link-future">{{ case.second_status_preview.omschrijving }}</span></div>
                 </div>
@@ -77,6 +80,7 @@
         {% if case.end_statustype_data %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
+                <span class="sr-only">{% trans 'Toekomstige voltooide status' %}</span>
                 <div class="status-list__notification status-list__notification--future">
                     <div class="status-list__open"><span class="link link-future">{{ case.end_statustype_data.label }}</span></div>
                 </div>

--- a/src/open_inwoner/templates/pages/cases/statuses.html
+++ b/src/open_inwoner/templates/pages/cases/statuses.html
@@ -13,7 +13,7 @@
                 {% firstof case.id|slugify as id %}
                 {% firstof 'content-'|add:id|add:'-id' as content_id %}
                     {% icon icon="circle" extra_classes="status-step" %}
-                    <span class="sr-only">{% trans 'Niet voltooid' %}</span>
+                    <span class="sr-only">{% trans "Niet voltooid" %}</span>
                     <div class="status-list__notification status-list__notification--{{ status.status_indicator }}">
                         <h3 class="utrecht-heading-3 utrecht-accordion__header">
                             <button class="button--borderless {% if case.end_statustype_data %}status-list__button{% endif %} {# Final status class #}{% if not case.end_statustype_data %}status-list__open-button{% endif %}" aria-controls="{{ content_id }}" aria-expanded="true" id="{{ id }}">
@@ -48,7 +48,7 @@
                 {% firstof case.id|slugify as id %}
                 {% firstof 'completed-'|add:id|add:'-id' as completed_id %}
                     {% icon icon="task_alt" %}
-                    <span class="sr-only">{% trans 'Voltooid' %}</span>
+                    <span class="sr-only">{% trans "Voltooid" %}</span>
                     <div class="status-list__notification">
                         <h3 class="utrecht-heading-3 utrecht-accordion__header">
                             <button class="status-list__button button--borderless" aria-controls="{{ completed_id }}" aria-expanded="false" id="{{ id }}"><a href="#" class="link link-success">{{ status.label }}</a>{% icon icon="expand_more" icon_position="after" outlined=True %}</button>
@@ -69,7 +69,7 @@
         {% if case.second_status_preview %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
-                <span class="sr-only">{% trans 'Toekomstige status' %}</span>
+                <span class="sr-only">{% trans "Toekomstige status" %}</span>
                 <div class="status-list__notification status-list__notification">
                     <div class="status-list__open"><span class="link link-future">{{ case.second_status_preview.omschrijving }}</span></div>
                 </div>
@@ -80,7 +80,7 @@
         {% if case.end_statustype_data %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
-                <span class="sr-only">{% trans 'Toekomstige voltooide status' %}</span>
+                <span class="sr-only">{% trans "Toekomstige voltooide status" %}</span>
                 <div class="status-list__notification status-list__notification--future">
                     <div class="status-list__open"><span class="link link-future">{{ case.end_statustype_data.label }}</span></div>
                 </div>


### PR DESCRIPTION
icons need to remain hidden for screenreaders (aria-hidden=true) because material-icons and font-awesome etc. do not provide proper meaningful text, so to add meaning we add a span with the visually hidden sr-only class.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2344