### PR TITLE
[#2606] Refactor flakey test, use more general assertions

### DIFF
--- a/src/open_inwoner/questionnaire/tests/test_admin.py
+++ b/src/open_inwoner/questionnaire/tests/test_admin.py
@@ -82,6 +82,7 @@ class TestQuestionnaireStepForm(WebTest):
         questionnaire = QuestionnaireStepFactory(
             related_products=(product1, product2, product3)
         )
+
         form = self.app.get(
             reverse(
                 "admin:questionnaire_questionnairestep_change",
@@ -90,10 +91,7 @@ class TestQuestionnaireStepForm(WebTest):
             user=self.user,
         ).forms["questionnairestep_form"]
         options = form["related_products"].options
-        self.assertEqual(
-            options,
-            [
-                (str(product1.id), True, product1.name),
-                (str(product2.id), True, product2.name),
-            ],
-        )
+
+        self.assertIn((str(product1.id), True, product1.name), options)
+        self.assertIn((str(product2.id), True, product2.name), options)
+        self.assertNotIn((str(product3.id), True, product3.name), options)


### PR DESCRIPTION
- The test asserted equality of expected + actual list, which is not guaranteed (presumably this is due to parallel tests; it doesn't seem to occur when tests run sequentially)
- Needed are only the weaker assertions about content being/not being included in the form options

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2602