### PR TITLE
[#2566] Persist the originating ZGW service on the client

### DIFF
--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 from datetime import date
+from typing import Literal, Mapping, Type, TypeAlias
 
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -680,9 +681,15 @@ class FormClient(APIClient):
         return results
 
 
-def _build_zgw_client(type_) -> APIClient | None:
+ZgwClientType = Literal["zaak", "catalogi", "document", "form"]
+ZgwClientFactoryReturn: TypeAlias = (
+    ZakenClient | CatalogiClient | DocumentenClient | FormClient
+)
+
+
+def _build_zgw_client(type_: ZgwClientType) -> ZgwClientFactoryReturn | None:
     config = OpenZaakConfig.get_solo()
-    services_to_client_mapping = {
+    services_to_client_mapping: Mapping[ZgwClientType, Type[ZgwClientFactoryReturn]] = {
         "zaak": ZakenClient,
         "catalogi": CatalogiClient,
         "document": DocumentenClient,

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -13,6 +13,7 @@ from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.catalogi import Catalogus
 from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
 from zgw_consumers.client import build_client
+from zgw_consumers.models import Service
 from zgw_consumers.service import pagination_helper
 
 from open_inwoner.openzaak.api_models import InformatieObject
@@ -39,7 +40,17 @@ CRS_HEADERS = {"Content-Crs": "EPSG:4326", "Accept-Crs": "EPSG:4326"}
 logger = logging.getLogger(__name__)
 
 
-class ZakenClient(APIClient):
+class ZgwAPIClient(APIClient):
+    """A client for interacting with ZGW services."""
+
+    configured_from: Service
+
+    def __init__(self, *args, **kwargs):
+        self.configured_from = kwargs.pop("configured_from")
+        super().__init__(*args, **kwargs)
+
+
+class ZakenClient(ZgwAPIClient):
     def fetch_cases(
         self,
         user_bsn: str | None = None,
@@ -424,7 +435,7 @@ class ZakenClient(APIClient):
         return data
 
 
-class CatalogiClient(APIClient):
+class CatalogiClient(ZgwAPIClient):
     # not cached because only used by tools,
     # and because caching (stale) listings can break lookups
     def fetch_status_types_no_cache(self, case_type_url: str) -> list[StatusType]:
@@ -583,7 +594,7 @@ class CatalogiClient(APIClient):
         return information_object_type
 
 
-class DocumentenClient(APIClient):
+class DocumentenClient(ZgwAPIClient):
     def _fetch_single_information_object(
         self, *, url: str | None = None, uuid: str | None = None
     ) -> InformatieObject | None:
@@ -645,7 +656,7 @@ class DocumentenClient(APIClient):
         return data
 
 
-class FormClient(APIClient):
+class FormClient(ZgwAPIClient):
     def fetch_open_submissions(self, bsn: str) -> list[OpenSubmission]:
         if not bsn:
             return []
@@ -698,7 +709,9 @@ def _build_zgw_client(type_: ZgwClientType) -> ZgwClientFactoryReturn | None:
     if client_class := services_to_client_mapping.get(type_):
         service = getattr(config, f"{type_}_service")
         if service:
-            client = build_client(service, client_factory=client_class)
+            client = build_client(
+                service, client_factory=client_class, configured_from=service
+            )
             return client
 
     logger.warning("no service defined for %s", type_)

--- a/src/open_inwoner/openzaak/tests/factories.py
+++ b/src/open_inwoner/openzaak/tests/factories.py
@@ -4,6 +4,7 @@ from simple_certmanager.constants import CertificateTypes
 from simple_certmanager.models import Certificate
 from zgw_consumers.api_models.base import factory as zwg_factory
 from zgw_consumers.api_models.constants import RolOmschrijving
+from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
 from zgw_consumers.test import generate_oas_component
 
@@ -11,11 +12,13 @@ from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.openzaak.api_models import Notification, Rol
 from open_inwoner.openzaak.models import (
     CatalogusConfig,
+    OpenZaakConfig,
     UserCaseInfoObjectNotification,
     UserCaseStatusNotification,
     ZaakTypeConfig,
     ZaakTypeInformatieObjectTypeConfig,
     ZaakTypeStatusTypeConfig,
+    ZGWApiGroupConfig,
 )
 
 
@@ -25,6 +28,18 @@ class ServiceFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Service
+
+
+class ZGWApiGroupConfigFactory(factory.django.DjangoModelFactory):
+    name = factory.Sequence(lambda n: f"API-{n}")
+    open_zaak_config = factory.LazyAttribute(lambda _: OpenZaakConfig.get_solo())
+    zrc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.zrc)
+    drc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.drc)
+    ztc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.ztc)
+    form_service = factory.SubFactory(ServiceFactory, api_type=APITypes.orc)
+
+    class Meta:
+        model = ZGWApiGroupConfig
 
 
 class CertificateFactory(factory.django.DjangoModelFactory):

--- a/src/open_inwoner/openzaak/tests/test_clients.py
+++ b/src/open_inwoner/openzaak/tests/test_clients.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from zgw_consumers.constants import APITypes
+from zgw_consumers.models import Service
+
+from open_inwoner.openzaak.clients import (
+    build_catalogi_client,
+    build_documenten_client,
+    build_forms_client,
+    build_zaken_client,
+)
+from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
+
+
+class ClientFactoryTestCase(TestCase):
+    def setUp(self):
+        ZGWApiGroupConfigFactory()
+
+    def test_originating_service_is_persisted_on_client(self):
+        for factory, api_type in (
+            (build_forms_client, APITypes.orc),
+            (build_zaken_client, APITypes.zrc),
+            (build_documenten_client, APITypes.drc),
+            (build_catalogi_client, APITypes.ztc),
+        ):
+            client = factory()
+            self.assertIsInstance(client.configured_from, Service)
+            self.assertEqual(client.configured_from.api_type, api_type)


### PR DESCRIPTION
[#2566] Persist originating service on zgw clients
    
To support multiple zgw backends, we frequently need to determine
which backend to query for which resource. As a first step to
keeping better track of where ZGW objects come from, in this
commit we persist the zgw service used to configure a client
on the client object, so that we can later fetch and persist
this service to facilitate easier target backend resolution.