### PR TITLE
[#2657] migrate send_failed_email_digest cron to Celery

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -692,6 +692,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "open_inwoner.search.tasks.rebuild_search_index",
         "schedule": crontab(minute="0", hour="4", day_of_month="*"),
     },
+    "Dagelijkse misluke email samenvatting": {
+        "task": "open_inwoner.configurations.tasks.send_failed_email_digest",
+        "schedule": crontab(minute="0", hour="7", day_of_month="*"),
+    },
     "Probeer emails opnieuw te sturen": {
         "task": "django_yubin.tasks.retry_emails",
         "schedule": crontab(minute="1", hour="*", day_of_month="*"),

--- a/src/open_inwoner/configurations/tasks.py
+++ b/src/open_inwoner/configurations/tasks.py
@@ -1,0 +1,16 @@
+import logging
+
+from django.core.management import call_command
+
+from open_inwoner.celery import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.task
+def send_failed_email_digest():
+    logger.info("starting send_failed_email_digest() task")
+
+    call_command("send_failed_email_digest")
+
+    logger.info("finished send_failed_email_digest() task")


### PR DESCRIPTION
[Taiga 2657](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2657).