### PR TITLE
[#2230] Add tests for document upload/download with multiple backends

### DIFF
--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -21,7 +21,11 @@ from zgw_consumers.constants import AuthTypes
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.cms.cases.views.status import SimpleFile
-from open_inwoner.openzaak.clients import build_documenten_client, build_zaken_client
+from open_inwoner.openzaak.clients import (
+    build_documenten_client,
+    build_documenten_clients,
+    build_zaken_client,
+)
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 from ..models import OpenZaakConfig
@@ -32,7 +36,14 @@ from .factories import (
     ZGWApiGroupConfigFactory,
 )
 from .helpers import generate_oas_component_cached
-from .shared import CATALOGI_ROOT, DOCUMENTEN_ROOT, ZAKEN_ROOT
+from .shared import (
+    ANOTHER_CATALOGI_ROOT,
+    ANOTHER_DOCUMENTEN_ROOT,
+    ANOTHER_ZAKEN_ROOT,
+    CATALOGI_ROOT,
+    DOCUMENTEN_ROOT,
+    ZAKEN_ROOT,
+)
 
 
 def get_temporary_text_file():
@@ -58,6 +69,12 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
             ztc_service__api_root=CATALOGI_ROOT,
             zrc_service__api_root=ZAKEN_ROOT,
             drc_service__api_root=DOCUMENTEN_ROOT,
+            form_service=None,
+        )
+        self.api_group_alt = ZGWApiGroupConfigFactory(
+            ztc_service__api_root=ANOTHER_CATALOGI_ROOT,
+            zrc_service__api_root=ANOTHER_ZAKEN_ROOT,
+            drc_service__api_root=ANOTHER_DOCUMENTEN_ROOT,
             form_service=None,
         )
         self.zaken_client = build_zaken_client()
@@ -164,6 +181,101 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
             ),
         )
 
+        #
+        # additional mocks for testing different backends
+        #
+        self.zaak_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Zaak",
+            uuid="d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaken/d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
+            zaaktype=f"{ANOTHER_CATALOGI_ROOT}zaaktypen/0caa29cb-0167-426f-8dc1-88bebd7c8804",
+            identificatie="ZAAK-2022-0000000024",
+            omschrijving="Zaak naar aanleiding van ingezonden formulier",
+            startdatum="2022-01-02",
+            einddatum=None,
+            status=f"{ANOTHER_ZAKEN_ROOT}statussen/3da89990-c7fc-476a-ad13-c9023450083c",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+            bronorganisatie="123456782",
+        )
+        self.zaaktype_alt = generate_oas_component_cached(
+            "ztc",
+            "schemas/ZaakType",
+            url=self.zaak_alt["zaaktype"],
+            uuid="0caa29cb-0167-426f-8dc1-88bebd7c8804",
+            omschrijving="Coffee zaaktype",
+            catalogus=f"{ANOTHER_CATALOGI_ROOT}catalogussen/1b643db-81bb-d71bd5a2317a",
+            # openbaar and extern
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+            indicatieInternOfExtern="extern",
+        )
+        self.zaak_informatie_object_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/ZaakInformatieObject",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
+            informatieobject=f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/90ce7081-9ae6-429a-b42f-61f90c19003f",
+            zaak=self.zaak["url"],
+            aardRelatieWeergave="some content",
+            titel="",
+            beschrijving="",
+            registratiedatum="2021-01-12",
+        )
+        self.user_role_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Rol",
+            url=f"{ANOTHER_ZAKEN_ROOT}rollen/f33153aa-ad2c-4a07-ae75-15add5891",
+            omschrijvingGeneriek=RolOmschrijving.initiator,
+            betrokkeneType=RolTypes.natuurlijk_persoon,
+            betrokkeneIdentificatie={
+                "inpBsn": "900222086",
+                "voornamen": "Foo Bar",
+                "voorvoegselGeslachtsnaam": "van der",
+                "geslachtsnaam": "Bazz",
+            },
+        )
+        self.informatie_object_content_alt = b"my alternative document content"
+        self.informatie_object_alt = generate_oas_component_cached(
+            "drc",
+            "schemas/EnkelvoudigInformatieObject",
+            uuid="90ce7081-9ae6-429a-b42f-61f90c19003f",
+            url=self.zaak_informatie_object_alt["informatieobject"],
+            inhoud=f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/90ce7081-9ae6-429a-b42f-61f90c19003f/download",
+            informatieobjecttype=f"{ANOTHER_CATALOGI_ROOT}informatieobjecttype/014c38fe-b010-4412-881c-3000032fb321",
+            status="definitief",
+            indicatieGebruiksrecht=False,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+            formaat="text/plain",
+            bestandsnaam="my_alt_document.txt",
+            bestandsomvang=len(self.informatie_object_content_alt),
+            bronorganisatie="1233456782",
+            creatiedatum=date.today().strftime("%Y-%m-%d"),
+            titel="",
+            auteur="Open Inwoner Platform",
+        )
+        self.informatie_object_file_alt = SimpleFile(
+            name="my_alt_document.txt",
+            size=len(self.informatie_object_content_alt),
+            url=reverse(
+                "cases:document_download",
+                kwargs={
+                    "object_id": self.zaak_alt["uuid"],
+                    "info_id": self.informatie_object_alt["uuid"],
+                    "api_group_id": self.api_group_alt.id,
+                },
+            ),
+        )
+        self.zaak_informatie_object_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/ZaakInformatieObject",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten/e55153aa-ad2c-4a07-ae75-15add57d6",
+            informatieobject=f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/90ce7081-9ae6-429a-b42f-61f90c19003f",
+            zaak=self.zaak_alt["url"],
+            aardRelatieWeergave="some content",
+            titel="",
+            beschrijving="",
+            registratiedatum="2021-01-12",
+        )
+
     def _setUpAccessMocks(self, m):
         # the minimal mocks needed to be able to access the information object
         m.get(self.zaak["url"], json=self.zaak)
