### PR TITLE
[#2644] Display related case number in task userfeed

### DIFF
--- a/src/open_inwoner/openzaak/api_models.py
+++ b/src/open_inwoner/openzaak/api_models.py
@@ -332,3 +332,4 @@ class OpenTask(Model):
     naam: str
     startdatum: date
     formulier_link: str
+    zaak_identificatie: str

--- a/src/open_inwoner/openzaak/tests/mocks.py
+++ b/src/open_inwoner/openzaak/tests/mocks.py
@@ -45,6 +45,7 @@ class ESuiteTaskData:
             "naam": "Aanvullende informatie gewenst",
             "startdatum": "2023-11-14",
             "formulierLink": "https://maykinmedia.nl",
+            "zaakIdentificatie": "6789-2024",
         }
         self.task2 = {
             "url": "https://maykinmedia.nl",
@@ -53,6 +54,7 @@ class ESuiteTaskData:
             "naam": "Aanvullende informatie gewenst",
             "startdatum": "2023-10-11",
             "formulierLink": "https://maykinmedia.nl",
+            "zaakIdentificatie": "9876-2024",
         }
 
     def install_mocks(self, m):

--- a/src/open_inwoner/userfeed/hooks/external_task.py
+++ b/src/open_inwoner/userfeed/hooks/external_task.py
@@ -20,11 +20,15 @@ logger = logging.getLogger(__name__)
 
 class OpenTaskFeedItem(FeedItem):
     base_title = _("Open task")
+    extra_title = _("Case number")
     base_message = _("Open task that is yet to be completed")
 
     @property
     def title(self) -> str:
-        return f"{self.base_title} ({self.get_data('task_identificatie')})"
+        return (
+            f"{self.base_title} {self.get_data('task_identificatie')} "
+            f"({self.extra_title}: {self.get_data('zaak_identificatie')})"
+        )
 
     @property
     def message(self) -> str:
@@ -53,6 +57,7 @@ def update_external_task_items(user: User, openstaande_taken: list[OpenTask]):
             "action_url": task.formulier_link,
             "task_name": task.naam,
             "task_identificatie": task.identificatie,
+            "zaak_identificatie": task.zaak_identificatie,
         }
         if existing_item := existing_uuid_mapping.get(task.uuid):
             if existing_item.type_data != type_data:

--- a/src/open_inwoner/userfeed/tests/test_external_tasks.py
+++ b/src/open_inwoner/userfeed/tests/test_external_tasks.py
@@ -38,6 +38,7 @@ class UserFeedExternalTasksTestCase(TestCase):
                 "task_name": "Aanvullende informatie gewenst",
                 "task_identificatie": "4321-2023",
                 "action_url": "https://maykinmedia.nl",
+                "zaak_identificatie": "6789-2024",
             },
         )
 
@@ -49,7 +50,8 @@ class UserFeedExternalTasksTestCase(TestCase):
             # `cms_tools.render_plugin` renders twice
             mock.assert_has_calls([call(self.user), call(self.user)])
 
-            self.assertIn(f"{_('Open task')} (4321-2023)", html)
+            self.assertIn(f"{_('Open task')} 4321-2023", html)
+            self.assertIn(f"({_('Case number')}: 6789-2024)", html)
             self.assertIn("Aanvullende informatie gewenst", html)
 
     @requests_mock.Mocker()
@@ -74,6 +76,7 @@ class UserFeedExternalTasksTestCase(TestCase):
                     "task_name": "Aanvullende informatie gewenst",
                     "task_identificatie": "1234-2023",
                     "action_url": "https://maykinmedia.nl",
+                    "zaak_identificatie": "6789-2024",
                 },
             )
             self.assertEqual(
@@ -89,6 +92,7 @@ class UserFeedExternalTasksTestCase(TestCase):
                     "task_name": "Aanvullende informatie gewenst",
                     "task_identificatie": "4321-2023",
                     "action_url": "https://maykinmedia.nl",
+                    "zaak_identificatie": "9876-2024",
                 },
             )
             self.assertEqual(
@@ -114,6 +118,7 @@ class UserFeedExternalTasksTestCase(TestCase):
                 "task_name": "Aanvullende informatie gewenst",
                 "task_identificatie": "4321-2023",
                 "action_url": "https://maykinmedia.nl",
+                "zaak_identificatie": "9876-2024",
             },
         )
 
@@ -181,5 +186,6 @@ class UserFeedExternalTasksTestCase(TestCase):
                 "task_name": "Aanvullende informatie gewenst",
                 "task_identificatie": "1234-2023",
                 "action_url": "https://maykinmedia.nl",
+                "zaak_identificatie": "6789-2024",
             },
         )


### PR DESCRIPTION
The identification number of a related case is shown in the task userfeed, in addition to the task number

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2644