### PR TITLE
:bug: [#2508] Fix hotfix for non-business login tab-panel

### DIFF
--- a/src/open_inwoner/js/components/tab-panels/index.js
+++ b/src/open_inwoner/js/components/tab-panels/index.js
@@ -7,18 +7,20 @@ export class TabPanel {
     this.tabHeaders = node.querySelectorAll('.tab__header')
     this.tabContent = node.querySelectorAll('.tab__content')
 
-    this.tabHeadersRow.addEventListener('click', (e) => {
-      e.preventDefault() // Prevent 'other' tab__panel from disappearing immediately
+    if (this.tabHeadersRow) {
+      this.tabHeadersRow.addEventListener('click', (e) => {
+        e.preventDefault() // Prevent 'other' tab__panel from disappearing immediately
 
-      const target = e.target.closest('.tab__header')
-      if (target) {
-        const index = [...this.tabHeaders].indexOf(target)
-        if (index !== -1) {
-          this.hideContent()
-          this.showContent(index)
+        const target = e.target.closest('.tab__header')
+        if (target) {
+          const index = [...this.tabHeaders].indexOf(target)
+          if (index !== -1) {
+            this.hideContent()
+            this.showContent(index)
+          }
         }
-      }
-    })
+      })
+    }
   }
 
   hideContent() {


### PR DESCRIPTION
issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2508 

Test: http://localhost:8000/accounts/login/ 

If 'zakelijk'/eHerkenning is turned off, then there will be no tab-headers visible, which means no tab-panel Nodes should be rendered 

fixing the console error:
```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at new TabPanel (open_inwoner-js.js:4704:24)
    at open_inwoner-js.js:4805:10 ...
    ...
```