### PR TITLE
[#2757] Add home view styling for registratiemelding notifications

### DIFF
--- a/src/open_inwoner/js/components/index.js
+++ b/src/open_inwoner/js/components/index.js
@@ -36,6 +36,7 @@ import './siteimprove/tracking'
 import './twofactor-sms'
 import { FileInput } from './form/FileInput'
 import { ToggleHide } from './card/ToggleHide'
+import './views'
 
 const htmx = (window.htmx = require('htmx.org'))
 

--- a/src/open_inwoner/js/components/notifications/index.js
+++ b/src/open_inwoner/js/components/notifications/index.js
@@ -93,6 +93,8 @@ export class Notification {
    */
   close() {
     this.node.parentElement.removeChild(this.node)
+    // Dispatch a custom event to notify other components that a notification has been closed
+    document.dispatchEvent(new CustomEvent('notificationClosed'))
   }
 
   /**

--- a/src/open_inwoner/js/components/views/home-view.js
+++ b/src/open_inwoner/js/components/views/home-view.js
@@ -1,0 +1,44 @@
+export class NotificationHandler {
+  static selector = '.view---pages-root'
+
+  constructor(root) {
+    this.root = root
+    this.notificationsSection = document.querySelector('.notification')
+
+    this.checkNotifications()
+
+    // Listen for the dispatch event from notifications
+    document.addEventListener(
+      'notificationClosed',
+      this.updateStyling.bind(this)
+    )
+  }
+
+  checkNotifications() {
+    if (
+      this.notificationsSection &&
+      this.notificationsSection.children.length > 0
+    ) {
+      this.root.classList.add('has-notifications')
+    }
+  }
+
+  /**
+   * Updates styling based on presence of the dispatch event
+   */
+  updateStyling() {
+    const notificationExists =
+      this.notificationsSection.querySelector('.notification')
+    if (!notificationExists) {
+      this.root.classList.remove('has-notifications')
+    }
+  }
+}
+
+/**
+ * Controls deviant styling of notifications in Homepage
+ */
+const rootElement = document.querySelector(NotificationHandler.selector)
+if (rootElement) {
+  new NotificationHandler(rootElement)
+}

--- a/src/open_inwoner/js/components/views/index.js
+++ b/src/open_inwoner/js/components/views/index.js
@@ -1,0 +1,2 @@
+// Handling exceptions in certain views
+import './home-view'

--- a/src/open_inwoner/scss/components/Grid/Grid.scss
+++ b/src/open_inwoner/scss/components/Grid/Grid.scss
@@ -90,7 +90,7 @@
   }
 
   &__welcome.plugin {
-    margin-top: -80px;
+    margin-top: -130px;
     background-color: var(--color-white);
     border-radius: var(--border-radius);
     padding: var(--spacing-large);
@@ -98,7 +98,6 @@
     width: 100%;
 
     @media (min-width: 768px) {
-      margin-top: -130px;
       width: 50%;
     }
   }

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -1,4 +1,30 @@
 .view {
+  &---pages-root {
+    &.has-notifications {
+      .notifications {
+        margin-top: -41px;
+        @media (min-width: 768px) {
+          margin-top: -32px;
+        }
+      }
+      .grid__welcome.plugin {
+        margin-top: -40px;
+        padding: 0;
+
+        @media (min-width: 768px) {
+          margin-top: -30px;
+        }
+      }
+    }
+    .container .button--icon-after {
+      padding-left: 0;
+
+      @media (min-width: 768px) {
+        padding-left: var(--spacing-large);
+      }
+    }
+  }
+
   &--accounts-contact_list {
     .form--horizontal {
       padding-top: var(--row-height);


### PR DESCRIPTION
userstory:  https://taiga.maykinmedia.nl/project/open-inwoner/us/2475

Figma design: https://www.figma.com/design/iKGhWhstaLIlFSaND2q7cE/OIP---Designs-(new)?t=h3bwJSSWV49cLKFB-0

Testing: 
Login and go to URL http://localhost:8000/accounts/register/ to see Notification

IF notification exists, margins and padding will change on Home page only: so the Welcome message drops lower and becomes readable again, also there is a difference between the margins on mobile and desktop:

<img width="904" alt="home-margins" src="https://github.com/user-attachments/assets/932f2349-2157-43e5-99f7-690e6bd5856e">


When the user closes the notification, 
styling should jump back to normal.

<img width="1191" alt="Screenshot 2024-11-14 at 13 50 26" src="https://github.com/user-attachments/assets/b7dbf063-0378-4549-936b-603c2dfdbaf0">
