### PR TITLE
Bump zgw-consumers to 0.34, install zgw-consumers-oas for tests

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -92,6 +92,7 @@ git+https://github.com/maykinmedia/django-celery-monitor@513dc28#egg=django_cele
 
 # Common Ground integration
 zgw-consumers
+zgw-consumers-oas
 notifications-api-common
 
 # 2FA SMS verification

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -147,6 +147,7 @@ django==4.2.15
     #   mozilla-django-oidc-db
     #   notifications-api-common
     #   zgw-consumers
+    #   zgw-consumers-oas
 django-admin-index==3.1.0
     # via -r requirements/base.in
 django-appconf==1.0.5
@@ -334,6 +335,8 @@ et-xmlfile==1.1.0
     # via openpyxl
 face==20.1.1
     # via glom
+faker==27.0.0
+    # via zgw-consumers-oas
 fontawesomefree==6.4.2
     # via -r requirements/base.in
 fonttools[woff]==4.43.0
@@ -346,9 +349,7 @@ furl==2.1.3
     #   ape-pie
     #   django-digid-eherkenning
 gemma-zds-client==2.0.0
-    # via
-    #   notifications-api-common
-    #   zgw-consumers
+    # via notifications-api-common
 geographiclib==1.52
     # via geopy
 geopy==2.2.0
@@ -449,13 +450,13 @@ pyjwt==2.8.0
     # via
     #   gemma-zds-client
     #   messagebird
+    #   zgw-consumers
 pyopenssl==24.0.0
     # via
     #   -r requirements/base.in
     #   django-simple-certmanager
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.12.0
     # via weasyprint
 pyrsistent==0.18.0
@@ -467,6 +468,7 @@ python-dateutil==2.8.2
     #   celery
     #   django-relativedelta
     #   elasticsearch-dsl
+    #   faker
     #   messagebird
     #   python-crontab
 python-decouple==3.5
@@ -485,6 +487,7 @@ pyyaml==6.0
     #   drf-spectacular
     #   gemma-zds-client
     #   tablib
+    #   zgw-consumers-oas
 qrcode==6.1
     # via django-two-factor-auth
 redis==5.0.3
@@ -545,6 +548,8 @@ typing-extensions==4.10.0
     #   pydantic-core
     #   pyee
     #   xsdata
+    #   zgw-consumers
+    #   zgw-consumers-oas
 tzdata==2024.1
     # via
     #   celery
@@ -585,10 +590,12 @@ xmlsec==1.3.12
     # via maykin-python3-saml
 xsdata==23.8
     # via -r requirements/base.in
-zgw-consumers==0.29.0
+zgw-consumers==0.34.0
     # via
     #   -r requirements/base.in
     #   notifications-api-common
+zgw-consumers-oas==1.0.0
+    # via -r requirements/base.in
 zopfli==0.1.9
     # via fonttools
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -239,6 +239,7 @@ django==4.2.15
     #   mozilla-django-oidc-db
     #   notifications-api-common
     #   zgw-consumers
+    #   zgw-consumers-oas
 django-admin-index==3.1.0
     # via
     #   -c requirements/base.txt
@@ -589,10 +590,13 @@ face==20.1.1
     #   glom
 factory-boy==3.2.0
     # via -r requirements/test-tools.in
-faker==9.9.0
+faker==27.0.0
     # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
     #   factory-boy
     #   polyfactory
+    #   zgw-consumers-oas
 flake8==7.0.0
     # via -r requirements/test-tools.in
 fontawesomefree==6.4.2
@@ -618,7 +622,6 @@ gemma-zds-client==2.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   notifications-api-common
-    #   zgw-consumers
 geographiclib==1.52
     # via
     #   -c requirements/base.txt
@@ -863,6 +866,7 @@ pyjwt==2.8.0
     #   -r requirements/base.txt
     #   gemma-zds-client
     #   messagebird
+    #   zgw-consumers
 pylint==2.17.7
     # via -r requirements/test-tools.in
 pyopenssl==24.0.0
@@ -873,7 +877,6 @@ pyopenssl==24.0.0
     #   django-simple-certmanager
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.12.0
     # via
     #   -c requirements/base.txt
@@ -930,6 +933,7 @@ pyyaml==6.0
     #   drf-spectacular
     #   gemma-zds-client
     #   tablib
