### PR TITLE
Use uv for pip install in code quality CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,17 +35,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install libxml
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          pip install -r requirements/dev.txt
+          pip install uv
+          grep ^black requirements/ci.txt | uv pip install --system -r /dev/stdin
       - name: Run black
         run: |
           black --check --diff src
@@ -146,7 +143,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: grep ^ruff requirements/ci.txt | pip install -r /dev/stdin
+        run: |
+          pip install uv
+          grep ^ruff requirements/ci.txt | uv pip install --system -r /dev/stdin
       - name: Run ruff on all files
         run: ruff check --output-format=github src
 
@@ -165,7 +164,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          pip install -r requirements/dev.txt
+          pip install uv
+          uv pip install --system -r requirements/dev.txt
       - name: Run Bandit
         run: |
           bandit -r ./src/ -x tests,conf/utils.py -s B101


### PR DESCRIPTION
This significantly speeds up the `black`, `ruff` and `bandit` steps (the former to <10 seconds total, the latter still needs full dependencies, but it's still faster).