### PR TITLE
:wheelchair: [#2955] A11y: Remove B-tags if they are used for styling

### DIFF
--- a/src/open_inwoner/scss/components/Contactmomenten/Contactmomenten.scss
+++ b/src/open_inwoner/scss/components/Contactmomenten/Contactmomenten.scss
@@ -75,10 +75,6 @@
 .contactmoment {
   &__heading {
     margin: 0 0 var(--spacing-large) 0;
-    line-height: var(--font-line-height-heading-3);
-    font-family: var(--font-family-heading);
-    font-size: var(--font-size-heading-3);
-    font-weight: var(--font-weight-heading-3);
   }
 
   &__text {

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -30,7 +30,7 @@
 <div class="card__grid">
 {% render_grid %}
     {% if not cases %}
-        <b>{% trans "U heeft op dit moment nog geen lopende aanvragen." %}</b>
+        <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen lopende aanvragen." %}</strong></p>
     {% endif %}
 
     {% for case in cases %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -93,6 +93,6 @@
         {% endrender_column %}
     {% endrender_grid %}
 {% else %}
-    <h2 class="utrecht-heading-2">{% trans 'There is no available data at the moment.' %}</h2>
+    <p class="utrecht-paragraph"><strong>{% trans 'There is no available data at the moment.' %}</strong></p>
 {% endif %}
 </div>

--- a/src/open_inwoner/templates/pages/contactmoment/detail.html
+++ b/src/open_inwoner/templates/pages/contactmoment/detail.html
@@ -14,11 +14,11 @@
             {% render_column start=4 span=6 %}
                 <section class="contactmoment">
                     <div>
-                        <h2 class="contactmoment__heading">{% trans "Uw vraag" %}</h2>
+                        <h2 class="utrecht-heading-3 contactmoment__heading">{% trans "Uw vraag" %}</h2>
                         <p class="contactmoment__text">{{ question.question_text }}</p>
                     </div>
                     <div>
-                        <h2 class="contactmoment__heading">{% trans "Antwoord" %}</h2>
+                        <h2 class="utrecht-heading-3 contactmoment__heading">{% trans "Antwoord" %}</h2>
                         {% if question.answer_text %}
                             <p class="contactmoment__text">{{ question.answer_text }}</p>
                         {% else %}
@@ -42,6 +42,6 @@
         {% endrender_grid %}
 
     {% else %}
-        <h2 class="utrecht-heading-2">{% trans 'There is no available data at the moment.' %}</h2>
+        <p class="utrecht-paragraph"><strong>{% trans 'There is no available data at the moment.' %}</strong></p>
     {% endif %}
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -29,7 +29,7 @@
         {% if questions %}
             <h2 class="contactmomenten__title">{% trans "Eerder gestelde vragen" %}</h2>
         {% else %}
-            <h2>{% trans "U heeft op dit moment nog geen vragen." %}</h2>
+            <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></p>
         {% endif %}
 
         {% render_grid %}

--- a/src/open_inwoner/templates/pages/profile/appointments.html
+++ b/src/open_inwoner/templates/pages/profile/appointments.html
@@ -39,7 +39,7 @@
     {% endrender_grid %}
     </div>
 {% else %}
-    <p class="tabled__key">{% trans "Geen afspraken beschikbaar" %}</p>
+    <p class="utrecht-paragraph"><strong>{% trans "Geen afspraken beschikbaar" %}</strong></p>
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
`B`-tags should not be used lightly, usually these need to be replaced with a `STRONG` tag or a correct styling class, since B has no meaning and is only a visual tag (but we should use CSS for that). 
`Strong` has emphasis in meaning and tone, which is useful to (for example) notify the user there is no data available.
Screen-reader software responds differently to `B`-tags and Strong tags so they are more than just a 'style'.
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/2955

Also: it is NOT allowed to use `H2` headings if that heading has no paragraph and doesn't actually summarize any content - for accessibility software Headings have a specific meaning and are read out loud as a list with nested hierarchy.

So: if there is data, then it is fine to use the `H2`, but if there isn't, it should be a paragraph.

Additionally we should aim to always use the NLDS classes for headings, so municipalities can overwrite these with their own tokens.

The Heading hierarchy should be correct for accessibility, and it is perfectly acceptable to use the H3 CSS style for an H2 heading, as long as the HTML structure stays correct.