### PR TITLE
Add ruff to the code quality checkers

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -94,8 +94,7 @@ jobs:
         ports:
           - 5432:5432
         # Needed because the postgres container does not provide a healthcheck
-        options:
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v3
@@ -135,6 +134,43 @@ jobs:
       - name: Run Prettier
         run: |
           npm run check-linting
+
+  ruff:
+    name: Lint code with ruff
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to get all history for comparing changes
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      # This is mostly to have an convenient location to check how far away we are from
+      # 100% compliance for the whole codebase. The -e flag ensures it'll always return
+      # 0.
+      - name: Run ruff on all files
+        run: ruff check -e --output-format=github .
+      # Run ruff with a non-zero exit code on the changed files
+      - name: Run ruff on changed files
+        run: |
+          # Get changed Python files only
+          CHANGED_FILES=$(git diff --name-only origin/${GITHUB_BASE_REF}...HEAD | grep '\.py$' || true)
+
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Changed Python files:"
+            echo "$CHANGED_FILES"
+            echo "Running Ruff on changed files..."
+            echo "$CHANGED_FILES" | xargs ruff check --output-format=github
+          else
+            echo "No Python files changed"
+          fi
+
   bandit:
     name: Python security check using Bandit
     runs-on: ubuntu-latest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,81 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "env",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[lint]
+select = [
+    # https://docs.astral.sh/ruff/rules/#error-e
+    "E",
+    # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "F",
+    # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "B",
+    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
+    "ISC",
+    # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "C4",
+    # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
+    "SIM",
+]
+ignore = [
+    # Whitespace before ':' (conflicts with Black)
+    "E203",
+    # Two spaces before inline comment
+    "E261",
+    # Line too long
+    "E501",
+    # Do not assign a lambda expression
+    "E731",
+    # Name may be undefined from '*' import
+    "F405",
+    # Blank line contains whitespace
+    "W293",
+    # Trailing whitespace
+    "W291",
+    # Local variable is assigned but never used
+    "F841",
+    # Ambiguous variable name
+    "E741",
+]
+
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/src/open_inwoner/configurations/bootstrap/utils.py
+++ b/src/open_inwoner/configurations/bootstrap/utils.py
@@ -27,6 +27,7 @@ def get_service(slug: str) -> Service:
     easier
     """
     try:
+        # Trick ruff into validating this file.
         return Service.objects.get(slug=slug)
     except Service.DoesNotExist as e:
         raise Service.DoesNotExist(f"{str(e)} (identifier = {slug})")


### PR DESCRIPTION
This introduces ruff to the CI in two flavours:

1. A full repo run, which will not fail the pipeline on errors but serves as a convenient check of progress to 100% on legacy code.
2. A run purely on changed files for a PR, to ensure that new code is ruff compliant.