### PR TITLE
[#3052] Fix clickthrough zaak -> vraag

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -202,7 +202,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
             service = self.get_service(service_type=KlantenServiceType.OPENKLANT2)
 
         origin = self.request.headers.get("Referer")
-        question, zaak = service.retrieve_question(
+        question, zaak_with_api_group = service.retrieve_question(
             self.get_fetch_params(service),
             question_uuid=kwargs["kcm_uuid"],
             user=self.request.user,
@@ -220,16 +220,16 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
             local_kcm.save()
 
         ctx["question"] = question
-        ctx["zaak"] = zaak.zaak if zaak else None
+        ctx["zaak"] = getattr(zaak_with_api_group, "zaak", None)
         case_url = (
             reverse(
                 "cases:case_detail",
                 kwargs={
-                    "object_id": str(zaak.zaak.uuid),
-                    "api_group_id": zaak.api_group.id,
+                    "object_id": str(zaak_with_api_group.zaak.uuid),
+                    "api_group_id": zaak_with_api_group.api_group.id,
                 },
             )
-            if zaak
+            if zaak_with_api_group
             else None
         )
         ctx["metrics"] = [
@@ -255,7 +255,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
                 "label": _("Terug naar overzicht"),
                 "url": origin,
             }
-            if zaak:
+            if zaak_with_api_group:
                 ctx["destination"] = {
                     "label": _("Naar aanvraag"),
                     "url": case_url,

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1465,8 +1465,6 @@ class OpenKlant2Service(LogMixin, KlantenService):
 
         onderwerp_object = onderwerp_objecten[0]
 
-        zaak_with_api_group = None
-
         # fetch zaken for user
         groups = ZGWApiGroupConfig.objects.filter(
             klant_backend=KlantenServiceType.OPENKLANT2.value
@@ -1480,17 +1478,22 @@ class OpenKlant2Service(LogMixin, KlantenService):
             )
             return self._build_question_dto(question_ok2=question, user=user), None
 
-        # find the unique zaak for the question
+        # find the unique zaak + relevant api client for the question
         zaken_for_question = []
+        clients = []
         for response in truthy_responses:
             # discard the client for determining the api_group; we only need the zaak
             zaken = response.result
+            client = response.client
             zaken_filtered = filter(
                 lambda z: z.identificatie
                 == onderwerp_object["onderwerpobjectidentificator"]["objectId"],
                 zaken,
             )
             zaken_for_question.extend(zaken_filtered)
+            clients.append(client)
+
+        # sanity checks
         if not zaken_for_question:
             logger.info(
                 "Could not find zaak corresponding to question %s",
@@ -1503,10 +1506,18 @@ class OpenKlant2Service(LogMixin, KlantenService):
                 question.question_kcm_uuid,
             )
             return self._build_question_dto(question_ok2=question, user=user), None
+        if len(clients) > 1:
+            logger.error("Found one zaak in multiple backends")
+            return self._build_question_dto(question_ok2=question, user=user), None
+
+        group = ZGWApiGroupConfig.objects.resolve_group_from_hints(client=clients[0])
+        zaak_with_api_group = ZaakWithApiGroup(
+            zaak=zaken_for_question[0], api_group=group
+        )
 
         return (
             self._build_question_dto(question_ok2=question, user=user),
-            zaken_for_question[0],
+            zaak_with_api_group,
         )
 
     def _build_question_dtos(


### PR DESCRIPTION
Clicking through from a zaak to an associated vraag results in `AttributeError` for vragen fetched with OpenKlant.

Cause: our use of the `MultiZgwClientProxy` results is inconsistent: sometimes we use it to return a zaak, sometimes a tuple (zaak, zgw_api_group).

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3052