### PR TITLE
[#dimpact-138] Fix creation of contactmoment without medewerker

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -1009,10 +1009,9 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
             "tekst": question,
             "type": config.register_type,
             "kanaal": "contactformulier",
-            "medewerkerIdentificatie": {
-                "identificatie": config.register_employee_id,
-            },
         }
+        if employee_id := config.register_employee_id:
+            data["medewerkerIdentificatie"] = {"identificatie": employee_id}
         if ztc and ztc.contact_subject_code:
             data["onderwerp"] = ztc.contact_subject_code
 


### PR DESCRIPTION
The creation of contactmomenten without default medewerker was fixed for the standalone contactform, but not for the form embedded in particular zaken.

Taiga:https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/138