### PR TITLE
[#2700] Support multiple ZGW backends for zaak notifications

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -38,7 +38,7 @@ from open_inwoner.openklant.wrap import (
 from open_inwoner.openzaak.api_models import Status, StatusType, Zaak
 from open_inwoner.openzaak.clients import CatalogiClient, ZakenClient
 from open_inwoner.openzaak.documents import (
-    fetch_single_information_object_url,
+    fetch_single_information_object_from_url,
     fetch_single_information_object_uuid,
 )
 from open_inwoner.openzaak.models import (
@@ -630,7 +630,9 @@ class InnerCaseDetailView(
         #         [case_info.informatieobject for case_info in case_info_objects],
         #     )
         info_objects = [
-            fetch_single_information_object_url(case_info.informatieobject)
+            fetch_single_information_object_from_url(
+                case_info.informatieobject, api_group=api_group
+            )
             for case_info in case_info_objects
         ]
 

--- a/src/open_inwoner/openzaak/documents.py
+++ b/src/open_inwoner/openzaak/documents.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 
 from open_inwoner.openzaak.api_models import InformatieObject
-from open_inwoner.openzaak.clients import DocumentenClient, build_documenten_client
+from open_inwoner.openzaak.clients import DocumentenClient
 
 from ..utils.decorators import cache as cache_result
 
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 @cache_result("information_object_url:{url}", timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT)
-def fetch_single_information_object_url(url: str) -> InformatieObject | None:
-    if client := build_documenten_client():
-        return client._fetch_single_information_object(url=url)
+def fetch_single_information_object_from_url(
+    url: str, api_group
+) -> InformatieObject | None:
+    return api_group.documenten_client._fetch_single_information_object(url=url)
 
 
 # not cached because currently only used in info-object download view

--- a/src/open_inwoner/openzaak/tests/test_notification_data.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_data.py
@@ -304,9 +304,9 @@ class MockAPIDataAlt:
         self.zaak_type_alt = generate_oas_component_cached(
             "ztc",
             "schemas/ZaakType",
-            uuid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
-            url=f"{ANOTHER_CATALOGI_ROOT}zaaktype/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
-            catalogus=f"{ANOTHER_CATALOGI_ROOT}catalogussen/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            uuid="22fd7613-3c9d-4507-a0b1-32c503488988",
+            url=f"{ANOTHER_CATALOGI_ROOT}zaaktype/22fd7613-3c9d-4507-a0b1-32c503488988",
+            catalogus=f"{ANOTHER_CATALOGI_ROOT}catalogussen/22fd7613-3c9d-4507-a0b1-32c503488988",
             identificatie="My Zaaktype",
             indicatieInternOfExtern="extern",
             omschrijving="My Zaaktype omschrijving",
@@ -336,10 +336,10 @@ class MockAPIDataAlt:
         self.zaak_alt = generate_oas_component_cached(
             "zrc",
             "schemas/Zaak",
-            url=f"{ANOTHER_ZAKEN_ROOT}zaken/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaken/22fd7613-3c9d-4507-a0b1-32c503488988",
             zaaktype=self.zaak_type_alt["url"],
-            status=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-222222222222",
-            resultaat=f"{ANOTHER_ZAKEN_ROOT}resultaten/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            status=f"{ANOTHER_ZAKEN_ROOT}statussen/22fd7613-3c9d-4507-a0b1-32c503488988",
+            resultaat=f"{ANOTHER_ZAKEN_ROOT}resultaten/22fd7613-3c9d-4507-a0b1-32c503488988",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
         self.zaak2_alt = generate_oas_component_cached(
@@ -354,14 +354,14 @@ class MockAPIDataAlt:
         self.status_initial_alt = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
-            url=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-111111111111",
+            url=f"{ANOTHER_ZAKEN_ROOT}statussen/22fd7613-3c9d-4507-a0b1-32c503488988",
             zaak=self.zaak_alt["url"],
             statustype=self.status_type_initial_alt["url"],
         )
         self.status_final_alt = generate_oas_component_cached(
             "zrc",
             "schemas/Status",
-            url=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-222222222222",
+            url=f"{ANOTHER_ZAKEN_ROOT}statussen/22fd7613-3c9d-4507-a0b1-32c503488988",
             zaak=self.zaak_alt["url"],
             statustype=self.status_type_final_alt["url"],
         )

--- a/src/open_inwoner/openzaak/tests/test_notification_data.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_data.py
@@ -14,9 +14,15 @@ from open_inwoner.openzaak.tests.factories import (
 )
 from open_inwoner.utils.test import paginated_response
 
-from ..models import OpenZaakConfig
 from .helpers import generate_oas_component_cached
-from .shared import CATALOGI_ROOT, DOCUMENTEN_ROOT, ZAKEN_ROOT
+from .shared import (
+    ANOTHER_CATALOGI_ROOT,
+    ANOTHER_DOCUMENTEN_ROOT,
+    ANOTHER_ZAKEN_ROOT,
+    CATALOGI_ROOT,
+    DOCUMENTEN_ROOT,
+    ZAKEN_ROOT,
+)
 
 
 class MockAPIData:
@@ -218,7 +224,7 @@ class MockAPIData:
             hoofd_object=self.zaak2["url"],
         )
 
-    def install_mocks(self, m, *, res404: list[str] | None = None) -> "MockAPIData":
+    def install_mocks(self, m, *, res404: list[str] | None = None):
         if res404 is None:
             res404 = []
         for attr in res404:
@@ -270,13 +276,251 @@ class MockAPIData:
 
     @classmethod
     def setUpServices(cls):
-        # openzaak config
-        config = OpenZaakConfig.get_solo()
-        ZGWApiGroupConfigFactory(
+        cls.api_group = ZGWApiGroupConfigFactory(
             ztc_service__api_root=CATALOGI_ROOT,
             zrc_service__api_root=ZAKEN_ROOT,
             drc_service__api_root=DOCUMENTEN_ROOT,
             form_service=None,
         )
-        config.zaak_max_confidentiality = VertrouwelijkheidsAanduidingen.openbaar
-        config.save()
+
+
+class MockAPIDataAlt:
+    """
+    Additional API data for testing multiple ZGW backends.
+
+    The set of mocks is a replica of `MockAPIData` but with different API roots
+    """
+
+    def __init__(self):
+        self.user_initiator_alt = DigidUserFactory(
+            bsn="200000002",
+            email="initiator_alt@example.com",
+        )
+        self.eherkenning_user_initiator_alt = eHerkenningUserFactory(
+            kvk="87654321",
+            rsin="000000000",
+            email="initiator_alt_kvk@example.com",
+        )
+        self.zaak_type_alt = generate_oas_component_cached(
+            "ztc",
+            "schemas/ZaakType",
+            uuid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            url=f"{ANOTHER_CATALOGI_ROOT}zaaktype/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            catalogus=f"{ANOTHER_CATALOGI_ROOT}catalogussen/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            identificatie="My Zaaktype",
+            indicatieInternOfExtern="extern",
+            omschrijving="My Zaaktype omschrijving",
+        )
+        self.status_type_initial_alt = generate_oas_component_cached(
+            "ztc",
+            "schemas/StatusType",
+            url=f"{ANOTHER_CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-111111111111",
+            zaaktype=self.zaak_type_alt["url"],
+            informeren=True,
+            volgnummer=1,
+            omschrijving="initial",
+            statustekst="",
+            isEindStatus=False,
+        )
+        self.status_type_final_alt = generate_oas_component_cached(
+            "ztc",
+            "schemas/StatusType",
+            url=f"{ANOTHER_CATALOGI_ROOT}statustypen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
+            zaaktype=self.zaak_type_alt["url"],
+            informeren=True,
+            volgnummer=2,
+            omschrijving="final",
+            statustekst="status_type_final_statustekst",
+            isEindStatus=True,
+        )
+        self.zaak_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaken/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            zaaktype=self.zaak_type_alt["url"],
+            status=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-222222222222",
+            resultaat=f"{ANOTHER_ZAKEN_ROOT}resultaten/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+        self.zaak2_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaken/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            zaaktype=self.zaak_type_alt["url"],
+            status=f"{ANOTHER_ZAKEN_ROOT}statussen/aaaaaaaa-aaaa-aaaa-aaaa-222222222222",
+            resultaat=f"{ANOTHER_ZAKEN_ROOT}resultaten/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+        self.status_initial_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Status",
+            url=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-111111111111",
+            zaak=self.zaak_alt["url"],
+            statustype=self.status_type_initial_alt["url"],
+        )
+        self.status_final_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Status",
+            url=f"{ANOTHER_ZAKEN_ROOT}statussen/xxxxxxxx-xxxx-xxxx-xxxx-222222222222",
+            zaak=self.zaak_alt["url"],
+            statustype=self.status_type_final_alt["url"],
+        )
+
+        self.informatie_object_alt = generate_oas_component_cached(
+            "drc",
+            "schemas/EnkelvoudigInformatieObject",
+            url=f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/aaaaaaaa-0001-bbbb-aaaa-aaaaaaaaaaaa",
+            informatieobjecttype=f"{ANOTHER_CATALOGI_ROOT}informatieobjecttypen/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            status="definitief",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+        self.zaak_informatie_object_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/ZaakInformatieObject",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0001-aaaa-aaaa-aaaaaaaaaaaa",
+            informatieobject=self.informatie_object_alt["url"],
+            zaak=self.zaak_alt["url"],
+        )
+        self.zaak_informatie_object2_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/ZaakInformatieObject",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0002-aaaa-aaaa-aaaaaaaaaaaa",
+            informatieobject=self.informatie_object_alt["url"],
+            zaak=self.zaak2_alt["url"],
+        )
+        self.informatie_object_extra_alt = generate_oas_component_cached(
+            "drc",
+            "schemas/EnkelvoudigInformatieObject",
+            url=f"{ANOTHER_DOCUMENTEN_ROOT}enkelvoudiginformatieobjecten/aaaaaaaa-0002-bbbb-aaaa-aaaaaaaaaaaa",
+            informatieobjecttype=f"{ANOTHER_CATALOGI_ROOT}informatieobjecttypen/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            status="definitief",
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+        self.zaak_informatie_object_extra_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/ZaakInformatieObject",
+            url=f"{ANOTHER_ZAKEN_ROOT}zaakinformatieobjecten/aaaaaaaa-0003-aaaa-aaaa-aaaaaaaaaaaa",
+            informatieobject=self.informatie_object_extra_alt["url"],
+            zaak=self.zaak_alt["url"],
+        )
+
+        self.role_initiator_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Rol",
+            url=f"{ANOTHER_ZAKEN_ROOT}rollen/aaaaaaaa-0001-aaaa-aaaa-aaaaaaaaaaaa",
+            omschrijvingGeneriek=RolOmschrijving.initiator,
+            betrokkeneType=RolTypes.natuurlijk_persoon,
+            betrokkeneIdentificatie={
+                "inpBsn": self.user_initiator_alt.bsn,
+            },
+        )
+        self.eherkenning_role_initiator_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Rol",
+            url=f"{ANOTHER_ZAKEN_ROOT}rollen/aaaaaaaa-0002-aaaa-aaaa-aaaaaaaaaaaa",
+            omschrijvingGeneriek=RolOmschrijving.initiator,
+            betrokkeneType=RolTypes.niet_natuurlijk_persoon,
+            betrokkeneIdentificatie={
+                "innNnpId": self.eherkenning_user_initiator_alt.kvk,
+            },
+        )
+        self.eherkenning_role_initiator2_alt = generate_oas_component_cached(
+            "zrc",
+            "schemas/Rol",
+            url=f"{ANOTHER_ZAKEN_ROOT}rollen/aaaaaaaa-0003-aaaa-aaaa-aaaaaaaaaaaa",
+            omschrijvingGeneriek=RolOmschrijving.initiator,
+            betrokkeneType=RolTypes.niet_natuurlijk_persoon,
+            betrokkeneIdentificatie={
+                "innNnpId": self.eherkenning_user_initiator_alt.rsin,
+            },
+        )
+
+        self.case_roles_alt = [self.role_initiator_alt]
+        self.eherkenning_case_roles_alt = [
+            self.eherkenning_role_initiator_alt,
+            self.eherkenning_role_initiator2_alt,
+        ]
+        self.status_history_alt = [self.status_initial_alt, self.status_final_alt]
+
+        self.status_notification_alt = NotificationFactory(
+            resource="status",
+            actie="update",
+            resource_url=self.status_final_alt["url"],
+            hoofd_object=self.zaak_alt["url"],
+        )
+        self.zio_notification_alt = NotificationFactory(
+            resource="zaakinformatieobject",
+            actie="create",
+            resource_url=self.zaak_informatie_object_alt["url"],
+            hoofd_object=self.zaak_alt["url"],
+        )
+        self.zio_notification2_alt = NotificationFactory(
+            resource="zaakinformatieobject",
+            actie="create",
+            resource_url=self.zaak_informatie_object2_alt["url"],
+            hoofd_object=self.zaak2_alt["url"],
+        )
+
+    def install_mocks(self, m, *, res404: list[str] | None = None) -> "MockAPIData":
+        if res404 is None:
+            res404 = []
+        for attr in res404:
+            if not hasattr(self, attr):
+                raise Exception("configuration error")
+
+        if "case_roles" in res404:
+            m.get(
+                f"{ANOTHER_ZAKEN_ROOT}rollen?zaak={self.zaak_alt['url']}",
+                status_code=404,
+            )
+        else:
+            m.get(
+                f"{ANOTHER_ZAKEN_ROOT}rollen?zaak={self.zaak_alt['url']}",
+                json=paginated_response(self.case_roles_alt),
+            )
+            m.get(
+                f"{ANOTHER_ZAKEN_ROOT}rollen?zaak={self.zaak2_alt['url']}",
+                json=paginated_response(self.eherkenning_case_roles_alt),
+            )
+
+        if "status_history" in res404:
+            m.get(
+                f"{ANOTHER_ZAKEN_ROOT}statussen?zaak={self.zaak_alt['url']}",
+                status_code=404,
+            )
+        else:
+            m.get(
+                f"{ANOTHER_ZAKEN_ROOT}statussen?zaak={self.zaak_alt['url']}",
+                json=paginated_response(self.status_history_alt),
+            )
+
+        for resource_attr in [
+            "zaak_alt",
+            "zaak2_alt",
+            "zaak_type_alt",
+            "status_initial_alt",
+            "status_final_alt",
+            "status_type_initial_alt",
+            "status_type_final_alt",
+            "informatie_object_alt",
+            "zaak_informatie_object_alt",
+            "zaak_informatie_object2_alt",
+            "informatie_object_extra_alt",
+            "zaak_informatie_object_extra_alt",
+        ]:
+            resource = getattr(self, resource_attr)
+            if resource_attr in res404:
+                m.get(resource["url"], status_code=404)
+            else:
+                m.get(resource["url"], json=resource)
+
+        return self
+
+    @classmethod
+    def setUpServices(cls):
+        cls.api_group_alt = ZGWApiGroupConfigFactory(
+            ztc_service__api_root=ANOTHER_CATALOGI_ROOT,
+            zrc_service__api_root=ANOTHER_ZAKEN_ROOT,
+            drc_service__api_root=ANOTHER_DOCUMENTEN_ROOT,
+            form_service=None,
+        )

--- a/src/open_inwoner/openzaak/tests/test_notification_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_utils.py
@@ -57,7 +57,11 @@ class NotificationHandlerUtilsTestCase(TestCase):
         ) as format_identificatie:
             format_identificatie.return_value = ret_val
             send_case_update_email(
-                user, case, "case_status_notification", status=status
+                user,
+                case,
+                "case_status_notification",
+                status=status,
+                api_group=self.api_group,
             )
 
         format_identificatie.assert_called_once()
