### PR TITLE
Disambiguate missing cache values from None

### DIFF
--- a/src/open_inwoner/utils/decorators.py
+++ b/src/open_inwoner/utils/decorators.py
@@ -120,11 +120,12 @@ def cache(
 
             cache_key = cache_key_with_attr_placeholders.format(**key_kwargs)
             logger.debug("Resolved cache_key `%s` to `%s`", key, cache_key)
-            _cache: BaseCache = caches[alias]
-            result = _cache.get(cache_key)
 
-            # The key exists in cache so we return the already cached data
-            if result is not None:
+            _cache: BaseCache = caches[alias]
+
+            CACHE_MISS = object()
+            result = _cache.get(cache_key, default=CACHE_MISS)
+            if result is not CACHE_MISS:
                 logger.debug("Cache hit: '%s'", cache_key)
                 return result
 

--- a/src/open_inwoner/utils/tests/test_utils.py
+++ b/src/open_inwoner/utils/tests/test_utils.py
@@ -55,11 +55,11 @@ class DynamicCacheKeyTest(DjangoTestCase):
 
         self.cache.get.assert_has_calls(
             [
-                mock.call("alpha:charlie:bravo:42"),
-                mock.call("alpha:bar:bravo:baz"),
-                mock.call("alpha:bar:bravo:5"),
-                mock.call("alpha:bar:bravo:baz:charlie:charlie:42"),
-                mock.call("static"),
+                mock.call("alpha:charlie:bravo:42", default=mock.ANY),
+                mock.call("alpha:bar:bravo:baz", default=mock.ANY),
+                mock.call("alpha:bar:bravo:5", default=mock.ANY),
+                mock.call("alpha:bar:bravo:baz:charlie:charlie:42", default=mock.ANY),
+                mock.call("static", default=mock.ANY),
             ]
         )
 
@@ -201,3 +201,19 @@ class CacheBehaviorTest(DjangoTestCase):
 
         with self.assertRaises(ValueError):
             foo()
+
+    def test_returning_None_is_not_treated_as_a_cache_miss(self):
+        m = mock.Mock()
+
+        @cache("foo")
+        def returns_none():
+            m()
+            return None
+
+        # The second call should return the cached "None" from the first call,
+        # which the cache decorator should interpret as a valid cached value,
+        # not as a cache miss.
+        returns_none()
+        returns_none()
+
+        m.assert_called_once()


### PR DESCRIPTION
We have observed an issue with spurious cache hits in development, that we've been unable to reproduce so far. Looking into this did however prompt an audit of the caching decorator, which reveals we potentially have an issue where a cached "None" value is mis- interpreted as "not cached" rather than "cached as None". This commit clarifies the expected behaviour with a test and a more robust cache check.