### PR TITLE
[#1432] Opening links from FAQ

### DIFF
--- a/src/open_inwoner/scss/components/Faq/_Faq.scss
+++ b/src/open_inwoner/scss/components/Faq/_Faq.scss
@@ -65,8 +65,15 @@
   &__answer--open {
     margin-top: var(--spacing-large) !important;
 
-    .link {
-      text-decoration: underline;
+    .utrecht-paragraph .link {
+      display: inline;
+
+      [class*='icons'] {
+        display: inline-block;
+        text-decoration: none;
+        transform: scale(0.75);
+        vertical-align: bottom;
+      }
     }
   }
 

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -58,7 +58,7 @@ def get_rendered_content(content: str) -> str:
                 icon.attrs.update(
                     {
                         "aria-hidden": "true",
-                        "class": "material-icons text-decoration-none",
+                        "class": "material-icons",
                     }
                 )
                 icon.append("open_in_new")

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -53,7 +53,21 @@ def get_rendered_content(content: str) -> str:
         for element in soup.find_all(tag):
             element.attrs["class"] = class_name
             if element.name == "a" and element.attrs.get("href", "").startswith("http"):
-                element.attrs["target"] = "_blank"
+                # icon & screenreader support
+                icon = soup.new_tag("span")
+                icon.attrs.update({"aria-hidden": "true", "class": "material-icons"})
+                icon.append("open_in_new")
+
+                screen_reader_only_text = soup.new_tag("span")
+                screen_reader_only_text.attrs.update(
+                    {
+                        "class": "sr-only",
+                    }
+                )
+                screen_reader_only_text.append(_("Opens external website"))
+
+                element.append(icon)
+                element.append(screen_reader_only_text)
 
     return str(soup)
 

--- a/src/open_inwoner/utils/ckeditor.py
+++ b/src/open_inwoner/utils/ckeditor.py
@@ -55,7 +55,12 @@ def get_rendered_content(content: str) -> str:
             if element.name == "a" and element.attrs.get("href", "").startswith("http"):
                 # icon & screenreader support
                 icon = soup.new_tag("span")
-                icon.attrs.update({"aria-hidden": "true", "class": "material-icons"})
+                icon.attrs.update(
+                    {
+                        "aria-hidden": "true",
+                        "class": "material-icons text-decoration-none",
+                    }
+                )
                 icon.append("open_in_new")
 
                 screen_reader_only_text = soup.new_tag("span")


### PR DESCRIPTION
Edited `utils/ckeditor.py` so that the links on the FAQ answers don't open in a new tab anymore. Also added link icons to them. 

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/1432

![image](https://github.com/user-attachments/assets/2dde360d-53b5-4b9f-b672-3a27cf946833)