### PR TITLE
[#2596] Disable scroll zoom on Productkaart homepage

### DIFF
--- a/src/open_inwoner/js/components/map/index.js
+++ b/src/open_inwoner/js/components/map/index.js
@@ -32,9 +32,11 @@ class Map {
     this.lat = node.dataset.lat || 52
     this.lng = node.dataset.lng || 11
     this.zoom = node.dataset.zoom || 13
+    this.scrollWheelZoom = false
 
     const mapOptions = {
       center: L.latLng(this.lat, this.lng),
+      scrollWheelZoom: this.scrollWheelZoom,
       zoom: this.zoom,
       crs: RD_CRS,
     }


### PR DESCRIPTION
feature: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2596

Disables the annoying zoom in the map (leaflet/"Productlocatie Plugin" CMS) on Homepage when you just want to scroll down.
tested in multiple browsers, including on BrowserStack.