### PR TITLE
[#2698] Remove default Django authentication backend

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -495,7 +495,6 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = [
     "open_inwoner.accounts.backends.CustomAxesBackend",
     "open_inwoner.accounts.backends.UserModelEmailBackend",
-    "django.contrib.auth.backends.ModelBackend",
     "digid_eherkenning.backends.DigiDBackend",
     "eherkenning.backends.eHerkenningBackend",
     "digid_eherkenning_oidc_generics.backends.OIDCAuthenticationDigiDBackend",

--- a/src/open_inwoner/conf/dev.py
+++ b/src/open_inwoner/conf/dev.py
@@ -79,19 +79,6 @@ CACHES = {
 #
 # Library settings
 #
-
-# Allow logging in with both username+password and email+password
-AUTHENTICATION_BACKENDS = [
-    "open_inwoner.accounts.backends.CustomAxesBackend",
-    "open_inwoner.accounts.backends.UserModelEmailBackend",
-    "django.contrib.auth.backends.ModelBackend",
-    "digid_eherkenning.mock.backends.DigiDBackend",
-    "eherkenning.mock.backends.eHerkenningBackend",
-    "digid_eherkenning_oidc_generics.backends.OIDCAuthenticationDigiDBackend",
-    "digid_eherkenning_oidc_generics.backends.OIDCAuthenticationEHerkenningBackend",
-    "open_inwoner.accounts.backends.CustomOIDCBackend",
-]
-
 ELASTIC_APM["DEBUG"] = True
 
 if "test" in sys.argv:


### PR DESCRIPTION
- The default Django auth backend is not compatible with our practice of (a) using email as username and (b) allowing duplicate emails for DigiD users, because it checks for duplicate emails regardless of login type
- The auth backend overrides in the dev settings are redundant and potentially confusing (in case someone overrides base.py for local testing purposes)

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2698