### PR TITLE
Fix support for loading SQL dumps in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .vscode/
 .sass-cache/
 *.db
-docker-init-db.sql/*
 *.pyc
 __pycache__
 *~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
     image: postgis/postgis:${PG_VERSION:-14-master}
     container_name: open-inwoner-db
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_HOST_AUTH_METHOD=${POSTGRES_HOST_AUTH_METHOD:-trust}
+      - POSTGRES_DB=${POSTGRES_DB:-open_inwoner}
+      - POSTGRES_USER=${POSTGRES_USER:-open_inwoner}
     volumes:
-      - ./docker-init-db.sql:/docker-entrypoint-initdb.d/init_db.sql
+      - ./docker-initdb.d/:/docker-entrypoint-initdb.d
       - db:/var/lib/postgresql/data
     networks:
       - openinwoner-dev
@@ -135,11 +137,11 @@ services:
     volumes: *web_volumes
     depends_on:
       web:
-        # This health check condition is needed because Celery Beat will 
-        # try to convert the CELERY_BEAT_SCHEDULE into database entries. For 
-        # this, migrations need to be finished. If Celery tasks were still 
-        # pending, the database also needs to be ready for Celery itself. We 
-        # therefore have the health check here, and make Celery beat and 
+        # This health check condition is needed because Celery Beat will
+        # try to convert the CELERY_BEAT_SCHEDULE into database entries. For
+        # this, migrations need to be finished. If Celery tasks were still
+        # pending, the database also needs to be ready for Celery itself. We
+        # therefore have the health check here, and make Celery beat and
         # monitor containers depend on the celery container.
         condition: service_healthy
       redis:

--- a/docker-init-db.sql
+++ b/docker-init-db.sql
@@ -1,7 +1,0 @@
-CREATE USER open_inwoner;
-CREATE DATABASE open_inwoner;
-GRANT ALL PRIVILEGES ON DATABASE open_inwoner TO open_inwoner;
-\c open_inwoner;
-CREATE EXTENSION postgis;
--- On Postgres 15+, connect to the database and grant schema permissions.
--- GRANT USAGE, CREATE ON SCHEMA public TO openforms;

--- a/docker-initdb.d/initialize_db.sql
+++ b/docker-initdb.d/initialize_db.sql
@@ -1,0 +1,22 @@
+-- create user + database 'open_inwoner' if they don't already exist
+DO
+$$
+begin
+    IF NOT EXISTS (SELECT * FROM pg_user WHERE usename = 'open_inwoner') THEN
+        CREATE role open_inwoner WITH login;
+    END IF;
+
+    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'open_inwoner') THEN
+        CREATE EXTENSION IF NOT EXISTS dblink;
+        PERFORM dblink_exec('dbname=' || current_database(), 'CREATE DATABASE open_inwoner');
+    END IF;
+END
+$$
+;
+
+GRANT ALL PRIVILEGES ON DATABASE open_inwoner TO open_inwoner;
+
+\c open_inwoner;
+GRANT USAGE, CREATE ON SCHEMA public TO open_inwoner;
+
+CREATE EXTENSION postgis;


### PR DESCRIPTION
Instead of mounting a script that creates a database user and grants appropriate permission, we set the default database and user to `open_inwoner`, thus ensuring that these are created when the container starts. This facilitates loading in SQL dumps to initialize the container. The dump should be placed in `docker-initdb.d` and is not checked into version control.