@@ -88,7 +92,9 @@ class NotificationHandlerUtilsTestCase(TestCase):
             kwargs={"object_id": str(case.uuid), "api_group_id": self.api_group.id},
         )
 
-        send_case_update_email(user, case, "case_document_notification")
+        send_case_update_email(
+            user, case, "case_document_notification", api_group=self.api_group
+        )
 
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
@@ -5,7 +5,6 @@ from django.test import TestCase, override_settings
 
 import requests_mock
 from freezegun import freeze_time
-from notifications_api_common.models import NotificationsConfig
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
@@ -24,7 +23,7 @@ from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
 from ..api_models import InformatieObject, Zaak, ZaakInformatieObject, ZaakType
 from ..models import OpenZaakConfig, UserCaseInfoObjectNotification
 from .helpers import copy_with_new_uuid
-from .test_notification_data import MockAPIData
+from .test_notification_data import MockAPIData, MockAPIDataAlt
 
 
 @requests_mock.Mocker()
@@ -36,39 +35,66 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
     AssertTimelineLogMixin, ClearCachesMixin, TestCase
 ):
     maxDiff = None
-    config: OpenZaakConfig
-    note_config: NotificationsConfig
 
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
         MockAPIData.setUpServices()
+        MockAPIDataAlt.setUpServices()
 
