### PR TITLE
♿ [#2352] Set meaningful order in cards with status-indicator

### DIFF
--- a/src/open_inwoner/scss/components/Card/CardGrid.scss
+++ b/src/open_inwoner/scss/components/Card/CardGrid.scss
@@ -3,7 +3,7 @@
     grid-column-gap: var(--spacing-extra-large);
 
     // Tablets
-    @media (min-width: 500px) and (max-width: 767px) {
+    @media (min-width: 512px) and (max-width: 767px) {
       flex-direction: row;
       flex-wrap: wrap;
 

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -1,8 +1,48 @@
 .cases {
   /// cards on cases list
   .card {
-    .cases__link {
-      text-decoration: none;
+    &__body {
+      display: flex;
+      flex-direction: column;
+      padding: 0;
+
+      .list:last-of-type {
+        padding-bottom: 0;
+        @media (min-width: 500px) {
+          padding-bottom: calc(2 * var(--card-spacing-vertical));
+        }
+      }
+
+      // Meaningful sequence for accessibility
+      .card__heading-2 {
+        order: 2;
+        padding: var(--card-spacing-vertical) var(--card-spacing-horizontal) 0
+          var(--card-spacing-horizontal);
+      }
+
+      .card__header {
+        order: 1;
+      }
+
+      .list {
+        box-sizing: border-box;
+        order: 3;
+        padding: 0 var(--card-spacing-horizontal);
+      }
+
+      .link--secondary {
+        order: 4;
+        padding: 0 var(--card-spacing-horizontal);
+      }
+    }
+
+    &--stretch .list + .link:first-of-type:last-of-type {
+      padding-bottom: var(--card-spacing-vertical);
+
+      @media (min-width: 500px) {
+        padding-bottom: 0;
+        position: absolute;
+      }
     }
   }
 

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -11,50 +11,60 @@
 
     {% for case in cases %}
         {% render_column start=forloop.counter_0|multiply:4 span=4 %}
-    <div class="card card--compact card--stretch">
-            {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=case.statustype_config.status_indicator status_indicator_text=case.statustype_config.status_indicator_text %}
-            <div class="card__body">
-                <!-- submission cases -->
-                {% if case.case_type == "OpenSubmission" %}
-                    <a href="{{ case.vervolg_link }}" class="cases__link">
-                    <h2 class="card__heading-2">{{ case.naam }}</h2>
-                    {% render_list %}
-                        <li class="list-item list-item--compact">
-                            {% with end_date=case.eind_datum_geldigheid|default:"Geen" %}
-                            <p class="card__caption card__text--small"><span>{% trans "Aanvraag verloopt op:" %}</span><span class="card__text--dark">{{ end_date|date }}</span></p>
-                            {% endwith %}
-                        </li>
-                        {% list_item text="Openstaande aanvraag" caption=_("Status") compact=True strong=False %}
-                    {% endrender_list %}
-                    <span class="link link--icon link--secondary">
+
+            <!-- submission cases -->
+            {% if case.case_type == "OpenSubmission" %}
+
+                <a href="{{ case.vervolg_link }}" class="card card card__description-card card--stretch">
+                    <div class="card__body">
+
+                        <h2 class="card__heading-2">{{ case.naam }}</h2>
+                        {# Meaningful sequence for accessibility: any text belonging to a heading must be below the heading #}
+                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=case.statustype_config.status_indicator status_indicator_text=case.statustype_config.status_indicator_text %}
+
+                        {% render_list %}
+                            <li class="list-item list-item--compact">
+                                {% with end_date=case.eind_datum_geldigheid|default:"Geen" %}
+                                    <p class="card__caption card__text--small"><span>{% trans "Aanvraag verloopt op:" %}</span><span class="card__text--dark">{{ end_date|date }}</span></p>
+                                {% endwith %}
+                            </li>
+                            {% list_item text="Openstaande aanvraag" caption=_("Status") compact=True strong=False %}
+                        {% endrender_list %}
+                        <span class="link link--icon link--secondary">
                         <span class="link__text">{% trans "Aanvraag afronden" %}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
-                    </a>
+                    </div>
+                </a>
                 <!-- other cases -->
-                {% else %}
-                    <a href="{% url 'cases:case_detail' object_id=case.uuid %}" class="cases__link">
-                    <h2 class="card__heading-2">{{ case.description }}</h2>
-                    {% render_list %}
-                        <li class="list-item list-item--compact">
-                            <p class="card__caption card__text--small"><span>{% trans "Aanvraag ingediend op:" %}</span><span class="card__text--dark">{{ case.start_date }}</span></p>
-                        </li>
-                        {% if case.current_status %}
-                            {% list_item case.current_status caption=_("Status") compact=True strong=False %}
-                        {% else %}
-                            {% list_item "No status" caption=_("Status") compact=True strong=False %}
-                        {% endif%}
-                        {% list_item case.identification caption=_("Zaaknummer") compact=True strong=False %}
-                    {% endrender_list %}
+            {% else %}
+                <a href="{% url 'cases:case_detail' object_id=case.uuid %}" class="card card card__description-card card--stretch">
+                    <div class="card__body">
 
-                    <span class="link link--icon link--secondary">
+                        <h2 class="card__heading-2">{{ case.description }}</h2>
+                        {# Meaningful sequence for accessibility: any text belonging to a heading must be below the heading #}
+                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=case.statustype_config.status_indicator status_indicator_text=case.statustype_config.status_indicator_text %}
+
+                        {% render_list %}
+                            <li class="list-item list-item--compact">
+                                <p class="card__caption card__text--small"><span>{% trans "Aanvraag ingediend op:" %}</span><span class="card__text--dark">{{ case.start_date }}</span></p>
+                            </li>
+                            {% if case.current_status %}
+                                {% list_item case.current_status caption=_("Status") compact=True strong=False %}
+                            {% else %}
+                                {% list_item "No status" caption=_("Status") compact=True strong=False %}
+                            {% endif %}
+                            {% list_item case.identification caption=_("Zaaknummer") compact=True strong=False %}
+                        {% endrender_list %}
+
+                        <span class="link link--icon link--secondary">
                         <span class="link__text">{{ case.statustype_config.case_link_text|default:"Bekijk aanvraag" }}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
-                    </a>
-                {% endif %}
-            </div>
-        </div>
+                    </div>
+                </a>
+            {% endif %}
+
         {% endrender_column %}
     {% endfor %}
 {% endrender_grid %}


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2352

Meaningful sequence for accessibility: any text belonging to a heading must be below the heading
Also corrected faulty build of this Card: the entire card needs to be an anchor, including the spacing/padding.
Which means an extra complication when there is an element that needs to be independent from the other padding (the colored status indicator headers), therefore setting padding to each element inside the card body, which also influences the Grid.