### PR TITLE
Remove admin inline CSS overrides

### DIFF
--- a/src/open_inwoner/scss/admin/admin_overrides.scss
+++ b/src/open_inwoner/scss/admin/admin_overrides.scss
@@ -6,8 +6,3 @@
 @import './app_overrides';
 @import './ck_editor';
 @import '../components/Map/Map.scss';
-
-// hide title from admin.StackedInline
-.inline-related > h3 {
-  display: none;
-}


### PR DESCRIPTION
  Our custom CSS overrides for the StackedInline had the side-effect of hiding the delete button