### PR TITLE
♿ [#2340] Header/footer logo use alt from image configuration

### DIFF
--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -149,7 +149,8 @@
                 {% endif %}
                 {% if footer.logo %}
                     <div class="footer__logo">
-                        {% include "components/Logo/Logo.html" with src=footer.logo.url alt=footer.logo_alt href=footer.logo_url svg_height=60 only %}
+                    {% firstof config.footer_logo.default_alt_text config.name as logo_alt_text %}
+                        {% include "components/Logo/Logo.html" with src=footer.logo.url alt=logo_alt_text href=footer.logo_url svg_height=60 only %}
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2340

Both the header logo and the footer logo need to use the same ALT that can be set in the Admin in the '**mappen**' configuration: http://localhost:8000/admin/filer/folder/

Each image in there (navigate to any in the mappen/directories) has an 'ALT' field that can be set - but when empty the image should just receive value from the Site Name.

<img width="1347" alt="Screenshot 2024-06-17 at 17 41 58" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/efa113db-cc2b-49c9-abae-9a9cefe4a448">
