### PR TITLE
♿ [#2357] Correct product-pages 400% zoom

### DIFF
--- a/src/open_inwoner/scss/components/ReadMore/ReadMore.scss
+++ b/src/open_inwoner/scss/components/ReadMore/ReadMore.scss
@@ -16,12 +16,12 @@
     display: grid;
     grid-template-rows: 0fr;
     transition: 0.5s;
-    overflow: hidden;
 
     &--hidden {
       // hide content if toggle-button is active
       // always show for screenreaders
       min-height: 0;
+      overflow: hidden;
     }
   }
 
@@ -41,6 +41,10 @@
     .readmore__content {
       scroll-margin-top: var(--spacing-giant);
       grid-template-rows: 1fr;
+
+      &--hidden {
+        overflow: visible;
+      }
     }
   }
 }


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2357

This Zoom issue was already solved for just the Tables by #1258 (by making them break on word normally)
so all that was left, is to actually show the overflowing content...

Problem happens for example when zooming in 400% in case of a product-page with an extremely long H1 title, with more than 24 characters without any breaking dashes etc. which will make an overflow dus to its large font-size.
So here the 'readmore' content should only remain hidden when that functionality is toggled.
When 'readmore' is off or toggled 'open', all content should be visible at all zoom-levels.

Note: Scrollbars appearing are OK for accessibility.
We cannot control the use of long words, and words like 'Verkiezingsprogrammalijst' do exist in Dutch, so if these are in a Heading, scrollbars will appear.

Toggle functionality for editing/posting a product-page >> "_Productcontent ingeklapt / Bepaalt of de productcontent standaard is ingeklapt._"