### PR TITLE
[#dimpact-107] Hotfix for celery search task not showing in admin

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -187,7 +187,6 @@ INSTALLED_APPS = [
     "django_jsonform",
     "simple_certmanager",
     "zgw_consumers",
-    "notifications_api_common",
     "mail_editor",
     "ckeditor",
     "privates",
@@ -238,6 +237,12 @@ INSTALLED_APPS = [
     "djchoices",
     "django_celery_beat",
     "django_celery_monitor",
+    # Temporary fix: the notifications lib interferes with
+    # celery's task loading meachanism, which prevents certain
+    # tasks from showing up in the admin when OIP is run with
+    # Docker; this needs to be fixed this in the library eventually;
+    # for now we load it after all our apps.
+    "notifications_api_common",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Our [notifications-api-common](https://github.com/maykinmedia/notifications-api-common) library interferes with Celery's task loading by patching the autoretry meachanism ([code](https://github.com/maykinmedia/notifications-api-common/blob/main/notifications_api_common/autoretry.py)), which somehow prevents tasks form our apps from showing up in the admin. The temporary fix is to load the library after all our apps.

Eventually needs to be fixed in the library itself.

Taiga: https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/107