### PR TITLE
:lipstick: [#3017] Desktop design for search results

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -891,6 +891,8 @@ ES_INDEX_PRODUCTS = config("ES_INDEX_PRODUCTS", "products")
 ES_MAX_SIZE = 10000
 ES_SUGGEST_SIZE = 5
 
+# Search page pagination trigger
+RESULTS_PER_PAGE = config("RESULTS_PER_PAGE", default=9)
 
 # django import-export
 IMPORT_EXPORT_USE_TRANSACTIONS = True

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -141,11 +141,11 @@
     position: relative;
     color: var(--color-primary);
     filter: saturate(50%);
-    border-radius: 100px; // This is big to make sure the corners are rounded properly.
+    border-radius: var(--border-radius-rounded);
 
     &:before {
       content: ' ';
-      border-radius: 100px; // This is big to make sure the corners are rounded properly.
+      border-radius: var(--border-radius-rounded);
       position: absolute;
       top: 0;
       bottom: 0;

--- a/src/open_inwoner/scss/components/Form/ChoiceList.scss
+++ b/src/open_inwoner/scss/components/Form/ChoiceList.scss
@@ -114,7 +114,7 @@
     width: var(--font-line-height-body-small);
     height: var(--font-line-height-body-small);
     border: var(--border-width) solid var(--color-gray-dark);
-    border-radius: 100%;
+    border-radius: var(--border-radius-rounded);
     background-color: var(--color-white);
   }
 

--- a/src/open_inwoner/scss/components/Form/Radio.scss
+++ b/src/open_inwoner/scss/components/Form/Radio.scss
@@ -32,7 +32,7 @@
       width: var(--font-line-height-body-small);
       height: var(--font-line-height-body-small);
       border: var(--border-width) solid var(--color-gray-dark);
-      border-radius: 100%;
+      border-radius: var(--border-radius-rounded);
       background-color: var(--color-white);
     }
   }

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -51,7 +51,7 @@ $vm: var(--spacing-large);
       width: 6px;
       display: inline-block;
       border: 2px solid white;
-      border-radius: 100px; // This is big to make sure the corners are rounded properly.
+      border-radius: var(--border-radius-rounded);
     }
   }
 

