### PR TITLE
♿ [#2369] Add focus-style for custom file-input

### DIFF
--- a/src/open_inwoner/components/templates/components/Form/FileInput.html
+++ b/src/open_inwoner/components/templates/components/Form/FileInput.html
@@ -3,7 +3,7 @@
 <div class="form__control file-input" aria-live="polite">
     {% render_card direction="vertical" %}
         {% icon icon="upload" icon_position="before" outlined=True extra_classes="icon--large" %}
-        <input class="file-input__input" id="{{ field.auto_id }}" name="file" type="file"{% if field.field.required %} required{% endif %}{% if multiple %} multiple{% endif %} data-max-size="{{ max_upload_size }}" data-file-types="{{ allowed_file_extensions }}">
+        <input class="file-input__input" id="{{ field.auto_id }}" name="file" type="file"{% if field.field.required %} required{% endif %}{% if multiple %} multiple{% endif %} data-max-size="{{ max_upload_size }}" data-file-types="{{ allowed_file_extensions }}" />
         <label class="button button--primary file-input__label-empty" for="{{ field.auto_id }}">
             {% if multiple %}{% trans 'Sleep of selecteer bestanden' %}{% else %}{% trans 'Sleep of selecteer bestand' %}{% endif %}
         </label>

--- a/src/open_inwoner/scss/components/Form/FileInput.scss
+++ b/src/open_inwoner/scss/components/Form/FileInput.scss
@@ -71,6 +71,24 @@
     pointer-events: none;
     width: 100%;
     height: var(--row-height-giant);
+
+    // Adjacent keyboard focus for custom hidden file-input
+    &:focus + .file-input__label-empty,
+    &:focus + .file-input__label-empty + .file-input__label-selected {
+      outline: var(--focus-border-style) var(--focus-border-width)
+        var(--color-primary);
+      padding: 0 var(--spacing-large);
+    }
+  }
+
+  // Active adjacent styles for custom hidden file-input
+  &__label-empty,
+  &__label-selected {
+    &:active {
+      outline: var(--focus-border-style) var(--focus-border-width)
+        var(--color-primary);
+      padding: 0 var(--spacing-large);
+    }
   }
 
   > .utrecht-paragraph {

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -254,6 +254,11 @@
 
   /// Common widths
   --form-width: 500px;
+
+  /// Custom focus outline for elements that do not receive default client focus-styles
+  --focus-border-width: 3px;
+  --focus-border-style: dashed;
+  // focus-border colors can be determined by what kind of element receive them
 }
 
 @font-face {


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2369

Will look a bit different in various browsers:

<img width="1079" alt="outline" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/e0ad51fa-2e58-40c9-89c6-563070776035">
