### PR TITLE
[#2606] Lazy load synonyms for Elasticsearch

### DIFF
--- a/src/open_inwoner/search/utils.py
+++ b/src/open_inwoner/search/utils.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db.utils import DatabaseError
+from django.utils.functional import lazy
 
 from .models import Synonym
 
@@ -8,12 +9,17 @@ logger = logging.getLogger(__name__)
 
 
 def load_synonyms() -> list:
-    """used for ES"""
-    # todo should be refactored to be run after django migrations
-    try:
-        synonyms = [s.synonym_line() for s in Synonym.objects.all()]
-    except DatabaseError as exc:
-        logger.warning(f"Synonyms for elasticsearch were not loaded: {exc}")
-        return []
+    """
+    Lazy load synonyms for Elasticsearch
+    """
 
-    return synonyms
+    def _load_synonyms():
+        try:
+            synonyms = [s.synonym_line() for s in Synonym.objects.all()]
+        except DatabaseError as exc:
+            logger.warning(f"Synonyms for elasticsearch were not loaded: {exc}")
+            return []
+
+        return synonyms
+
+    return lazy(_load_synonyms)


### PR DESCRIPTION
The synonyms for Elastic Search need to be loaded *after* all the migrations have been run.

Taiga: [issue #2606](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2606)