### PR TITLE
[#2782+#2780] Disable first name editing for DigiD user with BRP

### DIFF
--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -463,6 +463,10 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         response = self.app.get(self.url, user=user)
         form = response.forms["profile-edit"]
 
+        # check that first_name field is not rendered for digid_brp_user
+        with self.assertRaises(AssertionError):
+            form["first_name"] = "test"
+
         form["email"] = "user@example.com"
         form["phonenumber"] = "0612345678"
         response = form.submit()

--- a/src/open_inwoner/templates/pages/profile/edit.html
+++ b/src/open_inwoner/templates/pages/profile/edit.html
@@ -27,7 +27,6 @@
                             {% input form.email %}
                             {% input form.phonenumber %}
                         {% elif user.is_digid_user_with_brp %}
-                            {% input form.first_name %}
                             {% input form.email %}
                             {% input form.phonenumber %}
                             {% if user.contact_type == "begeleider" %}


### PR DESCRIPTION
Users should not be able to edit their first name in OIP if the Hall Centraal API is configured to pull data from BRP

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2782 and https://taiga.maykinmedia.nl/project/open-inwoner/issue/2780