### PR TITLE
Disable playwright browser cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,14 +166,6 @@ jobs:
           setup-node: 'yes'
           npm-ci-flags: '--legacy-peer-deps'
 
-      # See https://playwright.dev/python/docs/ci#caching-browsers
-      - name: Cache Playwright browser
-        id: cache-browser
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ matrix.browser }}-playwright-${{ hashFiles('requirements/ci.txt') }}
-
       - name: Install playwright deps
         run: playwright install --with-deps ${{ matrix.browser }}
 


### PR DESCRIPTION
[As per the Playwright docs](https://playwright.dev/python/docs/ci#caching-browsers), caching browsers is not recommended, both because downloading the binary is not much slower, but also because system dependencies are required, and these cannot be cached. Even worse, the system dependencies can become stale as the CI images get upgraded. This seems to have happened recently, with persistent "It looks like you are using Playwright Sync API inside the asyncio loop." errors sporadically appearing (in this case, for webkit only) and this being fixed, without further code changes, by disabling the browser cache.