### PR TITLE
Add system logging for company branch selection

### DIFF
--- a/src/open_inwoner/kvk/views.py
+++ b/src/open_inwoner/kvk/views.py
@@ -97,6 +97,16 @@ class CompanyBranchChoiceView(LogMixin, FormView):
 
         # empty string for KVK_BRANCH_SESSION_VARIABLE is interpreted as
         # "interact as the rechtspersoon, not as any specific branch"
-        request.session[KVK_BRANCH_SESSION_VARIABLE] = request.POST["branch_number"]
+        branch_number = request.POST["branch_number"]
+        request.session[KVK_BRANCH_SESSION_VARIABLE] = branch_number
+        self.log_user_action(
+            request.user,
+            (
+                "Selected branch %s of rechtspersoon %s"
+                % (branch_number, request.user.kvk)
+                if branch_number
+                else "Selected rechtspersoon %s" % request.user.kvk
+            ),
+        )
 
         return HttpResponseRedirect(redirect)


### PR DESCRIPTION
Small logging addition which came in useful while verifying whether the branch selection could be re-initiated in the same session (it can, might be a future feature to make that user-accessible if it is up to Zwolle).