### PR TITLE
♿ [#2362] a11y Force focus order in opened mobile menu

### DIFF
--- a/src/open_inwoner/js/components/header/header.js
+++ b/src/open_inwoner/js/components/header/header.js
@@ -69,6 +69,14 @@ class Header extends Component {
       )
     })
     window.scrollTo(0, 0)
+
+    // Focus on the first navigation item in opened mobile menu
+    const firstNavItem = document.querySelector(
+      '.primary-navigation__list-item .link'
+    )
+    if (firstNavItem) {
+      firstNavItem.focus()
+    }
   }
 
   /**


### PR DESCRIPTION
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2362

When opening mobile menu, focus should Tab/jump away from menu button and not hop to the logo or search field, but instead should jump to first navigation element.