### PR TITLE
[#2946] Fix login for eHerkenning user with single vestiging

### DIFF
--- a/src/open_inwoner/templates/pages/kvk/branches.html
+++ b/src/open_inwoner/templates/pages/kvk/branches.html
@@ -13,7 +13,7 @@
 
                 <ul class="choice-list choice-list--single">
                     {# first only show option to select entire company in separate list-item #}
-                    <p><strong>{% trans "Log in namens alle vestigingen" %}</strong></p>
+                    <p><strong>{% trans "Log in namens rechtspersoon" %}</strong></p>
                     {% with entire_company=company_branches.0 %}
                         <li class="choice-list__item">
                             <label class="choice-list__label">


### PR DESCRIPTION
The KVK branch selection view should be displayed, and the vestigingsnummer of the company should be stored in the session, for companies that have only a single vestiging (i.e. a hoofdvestiging but no nevenvestiging).

We currently skip the KVK branch selection view for companies with a single vestiging. The reason for doing this was a problem with endless redirects caused by our middleware (see [https://taiga.maykinmedia.nl/project/open-inwoner/task/2000](https://taiga.maykinmedia.nl/project/open-inwoner/task/2000.)).

The issue now is that if a client logs in with a KVK nummer that has only one vestiging, the vestigingsnummer is not stored in the session. Consequently, any calls to APIS that make use of the KVK + vestigingsnummer will give the wrong results for this KVK number.

Reproducible with KVK number 90002490, which has only a hoofdvestiging.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/task/2946