### PR TITLE
[#2816] Split user/password auth from token verification

### DIFF
--- a/src/open_inwoner/accounts/tests/test_backends.py
+++ b/src/open_inwoner/accounts/tests/test_backends.py
@@ -1,13 +1,18 @@
+import datetime
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib import auth
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
+from freezegun import freeze_time
 from furl import furl
 from mozilla_django_oidc_db.config import store_config
+from oath import totp
 
-from .factories import UserFactory
+from open_inwoner.accounts.choices import LoginTypeChoices
+from open_inwoner.accounts.tests.factories import UserFactory
 
 
 class OIDCBackendTestCase(TestCase):
@@ -90,3 +95,108 @@ class OIDCBackendTestCase(TestCase):
         self.assertEqual(
             result.backend, "open_inwoner.accounts.backends.CustomOIDCBackend"
         )
+
+
+@override_settings(
+    AUTHENTICATION_BACKENDS=[
+        "open_inwoner.accounts.backends.UserModelEmailBackend",
+    ]
+)
+class UserModelEmailBackendTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.password = "keepitsecert"
+        cls.user = UserFactory(
+            login_type=LoginTypeChoices.default, password=cls.password
+        )
+        for login_type in LoginTypeChoices:
+            UserFactory(login_type=login_type)
+
+    def test_duplicate_emails_on_case_results_in_no_match(self):
+        request = RequestFactory().post(reverse("login"))
+
+        UserFactory(email=self.user.email.upper(), login_type=self.user.login_type)
+        result = auth.authenticate(
+            request, username=self.user.email, password=self.password
+        )
+        self.assertEqual(result, None)
+
+    def test_correct_username_password_return_user(self):
+        request = RequestFactory().post(reverse("login"))
+
+        result = auth.authenticate(
+            request, username=self.user.email, password=self.password
+        )
+        self.assertEqual(result, self.user)
+
+    def test_incorrect_username_password_return_none(self):
+        request = RequestFactory().post(reverse("login"))
+
+        for username, password in (
+            (self.user.email, "incorrect"),
+            ("incorrect", self.password),
+        ):
+            result = auth.authenticate(request, username=username, password=password)
+            self.assertEqual(result, None)
+
+    def test_missing_username_and_or_password_returns_none(self):
+        for username in (self.user.email, "", None):
+            for password in (self.password, "", None):
+                if username and password:
+                    # This is the successful case, exclude it, but ensure we
+                    # also have permutations with one valid/one invalid value.
+                    continue
+
+                with self.subTest(f"{username=} {password=}"):
+                    request = RequestFactory().post(reverse("login"))
+                    result = auth.authenticate(
+                        request, username=username, password=password
+                    )
+                    self.assertEqual(result, None)
+
+
+@override_settings(
+    AUTHENTICATION_BACKENDS=[
+        "open_inwoner.accounts.backends.Verify2FATokenBackend",
+    ]
+)
+class Verify2FATokenBackendTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = UserFactory(login_type=LoginTypeChoices.default)
+        cls.expires_in = getattr(settings, "ACCOUNTS_USER_TOKEN_EXPIRE_TIME", 300)
+        cls.make_token = lambda: totp(cls.user.seed, period=cls.expires_in)
+
+    @freeze_time("2023-05-22 12:05:01")
+    def test_valid_token_and_user_returns_user(self):
+        request = RequestFactory().get(reverse("verify_token"))
+
+        result = auth.authenticate(request, user=self.user, token=self.make_token())
+        self.assertEqual(result, self.user)
+
+    def test_expired_token_and_valid_user_returns_none(self):
+        request = RequestFactory().get(reverse("verify_token"))
+
+        with freeze_time("2023-05-22 12:05:01") as ft:
+            token = self.make_token()
+
+            ft.tick(delta=datetime.timedelta(seconds=self.expires_in * 2))
+            result = auth.authenticate(request, user=self.user, token=token)
+            self.assertEqual(result, None)
+
+    def test_missing_user_and_or_token_returns_none(self):
+        for user in (self.user.email, "", None):
+            for token in (self.make_token(), "", None):
+                if user and token:
+                    # This is the successful case, exclude it, but ensure we
+                    # also have permutations with one valid/one invalid value.
+                    continue
+
+                with self.subTest(f"{user=} {token=}"):
+                    request = RequestFactory().get(reverse("verify_token"))
+                    result = auth.authenticate(request, user=user, token=token)
+                    self.assertEqual(result, None)

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -492,11 +492,10 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 
-# Allow logging in with email+password
 AUTHENTICATION_BACKENDS = [
     "open_inwoner.accounts.backends.CustomAxesBackend",
     "open_inwoner.accounts.backends.UserModelEmailBackend",
-    "django.contrib.auth.backends.ModelBackend",
+    "open_inwoner.accounts.backends.Verify2FATokenBackend",
     "digid_eherkenning.backends.DigiDBackend",
     "eherkenning.backends.eHerkenningBackend",
     "open_inwoner.accounts.backends.DigiDEHerkenningOIDCBackend",

--- a/src/open_inwoner/conf/ci.py
+++ b/src/open_inwoner/conf/ci.py
@@ -32,6 +32,7 @@ CACHES.update(
 AUTHENTICATION_BACKENDS = [
     "open_inwoner.accounts.backends.CustomAxesBackend",
     "open_inwoner.accounts.backends.UserModelEmailBackend",
+    "open_inwoner.accounts.backends.Verify2FATokenBackend",
     "django.contrib.auth.backends.ModelBackend",
     # mock login like dev.py
     "digid_eherkenning.mock.backends.DigiDBackend",


### PR DESCRIPTION
Previously, the UserModelEmailBackend was overloaded to support both username/password authentication, as well as TOTP validation. It did this, in part, by verifying the 2FA flag on the site configuration.

This was both confusing (an authentication backend should do one thing only, multiple logics means multiple backends), as well as mixing concerns (the _view_ should decide which arguments to pass to to authentication backend based on the site configuration, authentication backends should only authenticate).

This commit separates both concerns into independent backends, and adds some tests to ensure that they are properly invoked.