-    def test_ziohandle_zaken_notification(self, m, mock_handle: Mock):
+    def test_handle_zaak_informatie_object_notifications(self, m, mock_handle: Mock):
         """
-        happy-flow from valid data calls the (mocked) handle_zaakinformatieobject()
+        Happy flow (with multiple ZGW backends) for notifications about zaak informatie objecten
         """
         data = MockAPIData().install_mocks(m)
+        data_alt = MockAPIDataAlt().install_mocks(m)
 
         ZaakTypeInformatieObjectTypeConfigFactory.from_case_type_info_object_dicts(
-            data.zaak_type, data.informatie_object, document_notification_enabled=True
+            data.zaak_type,
+            data.informatie_object,
+            document_notification_enabled=True,
+        )
+        ZaakTypeInformatieObjectTypeConfigFactory.from_case_type_info_object_dicts(
+            data_alt.zaak_type_alt,
+            data_alt.informatie_object_alt,
+            document_notification_enabled=True,
         )
 
-        handle_zaken_notification(data.zio_notification)
+        for api_group, notification, zaak, zaak_info_obj, user_initiator in [
+            (
+                data.api_group,
+                data.zio_notification,
+                data.zaak,
+                data.zaak_informatie_object,
+                data.user_initiator,
+            ),
+            (
+                data_alt.api_group_alt,
+                data_alt.zio_notification_alt,
+                data_alt.zaak_alt,
+                data_alt.zaak_informatie_object_alt,
+                data_alt.user_initiator_alt,
+            ),
+        ]:
+            with self.subTest(f"api_group {api_group.id}"):
+                handle_zaken_notification(notification)
 
