### PR TITLE
[#2574] Added format-detection meta-tag for Safari iOS

### DIFF
--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -2,6 +2,7 @@
 <html lang="nl" class="view utrecht-document openinwoner-theme {% block view_class %}view--{{ request.resolver_match.namespaces|join:'-' }}-{{ request.resolver_match.url_name }}{% endblock %}">
     <head>
         <meta charset="utf-8">
+        <meta name="format-detection" content="telephone=no">
         <title>{% block title %}{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2574

Test this on https://live.browserstack.com/ 
(if you have the browserstack local binary set-up working)
NB: if your localhost URL doesn't work, use http://bs-local.com:8000/ 

There are many browser differences on iOS but the meta-tag seems to be the wisest solution here, in order to also turn-off phone-number detection for ALL dynamic content.
it is also possible to add a (very hacky) “zero-width joiner `&zwj;`" or an empty `<span>` in every case-number, but then it would only work for all those individual numbers and not for the rest of the site.

Note to future self: if the user would create a **bookmark** and add the OIP site/icon as an app _to the Home screen_ of the iPhone, then it will open in something that looks exactly like Safari, but actually isn't. 
It may open in the 'shortcut browser' - where this meta tag will not work. There is no solution for this currently. Also: it depends on the iPhone version whether the Shortcut Browser is used or not.