### PR TITLE
[#2568] Remove deprecated lxml/xmlsec dev packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
+          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
           python-version: '3.11'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
@@ -116,7 +116,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
+          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
           python-version: '3.11'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
@@ -157,7 +157,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext libgdal-dev gdal-bin graphviz'
+          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext libgdal-dev gdal-bin graphviz'
           python-version: '3.11'
           setup-node: 'no'
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gdal-bin'
+          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
           python-version: '3.11'
           setup-node: 'no'
       - name: Run flake8
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
           pip install -r requirements/dev.txt
       - name: Run manage.py makemigrations --check --dry-run
         run: |
@@ -143,7 +143,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         git \
         libpq-dev \
-        libxml2-dev \
-        libxmlsec1-dev \
         libxmlsec1-openssl \
         libgdk-pixbuf2.0-0 \
         libffi-dev \
@@ -71,7 +69,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         libgdal32 \
         libgeos-c1v5 \
         libproj25 \
-        libxmlsec1-dev \
         libxmlsec1-openssl \
         libgdk-pixbuf2.0-0 \
         libffi-dev \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -557,7 +557,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.23
+uwsgi==2.0.26
     # via -r requirements/base.in
 vine==5.1.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1080,7 +1080,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.23
+uwsgi==2.0.26
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1283,7 +1283,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.23
+uwsgi==2.0.26
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Since bumping our lxml/xmlsec requirements, we can utilize
the pre-built binaries and no longer have a need for the
*-dev system packages. Apart from making things leaner,
this also addresses the following issue in python-xmlsec:
https://github.com/xmlsec/python-xmlsec/issues/320

---

Based on https://github.com/open-formulieren/open-forms/pull/4415