### PR TITLE
[2833] Fixed white screen after switching to desktop from mobile nav

### DIFF
--- a/src/open_inwoner/scss/views/_body.scss
+++ b/src/open_inwoner/scss/views/_body.scss
@@ -1,16 +1,18 @@
-.body--open {
-  overflow: hidden;
-  position: fixed;
-  width: 100%;
+@media (max-width: 767px) {
+  .body--open {
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
 
-  // Hide focus for accessibility
-  .container,
-  .footer {
-    display: none;
-  }
+    // Hide focus for accessibility
+    .container,
+    .footer {
+      display: none;
+    }
 
-  @media (min-width: 768px) {
-    height: auto;
-    overflow: auto;
+    @media (min-width: 768px) {
+      height: auto;
+      overflow: auto;
+    }
   }
 }


### PR DESCRIPTION
When the mobile navigation menu is opened, and the user switches to the desktop view without first clicking the 'close navigation' button, the main elements of the page do not reappear and the user sees an empty/white screen. This is because the `body--open` class, which hides the main elements on the page, does not get removed unless explicitly clicking the 'close navigation' button and so it stays behind still hiding the main content even though the mobile navigation menu is closed.

To fix it, I added a media query around the CSS controlling `.body_open` in `_body.scss` that limits the effects of `body--open` to smaller screens only. 

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2833