### PR TITLE
♿ [#2435] Add aria-expanded to mobile anchors navigation

### DIFF
--- a/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
+++ b/src/open_inwoner/components/templates/components/AnchorMenu/AnchorMenu.html
@@ -3,8 +3,8 @@
 <aside class="anchor-menu {% if desktop %}anchor-menu--desktop{% else %}anchor-menu--mobile{% endif %}" aria-label="{% trans "Secundaire paginanavigatie" %}">
     {% if not desktop %}
     <div class="anchor-menu--container">
-        {% button href="#" icon="expand_more" icon_position="after" extra_classes="anchor-menu--mobile__title anchor-menu__toggle" bordered=False text=_("Op deze pagina") %}
-        <ul class="anchor-menu__list">
+        {% button icon="expand_more" icon_position="after" extra_classes="anchor-menu--mobile__title anchor-menu__toggle" bordered=False text=_("Op deze pagina") ariaExpanded="false" ariaControls="anchor-menu-list-mobile" %}
+        <ul class="anchor-menu__list" id="anchor-menu-list-mobile">
             {% for anchor in anchors %}
                 <li class="anchor-menu__list-item">
                     <a class="link" href="{{ anchor.0 }}">{{ anchor.1 }}</a>

--- a/src/open_inwoner/components/templates/components/Button/Button.html
+++ b/src/open_inwoner/components/templates/components/Button/Button.html
@@ -9,6 +9,7 @@
         {% if href|startswith:"http" %}target="_blank"{% endif %}
         {% as_attributes extra_attributes %}
         {% if ariaExpanded %} aria-expanded="{{ ariaExpanded }}" {% endif %}
+        {% if ariaControls %} aria-controls="{{ ariaControls }}" {% endif %}
     >
         {% if icon %}{% icon icon=icon outlined=icon_outlined %}{% endif %}
         {% if text_icon %}
@@ -32,6 +33,7 @@
         {% if id %} id="{{ id }}" {% endif %}
         {% if form_id %} form="{{ form_id }}"{% endif %}
         {% if ariaExpanded %} aria-expanded="{{ ariaExpanded }}" {% endif %}
+        {% if ariaControls %} aria-controls="{{ ariaControls }}" {% endif %}
     >
         {% if icon %}{% icon icon=icon outlined=icon_outlined %}{% endif %}
         {% if text_icon %}

--- a/src/open_inwoner/js/components/anchor-menu/anchor-menu-mobile.js
+++ b/src/open_inwoner/js/components/anchor-menu/anchor-menu-mobile.js
@@ -9,12 +9,18 @@ export class AnchorMobile {
 
   toggleOpen(event) {
     event.preventDefault()
-    this.node.parentElement.classList.toggle('anchor-menu__list--open')
+    const isExpanded = this.node.getAttribute('aria-expanded') === 'true'
+    this.node.parentElement.classList.toggle(
+      'anchor-menu__list--open',
+      !isExpanded
+    )
+    this.node.setAttribute('aria-expanded', !isExpanded)
   }
 
   anchorClosing(event) {
     if (event.type === 'keydown' && event.key === 'Escape') {
       this.node.parentElement.classList.remove('anchor-menu__list--open')
+      this.node.setAttribute('aria-expanded', 'false')
     }
   }
 }


### PR DESCRIPTION
issue https://taiga.maykinmedia.nl/project/open-inwoner/task/2435 

note: 

- `aria-expanded` only works for the elements that indicate if a **control** is expanded or collapsed.
- `aria-controls` is not a hard requirement, but 'recommended'