-        mock_handle.assert_called_once()
+                mock_handle.assert_called()
 
-        # check call arguments
-        args = mock_handle.call_args.args
-        self.assertEqual(args[0], data.user_initiator)
-        self.assertEqual(args[1].url, data.zaak["url"])
-        self.assertEqual(args[2].url, data.zaak_informatie_object["url"])
+                # check call arguments
+                args = mock_handle.call_args.args
+                self.assertEqual(args[0], user_initiator)
+                self.assertEqual(args[1].url, zaak["url"])
+                self.assertEqual(args[2].url, zaak_info_obj["url"])
 
-        self.assertTimelineLog(
-            "accepted zaakinformatieobject notification: attempt informing users ",
-            lookup=Lookups.startswith,
-            level=logging.INFO,
+        log_dump = self.getTimelineLogDump()
+        self.assertIn("total 2 timelinelogs", log_dump)
+        self.assertIn(
+            "accepted zaakinformatieobject notification: attempt informing users",
+            log_dump,
         )
+        self.assertIn(data.user_initiator.email, log_dump)
+        self.assertIn(data_alt.user_initiator_alt.email, log_dump)
 
     def test_ziohandle_zaken_notification_niet_natuurlijk_persoon_initiator(
         self, m, mock_handle: Mock
@@ -113,6 +139,16 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
                 )
 
     # start of generic checks
+
+    def test_no_api_group_found(self, m, mock_handle: Mock):
+        data = MockAPIData().install_mocks(m)
+
+        # API group is resolved from zaak url == hoofd_object
+        data.zio_notification.hoofd_object = "http://www.bogus.com"
+
+        handle_zaken_notification(data.zio_notification)
+
+        mock_handle.assert_not_called()
 
     def test_zio_bails_when_bad_notification_channel(self, m, mock_handle: Mock):
         notification = NotificationFactory(kanaal="not_zaken")
@@ -322,8 +358,6 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
             level=logging.INFO,
         )
 
