### PR TITLE
Enable log level filtering on the TimelineLogAdmin page

### DIFF
--- a/src/open_inwoner/utils/admin.py
+++ b/src/open_inwoner/utils/admin.py
@@ -4,6 +4,7 @@ import logging
 from django.contrib import admin
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import NoReverseMatch, path, reverse
 from django.utils.html import escape, format_html
@@ -62,6 +63,32 @@ class ContentTypeUsedListFilter(admin.SimpleListFilter):
         return queryset
 
 
+class TimelineLogLevelFilter(admin.SimpleListFilter):
+    title = _("log level")
+    parameter_name = "log_level"
+
+    def lookups(self, request, model_admin):
+        return [(v, v) for v in logging.getLevelNamesMapping()] + [
+            ("unknown", _("Unknown"))
+        ]
+
+    def queryset(self, request, queryset):
+        if not (value := self.value()):
+            return queryset
+
+        if value == "unknown":
+            return queryset.filter(
+                ~Q(extra_data__has_key="log_level")
+                | Q(extra_data__log_level__isnull=True)
+            )
+
+        try:
+            log_level = logging.getLevelNamesMapping()[value]
+            return queryset.filter(extra_data__log_level=log_level)
+        except KeyError:
+            return queryset
+
+
 class CustomTimelineLogAdmin(ExportMixin, TimelineLogAdmin):
     show_full_result_count = False
     fields = ["content_type", "timestamp", "extra_data", "user"]
@@ -74,7 +101,12 @@ class CustomTimelineLogAdmin(ExportMixin, TimelineLogAdmin):
         "get_action_flag",
         "message",
     ]
-    list_filter = ["timestamp", LogActionListFilter, ContentTypeUsedListFilter]
+    list_filter = [
+        "timestamp",
+        TimelineLogLevelFilter,
+        LogActionListFilter,
+        ContentTypeUsedListFilter,
+    ]
     list_select_related = ["content_type"]
     search_fields = [
         "user__email",

--- a/src/open_inwoner/utils/admin.py
+++ b/src/open_inwoner/utils/admin.py
@@ -69,14 +69,14 @@ class TimelineLogLevelFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         return [(v, v) for v in logging.getLevelNamesMapping()] + [
-            ("unknown", _("Unknown"))
+            ("missing", _("Missing"))
         ]
 
     def queryset(self, request, queryset):
         if not (value := self.value()):
             return queryset
 
-        if value == "unknown":
+        if value == "missing":
             return queryset.filter(
                 ~Q(extra_data__has_key="log_level")
                 | Q(extra_data__log_level__isnull=True)

--- a/src/open_inwoner/utils/admin.py
+++ b/src/open_inwoner/utils/admin.py
@@ -100,6 +100,7 @@ class CustomTimelineLogAdmin(ExportMixin, TimelineLogAdmin):
         "object_id",
         "get_action_flag",
         "message",
+        "get_log_level",
     ]
     list_filter = [
         "timestamp",
@@ -143,6 +144,13 @@ class CustomTimelineLogAdmin(ExportMixin, TimelineLogAdmin):
     def message(self, obj):
         return obj.extra_data.get("message") if obj.extra_data else ""
 
+    def get_log_level(self, obj):
+        if obj.extra_data and "log_level" in obj.extra_data:
+            log_level = obj.extra_data.get("log_level")
+            if log_level is not None:
+                return logging.getLevelName(log_level)
+        return ""
+
     def object_link(self, obj):
         if not obj.extra_data:
             return ""
@@ -172,6 +180,7 @@ class CustomTimelineLogAdmin(ExportMixin, TimelineLogAdmin):
 
     get_action_flag.short_description = _("Actie")
     message.short_description = _("Bericht")
+    get_log_level.short_description = _("Log Level")
     object_link.short_description = _("Object")
 
     def has_add_permission(self, request):


### PR DESCRIPTION
The log level is actually included in our timeline logger, although (mostly) the level defaults to `INFO`: that's something I'd like to start changing in future, but for now, we can actually already filter on logging level without adding a special flag, by using Postgres JSON field lookup functionality.

![Screenshot from 2024-10-15 12-10-22](https://github.com/user-attachments/assets/adb8d86e-8bd1-4a1f-b3ab-1806e734a269)
