### PR TITLE
Remove max-requests and add die-on-term uwsgi flag in docker

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -16,7 +16,6 @@ uwsgi_port=${UWSGI_PORT:-8000}
 uwsgi_processes=${UWSGI_PROCESSES:-4}
 uwsgi_threads=${UWSGI_THREADS:-8}
 uwsgi_http_timeout=${UWSGI_HTTP_TIMEOUT:-120}
-uwsgi_max_requests=${UWSGI_MAX_REQUESTS:-100}
 
 # Apply database migrations
 >&2 echo "Apply database migrations"
@@ -25,9 +24,9 @@ python src/manage.py migrate
 # Start server
 >&2 echo "Starting server"
 exec uwsgi \
+    --die-on-term \
     --http :$uwsgi_port \
     --http-keepalive \
-    --max-requests $uwsgi_max_requests \
     --http-timeout $uwsgi_http_timeout \
     --module open_inwoner.wsgi \
     --static-map /static=/app/static \


### PR DESCRIPTION
We've been seeing issues in k8s whereby the uwsgi pod would hang after 10 minutes and persist in a "Terminated" state. The theory is that the max_requests limit is reached, uwsgi tries to restart and k8s interprets this as a failing pod that needs to be replaced, but never is because k8s sends SIGTERM and uwsgi ignores this without the --die-on-term flag. This addresses both issues.

---

- [Kubernetes docs describing the pod termination process](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
- UWSGI explaining that `--die-on-term` is needed in analogous environments e.g. [Heroku](https://uwsgi-docs.readthedocs.io/en/latest/tutorials/heroku_python.html#creating-the-uwsgi-config-file), [Upstart](https://uwsgi-docs.readthedocs.io/en/latest/Upstart.html#what-is-die-on-term).
- [UWSGI docs on `--die-on-term`](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#die-on-term).