### PR TITLE
♿ [#2584] Refactor heading architecture (no flexbox)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4140,9 +4140,9 @@
       }
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.5-alpha.5",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.5.tgz",
-      "integrity": "sha512-oPTrpY/OA0oOMjgKauqEAzXJuggbb1+m3LvHFzLYZhiLPfqgJV+B6KcOT+gD2sHsiP74e8A8EgiC0rZBa16l1A=="
+      "version": "0.0.6-alpha.1",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.6-alpha.1.tgz",
+      "integrity": "sha512-H22QdrBxpR/7gJ+6L0OAKVMV+m77phIeCoMQd/K0+30UwlmfTFitAmp9aQBvu3DBfMKkohd+ZnfvNQR66MZ7wg=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.5",
@@ -22718,9 +22718,9 @@
       }
     },
     "@open-inwoner/design-tokens": {
-      "version": "0.0.5-alpha.5",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.5-alpha.5.tgz",
-      "integrity": "sha512-oPTrpY/OA0oOMjgKauqEAzXJuggbb1+m3LvHFzLYZhiLPfqgJV+B6KcOT+gD2sHsiP74e8A8EgiC0rZBa16l1A=="
+      "version": "0.0.6-alpha.1",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.6-alpha.1.tgz",
+      "integrity": "sha512-H22QdrBxpR/7gJ+6L0OAKVMV+m77phIeCoMQd/K0+30UwlmfTFitAmp9aQBvu3DBfMKkohd+ZnfvNQR66MZ7wg=="
     },
     "@popperjs/core": {
       "version": "2.11.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@joeattardi/emoji-button": "^4.6.4",
-    "@open-inwoner/design-tokens": "^0.0.5-alpha.5",
+    "@open-inwoner/design-tokens": "^0.0.6-alpha.1",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "bem.js": "^1.0.10",
     "emojibase-data": "^7.0.1",

--- a/src/open_inwoner/scss/components/Grid/Grid.scss
+++ b/src/open_inwoner/scss/components/Grid/Grid.scss
@@ -25,7 +25,7 @@
         margin-bottom: var(--spacing-large);
       }
 
