### PR TITLE
♿ [#2352] Remove faulty aria-label and add external link

### DIFF
--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -104,16 +104,16 @@ def get_product_rendered_content(product):
                     }
                 )
                 icon.append("open_in_new")
-                # Create the screen reader only text span element
-                sr_only_text = soup.new_tag("span")
-                sr_only_text.attrs.update(
+
+                screen_reader_only_text = soup.new_tag("span")
+                screen_reader_only_text.attrs.update(
                     {
                         "class": "sr-only",
                     }
                 )
-                sr_only_text.append(_("Opens external website"))
-                # Append both elements to the anchor
+                screen_reader_only_text.append(_("Opens external website"))
+
                 element.append(icon)
-                element.append(sr_only_text)
+                element.append(screen_reader_only_text)
 
     return soup

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -100,11 +100,20 @@ def get_product_rendered_content(product):
                 icon.attrs.update(
                     {
                         "aria-hidden": "true",
-                        "aria-label": _("Opens in new window"),
                         "class": "material-icons",
                     }
                 )
                 icon.append("open_in_new")
+                # Create the screen reader only text span element
+                sr_only_text = soup.new_tag("span")
+                sr_only_text.attrs.update(
+                    {
+                        "class": "sr-only",
+                    }
+                )
+                sr_only_text.append(_("Opens external website"))
+                # Append both elements to the anchor
                 element.append(icon)
+                element.append(sr_only_text)
 
     return soup


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2343

This approach ensures that screen readers can read both the visible link text (inside the a-href anchor) _**and**_ the additional information about the link opening a new/different website, which is information coming from the meaningful icon.