### PR TITLE
Fix missing mock DigiD/eHerkenning backends in dev

### DIFF
--- a/src/open_inwoner/conf/dev.py
+++ b/src/open_inwoner/conf/dev.py
@@ -76,6 +76,17 @@ CACHES = {
     "oidc": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
 }
 
+_MOCK_AUTHENTICATION_BACKENDS = {
+    "digid_eherkenning.backends.DigiDBackend": "digid_eherkenning.mock.backends.DigiDBackend",
+    "eherkenning.backends.eHerkenningBackend": "eherkenning.mock.backends.eHerkenningBackend",
+}
+
+AUTHENTICATION_BACKENDS = [
+    _MOCK_AUTHENTICATION_BACKENDS.get(backend, backend)
+    for backend in AUTHENTICATION_BACKENDS
+]
+
+
 #
 # Library settings
 #


### PR DESCRIPTION
We were too eager in 65304e2 in removing all the dev backends, in an attempt to avoid divergence between the base and dev authentication backends. Unfortunately, we mistakenly also removed references to the mock backends, which broke local development which suddenly required production settings for DigiD and eHerkenning.

This commit makes more explicit that all we want to do on dev is replace these backends whilst keeping the other settings the same.