-      .utrecht-heading-2 {
+      .oip-header-group {
         margin-bottom: var(--spacing-medium);
       }
 

--- a/src/open_inwoner/scss/components/HeaderGroup/HeaderGroup.scss
+++ b/src/open_inwoner/scss/components/HeaderGroup/HeaderGroup.scss
@@ -1,0 +1,33 @@
+@import '~@utrecht/components/dist/heading-1/css/index.css';
+@import '~microscope-sass/lib/responsive';
+
+.oip-header-group {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+
+  &__indicator {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .indicator {
+    display: inline-block;
+    justify-content: flex-start;
+    overflow: visible;
+    position: relative;
+  }
+
+  @include mobile-only {
+    flex-direction: column;
+    align-items: flex-start;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
+  .utrecht-heading-2 + .button,
+  .utrecht-heading-4 + .button,
+  .utrecht-paragraph + .button {
+    margin-top: 0;
+  }
+}

--- a/src/open_inwoner/scss/components/Profile/_personal-overview.scss
+++ b/src/open_inwoner/scss/components/Profile/_personal-overview.scss
@@ -4,7 +4,7 @@
     padding-bottom: var(--spacing-large);
   }
 
-  .utrecht-heading-2 {
+  .oip-header-group {
     display: block;
     height: initial;
     margin: calc(var(--row-height)) 0 0 0;

--- a/src/open_inwoner/scss/components/Typography/H1.scss
+++ b/src/open_inwoner/scss/components/Typography/H1.scss
@@ -5,12 +5,8 @@
   // Reverse font-family fallback order
   font-family: var(--utrecht-heading-font-family),
     var(--utrecht-heading-1-font-family);
-  display: var(--oip-typography-heading-display);
-  justify-content: var(--oip-typography-heading-justify-content);
 
   @include mobile-only {
-    flex-direction: column;
-    align-items: flex-start;
     word-break: normal;
     overflow-wrap: break-word;
   }
@@ -35,8 +31,8 @@
   font-weight: var(--utrecht-heading-1-font-weight);
   line-height: var(--utrecht-heading-1-line-height);
   margin: var(--row-height) 0 0 0;
-  display: var(--oip-typography-heading-display);
-  justify-content: var(--oip-typography-heading-justify-content);
+  display: flex;
+  justify-content: space-between;
 
   @include mobile-only {
     flex-direction: column;

--- a/src/open_inwoner/scss/components/Typography/H2.scss
+++ b/src/open_inwoner/scss/components/Typography/H2.scss
@@ -5,8 +5,6 @@
   // Reverse font-family fallback order
   font-family: var(--utrecht-heading-font-family),
     var(--utrecht-heading-2-font-family);
-  display: var(--oip-typography-heading-display);
-  justify-content: var(--oip-typography-heading-justify-content);
 
   &--extra {
     margin: var(--row-height) 0 var(--spacing-medium) 0;

--- a/src/open_inwoner/scss/components/Typography/H3.scss
+++ b/src/open_inwoner/scss/components/Typography/H3.scss
@@ -22,8 +22,8 @@
   font-weight: var(--utrecht-heading-3-font-weight);
   line-height: var(--utrecht-heading-3-line-height);
   margin: 0;
-  display: var(--oip-typography-heading-display);
-  justify-content: var(--oip-typography-heading-justify-content);
+  display: flex;
+  justify-content: space-between;
 
   @include mobile-only {
     word-break: normal;

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -31,7 +31,8 @@
   }
 }
 
-*[class^='utrecht-heading'] + .utrecht-paragraph {
+*[class^='utrecht-heading'] + .utrecht-paragraph,
+.oip-header-group + .utrecht-paragraph {
   margin-top: var(--spacing-small);
 }
 

--- a/src/open_inwoner/scss/components/_index.scss
+++ b/src/open_inwoner/scss/components/_index.scss
@@ -52,6 +52,7 @@
 @import './Header/Breadcrumbs.scss';
 @import './Header/Header.scss';
 @import './Header/PrimaryNavigation.scss';
+@import './HeaderGroup/HeaderGroup.scss';
 @import './Hero/Hero.scss';
 @import './Icon/Icon.scss';
 @import './Image/Image.scss';

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -1,10 +1,10 @@
 {% load i18n button_tags card_tags utils icon_tags %}
 {% if request.user.is_authenticated %}
     <section class="plugin plugin__plans">
-        <h2 class="utrecht-heading-2">
-            {% trans 'Samenwerken' %}
+        <header class="oip-header-group">
+            <h2 class="utrecht-heading-2">{% trans 'Samenwerken' %}</h2>
             {% button href="collaborate:plan_list" text=_("Naar samenwerken") icon="arrow_forward" icon_position="after" %}
-        </h2>
+        </header>
         {% if plans %}
         <div class="plans-cards card-container card-container--columns-4">
             {% for plan in plans %}

--- a/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
+++ b/src/open_inwoner/templates/cms/plugins/userfeed/userfeed.html
@@ -2,14 +2,14 @@
 
 {% if userfeed %}
 <section class="plugin userfeed">
-    <div class="userfeed__header">
+    <header class="userfeed__header">
         <div class="heading-2__indicator">
             <h2 class="utrecht-heading-2 {% if userfeed.action_required %}indicator{% endif %}">
                 {{ instance.title }}
             </h2>
             {% if userfeed.action_required %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
         </div>
-    </div>
+    </header>
 
     <div class="userfeed__summary">
         <ul class="userfeed__list">

--- a/src/open_inwoner/templates/cms/products/categories_plugin.html
+++ b/src/open_inwoner/templates/cms/products/categories_plugin.html
@@ -1,12 +1,12 @@
 {% load i18n button_tags %}
 {% if categories %}
     <section class="plugin plugin__categories">
-        <h2 class="utrecht-heading-2">
-            {{ configurable_text.home_page.home_theme_title }}
+        <header class="oip-header-group">
+            <h2 class="utrecht-heading-2">{{ configurable_text.home_page.home_theme_title }}</h2>
             {% trans "Alle onderwerpen" as button_text %}
-            <span class="spacer"></span>
             {% button href='products:category_list' text=button_text icon="arrow_forward" icon_position="after" %}
-        </h2>
+        </header>
+
         <p class="utrecht-paragraph">{{ configurable_text.home_page.home_theme_intro|linebreaksbr }}</p>
 
         {% include "components/Card/CardContainer.html" with categories=categories columns=4 image_object_fit="cover" only %}

--- a/src/open_inwoner/templates/pages/category/detail.html
+++ b/src/open_inwoner/templates/pages/category/detail.html
@@ -11,12 +11,15 @@
 
 {% block content %}
     <div class="categories__content">
-        <h1 class="utrecht-heading-1">
-            {{ object.name }}
+        <header class="oip-header-group">
+            <h1 class="utrecht-heading-1">
+                {{ object.name }}
+            </h1>
             {% if request.user.is_staff %}
                 {% button icon="edit" text=_("Open in admin") hide_text=True href="admin:pdc_category_change" object_id=object.pk %}
             {% endif %}
-        </h1>
+        </header>
+
             {{ category_rendered_description|safe }}
 
         {% if subcategories %}

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -49,11 +49,12 @@
                             </div>
                             <div class="modal modal--no-reset" id="template-{{ plan_template.id }}">
                                 <div class="modal__container">
-                                    <h2 class="utrecht-heading-2 modal__title" id="modal__title">{{ plan_template.name }}
+                                    <header class="oip-header-group">
+                                        <h2 class="utrecht-heading-2 modal__title" id="modal__title">{{ plan_template.name }}</h2>
                                         <div class="modal__actions">
                                             {% button type="button" text=_("Sluiten") hide_text=True icon="close" outlined=True extra_classes="modal__button modal__close-title button__icon-close" %}
                                         </div>
-                                    </h2>
+                                    </header>
                                     <div class="modal__text" id="modal__text">{{ plan_template.string_preview }}</div>
                                     <div class="modal__actions modal__actions--align-right" id="modal__actions">
                                         <button class="button modal__button modal__close button--primary button-icon--primary" type="button" aria-label="Sluit"><span class="inner-text">Sluiten </span></button>

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -6,10 +6,12 @@
 {% endblock header_image %}
 
 {% block content %}
-    <h1 class="utrecht-heading-1">
-        {% trans "Samenwerken" %}
+    <header class="oip-header-group">
+        <h1 class="utrecht-heading-1">
+            {% trans "Samenwerken" %}
+        </h1>
         {% button href="collaborate:plan_create" text=_("Start nieuwe samenwerking") primary=True icon="group" icon_outlined=True %}
-    </h1>
+    </header>
     {% optional_paragraph configurable_text.plans_page.plans_intro %}
 
     {% if plans.extended_plans %}

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -3,10 +3,13 @@
 
 
 {% block content %}
-<h1 class="utrecht-heading-1" id="title">
-    {% trans "Mijn contacten" %}
+<header class="oip-header-group">
+    <h1 class="utrecht-heading-1" id="title">
+        {% trans "Mijn contacten" %}
+
+    </h1>
     {% button href="profile:contact_create" text=_("Nieuw contact toevoegen") icon="person" primary=True %}
-</h1>
+</header>
 
 <!--List of contact requests: receiver's view-->
 {% if pending_approvals %}

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -21,11 +21,12 @@
     {# Business information #}
     <section class="tabled tabled--flexible profile-section profile-section--bordered profile-section__business-overview">
         <div class="tabled__section">
-            <h2 class="utrecht-heading-2 title" id="business-overview">{% trans "Bedrijfsgegevens" %}
+            <header class="oip-header-group title">
+                <h2 class="utrecht-heading-2" id="business-overview">{% trans "Bedrijfsgegevens" %}</h2>
                 <div class="tabled__item--force-right tabled__item--mobile-big">
                     {% button href="profile:edit" text=_("Bewerk") icon="edit" transparent=True icon_outlined=True %}
                 </div>
-            </h2>
+            </header>
         </div>
         <div class="tabled__row tabled__row--blank">
             <div class="tabled__item tabled__key">{% trans "Handelsnaam" %}</div>
@@ -55,7 +56,8 @@
     {# Personal information #}
     <section class="tabled tabled--flexible profile-section profile-section--bordered profile-section__personal-info" id="personal-info">
         <div class="tabled__section">
-            <h2 class="utrecht-heading-2 title" id="personal-overview">{% trans "Persoonlijke gegevens" %}
+            <header class="oip-header-group title">
+                <h2 class="utrecht-heading-2 " id="personal-overview">{% trans "Persoonlijke gegevens" %}</h2>
                 <div class="tabled__item--force-right tabled__item--mobile-big">
                     {% button href="profile:edit" text=_("Bewerk") icon="edit" transparent=True icon_outlined=True %}
                     {% if user.is_digid_user_with_brp and view.config.my_data %}
@@ -64,7 +66,7 @@
                         {% button href="password_change" text=_("Password") icon="vpn_key" transparent=True icon_outlined=True %}
                     {% endif %}
                 </div>
-            </h2>
+            </header>
         </div>
         <div class="tabled__row tabled__row--blank">
             <div class="tabled__item tabled__key">{% trans "Voornaam" %}</div>
@@ -95,11 +97,14 @@
     {# Notifications #}
     <section class="tabled tabled--flexible profile-section profile-section--bordered profile-section__notifications" id="profile-notifications">
         <div class="tabled__section">
-            <h2 class="utrecht-heading-2 title" id="notifications">{% trans "Voorkeuren voor meldingen" %}
+            <header class="oip-header-group title">
+                <h2 class="utrecht-heading-2" id="notifications">{% trans "Voorkeuren voor meldingen" %}
+                </h2>
                 <div class="tabled__item--force-right tabled__item--mobile-big">
                     {% button href="profile:notifications" text=_("Bewerk") icon="edit" transparent=True icon_outlined=True %}
                 </div>
-            </h2>
+            </header>
+
         </div>
         <div class="tabled__row tabled__row--blank">
             <div class="tabled__item tabled__key">{% trans "Communicatiekanaal" %}</div>
@@ -117,7 +122,9 @@
     {% if view.config.newsletters and form.fields.newsletters.choices %}
     <section class="tabled tabled--flexible profile-section profile-section--bordered profile-section__newsletters" id="profile-newsletters">
         <div class="tabled__section">
-            <h2 class="utrecht-heading-2 title" id="newsletters">{% trans "Nieuwsbrieven" %}</h2>
+            <header class="oip-header-group title">
+                <h2 class="utrecht-heading-2" id="newsletters">{% trans "Nieuwsbrieven" %}</h2>
+            </header>
         </div>
             <p class="utrecht-paragraph">{% trans "Vink de nieuwsbrieven aan die u wilt ontvangen. Wilt u een nieuwsbrief niet meer ontvangen? Haal het vinkje dan weg. Sla daarna uw keuze op." %}</p>
             <form method="POST" id="newsletter-form" class="form" novalidate>
@@ -150,7 +157,9 @@
     {% if view.config.selected_categories or view.config.mentors or view.config.my_contacts or view.config.actions or view.config.ssd or view.config.selfdiagnose or view.config.appointments %}
     {# Overview #}
     <section class="profile-section profile-section__overview">
-        <h2 class="utrecht-heading-2 title" id="overview">{% trans "Overzicht" %}</h2>
+        <header class="oip-header-group title">
+            <h2 class="utrecht-heading-2" id="overview">{% trans "Overzicht" %}</h2>
+        </header>
         <div class="profile-cards card-container card-container--columns-3">
             {# Selected categories #}
             {% if view.config.selected_categories %}
@@ -310,7 +319,10 @@
 
     <section class="tabled profile-section profile-section--bordered profile-section__remove">
         <div class="tabled__section">
-            <h2 class="utrecht-heading-2 title" id="profile-remove">{% trans "Profiel verwijderen" %}</h2></div>
+            <header class="oip-header-group title">
+                <h2 class="utrecht-heading-2" id="profile-remove">{% trans "Profiel verwijderen" %}</h2>
+            </header>
+        </div>
             <div class="tabled">
                 <p class="utrecht-paragraph">
                     {% trans "Hiermee worden alleen uw persoonlijke voorkeuren verwijderd. U krijgt dan bijvoorbeeld geen e-mail meer van ons over wijzigingen van uw lopende zaken. Uw persoonsgegevens en uw lopende zaken zelf worden hiermee niet verwijderd." %}

--- a/src/open_inwoner/templates/pages/profile/mydata.html
+++ b/src/open_inwoner/templates/pages/profile/mydata.html
@@ -21,7 +21,9 @@
         {% with request.user as user %}
             <section class="tabled tabled--flexible profile-section" id="profile-notifications">
                 <div class="tabled__section">
-                    <h2 class="utrecht-heading-2 title" id="notifications">{% trans "Mijn BRP gegevens" %}</h2>
+                    <header class="oip-header-group title">
+                        <h2 class="utrecht-heading-2" id="notifications">{% trans "Mijn BRP gegevens" %}</h2>
+                    </header>
                 </div>
                 <div class="tabled__row tabled__row--blank">
                     <div class="tabled__item tabled__key">{% trans "Voornamen" %}</div>
@@ -60,7 +62,9 @@
             <!-- BRP registration data -->
             <section class="tabled tabled--flexible profile-section" id="profile-notifications">
                 <div class="tabled__section">
-                    <h2 class="utrecht-heading-2 title" id="notifications">{% trans "Inschrijfadres" %}</h2>
+                    <header class="oip-header-group title">
+                        <h2 class="utrecht-heading-2" id="notifications">{% trans "Inschrijfadres" %}</h2>
+                    </header>
                 </div>
                 <div class="tabled__row tabled__row--blank">
                     <div class="tabled__item tabled__key">{% trans "Straat" %}</div>
@@ -89,11 +93,12 @@
             <!-- BRP contact data -->
             <section class="tabled tabled--flexible profile-section" id="profile-notifications">
                 <div class="tabled__section">
-                    <h2 class="utrecht-heading-2 title" id="notifications">{% trans "Contactgegevens" %}
+                    <header class="oip-header-group title">
+                        <h2 class="utrecht-heading-2 title" id="notifications">{% trans "Contactgegevens" %}</h2>
                         <div class="tabled__item--force-right tabled__item--mobile-big">
                             {% button href="profile:edit" text=_("Bewerk") icon="edit" transparent=True icon_outlined=True %}
                         </div>
-                    </h2>
+                    </header>
                 </div>
                 <div class="tabled__row tabled__row--blank">
                     <div class="tabled__item tabled__key">{% trans "Roepnaam" %}</div>

--- a/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
+++ b/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
@@ -4,12 +4,14 @@
 {% block content %}
     {% render_grid %}
         {% render_column span=9 %}
-            <h1 class="utrecht-heading-1" data-title="{{ form.instance.get_title }}" data-code="{{ form.instance.code }}">
-                <span>{{ form.instance.get_title }}</span>
+            <header class="oip-header-group">
+                <h1 class="utrecht-heading-1" data-title="{{ form.instance.get_title }}" data-code="{{ form.instance.code }}">
+                    <span>{{ form.instance.get_title }}</span>
+                </h1>
                 {% if not form.instance.get_children %}
                     {% button href="products:questionnaire_export" text=_("Export pdf") primary=True icon="file-pdf" icon_position="after" title=_("Your results are also saved to your profile if you are logged in.") %}
                 {% endif %}
-            </h1>
+            </header>
 
             {% if form.instance.get_description %}
                 <p class="utrecht-paragraph">{{ form.instance.get_description }}</p>


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2584

for a correct screenreader order, interactive elements should not be inside a Heading element.

Connected to PR https://github.com/maykinmedia/open-inwoner-design-tokens/pull/10

Since design-tokens have been updated: $ npm ci --legacy-peer-deps
and $ npm run build

<img width="1050" alt="Screenshot 2024-07-11 at 14 07 23" src="https://github.com/maykinmedia/open-inwoner/assets/118177951/b5b1bc79-e8ae-4cce-bec2-c48a43883e27">
