### PR TITLE
♿  [#2727] Correct ALT text of footer logo

### DIFF
--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -143,8 +143,8 @@
                 {% endif %}
                 {% if footer.logo %}
                     <div class="footer__logo">
-                    {% firstof config.footer_logo.default_alt_text config.name as logo_alt_text %}
-                        {% include "components/Logo/Logo.html" with src=footer.logo.url alt=logo_alt_text href=footer.logo_url svg_height=60 only %}
+                        {% firstof footer.logo.default_alt_text config.name as footer_logo_alt_text %}
+                        {% include "components/Logo/Logo.html" with src=footer.logo.url alt=footer_logo_alt_text href=footer.logo_url svg_height=60 only %}
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2727

separated from double issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2595