### PR TITLE
[#2688] Improve template for user notifications

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -332,23 +332,27 @@ class UserNotificationsForm(forms.ModelForm):
     def __init__(self, user, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        config = SiteConfiguration.get_solo()
+        siteconfig = SiteConfiguration.get_solo()
+        self.any_notifications_enabled = siteconfig.any_notifications_enabled
 
-        if not config.enable_notification_channel_choice:
+        if not siteconfig.enable_notification_channel_choice:
             del self.fields["case_notification_channel"]
 
         if (
-            not config.notifications_cases_enabled
+            not siteconfig.notifications_cases_enabled
             or not case_page_is_published()
             or not user.login_type == LoginTypeChoices.digid
         ):
             del self.fields["cases_notifications"]
 
-        if not config.notifications_messages_enabled or not inbox_page_is_published():
+        if (
+            not siteconfig.notifications_messages_enabled
+            or not inbox_page_is_published()
+        ):
             del self.fields["messages_notifications"]
 
         if (
-            not config.notifications_plans_enabled
+            not siteconfig.notifications_plans_enabled
             or not collaborate_page_is_published()
         ):
             del self.fields["plans_notifications"]

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -121,6 +121,10 @@ class TestProfile(WebTest):
 
     @patch("open_inwoner.cms.utils.page_display._is_published", return_value=True)
     def test_user_notifications_update_is_logged(self, mock_cms_page_display):
+        config = SiteConfiguration.get_solo()
+        config.notifications_messages_enabled = True
+        config.save()
+
         form = self.app.get(reverse("profile:notifications"), user=self.user).forms[
             "change-notifications"
         ]

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -963,6 +963,14 @@ class EditIntrestsTests(WebTest):
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 @patch("open_inwoner.cms.utils.page_display._is_published", return_value=True)
 class EditNotificationsTests(AssertTimelineLogMixin, WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        config = SiteConfiguration.get_solo()
+        config.notifications_messages_enabled = True
+        config.notifications_cases_enabled = True
+        config.notifications_plans_enabled = True
+        config.save()
+
     def setUp(self):
         self.url = reverse("profile:notifications")
         self.user = UserFactory()
@@ -1065,8 +1073,13 @@ class NotificationsDisplayTests(WebTest):
         cls.url = reverse("profile:notifications")
         cls.user = UserFactory()
 
+        config = SiteConfiguration.get_solo()
+        config.notifications_messages_enabled = True
+        config.notifications_cases_enabled = True
+        config.notifications_plans_enabled = True
+        config.save()
+
     def test_inbox_notifications_display(self):
-        # inbox page not created
         response = self.app.get(self.url, user=self.user)
         form = response.forms["change-notifications"]
 

--- a/src/open_inwoner/templates/pages/profile/notifications.html
+++ b/src/open_inwoner/templates/pages/profile/notifications.html
@@ -11,35 +11,37 @@
         <form method="POST" id="change-notifications" action="{% url 'profile:notifications' %}" class="form" novalidate>
             {% csrf_token %}
 
-            {# Start of multiple checkbox fields #}
-            <ul class="choice-list choice-list-multiple">
+            {% if form.any_notifications_enabled %}
+                {# Start of multiple checkbox fields #}
+                <ul class="choice-list choice-list-multiple">
 
-            <h3 class="utrecht-heading-3">{% trans "Ontvang berichten over" %}</h3>
-                <p class="utrecht-paragraph">{% trans "Kies voor welk onderwerp je meldingen wilt ontvangen" %}</p>
+                <h3 class="utrecht-heading-3">{% trans "Ontvang berichten over" %}</h3>
+                    <p class="utrecht-paragraph">{% trans "Kies voor welk onderwerp je meldingen wilt ontvangen" %}</p>
 
-                {% if form.cases_notifications %}
-                    <li class="choice-list-multiple__item">
-                        <div class="choice-list-multiple__content">
-                            {% checkbox form.cases_notifications %}
-                        </div>
-                    </li>
-                {% endif %}
+                    {% if form.cases_notifications %}
+                        <li class="choice-list-multiple__item">
+                            <div class="choice-list-multiple__content">
+                                {% checkbox form.cases_notifications %}
+                            </div>
+                        </li>
+                    {% endif %}
 
-                {% if form.messages_notifications %}
-                    <li class="choice-list-multiple__item">
-                        <div class="choice-list-multiple__content">
-                            {% checkbox form.messages_notifications %}</div>
-                    </li>
-                {% endif %}
+                    {% if form.messages_notifications %}
+                        <li class="choice-list-multiple__item">
+                            <div class="choice-list-multiple__content">
+                                {% checkbox form.messages_notifications %}</div>
+                        </li>
+                    {% endif %}
 
-                {% if form.plans_notifications %}
-                    <li class="choice-list-multiple__item">
-                        <div class="choice-list-multiple__content">
-                            {% checkbox form.plans_notifications %}</div>
-                    </li>
-                {% endif %}
-            </ul>
-            {# End of multiple checkbox fields #}
+                    {% if form.plans_notifications %}
+                        <li class="choice-list-multiple__item">
+                            <div class="choice-list-multiple__content">
+                                {% checkbox form.plans_notifications %}</div>
+                        </li>
+                    {% endif %}
+                </ul>
+                {# End of multiple checkbox fields #}
+            {% endif %}
 
             <div class="choice-list choice-list-multiple">
                 {# Info on notifications that cannot be disabled #}
@@ -64,7 +66,9 @@
             {% endif %}
 
             <div class="form__actions form__actions--fullwidth">
-                {% button text=_("Sla wijzigingen op") primary=True type="submit" form_id="change-notifications" %}
+                {% if form.any_notifications_enabled or form.case_notification_channel %}
+                    {% button text=_("Sla wijzigingen op") primary=True type="submit" form_id="change-notifications" %}
+                {% endif %}
                 {% button href="profile:detail" icon="west" text=_("Terug naar Mijn profiel") icon_outlined=True transparent=True %}
             </div>
         </form>


### PR DESCRIPTION
The PR makes the presence of the heading ("choose notifications") contingent on whether any notifications have been enabled by staff users

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2688