### PR TITLE
Sync user's notification preferences from klant upon login

### DIFF
--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -24,6 +24,11 @@ MESSAGE_TYPE = {
 
 @receiver(user_logged_in)
 def update_user_from_klant_on_login(sender, user, request, *args, **kwargs):
+    # This additional guard is mainly to facilitate easier testing, where not
+    # all request factories return a full-fledged request object.
+    if not hasattr(request, "user"):
+        return
+
     if user.login_type in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
         if klant := get_or_create_klant_from_request(request):
             update_user_from_klant(klant, user)

--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -7,8 +7,10 @@ from open_inwoner.haalcentraal.models import HaalCentraalConfig
 from open_inwoner.haalcentraal.utils import update_brp_data_in_db
 from open_inwoner.utils.logentry import user_action
 
-from ..openklant.models import OpenKlantConfig
-from ..openklant.services import update_user_from_klant
+from ..openklant.services import (
+    get_or_create_klant_from_request,
+    update_user_from_klant,
+)
 from .choices import LoginTypeChoices
 
 MESSAGE_TYPE = {
@@ -18,6 +20,13 @@ MESSAGE_TYPE = {
     "frontend_oidc": _("user was logged in via frontend using OpenIdConnect"),
     "logout": _("user was logged out"),
 }
+
+
+@receiver(user_logged_in)
+def update_user_from_klant_on_login(sender, user, request, *args, **kwargs):
+    if user.login_type in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
+        if klant := get_or_create_klant_from_request(request):
+            update_user_from_klant(klant, user)
 
 
 @receiver(user_logged_in)
@@ -40,15 +49,10 @@ def log_user_login(sender, user, request, *args, **kwargs):
 
     # update brp fields when login with digid and brp is configured
     brp_config = HaalCentraalConfig.get_solo()
-    oc_config = OpenKlantConfig.get_solo()
 
     if user.login_type == LoginTypeChoices.digid:
         if brp_config.service:
             update_brp_data_in_db(user)
-
-    if user.login_type in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
-        if oc_config.klanten_service:
-            update_user_from_klant(request)
 
 
 @receiver(user_logged_out)

--- a/src/open_inwoner/openklant/api_models.py
+++ b/src/open_inwoner/openklant/api_models.py
@@ -31,7 +31,7 @@ class Klant(ZGWModel):
     achternaam: str = ""
     telefoonnummer: str = ""
     emailadres: str = ""
-    toestemmingZaakNotificatiesAlleenDigitaal: bool | None = None
+    toestemming_zaak_notificaties_alleen_digitaal: bool | None = None
 
     def get_name_display(self):
         return " ".join(

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1,6 +1,8 @@
 import logging
 
+from open_inwoner.accounts.choices import NotificationChannelChoice
 from open_inwoner.accounts.models import User
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openklant.api_models import Klant
 from open_inwoner.openklant.clients import build_klanten_client
 from open_inwoner.utils.logentry import system_action
@@ -36,6 +38,37 @@ def update_user_from_klant(klant: Klant, user: User):
     if klant.emailadres and klant.emailadres != user.email:
         if not User.objects.filter(email__iexact=klant.emailadres).exists():
             update_data["email"] = klant.emailadres
+
+    config = SiteConfiguration.get_solo()
+    if config.enable_notification_channel_choice:
+        if (
+            klant.toestemming_zaak_notificaties_alleen_digitaal is True
+            and user.case_notification_channel != NotificationChannelChoice.digital_only
+        ):
+            update_data[
+                "case_notification_channel"
+            ] = NotificationChannelChoice.digital_only
+
+        elif (
+            klant.toestemming_zaak_notificaties_alleen_digitaal is False
+            and user.case_notification_channel
+            != NotificationChannelChoice.digital_and_post
+        ):
+            update_data[
+                "case_notification_channel"
+            ] = NotificationChannelChoice.digital_and_post
+        else:
+            # This is a guard against the scenario where a deployment is
+            # configured to use an older version of the klanten backend (that
+            # is, one that lacks the toestemmingZaakNotificatiesAlleenDigitaal
+            # field). In such a scenario, the enable_notification_channel_choice
+            # flag really shouldn't be set until the update has completed, but
+            # we suspect this is rare. But to validate that assumption, we log
+            # an error so we can remedy this in case we're wrong.
+            logger.error(
+                "SiteConfig.enable_notification_channel_choice should not be set if"
+                " toestemmingZaakNotificatiesAlleenDigitaal is not available from the klanten backend"
+            )
 
     if update_data:
         for attr, value in update_data.items():

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1,18 +1,17 @@
+import logging
+
 from open_inwoner.accounts.models import User
+from open_inwoner.openklant.api_models import Klant
 from open_inwoner.openklant.clients import build_klanten_client
 from open_inwoner.utils.logentry import system_action
 
 from .wrap import get_fetch_parameters
 
+logger = logging.getLogger(__name__)
 
-def update_user_from_klant(request):
-    if not hasattr(request, "user"):
-        return
 
-    user: User = request.user
-
-    client = build_klanten_client()
-    if not client:
+def get_or_create_klant_from_request(request):
+    if not (client := build_klanten_client()):
         return
 
     fetch_params = get_fetch_parameters(request)
@@ -24,8 +23,11 @@ def update_user_from_klant(request):
     else:
         return
 
-    system_action(msg, content_object=user)
+    system_action(msg, content_object=request.user)
+    return klant
 
+
+def update_user_from_klant(klant: Klant, user: User):
     update_data = {}
 
     if klant.telefoonnummer and klant.telefoonnummer != user.phonenumber:

--- a/src/open_inwoner/openklant/tests/data.py
+++ b/src/open_inwoner/openklant/tests/data.py
@@ -59,6 +59,7 @@ class MockAPIReadPatchData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="bad@example.com",
             telefoonnummer="",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_bsn_updated = generate_oas_component_cached(
             "kc",
@@ -71,6 +72,7 @@ class MockAPIReadPatchData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="good@example.com",
             telefoonnummer="0123456789",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_eherkenning_old = generate_oas_component_cached(
             "kc",
@@ -81,6 +83,7 @@ class MockAPIReadPatchData(MockAPIData):
             },
             emailadres="bad@example.com",
             telefoonnummer="",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_eherkenning_updated = generate_oas_component_cached(
             "kc",
@@ -91,6 +94,7 @@ class MockAPIReadPatchData(MockAPIData):
             },
             emailadres="good@example.com",
             telefoonnummer="0123456789",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
 
     def install_mocks(self, m) -> "MockAPIReadPatchData":
@@ -150,6 +154,7 @@ class MockAPIReadData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_kvk = generate_oas_component_cached(
             "kc",
@@ -162,6 +167,7 @@ class MockAPIReadData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-ffffffffffff",
             emailadres="foo@bar.com",
             telefoonnummer="0687654321",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_vestiging = generate_oas_component_cached(
             "kc",
@@ -174,6 +180,7 @@ class MockAPIReadData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
             emailadres="foo@bar.com",
             telefoonnummer="0612345678",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.contactmoment = generate_oas_component_cached(
             "cmc",
@@ -366,6 +373,7 @@ class MockAPICreateData(MockAPIData):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="foo@example.com",
             telefoonnummer="0612345678",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_eherkenning_no_contact_info = generate_oas_component_cached(
             "kc",
@@ -380,6 +388,7 @@ class MockAPICreateData(MockAPIData):
             achternaam="Bar",
             emailadres="",
             telefoonnummer="",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.klant_bsn_no_contact_info = generate_oas_component_cached(
             "kc",
@@ -394,6 +403,7 @@ class MockAPICreateData(MockAPIData):
             achternaam="Bar",
             emailadres="",
             telefoonnummer="",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
         self.contactmoment = generate_oas_component_cached(
             "cmc",

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -41,6 +41,7 @@ class UpdateUserFromLoginSignalAPITestCase(
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="new@example.com",
             telefoonnummer="0612345678",
+            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
 
     def test_update_user_after_login(self, m):

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -4,9 +4,10 @@ from django.test import RequestFactory
 import requests_mock
 from django_webtest import WebTest
 
-from open_inwoner.accounts.choices import LoginTypeChoices
+from open_inwoner.accounts.choices import LoginTypeChoices, NotificationChannelChoice
 from open_inwoner.accounts.models import User
 from open_inwoner.accounts.tests.factories import UserFactory, eHerkenningUserFactory
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openklant.models import OpenKlantConfig
 from open_inwoner.openklant.tests.data import KLANTEN_ROOT, MockAPIReadData
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
@@ -26,6 +27,9 @@ class UpdateUserFromLoginSignalAPITestCase(
     def setUpTestData(cls):
         super().setUpTestData()
         MockAPIReadData.setUpServices()
+        config = SiteConfiguration.get_solo()
+        config.enable_notification_channel_choice = True
+        config.save()
 
     def setUp(self) -> None:
         super().setUp()
@@ -70,6 +74,88 @@ class UpdateUserFromLoginSignalAPITestCase(
         self.assertTimelineLog(
             "updated user from klant API with fields: email, phonenumber"
         )
+
+    def test_update_notification_channel_choice_after_login(self, m):
+        user = UserFactory(
+            phonenumber="0123456789",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+            bsn="999993847",
+        )
+
+        for (
+            toestemming_zaak_notificaties_alleen_digitaal,
+            expected_user_case_notification_channel,
+        ) in (
+            (True, NotificationChannelChoice.digital_only),
+            (False, NotificationChannelChoice.digital_and_post),
+            (None, NotificationChannelChoice.digital_and_post),  # The model default
+        ):
+            with self.subTest(
+                f"{toestemming_zaak_notificaties_alleen_digitaal=} leads to"
+                f" case notification_channel={expected_user_case_notification_channel}"
+            ):
+                m.get(
+                    f"{KLANTEN_ROOT}klanten?subjectNatuurlijkPersoon__inpBsn=999993847",
+                    json=paginated_response(
+                        [
+                            self.klant_bsn
+                            | {
+                                "toestemmingZaakNotificatiesAlleenDigitaal": toestemming_zaak_notificaties_alleen_digitaal
+                            }
+                        ]
+                    ),
+                )
+                request = RequestFactory().get("/dummy")
+                request.user = user
+                user_logged_in.send(User, user=user, request=request)
+                user.refresh_from_db()
+
+                self.assertEqual(
+                    user.case_notification_channel,
+                    expected_user_case_notification_channel,
+                )
+
+    def test_update_notification_Channel_choice_after_login_requires_notification_choice_enabled(
+        self, m
+    ):
+        config = SiteConfiguration.get_solo()
+        config.enable_notification_channel_choice = False
+        config.save()
+
+        user = UserFactory(
+            phonenumber="0123456789",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+            bsn="999993847",
+        )
+        initial_case_notification_channel = user.case_notification_channel
+
+        for toestemming_zaak_notificaties_alleen_digitaal in (True, False, None):
+            with self.subTest(
+                f"{toestemming_zaak_notificaties_alleen_digitaal=} has no effect"
+                f" if enable_case notification_channel=False"
+            ):
+                m.get(
+                    f"{KLANTEN_ROOT}klanten?subjectNatuurlijkPersoon__inpBsn=999993847",
+                    json=paginated_response(
+                        [
+                            self.klant_bsn
+                            | {
+                                "toestemmingZaakNotificatiesAlleenDigitaal": toestemming_zaak_notificaties_alleen_digitaal
+                            }
+                        ]
+                    ),
+                )
+                request = RequestFactory().get("/dummy")
+                request.user = user
+                user_logged_in.send(User, user=user, request=request)
+                user.refresh_from_db()
+
+                self.assertEqual(
+                    user.case_notification_channel,
+                    initial_case_notification_channel,
+                )
 
     def test_update_eherkenning_user_after_login(self, m):
         user = eHerkenningUserFactory(


### PR DESCRIPTION
Note that this PR also contains a fix for the misnamed `toestemming_zaak_notificaties_alleen_digitaal` on the `Klant` API model (was camel-cased) and some slight refactoring of the hooks for readability and composability.

It might be best to go commit-for-commit: the actual change is in the last commit.