### PR TITLE
[#2261, #2262, #2263] Fix display name in profile

### DIFF
--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -354,6 +354,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     def get_short_name(self):
         return self.first_name
 
+    @property
+    def call_name(self):
+        return self.display_name or self.first_name
+
     def get_address(self):
         if self.street:
             return f"{self.street} {self.housenumber}, {self.postcode} {self.city}"

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -61,7 +61,9 @@ class ProfileViewTests(WebTest):
     def setUp(self):
         self.url = reverse("profile:detail")
         self.return_url = reverse("logout")
-        self.user = UserFactory(street="MyStreet")
+        self.user = UserFactory(
+            first_name="Erik", display_name="Roep", street="MyStreet"
+        )
         self.digid_user = DigidUserFactory()
         self.eherkenning_user = eHerkenningUserFactory()
 
@@ -136,6 +138,7 @@ class ProfileViewTests(WebTest):
         response = self.app.get(self.url, user=self.user)
 
         self.assertContains(response, self.user.first_name)
+        self.assertContains(response, f"Welkom, {self.user.display_name}")
         self.assertContains(response, f"{self.user.infix} {self.user.last_name}")
         self.assertContains(response, self.user.email)
         self.assertContains(response, self.user.phonenumber)

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -12,7 +12,7 @@
 {% get_solo 'configurations.SiteConfiguration' as siteconfig %}
 
 <section class="tabled tabled--flexible">
-    <h1 class="utrecht-heading-1" id="title">{% trans "Welkom" %}{% if not user.is_eherkenning_user %}, {{ user.first_name }}{% endif %}</h1>
+    <h1 class="utrecht-heading-1" id="title">{% trans "Welkom" %}{% if not user.is_eherkenning_user %}, {{ user.call_name }}{% endif %}</h1>
     <p class="tabled__key">
     {% trans "voor het laatst ingelogd op" %}: <span
     class="tabled__value">{{ user.last_login|date:"j F Y" }} om {{ user.last_login|date:"G:i" }} uur</span>

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -79,6 +79,10 @@
             <div class="tabled__item tabled__value">{{ user.infix }} {{ user.last_name }}</div>
         </div>
         <div class="tabled__row tabled__row--blank">
+            <div class="tabled__item tabled__key">{% trans "Roepnaam" %}</div>
+            <div class="tabled__item tabled__value">{{ user.display_name }}</div>
+        </div>
+        <div class="tabled__row tabled__row--blank">
             <div class="tabled__item tabled__key">{% trans "Adres" %}</div>
             <div class="tabled__item tabled__value">
                 <div>{{ user.street }} {{ user.housenumber }}</div>


### PR DESCRIPTION
- Use display name ("roepnaam") in profile welcome message by default
- Use first name as fallback in case roepnaam is not set
- Show roepnaam in profile overview

Taiga: [#2261](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2661), [#2262](https://github.com/maykinmedia/open-inwoner/pull/new/issue/2662-profile-welcome), [#2263](https://taiga.maykinmedia.nl/project/open-inwoner/issue/2663)