### PR TITLE
[#2720] Fix email field prefill in NecessaryFieldsUserView

### DIFF
--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -410,16 +410,16 @@ class User(AbstractBaseUser, PermissionsMixin):
     def require_necessary_fields(self) -> bool:
         """returns whether user needs to fill in necessary fields"""
         if self.is_digid_user_with_brp:
-            return not self.has_usable_email()
+            return not self.has_usable_email
         elif self.login_type == LoginTypeChoices.digid:
             return (
-                not self.first_name or not self.last_name or not self.has_usable_email()
+                not self.first_name or not self.last_name or not self.has_usable_email
             )
         elif self.login_type in (
             LoginTypeChoices.oidc,
             LoginTypeChoices.eherkenning,
         ):
-            return not self.has_usable_email()
+            return not self.has_usable_email
         return False
 
     def get_logout_url(self) -> str:
@@ -440,13 +440,15 @@ class User(AbstractBaseUser, PermissionsMixin):
                 return reverse("eherkenning_oidc:logout")
             return reverse("logout")
 
+    @property
     def has_usable_email(self) -> bool:
-        return User.is_usable_email(self.email)
-
-    @classmethod
-    def is_usable_email(cls, email: str) -> bool:
-        # because of legacy reasons we have @example.org and @localhost in the database as placeholders
-        return email and not email.endswith(
+        """
+        For legacy reasons we have emails ending in @example.org and @localhost in
+        the database (these are auto-generated when users register with bsn, kvk, or
+        via oidc but no valid email could be retrieved from an external source, and
+        are overridden with user input via the NecessaryUserForm).
+        """
+        return self.email and not self.email.endswith(
             (
                 "@example.org",
                 "@localhost",
@@ -465,7 +467,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         return choice.label
 
     def get_contact_email(self):
-        return self.email if self.has_usable_email() else ""
+        return self.email if self.has_usable_email else ""
 
     def get_active_contacts(self):
         return self.user_contacts.filter(is_active=True)

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1507,6 +1507,7 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
         user = UserFactory(
             first_name="",
             last_name="",
+            email="test@example.org",
             login_type=LoginTypeChoices.digid,
         )
         self.assertTrue(user.require_necessary_fields())
@@ -1514,7 +1515,8 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
         response = self.app.get(self.url, user=user)
         form = response.forms["necessary-form"]
 
-        from open_inwoner.accounts.choices import NotificationChannelChoice
+        # check email is not prefilled
+        self.assertEqual(form["email"].value, "")
 
         form["email"] = "john@smith.com"
         form["first_name"] = "John"
@@ -1535,7 +1537,7 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
 
     def test_submit_with_invite(self):
         user = UserFactory()
-        contact = UserFactory.build()
+        contact = UserFactory.build(email="test@example.org")
         invite = InviteFactory.create(
             inviter=user,
             invitee_email=contact.email,

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -78,23 +78,18 @@ class UserTests(TestCase):
 
     def test_has_usable_email(self):
         user_ok1 = UserFactory(email="foo@bar.baz")
-        self.assertTrue(user_ok1.has_usable_email())
-        self.assertTrue(User.is_usable_email("foo@bar.baz"))
+        self.assertTrue(user_ok1.has_usable_email)
 
         user_ok2 = UserFactory(email="test@example.com")
-        self.assertTrue(user_ok2.has_usable_email())
-        self.assertTrue(User.is_usable_email("test@example.com"))
+        self.assertTrue(user_ok2.has_usable_email)
 
-        self.assertFalse(UserFactory(email="").has_usable_email())
-        self.assertFalse(User.is_usable_email(""))
+        self.assertFalse(UserFactory(email="").has_usable_email)
 
         # @example.org is used as placeholder
-        self.assertFalse(UserFactory(email="test@example.org").has_usable_email())
-        self.assertFalse(User.is_usable_email("test@example.org"))
+        self.assertFalse(UserFactory(email="test@example.org").has_usable_email)
 
         # @localhost occurs in some old code
-        self.assertFalse(UserFactory(email="test@localhost").has_usable_email())
-        self.assertFalse(User.is_usable_email("test@localhost"))
+        self.assertFalse(UserFactory(email="test@localhost").has_usable_email)
 
         actual = set(User.objects.having_usable_email())
         self.assertEqual(actual, {user_ok1, user_ok2})

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -18,7 +18,6 @@ from digid_eherkenning_oidc_generics.models import (
 from open_inwoner.accounts.choices import NotificationChannelChoice
 from open_inwoner.accounts.views.mixins import KlantenAPIMixin
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.utils.hash import generate_email_from_string
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
 
 from ...mail.verification import send_user_email_verification_mail
@@ -184,11 +183,9 @@ class NecessaryFieldsUserView(
         user = self.get_object()
         invite = self.get_invite()
 
-        if not invite and (
-            (user.bsn and user.email == generate_email_from_string(user.bsn))
-            or (user.oidc_id and user.email == generate_email_from_string(user.oidc_id))
-            or (user.kvk and user.email == f"user-{user.kvk}@localhost")
-        ):
+        # only prefill email field if user was invited or
+        # valid email has been entered or retrieved form external source
+        if not invite and not user.has_usable_email:
             initial["email"] = ""
 
         return initial


### PR DESCRIPTION
Temporary emails created for users who register with kvk, or via oidc must be prevented from prefilling the email field in the `NecessaryUserForm`; the logic for checking this is simplified by using the `has_usable_email` property.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2720