### PR TITLE
Check for missing ZGW backend config in zgw_import_data command

### DIFF
--- a/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
+++ b/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
@@ -2,6 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from open_inwoner.openzaak.models import ZGWApiGroupConfig
 from open_inwoner.openzaak.zgw_imports import (
     import_catalog_configs,
     import_zaaktype_configs,
@@ -47,6 +48,12 @@ class Command(BaseCommand):
         self.stdout.write("")
 
     def handle(self, *args, **options):
+        if ZGWApiGroupConfig.objects.count() == 0:
+            self.stdout.write(
+                "Please define at least one ZGWApiGroupConfig before running this command."
+            )
+            return
+
         # catalogus config
         imported = import_catalog_configs()
 

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
@@ -1,5 +1,6 @@
 import inspect
 from io import StringIO
+from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -20,6 +21,7 @@ from open_inwoner.openzaak.tests.test_zgw_imports import CatalogMockData
 from open_inwoner.openzaak.tests.test_zgw_imports_iotypes import (
     InformationObjectTypeMockData,
 )
+from open_inwoner.openzaak.zgw_imports import import_catalog_configs
 from open_inwoner.utils.test import ClearCachesMixin
 
 
@@ -134,3 +136,21 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
         ).strip()
 
         self.assertEqual(stdout, expected)
+
+
+class ZGWImportCommandWithoutConfigTest(TestCase):
+    def test_command_exits_early_if_no_zgw_api_defined(
+        self,
+    ):
+        mock_import_catalog_configs = mock.create_autospec(
+            import_catalog_configs, side_effect=import_catalog_configs
+        )
+
+        out = StringIO()
+        call_command("zgw_import_data", stdout=out)
+
+        self.assertEqual(
+            out.getvalue(),
+            "Please define at least one ZGWApiGroupConfig before running this command.\n",
+        )
+        mock_import_catalog_configs.assert_not_called()


### PR DESCRIPTION
Not having a ZGW backend configured is something that happens in the wild, and more broadly, it would be a good thing if the management command does not fail hard on a missing config (as now) but gracefully exits with an error message. Better reporting to users (including our Celery task wrapper for this command), and cuts down on false-positive Sentry pings.