### PR TITLE
[#3080] Replace error-darker red with notification-red in Profiel

### DIFF
--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -178,7 +178,7 @@
   }
 
   &--error {
-    color: var(--color-error-darker);
+    color: var(--color-red-notification);
   }
 
   &--primary-close {
@@ -188,7 +188,7 @@
   }
 
   &--error-confirm {
-    background-color: var(--color-error-darker);
+    background-color: var(--color-red-notification);
     color: var(--color-white);
   }
 


### PR DESCRIPTION
Replace the 'maroon' red with brighter red in Mijn profiel deletebutton + Modal button.

Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3080 