### PR TITLE
Fix uWSGI port config for Docker

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -41,8 +41,7 @@ export UWSGI_SINGLE_INTERPRETER=1
 export UWSGI_ENABLE_THREADS=1
 
 # --- HTTP Settings
-# Use http rather than wsgi protocol (also note that UWSGI_PORT is not a native uwsgi option).
-export UWSGI_HTTP=${UWSGI_PORT:-8000}
+export UWSGI_HTTP=0.0.0.0:${PORT:-8000}
 export UWSGI_HTTP_KEEPALIVE=${UWSGI_HTTP_KEEPALIVE:-1}
 export UWSGI_HTTP_TIMEOUT=${UWSGI_HTTP_TIMEOUT:-120}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       # Overridable uwsgi settings
       - UWSGI_PROCESSES
       - UWSGI_THREADS
-      - UWSGI_PORT
+      - PORT
       - UWSGI_HTTP_KEEPALIVE
       - UWSGI_HTTP_TIMEOUT
       - UWSGI_HARAKIRI


### PR DESCRIPTION
The Docker uWSGI config had two issues:

- It didn't specfy an address to listen on, so it would only listen on localhost by default
- It used UWSGI_PORT to customize the port, which is not a recognized uWSGI option, but because it follows the naming scheme, was evaluated by uWSGI which then failed because of strict mode.

This commit changes this to always bind on all addresses, and to use the more conventional $PORT environment variable.