### PR TITLE
Revert lxml/xmlsec/uwsgi version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
+          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
           python-version: '3.11'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
@@ -116,7 +116,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
+          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
           python-version: '3.11'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
@@ -157,7 +157,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gettext libgdal-dev gdal-bin graphviz'
+          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext libgdal-dev gdal-bin graphviz'
           python-version: '3.11'
           setup-node: 'no'
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: Set up backend environment
         uses: maykinmedia/setup-django-backend@v1
         with:
-          apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
+          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gdal-bin'
           python-version: '3.11'
           setup-node: 'no'
       - name: Run flake8
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
           pip install -r requirements/dev.txt
       - name: Run manage.py makemigrations --check --dry-run
         run: |
@@ -143,7 +143,7 @@ jobs:
       - name: Install libxml
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2 libxmlsec1 libxmlsec1-openssl
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         git \
         libpq-dev \
+        libxml2-dev \
+        libxmlsec1-dev \
         libxmlsec1-openssl \
         libgdk-pixbuf2.0-0 \
         libffi-dev \
@@ -69,6 +71,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         libgdal32 \
         libgeos-c1v5 \
         libproj25 \
+        libxmlsec1-dev \
         libxmlsec1-openssl \
         libgdk-pixbuf2.0-0 \
         libffi-dev \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -379,7 +379,7 @@ jsonschema==4.1.0
     # via drf-spectacular
 kombu==5.3.7
     # via celery
-lxml==5.2.2
+lxml==4.9.1
     # via
     #   django-digid-eherkenning
     #   mail-editor
@@ -557,7 +557,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.26
+uwsgi==2.0.23
     # via -r requirements/base.in
 vine==5.1.0
     # via
@@ -581,7 +581,7 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via maykin-python3-saml
 xsdata==23.8
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -691,7 +691,7 @@ kombu==5.3.7
     #   celery
 lazy-object-proxy==1.6.0
     # via astroid
-lxml==5.2.2
+lxml==4.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1080,7 +1080,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.26
+uwsgi==2.0.23
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1134,7 +1134,7 @@ xlwt==1.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -789,7 +789,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 locust==2.20.0
     # via -r requirements/dev.in
-lxml==5.2.2
+lxml==4.9.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1283,7 +1283,7 @@ urllib3==1.26.18
     #   elasticsearch
     #   requests
     #   sentry-sdk
-uwsgi==2.0.26
+uwsgi==2.0.23
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1352,7 +1352,7 @@ xlwt==1.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
This reverts commit 701b4026fcff695f7d543a1c41e3112c9ff37769 and 65115502afcd5b0bf073423cfc21adf91d5e7533. These changes worked on CI and Docker, but not on our test server. Rolling back until we can diagnose the issue: in the meantime, this shouldn't block deploys.