--- a/src/open_inwoner/scss/components/Pagination/Pagination.scss
+++ b/src/open_inwoner/scss/components/Pagination/Pagination.scss
@@ -28,7 +28,7 @@
     &--active {
       color: var(--color-white);
       background-color: var(--color-primary);
-      border-radius: 100px;
+      border-radius: var(--border-radius-rounded);
 
       &:hover {
         background-color: var(--color-body);

--- a/src/open_inwoner/scss/components/Pagination/Pagination.scss
+++ b/src/open_inwoner/scss/components/Pagination/Pagination.scss
@@ -26,22 +26,12 @@
     text-decoration: none;
 
     &--active {
-      color: var(--color-primary);
-
-      &:before {
-        background-color: var(--color-primary);
-        border-radius: 100px;
-        bottom: 0;
-        content: ' ';
-        left: 0;
-        opacity: 0.15;
-        position: absolute;
-        right: 0;
-        top: 0;
-      }
+      color: var(--color-white);
+      background-color: var(--color-primary);
+      border-radius: 100px;
 
       &:hover {
-        color: var(--color-body);
+        background-color: var(--color-body);
       }
     }
 

--- a/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
+++ b/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
@@ -5,20 +5,14 @@
     gap: var(--spacing-large);
   }
 
-  &__title {
-    margin: var(--spacing-giant) 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
   &__title-small {
-    color: var(--color-black);
+    color: var(--color-body);
     font-family: var(--font-family-body);
     font-size: var(--font-size-body);
     letter-spacing: 0;
     line-height: var(--font-line-height-body);
     font-weight: normal;
+    margin: var(--spacing-extra-large) 0 var(--row-height-giant) 0;
   }
 
   &__item {
@@ -29,14 +23,8 @@
     line-height: var(--font-line-height-body);
     text-decoration: none;
 
-    .utrecht-heading-3 {
+    .utrecht-heading-3.search-results__item-title {
       margin: 0 0 var(--spacing-large) 0;
-    }
-
-    &:has(.tag) {
-      .utrecht-heading-3 {
-        margin: var(--spacing-medium) 0 var(--spacing-large) 0;
-      }
     }
 
     .utrecht-paragraph {
@@ -44,31 +32,32 @@
     }
   }
 
-  .card__heading-2 {
-    margin-top: var(--spacing-medium);
-    margin-bottom: var(--card-spacing);
-  }
-
   .link {
     padding-top: var(--card-spacing);
   }
 
-  .tag-lists {
-    &:has(.tag) {
-      margin-top: calc(-1 * var(--spacing-large));
-    }
-  }
+  &--none {
+    display: flex;
+    border-radius: var(--border-radius);
+    background-color: var(--color-info-lighter);
+    color: var(--color-info-darker);
+    margin-top: var(--row-height);
 
-  .tag-list {
-    display: inline-block;
-    margin-top: 0;
+    &-column {
+      padding: var(--spacing-extra-large) 0 var(--spacing-extra-large)
+        var(--spacing-extra-large);
 
-    &__list {
-      display: inline-block;
+      .search-results__title {
+        color: var(--color-info-darker);
+        margin: 0;
+      }
+      .utrecht-paragraph,
+      .ul .li {
+        color: var(--color-info-darker);
+      }
 
-      &-item {
-        display: inline-block;
-        margin-top: var(--spacing-large);
+      *[class*='icons'] {
+        margin-top: var(--spacing-small);
       }
     }
   }

--- a/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
+++ b/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
@@ -28,38 +28,48 @@
     letter-spacing: 0;
     line-height: var(--font-line-height-body);
     text-decoration: none;
+
+    .utrecht-heading-3 {
+      margin: 0 0 var(--spacing-large) 0;
+    }
+
+    &:has(.tag) {
+      .utrecht-heading-3 {
+        margin: var(--spacing-medium) 0 var(--spacing-large) 0;
+      }
+    }
+
+    .utrecht-paragraph {
+      margin: 0;
+    }
   }
 
-  &__item-title {
-    font-size: var(--utrecht-heading-3-font-size);
-    line-height: var(--utrecht-heading-3-line-height);
-    letter-spacing: 0;
-    margin: 0 0 6px;
+  .card__heading-2 {
+    margin-top: var(--spacing-medium);
+    margin-bottom: var(--card-spacing);
   }
 
-  &__item-info-container {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: var(--spacing-large);
-    align-items: end;
+  .link {
+    padding-top: var(--card-spacing);
   }
 
-  &__item-intro {
-    color: var(--color-black);
-    font-family: var(--font-family-body);
-    font-size: var(--font-size-body);
-    letter-spacing: 0;
-    line-height: var(--font-line-height-body);
-    margin: 0;
+  .tag-lists {
+    &:has(.tag) {
+      margin-top: calc(-1 * var(--spacing-large));
+    }
   }
 
-  &__item-type {
-    color: var(--color-black);
-    font-family: var(--font-family-body);
-    font-size: var(--font-size-body);
-    letter-spacing: 0;
-    line-height: var(--font-line-height-body);
-    text-align: right;
-    margin: 0;
+  .tag-list {
+    display: inline-block;
+    margin-top: 0;
+
+    &__list {
+      display: inline-block;
+
+      &-item {
+        display: inline-block;
+        margin-top: var(--spacing-large);
+      }
+    }
   }
 }

--- a/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
+++ b/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
@@ -3,6 +3,10 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-large);
+
+    .grid {
+      gap: var(--spacing-large);
+    }
   }
 
   &__title-small {
@@ -12,7 +16,7 @@
     letter-spacing: 0;
     line-height: var(--font-line-height-body);
     font-weight: normal;
-    margin: var(--spacing-extra-large) 0 var(--row-height-giant) 0;
+    margin: var(--spacing-extra-large) 0 var(--row-height) 0;
   }
 
   &__item {
@@ -36,21 +40,28 @@
     padding-top: var(--card-spacing);
   }
 
-  &--none {
+  &--no-results {
     display: flex;
+    flex-direction: column;
     border-radius: var(--border-radius);
     background-color: var(--color-info-lighter);
     color: var(--color-info-darker);
-    margin-top: var(--row-height);
 
     &-column {
-      padding: var(--spacing-extra-large) 0 var(--spacing-extra-large)
+      padding: var(--spacing-extra-large) var(--spacing-extra-large) 0
         var(--spacing-extra-large);
 
       .search-results__title {
         color: var(--color-info-darker);
         margin: 0;
       }
+
+      .ul {
+        margin-block-start: var(--spacing-giant);
+        margin-inline-start: 11px;
+        padding-inline-start: 0;
+      }
+
       .utrecht-paragraph,
       .ul .li {
         color: var(--color-info-darker);
@@ -59,6 +70,24 @@
       *[class*='icons'] {
         margin-top: var(--spacing-small);
       }
+
+      &:first-child {
+        @media (min-width: 768px) {
+          padding: var(--spacing-extra-large) 0 var(--spacing-extra-large)
+            var(--spacing-extra-large);
+        }
+      }
+
+      &:last-child {
+        padding-top: var(--spacing-medium);
+        @media (min-width: 768px) {
+          padding-top: var(--spacing-extra-large);
+        }
+      }
+    }
+
+    @media (min-width: 768px) {
+      flex-direction: row;
     }
   }
 }

--- a/src/open_inwoner/scss/components/Status/_StatusList.scss
+++ b/src/open_inwoner/scss/components/Status/_StatusList.scss
@@ -86,7 +86,7 @@
       &::before {
         content: '';
         background-color: var(--color-white);
-        border-radius: 50%;
+        border-radius: var(--border-radius-rounded);
         top: 2px;
         left: 2px;
         height: 20px;

--- a/src/open_inwoner/scss/components/Step/_StepIndicator.scss
+++ b/src/open_inwoner/scss/components/Step/_StepIndicator.scss
@@ -39,7 +39,7 @@
   &__list-item:before {
     align-items: center;
     border: var(--border-width) solid var(--color-gray-dark);
-    border-radius: 100%;
+    border-radius: var(--border-radius-rounded);
     content: counter(step-indicator-list-counter);
     display: flex;
     flex-shrink: 0;

--- a/src/open_inwoner/scss/components/Tags/Tag.scss
+++ b/src/open_inwoner/scss/components/Tags/Tag.scss
@@ -1,5 +1,5 @@
 .tag {
-  border-radius: 100px; // This is big to make sure the corners are rounded properly.
+  border-radius: var(--border-radius-rounded);
   background-color: var(--color-info-lightest);
   color: var(--color-info-darker);
   font-family: var(--font-family-body);

--- a/src/open_inwoner/scss/components/Tags/Tag.scss
+++ b/src/open_inwoner/scss/components/Tags/Tag.scss
@@ -1,7 +1,7 @@
 .tag {
-  border-radius: var(--border-radius);
-  background-color: var(--color-gray-light);
-  color: var(--font-color-body);
+  border-radius: 100px; // This is big to make sure the corners are rounded properly.
+  background-color: var(--color-info-lightest);
+  color: var(--color-info-darker);
   font-family: var(--font-family-body);
   font-size: var(--font-size-body-small);
   line-height: var(--font-line-height-body-small);

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -161,6 +161,7 @@
     var(--color-info-s),
     calc(var(--color-info-l) + 10%)
   );
+  --color-info-lightest: hsl(210, 70%, 96%);
   --color-info-darker: hsl(
     var(--color-info-h),
     var(--color-info-s),

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -22,6 +22,7 @@
   --border-width-thin: 1px;
   --border-radius: 3px;
   --border-radius-large: 8px;
+  --border-radius-rounded: 999px;
 
   // Color.
 

--- a/src/open_inwoner/search/results.py
+++ b/src/open_inwoner/search/results.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from dataclasses import dataclass
-from operator import attrgetter
 from typing import Type
 
 from django.db import models
@@ -80,12 +79,6 @@ class Facet:
 
     def choices(self) -> list:
         return [(b.slug, b.label) for b in self.buckets]
-
-    def total_choices(self) -> list:
-        return [
-            (b.slug, b.label)
-            for b in sorted(self.total_buckets, key=attrgetter("slug"))
-        ]
 
 
 @dataclass()

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -230,7 +230,7 @@ class SearchPagePlaywrightTests(
         # search to find both products
         page.goto(self.live_reverse("search:search", params={"query": "summary"}))
         page.wait_for_url(self.live_reverse("search:search", star=True))
-        expect(page.locator(".search-results__item")).to_have_count(2)
+        expect(page.locator(".card")).to_have_count(2)
 
     def test_search_form_delegates_copy_query_value(self):
         context = self.browser.new_context()
@@ -270,11 +270,11 @@ class SearchPagePlaywrightTests(
 
                 # search from this page
                 _do_search("summary", form_id, open_menu)
-                expect(page.locator(".search-results__item")).to_have_count(2)
+                expect(page.locator(".card")).to_have_count(2)
 
                 # perform another search from the search results page
                 _do_search("other", form_id, open_menu)
-                expect(page.locator(".search-results__item")).to_have_count(1)
+                expect(page.locator(".card")).to_have_count(1)
 
                 page.close()
                 context.close()

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import override_settings, tag
 from django.urls import reverse_lazy
 
@@ -110,7 +111,9 @@ class SearchPageTests(ClearCachesMixin, ESMixin, WebTest):
         self.assertEqual(results[0].slug, self.product1.slug)
 
     def test_pagination_links(self):
-        products = ProductFactory.create_batch(9, content="content")
+        products = ProductFactory.create_batch(
+            settings.RESULTS_PER_PAGE, content="content"
+        )
         self.tag.products.add(*products)
         self.update_index()
 
@@ -119,7 +122,7 @@ class SearchPageTests(ClearCachesMixin, ESMixin, WebTest):
         self.assertEqual(response.status_code, 200)
 
         results = response.context["paginator"].object_list
-        self.assertEqual(len(results), 10)
+        self.assertEqual(len(results), settings.RESULTS_PER_PAGE + 1)
 
         pagination_div = response.html.find("div", {"class": "pagination"})
         pagination_links = pagination_div.find_all("a")

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -110,7 +110,7 @@ class SearchPageTests(ClearCachesMixin, ESMixin, WebTest):
         self.assertEqual(results[0].slug, self.product1.slug)
 
     def test_pagination_links(self):
-        products = ProductFactory.create_batch(20, content="content")
+        products = ProductFactory.create_batch(9, content="content")
         self.tag.products.add(*products)
         self.update_index()
 
@@ -119,7 +119,7 @@ class SearchPageTests(ClearCachesMixin, ESMixin, WebTest):
         self.assertEqual(response.status_code, 200)
 
         results = response.context["paginator"].object_list
-        self.assertEqual(len(results), 21)
+        self.assertEqual(len(results), 10)
 
         pagination_div = response.html.find("div", {"class": "pagination"})
         pagination_links = pagination_div.find_all("a")

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -28,7 +28,7 @@ class SearchView(
 ):
     form_class = SearchForm
     template_name = "pages/search.html"
-    paginate_by = 20
+    paginate_by = 9
     paginator_class = Paginator
     page_kwarg = "page"
     success_url = reverse_lazy("search:search")
@@ -114,7 +114,7 @@ class SearchView(
         # update form fields with choices
         for facet in results.facets:
             if facet.name in form.fields:
-                form.fields[facet.name].choices = facet.total_choices()
+                form.fields[facet.name].choices = facet.choices()
 
         # paginate
         paginator_dict = self.paginate_with_context(results.results)

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404
@@ -28,7 +29,7 @@ class SearchView(
 ):
     form_class = SearchForm
     template_name = "pages/search.html"
-    paginate_by = 9
+    paginate_by = settings.RESULTS_PER_PAGE
     paginator_class = Paginator
     page_kwarg = "page"
     success_url = reverse_lazy("search:search")

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -4,17 +4,18 @@
 {% block main_inner %}
     {#  search term section #}
     <div class="grid">
-        <div class="grid__sidebar">&nbsp;</div>
         <div class="grid__main">
-            <h1 class="utrecht-heading-1">{% trans "Zoeken naar " %} "{% firstof search_form.query.value "" %}"</h1>
+            <h1 class="utrecht-heading-1">{% trans "Zoekresultaten voor " %} "{% firstof search_form.query.value "" %}"</h1>
+            <p class="search-results__title-small">{{ paginator.count }} {% trans "resultaten" %} </p>
         </div>
     </div>
 
     {#  facets and results section #}
     <div class="grid">
-        <aside class="grid__sidebar grid__filters" aria-label="{% trans "Zoekfilters" %}">
+    {% if paginator.count %}
         {% if search_filter_categories or search_filter_tags or search_filter_organizations %}
-            <h2 class="utrecht-heading-2">{% trans "Zoekfilters" %}</h2>
+            <aside class="grid__sidebar grid__filters" aria-label="{% trans "Zoekfilters" %}">
+                <h2 class="utrecht-heading-2">{% trans "Zoekfilters" %}</h2>
                 {% if search_filter_categories %}
                     {% include "components/Filter/Filter.html" with field=search_form.categories form_id="search-form" only %}
                 {% endif %}
@@ -24,41 +25,29 @@
                 {% if search_filter_organizations %}
                     {% include "components/Filter/Filter.html" with field=search_form.organizations form_id="search-form" only %}
                 {% endif %}
-        {%  endif %}
+            </aside>
+        {% endif %}
         {#  end search filters #}
-        </aside>
+    {% endif %}
 
         <div class="grid__main grid__main--search">
             {% if paginator.count %}
                 <div class="search-results">
-                    <h2 class="utrecht-heading-2 search-results__title">
-                        {% trans "Zoekresultaten" %}
-                        <span class="search-results__title-small">{{ paginator.count }} zoekresultaten</span>
-                    </h2>
                     <div class="search-results__list">
-
                         <div class="card__grid">
                             {% render_grid %}
-
                                 {% for hit in page_obj %}
                                     {% render_column start=0 span=12 %}
-
                                         <a href="{% url 'products:product_detail' hit.slug %}" class="card card__description-card search-results__item">
                                             <div class="card__body">
-                                                <div class="tag-lists">
-                                                    {% include "components/Tag/Tag.html" with tags=hit.categories only %}
-                                                    {% include "components/Tag/Tag.html" with tags=hit.tags only %}
-                                                    {% include "components/Tag/Tag.html" with tags=hit.organizations only %}
-                                                </div>
                                                 <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>
                                                 <p class="utrecht-paragraph search-results__item-intro">{{ hit.summary }}</p>
                                                 <span class="link link--icon link--primary">
-                                                <span class="link__text">Bekijk {{ hit.name }}</span>
+                                                <span class="link__text">Bekijk resultaat</span>
                                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                             </span>
                                             </div>
                                         </a>
-
                                     {% endrender_column %}
                                 {% endfor %}
                             {% endrender_grid %}
@@ -99,22 +88,26 @@
                 {% endif %}
 
             {% else %}
-                <div class="search-results search-results--none">
-                    <h2 class="utrecht-heading-2 search-results__title">
-                        {% trans "Geen zoekresultaten" %}
-                    </h2>
-                    <p class="utrecht-paragraph">{% trans "Helaas, wij vonden geen resultaten voor jouw zoekopdracht." %}</p>
-                </div>
-                <ul class="ul">
-                   <li class="li">{% trans "Controleer de spelling van je zoekopdracht." %}</li>
-                   <li class="li">{% trans "Probeer een andere zoekopdracht." %}</li>
-                   <li class="li">{% trans "Vragen? Neem contact met ons op." %}</li>
-                </ul>
 
-                <div class="search-results search-suggestions">
-                    <h2 class="utrecht-heading-2">{% trans "Misschien bedoelt u:" %}</h2>
-                    <a class="link link--secondary" href="#">alt</a> <a class="link link--secondary" href="#">placeholder</a> <a class="link link--secondary" href="#">suggesties</a>
-                </div>
+                {% render_grid %}
+                    {% render_column start=0 span=10 %}
+                        <div class="search-results search-results--none">
+                            <div class="search-results--none-column">{% icon icon="info" icon_position="before" extra_classes="icon--info" outlined=True %}</div>
+                            <div class="search-results--none-column">
+                                <h2 class="utrecht-heading-2 search-results__title">
+                                    {% trans "We konden geen zoekresultaten vinden" %}
+                                </h2>
+                                <p class="utrecht-paragraph">{% trans "Probeer het nog eens met deze tips:" %}</p>
+
+                                <ul class="ul">
+                                    <li class="li">{% trans "Zorg ervoor dat alle woorden goed gespeld zijn." %}</li>
+                                    <li class="li">{% trans "Probeer andere zoektermen." %}</li>
+                                    <li class="li">{% trans "Maak de zoektermen algemener." %}</li>
+                                </ul>
+                            </div>
+                        </div>
+                    {% endrender_column %}
+                {% endrender_grid %}
             {% endif %}
         </div>
     </div>

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n form_tags utils icon_tags pagination_tags %}
+{% load i18n form_tags utils icon_tags grid_tags pagination_tags %}
 
 {% block main_inner %}
     {#  search term section #}
@@ -33,17 +33,37 @@
                 <div class="search-results">
                     <h2 class="utrecht-heading-2 search-results__title">
                         {% trans "Zoekresultaten" %}
-                        <span class="search-results__title-small">{{paginator.count}} zoekresultaten</span>
+                        <span class="search-results__title-small">{{ paginator.count }} zoekresultaten</span>
                     </h2>
                     <div class="search-results__list">
-                        {% for hit in page_obj %}
-                            <a class="search-results__item" href="{% url 'products:product_detail' hit.slug %}">
-                                <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>
-                                <div class="search-results__item-info-container">
-                                    <p class="search-results__item-intro">{{ hit.summary }}</p>
-                                </div>
-                            </a>
-                        {% endfor %}
+
+                        <div class="card__grid">
+                            {% render_grid %}
+
+                                {% for hit in page_obj %}
+                                    {% render_column start=0 span=12 %}
+
+                                        <a href="{% url 'products:product_detail' hit.slug %}" class="card card__description-card search-results__item">
+                                            <div class="card__body">
+                                                <div class="tag-lists">
+                                                    {% include "components/Tag/Tag.html" with tags=hit.categories only %}
+                                                    {% include "components/Tag/Tag.html" with tags=hit.tags only %}
+                                                    {% include "components/Tag/Tag.html" with tags=hit.organizations only %}
+                                                </div>
+                                                <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>
+                                                <p class="utrecht-paragraph search-results__item-intro">{{ hit.summary }}</p>
+                                                <span class="link link--icon link--primary">
+                                                <span class="link__text">Bekijk {{ hit.name }}</span>
+                                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                                            </span>
+                                            </div>
+                                        </a>
+
+                                    {% endrender_column %}
+                                {% endfor %}
+                            {% endrender_grid %}
+                        </div>
+                        {# end card grid#}
                     </div>
                 </div>
 
@@ -90,6 +110,11 @@
                    <li class="li">{% trans "Probeer een andere zoekopdracht." %}</li>
                    <li class="li">{% trans "Vragen? Neem contact met ons op." %}</li>
                 </ul>
+
+                <div class="search-results search-suggestions">
+                    <h2 class="utrecht-heading-2">{% trans "Misschien bedoelt u:" %}</h2>
+                    <a class="link link--secondary" href="#">alt</a> <a class="link link--secondary" href="#">placeholder</a> <a class="link link--secondary" href="#">suggesties</a>
+                </div>
             {% endif %}
         </div>
     </div>

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -34,25 +34,22 @@
             {% if paginator.count %}
                 <div class="search-results">
                     <div class="search-results__list">
-                        <div class="card__grid">
                             {% render_grid %}
                                 {% for hit in page_obj %}
-                                    {% render_column start=0 span=12 %}
-                                        <a href="{% url 'products:product_detail' hit.slug %}" class="card card__description-card search-results__item">
-                                            <div class="card__body">
-                                                <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>
-                                                <p class="utrecht-paragraph search-results__item-intro">{{ hit.summary }}</p>
-                                                <span class="link link--icon link--primary">
-                                                <span class="link__text">Bekijk resultaat</span>
-                                                {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
-                                            </span>
-                                            </div>
-                                        </a>
-                                    {% endrender_column %}
+                                <div class="column column--start-0 {% if search_filter_categories or search_filter_tags or search_filter_organizations %}column--span-12{% else %}column--span-8{% endif %}">
+                                    <a href="{% url 'products:product_detail' hit.slug %}" class="card card__description-card search-results__item">
+                                        <div class="card__body card__body--tabled">
+                                            <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>
+                                            <p class="utrecht-paragraph search-results__item-intro">{{ hit.summary }}</p>
+                                            <span class="link link--icon link--primary">
+                                                    <span class="link__text">Bekijk resultaat</span>
+                                                    {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                                                </span>
+                                        </div>
+                                    </a>
+                                </div>
                                 {% endfor %}
                             {% endrender_grid %}
-                        </div>
-                        {# end card grid#}
                     </div>
                 </div>
 
@@ -90,10 +87,10 @@
             {% else %}
 
                 {% render_grid %}
-                    {% render_column start=0 span=10 %}
-                        <div class="search-results search-results--none">
-                            <div class="search-results--none-column">{% icon icon="info" icon_position="before" extra_classes="icon--info" outlined=True %}</div>
-                            <div class="search-results--none-column">
+                    {% render_column start=0 span=8 %}
+                        <div class="search-results search-results--no-results">
+                            <div class="search-results--no-results-column">{% icon icon="info" icon_position="before" extra_classes="icon--info" outlined=True %}</div>
+                            <div class="search-results--no-results-column">
                                 <h2 class="utrecht-heading-2 search-results__title">
                                     {% trans "We konden geen zoekresultaten vinden" %}
                                 </h2>

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -36,7 +36,7 @@
                     <div class="search-results__list">
                             {% render_grid %}
                                 {% for hit in page_obj %}
-                                <div class="column column--start-0 {% if search_filter_categories or search_filter_tags or search_filter_organizations %}column--span-12{% else %}column--span-8{% endif %}">
+                                <div class="column column--start-0 column--span-{% if search_filter_categories or search_filter_tags or search_filter_organizations %}12{% else %}8{% endif %}">
                                     <a href="{% url 'products:product_detail' hit.slug %}" class="card card__description-card search-results__item">
                                         <div class="card__body card__body--tabled">
                                             <h3 class="utrecht-heading-3 search-results__item-title">{{ hit.name }}</h3>


### PR DESCRIPTION
Turn search results into cards + add new zero-results design,
issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3017 
Figma designs: https://www.figma.com/design/iKGhWhstaLIlFSaND2q7cE/OIP---Designs-(new)?node-id=3052-13688&t=cFRCmQ9FCAFHDmxv-1

- [x] change searchresults into Cards
- [x] remove redundant styling/classes 
- [x] change texts/translations
- [x] move results-counter outside grid
- [x] add no-results info area
- [x] adjust all spacing
- [x] remove ability to see filters if they have zero results for them ("zero" checkboxes will be invisible)
- [x] make filter-sidebar invisible if choices=zero
- [x] let pagination appear earlier than if results > 20 (e.g. 9)
- [x] change pagination-color like in design
- [x] make filter sidebar disappear and move results align to left if municipality has turned off all filters.
- [x] add new global css vars for border-radius-rounded and lightest info color

Filter sidebar can be turned off/on via Admin/Configuratie options

<img width="917" alt="Screenshot 2025-02-13 at 11 14 55" src="https://github.com/user-attachments/assets/a128139a-1ac2-405a-89f4-253ce5b24172" />
