### PR TITLE
Enable Mock DigiD IDP callback validation in production

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -190,7 +190,7 @@ django-csp==3.7
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning[oidc]==0.16.0
+django-digid-eherkenning[oidc]==0.19.2
     # via -r requirements/base.in
 django-elasticsearch-dsl==7.4
     # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,6 @@ celery-once==3.0.1
     # via -r requirements/base.in
 certifi==2023.11.17
     # via
-    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   requests
@@ -261,7 +260,7 @@ django-setup-configuration==0.5.0
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db
-django-simple-certmanager==1.4.1
+django-simple-certmanager==2.4.1
     # via
     #   django-digid-eherkenning
     #   zgw-consumers
@@ -466,7 +465,6 @@ pyjwt==2.8.0
 pyopenssl==24.0.0
     # via
     #   -r requirements/base.in
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
 pyphen==0.12.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -92,7 +92,6 @@ certifi==2023.11.17
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   requests
@@ -444,7 +443,7 @@ django-setup-configuration==0.5.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-django-simple-certmanager==1.4.1
+django-simple-certmanager==2.4.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -890,7 +889,6 @@ pyopenssl==24.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   -r requirements/test-tools.in
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
 pyphen==0.12.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -314,7 +314,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning[oidc]==0.16.0
+django-digid-eherkenning[oidc]==0.19.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -114,7 +114,6 @@ certifi==2023.11.17
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-simple-certmanager
     #   elastic-apm
     #   elasticsearch
     #   geventhttpclient
@@ -490,7 +489,7 @@ django-setup-configuration==0.5.0
     #   mozilla-django-oidc-db
 django-silk==5.1.0
     # via -r requirements/dev.in
-django-simple-certmanager==1.4.1
+django-simple-certmanager==2.4.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1030,7 +1029,6 @@ pyopenssl==24.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
 pyphen==0.12.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -356,7 +356,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-digid-eherkenning[oidc]==0.16.0
+django-digid-eherkenning[oidc]==0.19.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
[Taiga](https://taiga.maykinmedia.nl/project/open-inwoner/task/2961).

Note that the version bump of `django-digid-eherkenning` is sufficient: the validation flag is set to the inverse of `DEBUG`, so on public facing instances, callbacks should be validated as the debug flag won't be set.