### PR TITLE
[#2589] Run CI tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
   tests:
     name: Run the Django test suite
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-type: [main, elastic]
 
     services:
       postgres:
@@ -57,13 +60,20 @@ jobs:
           setup-node: 'yes'
           npm-ci-flags: '--legacy-peer-deps'
 
-      # We temporarily disable parallel test runs due to a Django bug:
-      # https://code.djangoproject.com/ticket/32114
-      # https://github.com/django/django/pull/17650
       - name: Run tests
         run: |
-          python src/manage.py collectstatic --noinput --link
-          coverage run src/manage.py test src --exclude-tag=e2e
+          if [ "${{ matrix.test-type }}" = "main" ]; then
+            coverage run \
+              src/manage.py test src \
+              --parallel \
+              --exclude-tag=e2e \
+              --exclude-tag=elastic
+          elif [ "${{ matrix.test-type }}" = "elastic" ]; then
+            coverage run src/manage.py test src --tag=elastic --exclude-tag=e2e
+          else
+            echo "Error: Unknown test type '${{ matrix.test-type }}'"
+            exit 1
+          fi
 
         env:
           DJANGO_SETTINGS_MODULE: open_inwoner.conf.ci


### PR DESCRIPTION
We have made several previous attempts at running the CI tests in
parallel, which were ultimately reverted because we ran into the
issue described at https://github.com/django/django/pull/17650 and
https://code.djangoproject.com/ticket/32114 (in this repo, see PRs
#1050, #948 and #690.

The Django ticket has been fixed, but will will only be included
in 5.1 onwards, and won't be backported to 4.2.x. However, it seems
the current testsuite no longer fails with the issue reported in the
Django ticket (pickle related errors). It is possible the potentially
failing tests are flaky, but so far we've not run into it during a
handful of parallel runs. This commit will re-enable parallel tests,
and we'll have to see if we run into the same issues again.