-    # TODO add some no-catalog variations
-
 
 @override_settings(ZGW_LIMIT_NOTIFICATIONS_FREQUENCY=3600)
 @freeze_time("2023-01-01 01:00:00")
@@ -331,6 +365,11 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
     """
     note these tests match with a similar test from `test_notification_zaak_status.py`
     """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        MockAPIData.setUpServices()
 
     @patch(
         "open_inwoner.userfeed.hooks.case_document_added_notification_received",
@@ -351,7 +390,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
-        _handle_zaakinformatieobject_update(user, case, zio)
+        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
 
         # not called because disabled notifications
         mock_send.assert_not_called()
@@ -384,7 +423,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
-        _handle_zaakinformatieobject_update(user, case, zio)
+        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
 
         # not called because bad email
         mock_send.assert_not_called()
@@ -416,9 +455,15 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
         # first call
-        _handle_zaakinformatieobject_update(user, case, zio)
+        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
 
         mock_send.assert_called_once()
+        mock_send.assert_called_with(
+            user,
+            case,
+            template_name="case_document_notification",
+            api_group=data.api_group,
+        )
 
         # check if userfeed hook was called
         mock_feed_hook.assert_called_once()
@@ -442,7 +487,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         )
 
         # second call with same case/status
-        _handle_zaakinformatieobject_update(user, case, zio)
+        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
 
         # no duplicate mail for this user/case/status
         mock_send.assert_not_called()
@@ -455,7 +500,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
 
         # other user is fine
         other_user = UserFactory.create()
-        _handle_zaakinformatieobject_update(other_user, case, zio)
+        _handle_zaakinformatieobject_update(
+            other_user, case, zio, api_group=data.api_group
+        )
 
         mock_send.assert_called_once()
 
@@ -474,7 +521,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             InformatieObject, copy_with_new_uuid(data.informatie_object)
         )
 
-        _handle_zaakinformatieobject_update(user, case, zio)
+        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
 
         # not sent because we already send to this user within the frequency
         mock_send.assert_not_called()
@@ -493,7 +540,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             zio.informatieobject = factory(
                 InformatieObject, copy_with_new_uuid(data.informatie_object)
             )
-            _handle_zaakinformatieobject_update(user, case, zio)
+            _handle_zaakinformatieobject_update(
+                user, case, zio, api_group=data.api_group
+            )
 
             # this one succeeds
             mock_send.assert_called_once()


### PR DESCRIPTION
- [x] Support multiple ZGW backends for status notifications
- [x] Support multiple ZGW backends for document notifications

Support for retrieving zaak notifications from different notification APIs is out of scope for this ticket

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2700