+    #   zgw-consumers-oas
 qrcode==6.1
     # via
     #   -c requirements/base.txt
@@ -1041,8 +1045,6 @@ tablib[html,ods,xls,xlsx,yaml]==3.1.0
     #   tablib
 tblib==1.7.0
     # via -r requirements/test-tools.in
-text-unidecode==1.3
-    # via faker
 tinycss2==1.1.1
     # via
     #   -c requirements/base.txt
@@ -1061,6 +1063,8 @@ typing-extensions==4.10.0
     #   pydantic-core
     #   pyee
     #   xsdata
+    #   zgw-consumers
+    #   zgw-consumers-oas
 tzdata==2024.1
     # via
     #   -c requirements/base.txt
@@ -1143,11 +1147,15 @@ xsdata==23.8
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-zgw-consumers==0.29.0
+zgw-consumers==0.34.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   notifications-api-common
+zgw-consumers-oas==1.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 zopfli==0.1.9
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -279,6 +279,7 @@ django==4.2.15
     #   mozilla-django-oidc-db
     #   notifications-api-common
     #   zgw-consumers
+    #   zgw-consumers-oas
 django-admin-index==3.1.0
     # via
     #   -c requirements/ci.txt
@@ -641,12 +642,13 @@ factory-boy==3.2.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-faker==9.9.0
+faker==27.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   factory-boy
     #   polyfactory
+    #   zgw-consumers-oas
 flake8==7.0.0
     # via
     #   -c requirements/ci.txt
@@ -685,7 +687,6 @@ gemma-zds-client==2.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   notifications-api-common
-    #   zgw-consumers
 geographiclib==1.52
     # via
     #   -c requirements/ci.txt
@@ -1001,6 +1002,7 @@ pyjwt==2.8.0
     #   -r requirements/ci.txt
     #   gemma-zds-client
     #   messagebird
+    #   zgw-consumers
 pylint==2.17.7
     # via
     #   -c requirements/ci.txt
@@ -1012,7 +1014,6 @@ pyopenssl==24.0.0
     #   django-simple-certmanager
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.12.0
     # via
     #   -c requirements/ci.txt
@@ -1074,6 +1075,7 @@ pyyaml==6.0
     #   drf-spectacular
     #   gemma-zds-client
     #   tablib
+    #   zgw-consumers-oas
 pyzmq==25.1.2
     # via locust
 qrcode==6.1
@@ -1234,11 +1236,6 @@ tblib==1.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-text-unidecode==1.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   faker
 tinycss2==1.1.1
     # via
     #   -c requirements/ci.txt
@@ -1264,6 +1261,8 @@ typing-extensions==4.10.0
     #   pydantic-core
     #   pyee
     #   xsdata
+    #   zgw-consumers
+    #   zgw-consumers-oas
 tzdata==2024.1
     # via
     #   -c requirements/ci.txt
@@ -1361,11 +1360,15 @@ xsdata==23.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-zgw-consumers==0.29.0
+zgw-consumers==0.34.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   notifications-api-common
+zgw-consumers-oas==1.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 zope-event==5.0
     # via gevent
 zope-interface==6.1

--- a/src/open_inwoner/openzaak/tests/helpers.py
+++ b/src/open_inwoner/openzaak/tests/helpers.py
@@ -2,7 +2,7 @@ import re
 from copy import deepcopy
 from uuid import uuid4
 
-from zgw_consumers.test import generate_oas_component
+from zgw_consumers_oas import generate_oas_component
 
 from open_inwoner.utils.hash import pyhash_value
 

--- a/src/open_inwoner/openzaak/tests/test_migrations.py
+++ b/src/open_inwoner/openzaak/tests/test_migrations.py
@@ -206,6 +206,7 @@ class TestZGWApiGroupServicesRequiredFailingMigration(TestFailingMigrations):
 class TestZGWApiGroupServicesRequiredSuccessfulMigration(TestSuccessfulMigrations):
     migrate_from = "0053_zaaktypeconfig_catalogus_is_required"
     migrate_to = "0054_zgw_api_group_requires_most_services"
+    extra_migrate_from = [("zgw_consumers", "0019_alter_service_uuid")]
     app = "openzaak"
 
     def setUpBeforeMigration(self, apps):


### PR DESCRIPTION
 zgw-consumers-oas includes tooling for OAS mocks and was deprecated in zgw-consumers 0.33