### PR TITLE
Fix specification of multiple package versions

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ pydantic[email]
 typing-extensions
 
 # Framework libraries
-Django>=4.2<5.0
+Django>=4.2,<5.0
 django-admin-index
 django-axes
 django-filer


### PR DESCRIPTION
Specifying multiple package versions without separator (comma, semicolon) is deprecated since pip 24.1 (https://pip.pypa.io/en/stable/news/).