### PR TITLE
Avoid resolving zgw objects in contactmomenten client

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -226,10 +226,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
         case_url = None
         ctx["zaak"] = None
         if client := build_contactmomenten_client():
-            # Note: we cannot be sure which zaken_client to pass here. However, given that it
-            # is only used to resolve the zaak, and we do that anyway below, it is safe to pass
-            # None.
-            ocm = client.retrieve_objectcontactmoment(kcm.contactmoment, "zaak", None)
+            ocm = client.retrieve_objectcontactmoment(kcm.contactmoment, "zaak")
             if ocm and ocm.object_type == "zaak":
                 zaak_url = ocm.object
                 groups = list(ZGWApiGroupConfig.objects.all())

--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -263,7 +263,7 @@ class ContactmomentenClient(APIClient):
         return object_contact_momenten
 
     def retrieve_objectcontactmomenten_for_contactmoment(
-        self, contactmoment: ContactMoment, zaken_client
+        self, contactmoment: ContactMoment
     ) -> list[ObjectContactMoment]:
         try:
             response = self.get(
@@ -276,21 +276,6 @@ class ContactmomentenClient(APIClient):
             return []
 
         object_contact_momenten = factory(ObjectContactMoment, all_data)
-
-        # resolve linked resources
-        if zaken_client:
-            object_mapping = {}
-            for ocm in object_contact_momenten:
-                assert ocm.contactmoment == contactmoment.url
-                ocm.contactmoment = contactmoment
-                if ocm.object_type == "zaak":
-                    object_url = ocm.object
-                    # Avoid fetching the same object, if multiple relations with the same object exist
-                    if ocm.object in object_mapping:
-                        ocm.object = object_mapping[object_url]
-                    else:
-                        ocm.object = zaken_client.fetch_case_by_url_no_cache(ocm.object)
-                        object_mapping[object_url] = ocm.object
 
         return object_contact_momenten
 
@@ -322,12 +307,10 @@ class ContactmomentenClient(APIClient):
         return klanten_contact_moments
 
     def retrieve_objectcontactmomenten_for_object_type(
-        self, contactmoment: ContactMoment, object_type: str, zaken_client
+        self, contactmoment: ContactMoment, object_type: str
     ) -> list[ObjectContactMoment]:
 
-        moments = self.retrieve_objectcontactmomenten_for_contactmoment(
-            contactmoment, zaken_client
-        )
+        moments = self.retrieve_objectcontactmomenten_for_contactmoment(contactmoment)
 
         # eSuite doesn't implement a `object_type` query parameter
         ret = [moment for moment in moments if moment.object_type == object_type]
@@ -335,10 +318,10 @@ class ContactmomentenClient(APIClient):
         return ret
 
     def retrieve_objectcontactmoment(
-        self, contactmoment: ContactMoment, object_type: str, zaken_client
+        self, contactmoment: ContactMoment, object_type: str
     ) -> ObjectContactMoment | None:
         ocms = self.retrieve_objectcontactmomenten_for_object_type(
-            contactmoment, object_type, zaken_client
+            contactmoment, object_type
         )
         if ocms:
             return ocms[0]


### PR DESCRIPTION
The immediate trigger for this is that passing a zaken_client to the objectcontactmomenten is fraught now we support multiple zgw backends: which backend do we pass to resolve the zaak?

More generally: resolving does not belong in the API client, which should focus on fetching data from a service and returning it to the caller, which is a distinct concern from enriching the objects thus retrieved.