### PR TITLE
:bug: [#2665] Fix phone-parsing Safari (iOS only)

### DIFF
--- a/src/open_inwoner/conf/parts/case_document_notification.html
+++ b/src/open_inwoner/conf/parts/case_document_notification.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-info td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900">Zaaknummer: </span><br/>{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/conf/parts/case_document_notification.html
+++ b/src/open_inwoner/conf/parts/case_document_notification.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-info td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 skip-phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/conf/parts/case_status_notification.html
+++ b/src/open_inwoner/conf/parts/case_status_notification.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-info td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900">Zaaknummer: </span><br/>{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/conf/parts/case_status_notification.html
+++ b/src/open_inwoner/conf/parts/case_status_notification.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-info td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 skip-phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/conf/parts/case_status_notification_action_required.html
+++ b/src/open_inwoner/conf/parts/case_status_notification_action_required.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-danger td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900">Zaaknummer: </span><br/>{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/conf/parts/case_status_notification_action_required.html
+++ b/src/open_inwoner/conf/parts/case_status_notification_action_required.html
@@ -22,7 +22,7 @@
             <h2>{{ type_description }}</h2>
         </td>
         <td class="td--responsive td-mail td-mail__bg-danger td__padding-all td__rightcell td__alignright" colspan="3">
-            <p><span class="text-color__small-gray-900 phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
+            <p><span class="text-color__small-gray-900 skip-phone-parsing">Zaaknummer: </span><br/>&zwj;{{ identification }}</p>
         </td>
     </tr>
 

--- a/src/open_inwoner/scss/components/AccessibilityHeader/AccessibilityHeader.scss
+++ b/src/open_inwoner/scss/components/AccessibilityHeader/AccessibilityHeader.scss
@@ -57,17 +57,6 @@
       line-height: var(--font-line-height-body-medium);
     }
   }
-
-  .skip-link {
-    position: absolute;
-    top: -50px;
-    transition: top 0.2s;
-
-    &:focus {
-      position: relative;
-      top: 0;
-    }
-  }
 }
 
 // Accessibility header within different components

--- a/src/open_inwoner/scss/components/AccessibilitySkipLink/AccessibilitySkipLink.scss
+++ b/src/open_inwoner/scss/components/AccessibilitySkipLink/AccessibilitySkipLink.scss
@@ -4,7 +4,10 @@
   text-decoration: none;
 
   &--visible-on-focus {
+    left: 100%;
+
     &:focus {
+      left: initial;
       text-decoration: none;
     }
   }

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -62,4 +62,14 @@
       display: inline;
     }
   }
+
+  // Remove Safari iOS phone-parsing from specific elements
+  .phone-parsing {
+    pointer-events: none;
+  }
+  // Hide style for iOS-rendered anchor element
+  .phone-parsing > a {
+    text-decoration: none;
+    color: inherit;
+  }
 }

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -64,11 +64,11 @@
   }
 
   // Remove Safari iOS phone-parsing from specific elements
-  .phone-parsing {
+  .skip-phone-parsing {
     pointer-events: none;
   }
   // Hide style for iOS-rendered anchor element
-  .phone-parsing > a {
+  .skip-phone-parsing > a {
     text-decoration: none;
     color: inherit;
   }

--- a/src/open_inwoner/static/mailcss/email.css
+++ b/src/open_inwoner/static/mailcss/email.css
@@ -260,6 +260,17 @@ strong .color--primary, strong .color--secondary {
     border-top: 3px solid #999999;
 }
 
+/* iOS specific */
+
+.phone-parsing {
+    pointer-events: none;
+}
+
+.phone-parsing > a {
+    text-decoration: none;
+    color: inherit;
+}
+
 /* CKEditor only */
 
 .cke_editable a {

--- a/src/open_inwoner/static/mailcss/email.css
+++ b/src/open_inwoner/static/mailcss/email.css
@@ -262,11 +262,11 @@ strong .color--primary, strong .color--secondary {
 
 /* iOS specific */
 
-.phone-parsing {
+.skip-phone-parsing {
     pointer-events: none;
 }
 
-.phone-parsing > a {
+.skip-phone-parsing > a {
     text-decoration: none;
     color: inherit;
 }

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -78,7 +78,10 @@
                             {% else %}
                                 {% list_item case.current_status caption=_("Status") compact=True strong=False %}
                             {% endif %}
-                            {% list_item case.identification caption=_("Zaaknummer") compact=True strong=False %}
+                            <li class="list-item list-item--compact">
+                               <p class="utrecht-paragraph list-item__caption">Zaaknummer</p>
+                               <p class="utrecht-paragraph phone-parsing">&zwj;{{ case.identification }}</p>
+                            </li>
                         {% endrender_list %}
 
                         <span class="link link--icon link--secondary">

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -80,7 +80,7 @@
                             {% endif %}
                             <li class="list-item list-item--compact">
                                <p class="utrecht-paragraph list-item__caption">Zaaknummer</p>
-                               <p class="utrecht-paragraph phone-parsing">&zwj;{{ case.identification }}</p>
+                               <p class="utrecht-paragraph skip-phone-parsing">&zwj;{{ case.identification }}</p>
                             </li>
                         {% endrender_list %}
 


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2665 

The _turn-numbers-into-phone-links_ feature should be disabled with the format-detection meta-tag, but... on every Safari and iOS update this breaks again 😡; many users on new devices report the meta tag does not solve the problem, so we need to create a hack with pointer-events is zero and add a zero-width joiner `&zwj;` to make the numbers unrecognizable.
I've also added these to the Zaaknummers e-mail templates, since those are also parsed in iOS.

While I was reproducing all this in [Browserstack](https://live.browserstack.com/) I found a bug in the skip-link specific for Safari only, which is also solved here.