### PR TITLE
[#2432] fix incorrect task invocation in notification processing

### DIFF
--- a/src/open_inwoner/accounts/notifications/tasks.py
+++ b/src/open_inwoner/accounts/notifications/tasks.py
@@ -52,8 +52,7 @@ def process_notifications(notifications: list[dict], notify_about: str, channel:
         for notification in notifications
     )
 
-    result = task_group.apply_async()
-    return result.get()
+    task_group.apply_async()
 
 
 @app.task

--- a/src/open_inwoner/accounts/tasks.py
+++ b/src/open_inwoner/accounts/tasks.py
@@ -14,9 +14,7 @@ def schedule_user_notifications(notify_about: str, channel: str):
     """
     # Note: the return value of `collect_notifications` is passed as the first
     # (positional) argument to `process_notifications` in `celery.chain()`
-    result = celery.chain(
+    celery.chain(
         collect_notifications.s(notify_about=notify_about),
         process_notifications.s(notify_about=notify_about, channel=channel),
     ).apply_async()
-
-    return result.get()


### PR DESCRIPTION
[Taiga #2632](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2632) and [Sentry #1](https://sentry.maykinmedia.nl/organizations/maykin-media/issues/364649), [Sentry #2](https://sentry.maykinmedia.nl/organizations/maykin-media/issues/364650/).

[See also the Celery docs](https://docs.celeryq.dev/en/latest/userguide/tasks.html#avoid-launching-synchronous-subtasks).