### PR TITLE
♿ [#2371] Make search label text same as placeholder

### DIFF
--- a/src/open_inwoner/search/forms.py
+++ b/src/open_inwoner/search/forms.py
@@ -11,9 +11,7 @@ class MultipleChoiceNoValidationField(forms.MultipleChoiceField):
 
 
 class SearchForm(forms.Form):
-    query = forms.CharField(
-        label=_("Zoek op trefwoord"), max_length=400, required=False
-    )
+    query = forms.CharField(label=_("Zoeken"), max_length=400, required=False)
     categories = MultipleChoiceNoValidationField(
         label=_("Categories"), required=False, widget=forms.CheckboxSelectMultiple
     )
@@ -26,7 +24,7 @@ class SearchForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["query"].widget.attrs["placeholder"] = _("Zoeken...")
+        self.fields["query"].widget.attrs["placeholder"] = _("Zoeken")
 
 
 class FeedbackForm(forms.ModelForm):


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2371 

hidden label text (visible for screenreaders) should start with text from placeholder.
We are adopting the 'Zoeken' example without dots, like on https://gemeente.groningen.nl/