### PR TITLE
[#2820] Reduce coupling of user signals and klanten API logic

### DIFF
--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.dispatch import receiver
 from django.urls import reverse
@@ -5,12 +6,10 @@ from django.utils.translation import gettext as _
 
 from open_inwoner.haalcentraal.models import HaalCentraalConfig
 from open_inwoner.haalcentraal.utils import update_brp_data_in_db
+from open_inwoner.openklant.models import OpenKlant2Config
+from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
 from open_inwoner.utils.logentry import user_action
 
-from ..openklant.services import (
-    get_or_create_klant_from_request,
-    update_user_from_klant,
-)
 from .choices import LoginTypeChoices
 
 MESSAGE_TYPE = {
@@ -29,9 +28,41 @@ def update_user_from_klant_on_login(sender, user, request, *args, **kwargs):
     if not hasattr(request, "user"):
         return
 
-    if user.login_type in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
-        if klant := get_or_create_klant_from_request(request):
-            update_user_from_klant(klant, user)
+    if user.login_type not in [LoginTypeChoices.digid, LoginTypeChoices.eherkenning]:
+        return
+
+    # OpenKlant2
+    # TODO: replace with proper config and refactor branching
+    use_ok2 = getattr(settings, "OPENKLANT2_ACTIVE", None)
+    if use_ok2 and (openklant2_config := OpenKlant2Config.from_django_settings()):
+        service = OpenKlant2Service(config=openklant2_config)
+
+        if not (
+            fetch_params := service.get_fetch_parameters(
+                request=request, use_vestigingsnummer=True
+            )
+        ):
+            return
+
+        partij, created = service.get_or_create_partij_for_user(
+            fetch_params=fetch_params, user=user
+        )
+        if partij and not created:
+            service.update_user_from_partij(partij_uuid=partij.uuid, user=user)
+
+    # eSuite
+    service = eSuiteKlantenService()
+
+    if not (
+        fetch_params := service.get_fetch_parameters(
+            request=request, use_vestigingsnummer=True
+        )
+    ):
+        return
+
+    klant, created = service.get_or_create_klant(fetch_params=fetch_params, user=user)
+    if klant and not created:
+        service.update_user_from_klant(klant, user)
 
 
 @receiver(user_logged_in)

--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -46,11 +46,7 @@ def update_user_from_klant_on_login(sender, user, request, *args, **kwargs):
             logger.error("OpenKlant2 service failed to build")
             return
 
-        if not (
-            fetch_params := service.get_fetch_parameters(
-                request=request, use_vestigingsnummer=True
-            )
-        ):
+        if not (fetch_params := service.get_fetch_parameters(request=request)):
             return
 
         partij, created = service.get_or_create_partij_for_user(
@@ -66,11 +62,7 @@ def update_user_from_klant_on_login(sender, user, request, *args, **kwargs):
         logger.error("eSuiteKlantenService failed to build")
         return
 
-    if not (
-        fetch_params := service.get_fetch_parameters(
-            request=request, use_vestigingsnummer=True
-        )
-    ):
+    if not (fetch_params := service.get_fetch_parameters(request=request)):
         return
 
     klant, created = service.get_or_create_klant(fetch_params=fetch_params, user=user)

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1920,7 +1920,7 @@ class TestUpdateUserFromKlantUponLoginTests(TestCase):
                 self.data.user.login_type = login_type
                 self.data.user.save()
                 with patch(
-                    "open_inwoner.accounts.signals.update_user_from_klant_on_login"
+                    "open_inwoner.openklant.services.eSuiteKlantenService.update_user_from_klant"
                 ) as update_user_from_klant_mock:
                     update_user_from_klant_on_login(
                         self.__class__,

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1920,7 +1920,7 @@ class TestUpdateUserFromKlantUponLoginTests(TestCase):
                 self.data.user.login_type = login_type
                 self.data.user.save()
                 with patch(
-                    "open_inwoner.accounts.signals.update_user_from_klant"
+                    "open_inwoner.accounts.signals.update_user_from_klant_on_login"
                 ) as update_user_from_klant_mock:
                     update_user_from_klant_on_login(
                         self.__class__,

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -1,22 +1,30 @@
 import logging
 
-from open_inwoner.openklant.clients import build_klanten_client
-from open_inwoner.openklant.wrap import get_fetch_parameters
+from open_inwoner.openklant.models import OpenKlantConfig
+from open_inwoner.openklant.services import eSuiteKlantenService
 
 logger = logging.getLogger(__name__)
 
 
 class KlantenAPIMixin:
     def patch_klant(self, update_data: dict):
-        if update_data and (client := build_klanten_client()):
-            klant = client.retrieve_klant(**get_fetch_parameters(self.request))
-            if not klant:
-                logger.error("Failed to retrieve klant for user %s", self.request.user)
-                return
+        if not update_data:
+            return
 
-            self.log_system_action("retrieved klant for user", user=self.request.user)
-            client.partial_update_klant(klant, update_data)
-            self.log_system_action(
-                f"patched klant from user profile edit with fields: {', '.join(sorted(update_data.keys()))}",
-                user=self.request.user,
-            )
+        try:
+            service = eSuiteKlantenService(config=OpenKlantConfig.get_solo())
+        except RuntimeError:
+            logger.error("Error building KlantenService")
+            return
+
+        klant = service.retrieve_klant(**service.get_fetch_parameters(self.request))
+        if not klant:
+            logger.error("Failed to retrieve klant for user %s", self.request.user)
+            return
+
+        self.log_system_action("retrieved klant for user", user=self.request.user)
+        service.partial_update_klant(klant, update_data)
+        self.log_system_action(
+            f"patched klant from user profile edit with fields: {', '.join(sorted(update_data.keys()))}",
+            user=self.request.user,
+        )

--- a/src/open_inwoner/accounts/views/signals.py
+++ b/src/open_inwoner/accounts/views/signals.py
@@ -1,16 +1,20 @@
 import logging
 
+from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from open_inwoner.accounts.models import User
-from open_inwoner.openklant.clients import build_klanten_client
+from open_inwoner.openklant.models import OpenKlant2Config
+from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
 
 logger = logging.getLogger(__name__)
 
 
+# TODO: Should we also try to fetch pre-existing klant for new user and update?
+# The klant could have been created by a different service.
 @receiver(post_save, sender=User)
-def create_klant_for_new_user(
+def get_or_create_klant_for_new_user(
     sender: type, instance: User, created: bool, **kwargs
 ) -> None:
     if not created:
@@ -18,16 +22,53 @@ def create_klant_for_new_user(
 
     user = instance
 
-    if not user.bsn:
-        logger.info("Did not create klant for user %s because of missing bsn", user)
+    # OpenKlant2
+    # TODO: replace with proper config and refactor branching
+    use_ok2 = getattr(settings, "OPENKLANT2_ACTIVE", None)
+    if use_ok2 and (openklant2_config := OpenKlant2Config.from_django_settings()):
+        try:
+            service = OpenKlant2Service(config=openklant2_config)
+        except RuntimeError:
+            logger.error("OpenKlant2 service failed to build")
+            return
+
+        if not (
+            fetch_params := service.get_fetch_parameters(
+                user=user, use_vestigingsnummer=True
+            )
+        ):
+            return
+
+        partij, created = service.get_or_create_partij_for_user(
+            fetch_params=fetch_params, user=user
+        )
+        if not partij:
+            logger.error("Failed to create partij for new user %s", user)
+            return
+        elif not created:
+            service.update_user_from_partij(partij_uuid=partij.uuid, user=user)
+
+        logger.info("Created partij %s for new user %s", partij, user)
+
+    # eSuite
+    try:
+        service = eSuiteKlantenService()
+    except RuntimeError:
+        logger.error("eSuiteKlantenService failed to build")
         return
 
-    if not (client := build_klanten_client()):
-        logger.warning("Failed to create klanten client for new user %s", user)
+    if not (
+        fetch_params := service.get_fetch_parameters(
+            user=user, use_vestigingsnummer=True
+        )
+    ):
         return
 
-    if not (klant := client.create_klant(user_bsn=user.bsn)):
+    klant, created = service.get_or_create_klant(fetch_params=fetch_params, user=user)
+    if not klant:
         logger.error("Failed to create klant for new user %s", user)
         return
+    elif not created:
+        service.update_user_from_klant(klant, user)
 
     logger.info("Created klant %s for new user %s", klant, user)

--- a/src/open_inwoner/cms/cases/tests/test_contactform.py
+++ b/src/open_inwoner/cms/cases/tests/test_contactform.py
@@ -19,9 +19,9 @@ from open_inwoner.accounts.tests.factories import (
     DigidUserFactory,
     eHerkenningUserFactory,
 )
-from open_inwoner.openklant.clients import ContactmomentenClient
 from open_inwoner.openklant.constants import Status
 from open_inwoner.openklant.models import OpenKlantConfig
+from open_inwoner.openklant.services import eSuiteVragenService
 from open_inwoner.openklant.tests.data import CONTACTMOMENTEN_ROOT, KLANTEN_ROOT
 from open_inwoner.openzaak.models import CatalogusConfig, OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import (
@@ -50,7 +50,7 @@ PATCHED_MIDDLEWARE = [
     "open_inwoner.cms.cases.views.status.send_contact_confirmation_mail", autospec=True
 )
 @patch.object(
-    ContactmomentenClient,
+    eSuiteVragenService,
     "retrieve_objectcontactmomenten_for_zaak",
     autospec=True,
     return_value=[],
@@ -285,6 +285,10 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         m.get(
             f"{CATALOGI_ROOT}statustypen?zaaktype={self.zaak['zaaktype']}",
             json=paginated_response([self.status_type_new, self.status_type_finish]),
+        )
+        m.get(
+            f"{CONTACTMOMENTEN_ROOT}objectcontactmomenten?object={self.zaak['url']}",
+            json=paginated_response([]),
         )
 
         self.matchers += [

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -17,9 +17,9 @@ from zgw_consumers.constants import APITypes
 from open_inwoner.accounts.tests.factories import DigidUserFactory
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.openklant.clients import ContactmomentenClient
 from open_inwoner.openklant.constants import Status
 from open_inwoner.openklant.models import OpenKlantConfig
+from open_inwoner.openklant.services import eSuiteVragenService
 from open_inwoner.openklant.tests.data import CONTACTMOMENTEN_ROOT, KLANTEN_ROOT
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import (
@@ -47,7 +47,7 @@ from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 @tag("e2e")
 @requests_mock.Mocker()
 @patch.object(
-    ContactmomentenClient,
+    eSuiteVragenService,
     "retrieve_objectcontactmomenten_for_zaak",
     autospec=True,
     return_value=[],

--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -337,6 +337,8 @@ def _build_open_klant_client(type_) -> APIClient | None:
         service = getattr(config, f"{type_}_service")
         if service:
             client = build_client(service, client_factory=client_class)
+            if not client:
+                logger.error("%s could not be build", client_class)
             return client
 
     logger.warning("no service defined for %s", type_)

--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -337,8 +337,6 @@ def _build_open_klant_client(type_) -> APIClient | None:
         service = getattr(config, f"{type_}_service")
         if service:
             client = build_client(service, client_factory=client_class)
-            if not client:
-                logger.error("%s could not be build", client_class)
             return client
 
     logger.warning("no service defined for %s", type_)

--- a/src/open_inwoner/openklant/models.py
+++ b/src/open_inwoner/openklant/models.py
@@ -215,6 +215,7 @@ class OpenKlant2Config:
 
         if not (config := getattr(settings, "OPENKLANT2_CONFIG", None)):
             raise ImproperlyConfigured(
+            raise RuntimeError(
                 "Please set OPENKLANT2_CONFIG in your settings to configure OpenKlant2"
             )
 

--- a/src/open_inwoner/openklant/models.py
+++ b/src/open_inwoner/openklant/models.py
@@ -194,6 +194,7 @@ class KlantContactMomentAnswer(models.Model):
 
 @dataclass
 class OpenKlant2Config:
+    # TODO: move to service_config object
     api_root: str
     api_path: str
     api_token: str
@@ -220,3 +221,5 @@ class OpenKlant2Config:
             )
 
         return cls(**config)
+
+    # TODO: add from_openklant_config_model or similar

--- a/src/open_inwoner/openklant/models.py
+++ b/src/open_inwoner/openklant/models.py
@@ -194,7 +194,6 @@ class KlantContactMomentAnswer(models.Model):
 
 @dataclass
 class OpenKlant2Config:
-    # TODO: move to service_config object
     api_root: str
     api_path: str
     api_token: str
@@ -216,7 +215,6 @@ class OpenKlant2Config:
 
         if not (config := getattr(settings, "OPENKLANT2_CONFIG", None)):
             raise ImproperlyConfigured(
-            raise RuntimeError(
                 "Please set OPENKLANT2_CONFIG in your settings to configure OpenKlant2"
             )
 

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -6,16 +6,30 @@ from typing import Iterable, Literal, NotRequired, Protocol, Self, TypedDict
 from django.utils import timezone
 
 import glom
+from ape_pie.client import APIClient
 from attr import dataclass
+from requests.exceptions import RequestException
+from zgw_consumers.api_models.base import factory
+from zgw_consumers.client import build_client as build_zgw_client
 from zgw_consumers.models.services import Service as ServiceConfig
+from zgw_consumers.utils import pagination_helper
 
 from open_inwoner.accounts.choices import NotificationChannelChoice
 from open_inwoner.accounts.models import User
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.kvk.branches import get_kvk_branch_number
-from open_inwoner.openklant.api_models import Klant
-from open_inwoner.openklant.clients import KlantenClient, build_klanten_client
+from open_inwoner.openklant.api_models import (
+    ContactMoment,
+    ContactMomentCreateData,
+    Klant,
+    KlantContactMoment,
+    KlantContactRol,
+    KlantCreateData,
+    ObjectContactMoment,
+)
 from open_inwoner.openklant.models import OpenKlant2Config, OpenKlantConfig
+from open_inwoner.openzaak.api_models import Zaak
+from open_inwoner.utils.api import ClientError, get_json_response
 from open_inwoner.utils.logentry import system_action
 from openklant2.client import OpenKlant2Client
 from openklant2.types.resources.digitaal_adres import DigitaalAdres
@@ -43,12 +57,12 @@ FetchParameters = BsnFetchParam | OrgFetchParam
 class KlantenService(Protocol):
     config: OpenKlantConfig | OpenKlant2Config
     service_config: ServiceConfig
-    client: KlantenClient | OpenKlant2Client
+    client: APIClient
 
     def get_fetch_parameters(
         self,
-        user: User | None = None,
         request=None,
+        user: User | None = None,
         use_vestigingsnummer: bool = False,
     ) -> FetchParameters | None:
         """
@@ -79,7 +93,6 @@ class KlantenService(Protocol):
 
 class eSuiteKlantenService(KlantenService):
     config: OpenKlantConfig
-    client: KlantenClient
 
     def __init__(self, config: OpenKlantConfig | None = None):
         self.config = config or OpenKlantConfig.get_solo()
@@ -87,18 +100,22 @@ class eSuiteKlantenService(KlantenService):
             raise RuntimeError("eSuiteKlantenService instance needs a configuration")
 
         self.service_config = self.config.klanten_service
+        if not self.service_config:
+            raise RuntimeError(
+                "eSuiteKlantenService instance needs a servivce configuration"
+            )
 
-        self.client = build_klanten_client()
+        self.client = build_zgw_client(service=self.service_config)
         if not self.client:
             raise RuntimeError("eSuiteKlantenService instance needs a client")
 
     def get_or_create_klant(
         self, fetch_params: FetchParameters, user: User
-    ) -> (Klant | None, bool):
-        if klant := self.client.retrieve_klant(**fetch_params):
+    ) -> tuple[Klant | None, bool]:
+        if klant := self.retrieve_klant(**fetch_params):
             msg = "retrieved klant for user"
             created = False
-        elif klant := self.client.create_klant(**fetch_params):
+        elif klant := self.create_klant(**fetch_params):
             msg = f"created klant ({klant.klantnummer}) for user"
             created = True
         else:
@@ -106,6 +123,123 @@ class eSuiteKlantenService(KlantenService):
 
         system_action(msg, content_object=user)
         return klant, created
+
+    def retrieve_klant(
+        self,
+        user_bsn: str | None = None,
+        user_kvk_or_rsin: str | None = None,
+    ):
+        klanten = None
+        # this is technically a search operation and could return multiple records
+        if user_bsn:
+            klanten = self._retrieve_klanten_for_bsn(user_bsn)
+        elif user_kvk_or_rsin:
+            klanten = self._retrieve_klanten_for_kvk_or_rsin(user_kvk_or_rsin)
+
+        return klanten[0] if klanten else None
+
+    def _retrieve_klanten_for_bsn(self, user_bsn: str) -> list[Klant]:
+        try:
+            response = self.client.get(
+                "klanten",
+                params={"subjectNatuurlijkPersoon__inpBsn": user_bsn},
+            )
+            data = get_json_response(response)
+            all_data = list(pagination_helper(self, data))
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return []
+
+        klanten = factory(Klant, all_data)
+
+        return klanten
+
+    def _retrieve_klanten_for_kvk_or_rsin(
+        self, user_kvk_or_rsin: str, *, vestigingsnummer=None
+    ) -> list[Klant]:
+        params = {"subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin}
+
+        if vestigingsnummer:
+            params = {
+                "subjectVestiging__vestigingsNummer": vestigingsnummer,
+            }
+
+        try:
+            response = self.client.get(
+                "klanten",
+                params=params,
+            )
+            data = get_json_response(response)
+            all_data = list(pagination_helper(self, data))
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return []
+
+        klanten = factory(Klant, all_data)
+
+        return klanten
+
+    def create_klant(
+        self,
+        user_bsn: str | None = None,
+        user_kvk_or_rsin: str | None = None,
+        vestigingsnummer: str | None = None,
+        data: KlantCreateData = None,
+    ) -> Klant | None:
+        if user_bsn:
+            return self._create_klant_for_bsn(user_bsn)
+
+        if user_kvk_or_rsin:
+            return self._create_klant_for_kvk_or_rsin(
+                user_kvk_or_rsin, vestigingsnummer=vestigingsnummer
+            )
+
+        try:
+            response = self.post("klanten", json=data)
+            data = get_json_response(response)
+        except (RequestException, ClientError):
+            logger.exception("exception while making request")
+            return
+
+        klant = factory(Klant, data)
+
+        return klant
+
+    def _create_klant_for_bsn(self, user_bsn: str) -> Klant:
+        payload = {"subjectIdentificatie": {"inpBsn": user_bsn}}
+
+        try:
+            response = self.client.post("klanten", json=payload)
+            data = get_json_response(response)
+        except (RequestException, ClientError):
+            logger.exception("exception while making request")
+            return None
+
+        klant = factory(Klant, data)
+
+        return klant
+
+    def _create_klant_for_kvk_or_rsin(
+        self, user_kvk_or_rsin: str, *, vestigingsnummer=None
+    ) -> list[Klant]:
+        payload = {"subjectIdentificatie": {"innNnpId": user_kvk_or_rsin}}
+
+        if vestigingsnummer:
+            payload = {"subjectIdentificatie": {"vestigingsNummer": vestigingsnummer}}
+
+        try:
+            response = self.client.post(
+                "klanten",
+                json=payload,
+            )
+            data = get_json_response(response)
+        except (RequestException, ClientError):
+            logger.exception("exception while making request")
+            return None
+
+        klant = factory(Klant, data)
+
+        return klant
 
     def update_user_from_klant(self, klant: Klant, user: User):
         update_data = {}
@@ -158,6 +292,206 @@ class eSuiteKlantenService(KlantenService):
                 f"updated user from klant API with fields: {', '.join(sorted(update_data.keys()))}",
                 content_object=user,
             )
+
+    def partial_update_klant(self, klant: Klant, update_data) -> Klant | None:
+        try:
+            response = self.client.patch(url=klant.url, json=update_data)
+            data = get_json_response(response)
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return
+
+        klant = factory(Klant, data)
+
+        return klant
+
+
+class eSuiteVragenService(KlantenService):
+    config: OpenKlantConfig
+
+    def __init__(self, config: OpenKlantConfig | None = None):
+        self.config = config or OpenKlantConfig.get_solo()
+        if not self.config:
+            raise RuntimeError("eSuiteVragenService instance needs a configuration")
+
+        self.service_config = self.config.contactmomenten_service
+        if not self.service_config:
+            raise RuntimeError(
+                "eSuiteVragenService instance needs a servivce configuration"
+            )
+
+        self.client = build_zgw_client(service=self.service_config)
+        if not self.client:
+            raise RuntimeError("eSuiteVragenService instance needs a client")
+
+    #
+    # contactmomenten
+    #
+    def retrieve_contactmoment(self, url) -> ContactMoment | None:
+        try:
+            response = self.client.get(url)
+            data = get_json_response(response)
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return
+
+        contact_moment = factory(ContactMoment, data)
+
+        return contact_moment
+
+    def create_contactmoment(
+        self,
+        data: ContactMomentCreateData,
+        *,
+        klant: Klant | None = None,
+        rol: str | None = KlantContactRol.BELANGHEBBENDE,
+    ) -> ContactMoment | None:
+        try:
+            response = self.client.post("contactmomenten", json=data)
+            data = get_json_response(response)
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return
+
+        contactmoment = factory(ContactMoment, data)
+
+        if klant:
+            # relate contact to klant though a klantcontactmoment
+            try:
+                self.client.post(
+                    "klantcontactmomenten",
+                    json={
+                        "klant": klant.url,
+                        "contactmoment": contactmoment.url,
+                        "rol": rol,
+                    },
+                )
+            except (RequestException, ClientError) as e:
+                logger.exception("exception while making request", exc_info=e)
+                return
+
+        return contactmoment
+
+    #
+    # objectcontactmomenten
+    #
+    def retrieve_objectcontactmoment(
+        self, contactmoment: ContactMoment, object_type: str
+    ) -> ObjectContactMoment | None:
+        ocms = self.retrieve_objectcontactmomenten_for_object_type(
+            contactmoment, object_type
+        )
+        if ocms:
+            return ocms[0]
+
+    def retrieve_objectcontactmomenten_for_object_type(
+        self, contactmoment: ContactMoment, object_type: str
+    ) -> list[ObjectContactMoment]:
+
+        moments = self.retrieve_objectcontactmomenten_for_contactmoment(contactmoment)
+
+        # eSuite doesn't implement a `object_type` query parameter
+        ret = [moment for moment in moments if moment.object_type == object_type]
+
+        return ret
+
+    def create_objectcontactmoment(
+        self,
+        contactmoment: ContactMoment,
+        zaak: Zaak,
+        object_type: str = "zaak",
+    ) -> ObjectContactMoment | None:
+        try:
+            response = self.client.post(
+                "objectcontactmomenten",
+                json={
+                    "contactmoment": contactmoment.url,
+                    "object": zaak.url,
+                    "objectType": object_type,
+                },
+            )
+            data = get_json_response(response)
+        except (RequestException, ClientError) as exc:
+            logger.exception("exception while making request", exc_info=exc)
+            return None
+
+        object_contact_moment = factory(ObjectContactMoment, data)
+
+        return object_contact_moment
+
+    def retrieve_objectcontactmomenten_for_zaak(
+        self, zaak: Zaak
+    ) -> list[ObjectContactMoment]:
+        try:
+            response = self.client.get(
+                "objectcontactmomenten", params={"object": zaak.url}
+            )
+            data = get_json_response(response)
+            all_data = list(pagination_helper(self, data))
+        except (RequestException, ClientError) as exc:
+            logger.exception("exception while making request", exc_info=exc)
+            return []
+
+        object_contact_momenten = factory(ObjectContactMoment, all_data)
+
+        # resolve linked resources
+        contactmoment_mapping = {}
+        for ocm in object_contact_momenten:
+            assert ocm.object == zaak.url
+            ocm.object = zaak
+
+            contactmoment_url = ocm.contactmoment
+            if contactmoment_url in contactmoment_mapping:
+                ocm.contactmoment = contactmoment_mapping[contactmoment_url]
+            else:
+                ocm.contactmoment = self.retrieve_contactmoment(contactmoment_url)
+                contactmoment_mapping[contactmoment_url] = ocm.contactmoment
+
+        return object_contact_momenten
+
+    def retrieve_objectcontactmomenten_for_contactmoment(
+        self, contactmoment: ContactMoment
+    ) -> list[ObjectContactMoment]:
+        try:
+            response = self.client.get(
+                "objectcontactmomenten", params={"contactmoment": contactmoment.url}
+            )
+            data = get_json_response(response)
+            all_data = list(pagination_helper(self, data))
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return []
+
+        object_contact_momenten = factory(ObjectContactMoment, all_data)
+
+        return object_contact_momenten
+
+    #
+    # klantcontactmomenten
+    #
+    def retrieve_klantcontactmomenten_for_klant(
+        self, klant: Klant
+    ) -> list[KlantContactMoment]:
+        try:
+            response = self.client.get(
+                "klantcontactmomenten",
+                params={"klant": klant.url},
+            )
+            data = get_json_response(response)
+            all_data = list(pagination_helper(self, data))
+        except (RequestException, ClientError) as e:
+            logger.exception("exception while making request", exc_info=e)
+            return []
+
+        klanten_contact_moments = factory(KlantContactMoment, all_data)
+
+        # resolve linked resources
+        for kcm in klanten_contact_moments:
+            assert kcm.klant == klant.url
+            kcm.klant = klant
+            kcm.contactmoment = self.retrieve_contactmoment(kcm.contactmoment)
+
+        return klanten_contact_moments
 
 
 @dataclass(frozen=True)

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -36,8 +36,12 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
 
         # First call creates
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_bsn": "123456789"}, self.user
+        )
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
         )
 
         PartijValidator.validate_python(persoon)
@@ -58,8 +62,12 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         )
 
         # Second call gets
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_bsn": "123456789"}, self.user
+        )
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
         )
 
         PartijValidator.validate_python(persoon)
@@ -85,9 +93,13 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
 
         # First call creates
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_kvk_or_rsin": "123456789"},
             self.user,
+        )
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
         )
 
         PartijValidator.validate_python(persoon)
@@ -108,8 +120,12 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         )
 
         # Second call gets
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_kvk_or_rsin": "123456789"}, self.user
+        )
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
         )
 
         PartijValidator.validate_python(persoon)
@@ -135,9 +151,13 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
 
         # First call creates
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_kvk_or_rsin": "123456789", "vestigingsnummer": "987654321"},
             self.user,
+        )
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
         )
 
         PartijValidator.validate_python(persoon)
@@ -164,8 +184,12 @@ class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
         )
 
         # Second call gets
-        persoon = self.service.get_or_create_partij_for_user(
+        persoon, created = self.service.get_or_create_partij_for_user(
             {"user_kvk_or_rsin": "123456789"}, self.user
+        )
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
         )
 
         PartijValidator.validate_python(persoon)

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -28,9 +28,9 @@ from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory, eHerkenningUserFactory
 from open_inwoner.cms.cases.views.status import InnerCaseDetailView, SimpleFile
 from open_inwoner.openklant.api_models import ObjectContactMoment
-from open_inwoner.openklant.clients import ContactmomentenClient
 from open_inwoner.openklant.constants import Status as ContactMomentStatus
 from open_inwoner.openklant.models import OpenKlantConfig
+from open_inwoner.openklant.services import eSuiteVragenService
 from open_inwoner.openklant.tests.factories import make_contactmoment
 from open_inwoner.openzaak.constants import StatusIndicators
 from open_inwoner.openzaak.tests.factories import (
@@ -1434,7 +1434,7 @@ class TestCaseDetailView(
         self.assertContains(response, "uploaded_document_title")
 
     @patch.object(
-        ContactmomentenClient,
+        eSuiteVragenService,
         "retrieve_objectcontactmomenten_for_zaak",
         autospec=True,
         return_value=[],
@@ -1461,7 +1461,7 @@ class TestCaseDetailView(
 
     @set_kvk_branch_number_in_session("1234")
     @patch.object(
-        ContactmomentenClient,
+        eSuiteVragenService,
         "retrieve_objectcontactmomenten_for_zaak",
         autospec=True,
         return_value=[],
@@ -1526,7 +1526,7 @@ class TestCaseDetailView(
         self.assertEqual(self.user, log.content_object)
 
     @patch.object(
-        ContactmomentenClient,
+        eSuiteVragenService,
         "retrieve_objectcontactmomenten_for_zaak",
         autospec=True,
         return_value=[],
@@ -2557,7 +2557,7 @@ class TestCaseDetailView(
         )
 
     @patch.object(
-        ContactmomentenClient,
+        eSuiteVragenService,
         "retrieve_objectcontactmomenten_for_zaak",
         autospec=True,
     )


### PR DESCRIPTION
The `create_klant_for_new_user` and `update_user_from_klant_on_login` signals are coupled to the eSuite klanten API service. The PR introduces service objects which perform the actual fetch/create/update logic. This way we branch on eSuite or OpenKlant2.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2820