### PR TITLE
[#2933] Run select tests sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-type: [main, elastic, openklant]
+        test-type: [main, elastic, openklant, sequential]
 
     services:
       postgres:
@@ -67,11 +67,14 @@ jobs:
               src/manage.py test src \
               --parallel \
               --exclude-tag=e2e \
-              --exclude-tag=elastic
+              --exclude-tag=elastic \
+              --exclude-tag=sequential
           elif [ "${{ matrix.test-type }}" = "elastic" ]; then
             coverage run -p src/manage.py test src --tag=elastic --exclude-tag=e2e
           elif [ "${{ matrix.test-type }}" = "openklant" ]; then
             coverage run -m pytest --block-network --record-mode=none -vvv src/openklant2
+          elif [ "${{ matrix.test-type }}" = "sequential" ]; then
+            coverage run -p src/manage.py test src --tag=sequential
           else
             echo "Error: Unknown test type '${{ matrix.test-type }}'"
             exit 1
@@ -113,6 +116,7 @@ jobs:
           mv coverages/main/.coverage* .
           mv coverages/elastic/.coverage* .
           mv coverages/openklant/.coverage* .
+          mv coverages/sequential/.coverage* .
           coverage combine
       - name: Publish coverage report
         uses: codecov/codecov-action@v3

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import user_logged_in
-from django.test import RequestFactory
+from django.test import RequestFactory, tag
 
 import requests_mock
 from django_webtest import WebTest
@@ -19,6 +19,7 @@ from open_inwoner.utils.test import (
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
 
 
+@tag("sequential")
 @requests_mock.Mocker()
 class UpdateUserFromLoginSignalAPITestCase(
     ClearCachesMixin, DisableRequestLogMixin, AssertTimelineLogMixin, WebTest


### PR DESCRIPTION
Certain tests fail intermittently in CI but pass consistently on local machines when run sequentially. The PR introduces a tag to collect these tests and run them on their own.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2933