### PR TITLE
[#2825] Ensure we show case.omschrijving on the detailview if we configured to use this on the listview

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -246,7 +246,7 @@ class InnerCaseDetailView(
                 "end_date_legal": getattr(
                     self.case, "uiterlijke_einddatum_afdoening", None
                 ),
-                "description": self.case.zaaktype.omschrijving,
+                "description": self.case.description,
                 "statuses": self.get_statuses_data(
                     statuses, self.statustype_config_mapping
                 ),


### PR DESCRIPTION
Earlier PR worked for the listview, however on the case/status detailview zaaktype.description was always used. To be verified if this is okay...