### PR TITLE
:arrow_up: [#2562] Bump lxml and xmlsec to their latest versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -379,7 +379,7 @@ jsonschema==4.1.0
     # via drf-spectacular
 kombu==5.3.7
     # via celery
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   django-digid-eherkenning
     #   mail-editor
@@ -581,7 +581,7 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via maykin-python3-saml
 xsdata==23.8
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -691,7 +691,7 @@ kombu==5.3.7
     #   celery
 lazy-object-proxy==1.6.0
     # via astroid
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1134,7 +1134,7 @@ xlwt==1.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -789,7 +789,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 locust==2.20.0
     # via -r requirements/dev.in
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1352,7 +1352,7 @@ xlwt==1.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   tablib
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
xmlsec has done efforts to support binary wheels together with lxml to avoid compile/installation/runtime issues, which should also speed up installation since no source compilation is required.

Commit message from eeac088fe42ce943dbd904437066c3f9e7c9f830:

Several teammembers have faced sporadic issues installing xmlsec due to missing binaries and the resulting difficulties in building the packages with the right library versions. Requiring at least 1.3.14 allows us to use the pre-built binaries.