@@ -187,10 +299,48 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
             status_code=201,
             json=self.informatie_object,
         )
+        m.get(
+            f"{DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten",
+            status_code=201,
+            json=self.informatie_object,
+        )
         m.post(
             f"{ZAKEN_ROOT}zaakinformatieobjecten",
             status_code=201,
             json=self.zaak_informatie_object,
+        )
+
+    def _setUpAdditionalMocks(self, m):
+        # access mocks
+        m.get(self.zaak_alt["url"], json=self.zaak_alt)
+        m.get(
+            f"{ANOTHER_ZAKEN_ROOT}rollen?zaak={self.zaak_alt['url']}",
+            json=paginated_response([self.user_role_alt]),
+        )
+        m.get(self.zaaktype_alt["url"], json=self.zaaktype_alt)
+
+        m.get(
+            f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten?zaak={self.zaak_alt['url']}"
+            f"&informatieobject={self.informatie_object_alt['url']}",
+            # note the real API doesn't return a paginated_response here
+            json=[self.zaak_informatie_object_alt],
+        )
+
+        #
+        m.get(self.informatie_object_alt["url"], json=self.informatie_object_alt)
+        m.get(
+            self.informatie_object_alt["inhoud"],
+            content=self.informatie_object_content_alt,
+        )
+        m.post(
+            f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten",
+            status_code=201,
+            json=self.informatie_object_alt,
+        )
+        m.post(
+            f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten",
+            status_code=201,
+            json=self.zaak_informatie_object_alt,
         )
 
     def test_document_content_is_retrieved_when_user_logged_in_via_digid(self, m):
@@ -416,6 +566,77 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
         )
 
         self.assertEqual(created_document, self.informatie_object)
+
+    def test_document_upload_multiple_backends(self, m):
+        self._setUpMocks(m)
+        self._setUpAdditionalMocks(m)
+
+        zaak_type_config = ZaakTypeConfigFactory(
+            identificatie=self.zaaktype["identificatie"]
+        )
+        zaak_type_iotc = ZaakTypeInformatieObjectTypeConfigFactory(
+            zaaktype_config=zaak_type_config,
+            informatieobjecttype_url=self.informatie_object["url"],
+            zaaktype_uuids=[self.zaaktype["uuid"]],
+            document_upload_enabled=True,
+        )
+        file = get_temporary_text_file()
+        title = "my_document"
+
+        client, client_alt = build_documenten_clients()
+
+        # upload with first documenten backend
+        documenten_client = client
+        created_document = documenten_client.upload_document(
+            self.user, file, title, zaak_type_iotc.id, self.zaak["bronorganisatie"]
+        )
+
+        self.assertEqual(created_document["uuid"], self.informatie_object["uuid"])
+
+        # upload with second documenten backend
+        documenten_client = client_alt
+        created_document = documenten_client.upload_document(
+            self.user, file, title, zaak_type_iotc.id, self.zaak_alt["bronorganisatie"]
+        )
+
+        self.assertEqual(created_document["uuid"], self.informatie_object_alt["uuid"])
+
+    def test_document_download_multiple_backends(self, m):
+        self._setUpMocks(m)
+        self._setUpAdditionalMocks(m)
+
+        # download with first documenten backend
+        response = self.app.get(self.informatie_object_file.url, user=self.user)
+
+        self.assertEqual(response.body, self.informatie_object_content)
+        self.assertIn("Content-Disposition", response.headers)
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            'attachment; filename="my_document.txt"',
+        )
+        self.assertIn("Content-Type", response.headers)
+        self.assertEqual(response.headers["Content-Type"], "text/plain")
+        self.assertIn("Content-Length", response.headers)
+        self.assertEqual(
+            response.headers["Content-Length"], str(len(self.informatie_object_content))
+        )
+
+        # download with second documenten backend
+        response = self.app.get(self.informatie_object_file_alt.url, user=self.user)
+
+        self.assertEqual(response.body, self.informatie_object_content_alt)
+        self.assertIn("Content-Disposition", response.headers)
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            'attachment; filename="my_alt_document.txt"',
+        )
+        self.assertIn("Content-Type", response.headers)
+        self.assertEqual(response.headers["Content-Type"], "text/plain")
+        self.assertIn("Content-Length", response.headers)
+        self.assertEqual(
+            response.headers["Content-Length"],
+            str(len(self.informatie_object_content_alt)),
+        )
 
     def test_document_response_is_none_when_http_404(self, m):
         self._setUpMocks(m)


### PR DESCRIPTION
The PR adds tests for upload/download of files with multiple documenten backends; the functionality was already implemented.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2230