### PR TITLE
Make mozilla_django_oidc_db SessionRefresh middleware configurable

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -278,7 +278,6 @@ MIDDLEWARE = [
     "open_inwoner.accounts.middleware.NecessaryFieldsMiddleware",
     "open_inwoner.accounts.middleware.EmailVerificationMiddleware",
     "open_inwoner.cms.utils.middleware.AnonymousHomePageRedirectMiddleware",
-    "mozilla_django_oidc_db.middleware.SessionRefresh",
 ]
 
 ROOT_URLCONF = "open_inwoner.urls"
@@ -516,6 +515,17 @@ SESSION_COOKIE_AGE = 900  # Set to 15 minutes or less for testing
 
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
+
+# The SessionRefresh middleware is currently broken if multiple OIDC configurations
+# are active. As a workaround until this is fixed, we use this flag to optionally disable
+# it.
+# TODO: Remove when https://github.com/maykinmedia/mozilla-django-oidc-db/issues/136
+# has been resolved.
+USE_OIDC_SESSION_REFRESH_MIDDLEWARE = config(
+    "USE_OIDC_SESSION_REFRESH_MIDDLEWARE", default=True
+)
+if USE_OIDC_SESSION_REFRESH_MIDDLEWARE:
+    MIDDLEWARE.append("mozilla_django_oidc_db.middleware.SessionRefresh")
 
 #
 # SECURITY settings


### PR DESCRIPTION
This is a workaround for an issue in mozilla_django_oidc_db which hasn't yet been fully diagnosed, whereby the OIDC refresh middleware errors when multiple OIDC providers are configured (e.g. for the admin. and for DigiD). To limit the scope of the changes, we've made the middleware configurable, but enabled by default so that any behavioral changes are opt-in. This will have to be revisited once the issue has been addressed. See also Taiga #3027.