### PR TITLE
[#2535] Exclude closed actions from notifications

### DIFF
--- a/src/open_inwoner/accounts/notifications/actions/notify.py
+++ b/src/open_inwoner/accounts/notifications/actions/notify.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from mail_editor.helpers import find_template
 
+from open_inwoner.accounts.choices import StatusChoices
 from open_inwoner.accounts.models import Action, User
 from open_inwoner.utils.url import build_absolute_url
 
@@ -25,6 +26,7 @@ def collect_notifications_about_expiring_actions() -> list[dict]:
         is_active=True,
         plans_notifications=True,
         actions__end_date=today,
+        actions__status__in=[StatusChoices.open, StatusChoices.approval],
     ).distinct()
 
     notifications = [

--- a/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
+++ b/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
@@ -4,6 +4,7 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from open_inwoner.accounts.choices import StatusChoices
 from open_inwoner.accounts.tests.factories import ActionFactory, UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
 
@@ -65,6 +66,13 @@ class ExpiringActionsNotificationTest(TestCase):
 
     def test_no_email_about_action_already_expired(self):
         ActionFactory(end_date=date.today() - timedelta(days=1))
+
+        schedule_user_notifications.delay(notify_about="actions", channel="email")
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_no_email_about_closed_action(self):
+        ActionFactory(end_date=date.today(), status=StatusChoices.closed)
 
         schedule_user_notifications.delay(notify_about="actions", channel="email")
 


### PR DESCRIPTION
Spurious emails were sent about actions because we did not filter out closed actions.