### PR TITLE
Support both  successful and failing migrations in the migration test utility

### DIFF
--- a/src/open_inwoner/kvk/tests/test_migrations.py
+++ b/src/open_inwoner/kvk/tests/test_migrations.py
@@ -1,7 +1,7 @@
-from open_inwoner.utils.tests.test_migrations import TestMigrations
+from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
-class APIRootMigrationTest(TestMigrations):
+class APIRootMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0002_alter_kvkconfig_api_root"
     migrate_to = "0003_api_root"
     app = "kvk"

--- a/src/open_inwoner/openzaak/tests/test_migrations.py
+++ b/src/open_inwoner/openzaak/tests/test_migrations.py
@@ -1,10 +1,10 @@
 from zgw_consumers.constants import APITypes
 
 from open_inwoner.openzaak.tests.factories import ServiceFactory
-from open_inwoner.utils.tests.test_migrations import TestMigrations
+from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
-class TestMultiZGWBackendMigrations(TestMigrations):
+class TestMultiZGWBackendMigrations(TestSuccessfulMigrations):
     migrate_from = "0047_delete_statustranslation"
     migrate_to = "0051_drop_root_zgw_fields"
     app = "openzaak"

--- a/src/open_inwoner/utils/tests/test_migrations.py
+++ b/src/open_inwoner/utils/tests/test_migrations.py
@@ -1,21 +1,34 @@
+import contextlib
+
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TestCase
 
 
-class TestMigrations(TestCase):
+class TestMigrationsBase(TestCase):
+    app = None
+    migrate_from = None
+    migrate_to = None
+    extra_migrate_from: list[tuple[str, str]] = None
     """
     Test the effect of applying a migration
     Adapted from https://github.com/open-formulieren/open-forms/blob/e64c9368264d3f662542866e2d7d5ba15e0f265c/src/openforms/utils/tests/test_migrations.py
     """
 
-    app = None
-    migrate_from = None
-    migrate_to = None
+    @contextlib.contextmanager
+    def _immediate_constraints(self):
+        try:
+            # Force immediate constraint checks to stop error 'cannot ALTER TABLE "<..>"
+            # because it has pending trigger events' in the tests
+            with connection.cursor() as cursor:
+                cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
 
-    extra_migrate_from: list[tuple[str, str]] = None
+            yield
+        finally:
+            with connection.cursor() as cursor:
+                cursor.execute("SET CONSTRAINTS ALL DEFERRED")
 
-    def setUp(self):
+    def _revert_to_migrate_from(self):
         assert self.migrate_from and self.migrate_to and self.app, (
             "TestCase '%s' must define migrate_from, migrate_to and app properties"
             % type(self).__name__
@@ -28,27 +41,38 @@ class TestMigrations(TestCase):
 
         self.migrate_to = [(self.app, self.migrate_to)]
         executor = MigrationExecutor(connection)
-        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self.old_apps = executor.loader.project_state(self.migrate_from).apps
 
-        # Force immediate constraint checks to stop error 'cannot ALTER TABLE "<..>" because it has pending trigger events' in the tests
-        with connection.cursor() as cursor:
-            cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+        with self._immediate_constraints():
+            # Reverse to the original migration
+            executor.migrate(self.migrate_from)
 
-        # Reverse to the original migration
-        executor.migrate(self.migrate_from)
-
-        self.setUpBeforeMigration(old_apps)
-
+    def _apply_migration_to(self):
         # Run the migration to test
         executor = MigrationExecutor(connection)
         executor.loader.build_graph()  # reload.
-        executor.migrate(self.migrate_to)
-
-        # Restore constraint checks
-        with connection.cursor() as cursor:
-            cursor.execute("SET CONSTRAINTS ALL DEFERRED")
-
+        with self._immediate_constraints():
+            executor.migrate(self.migrate_to)
         self.apps = executor.loader.project_state(self.migrate_to).apps
 
     def setUpBeforeMigration(self, apps):
         pass
+
+
+class TestSuccessfulMigrations(TestMigrationsBase):
+    """Test a successful migration.
+
+    Set the class attributes `app`, `migration_from`, and `migrate_to`. You
+    can specify your pre-migration state in `setUpBeforeMigration()`, and
+    consequently assert against the resulting state (in your test, do
+    not import models directly but use:
+
+    ```
+    MyModel = self.apps.get_model(self.app, "MyModel")
+    ```
+    """
+
+    def setUp(self):
+        self._revert_to_migrate_from()
+        self.setUpBeforeMigration(self.old_apps)
+        self._apply_migration_to()

--- a/src/open_inwoner/utils/tests/test_migrations.py
+++ b/src/open_inwoner/utils/tests/test_migrations.py
@@ -76,3 +76,32 @@ class TestSuccessfulMigrations(TestMigrationsBase):
         self._revert_to_migrate_from()
         self.setUpBeforeMigration(self.old_apps)
         self._apply_migration_to()
+
+
+class TestFailingMigrations(TestMigrationsBase):
+    """Test a migration which is expected to fail.
+
+    Set the class attributes `app`, `migration_from`, and `migrate_to`. You
+    can specify your pre-migration state in `setUpBeforeMigration()`, though
+    you should not import models directly, but rather use:
+
+    ```
+    MyModel = self.apps.get_model(self.app, "MyModel")
+    ```
+
+    In your test, you can attempt to migration using `self.attempt_migration()`
+    and assert against the expected exception:
+    ```
+    def test_migration_should_fail(self):
+        # Setup failure conditions
+        self.assertRaises(SomeError):
+            self.attempt_migration()
+    ```
+    """
+
+    def setUp(self):
+        self._revert_to_migrate_from()
+        self.setUpBeforeMigration(self.old_apps)
+
+    def attempt_migration(self):
+        self._apply_migration_to()


### PR DESCRIPTION
I've had to write a few non-trivial migrations for the multi-ZGW backend work, and I suspect there will be a few more. To keep things consistent and readable, I've expanded the migration testing utility to support both successful and failing migrations.