### PR TITLE
[#2967] Fix verification email not sent

### DIFF
--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -245,12 +245,12 @@ class EmailVerificationUserView(LogMixin, LoginRequiredMixin, TemplateView):
                 get_next_url_from(self.request, default=reverse("pages-root"))
             )
 
-        # send verification email immediately on requesting page, but only once
-        if not request.session.get("verification_email_sent"):
+        # send verification email immediately on requesting page
+        if request.session.get("verification_email_sent_to") != user.email:
             send_user_email_verification_mail(
                 user, next_url=get_next_url_from(self.request, default="")
             )
-            request.session["verification_email_sent"] = True
+            request.session["verification_email_sent_to"] = user.email
 
         return super().get(request, *args, **kwargs)
 

--- a/src/open_inwoner/mail/tests/test_verification.py
+++ b/src/open_inwoner/mail/tests/test_verification.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.core import mail
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from django_webtest import WebTest
@@ -11,6 +11,7 @@ from furl.furl import furl
 from pyquery.pyquery import PyQuery
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.accounts.views.registration import EmailVerificationUserView
 from open_inwoner.cms.profile.cms_apps import ProfileApphook
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
@@ -322,3 +323,34 @@ class TestMailVerificationMiddlewareFlow(WebTest):
 
         # email sent after submitting form
         mock_send.assert_called_once_with(user, target_url)
+
+    @patch(
+        "open_inwoner.accounts.views.registration.send_user_email_verification_mail",
+        autospec=True,
+    )
+    def test_verification_email_dupes(self, mock_send):
+        request_factory = RequestFactory()
+        user = UserFactory(email="foo@example.com")
+
+        request = request_factory.get("/")
+        request.session = {}
+        request.user = user
+
+        view = EmailVerificationUserView.as_view()
+
+        # two requests with the same email: one call
+        view(request)
+        view(request)
+
+        mock_send.assert_called_once_with(user, next_url="")
+
+        # request with changed email: two calls
+        user.email = "changed@example.com"
+        view(request)
+
+        self.assertEqual(len(mock_send.call_args_list), 2)
+
+        # still two calls
+        view(request)
+
+        self.assertEqual(len(mock_send.call_args_list), 2)


### PR DESCRIPTION
 The verification email flow was previously changed to account for duplicate emails sent during registration or profile edits. This had the effect that emails were *not* automatically sent at all when the user changed their email again.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2967