### PR TITLE
[#2952] Wrap the zaak notification handler in a Celery task

### DIFF
--- a/src/open_inwoner/openzaak/api/views.py
+++ b/src/open_inwoner/openzaak/api/views.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 
 from rest_framework import status
@@ -10,7 +11,7 @@ from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.api_models import Notification
 from open_inwoner.openzaak.auth import get_valid_subscription_from_request
 from open_inwoner.openzaak.exceptions import InvalidAuth
-from open_inwoner.openzaak.notifications import handle_zaken_notification
+from open_inwoner.openzaak.tasks import process_zaken_notification
 from open_inwoner.utils.logentry import system_action as log_system_action
 
 logger = logging.getLogger(__name__)
@@ -95,4 +96,6 @@ class ZakenNotificationsWebhookView(NotificationsWebhookBaseView):
         config = SiteConfiguration.get_solo()
         if not config.notifications_cases_enabled:
             return
-        handle_zaken_notification(notification)
+
+        notification_data = dataclasses.asdict(notification)
+        process_zaken_notification.delay(notification_data)

--- a/src/open_inwoner/openzaak/models.py
+++ b/src/open_inwoner/openzaak/models.py
@@ -424,7 +424,6 @@ class OpenZaakConfig(SingletonModel):
         ),
         default=False,
     )
-
     order_statuses_by_date_set = models.BooleanField(
         verbose_name=_(
             "On the detail page of the case, order the statuses based on the date they have been set"

--- a/src/open_inwoner/openzaak/tasks.py
+++ b/src/open_inwoner/openzaak/tasks.py
@@ -3,7 +3,11 @@ import logging
 
 from django.core.management import call_command
 
+from zgw_consumers.api_models.base import factory
+
 from open_inwoner.celery import app
+from open_inwoner.openzaak.api_models import Notification
+from open_inwoner.openzaak.notifications import handle_zaken_notification
 
 logger = logging.getLogger(__name__)
 
@@ -19,3 +23,10 @@ def import_zgw_data():
     logger.info("finished import_zgw_data() task")
 
     return out.getvalue()
+
+
+@app.task
+def process_zaken_notification(notification_data: dict):
+    logger.info("Started process_zaken_notification() task")
+    notification = factory(Notification, notification_data)
+    handle_zaken_notification(notification)

--- a/src/open_inwoner/openzaak/tests/test_notification_webhook.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_webhook.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse_lazy
 
 from rest_framework import status
@@ -38,6 +38,7 @@ def generate_auth_header_value(client_id, secret):
     return auth_value
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
 class NotificationSubscriptionAuthTest(TestCase):
     def test_valid_auth_retrieves_subscription(self):
         subscription = SubscriptionFactory(client_id="foo", secret="password")
@@ -76,7 +77,8 @@ class NotificationSubscriptionAuthTest(TestCase):
             get_valid_subscriptions_from_bearer(auth_value)
 
 
-@patch("open_inwoner.openzaak.api.views.handle_zaken_notification", autospec=True)
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
+@patch("open_inwoner.openzaak.tasks.handle_zaken_notification", autospec=True)
 class NotificationWebhookAPITestCase(AssertTimelineLogMixin, APITestCase):
     """
     NOTE these tests run against the mounted zaken webhook (eg: ZakenNotificationsWebhookView),

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
@@ -29,6 +29,7 @@ from .helpers import copy_with_new_uuid
 from .test_notification_data import MockAPIData, MockAPIDataAlt
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)
 @requests_mock.Mocker()
 @patch("open_inwoner.openzaak.notifications._handle_status_update", autospec=True)
 class StatusNotificationHandlerTestCase(


### PR DESCRIPTION
[Taiga](https://taiga.maykinmedia.nl/project/open-inwoner/us/2952).