### PR TITLE
Mark incorrectly untagged elasticsearch tests

### DIFF
--- a/src/open_inwoner/api/search/tests/test_autocomplete_api.py
+++ b/src/open_inwoner/api/search/tests/test_autocomplete_api.py
@@ -2,6 +2,7 @@
 this file contains tests for the RESTful API
 The logic of `autocomplete` is tested at `open_inwoner.search.tests` folder
 """
+from django.test import tag
 from django.urls import reverse_lazy
 
 from rest_framework import status
@@ -11,6 +12,7 @@ from open_inwoner.pdc.tests.factories import ProductFactory
 from open_inwoner.search.tests.utils import ESMixin
 
 
+@tag("elastic")
 class AutocompleteApiTests(ESMixin, APITestCase):
     url = reverse_lazy("api:search_autocomplete")
 

--- a/src/open_inwoner/search/tests/test_search_products_boost.py
+++ b/src/open_inwoner/search/tests/test_search_products_boost.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from open_inwoner.pdc.tests.factories import ProductFactory
 
@@ -7,6 +7,7 @@ from ..searches import search_products
 from .utils import ESMixin
 
 
+@tag("elastic")
 class SearchBoostTests(ESMixin, TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
These always get in the way of my 100% pass rate when running `python src/manage.py test open_inwoner --exclude-tag=e2e --exclude-tag=elastic` (they pass on the CI main run, which runs with the same flags, because we always have an elasticsearch instance running).