### PR TITLE
[#3076] page title change with cms page title

### DIFF
--- a/src/open_inwoner/plans/views.py
+++ b/src/open_inwoner/plans/views.py
@@ -99,8 +99,10 @@ class PlanListView(
 
     @cached_property
     def crumbs(self):
+        current_page = self.request.current_page
+        title = current_page.get_title() if current_page else _("Samenwerken")
         return [
-            (_("Samenwerken"), reverse("collaborate:plan_list")),
+            (title, reverse("collaborate:plan_list")),
         ]
 
     def get_queryset(self):

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -6,23 +6,30 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
 from django.views.generic.edit import FormView
 
 from furl import furl
 from view_breadcrumbs import BaseBreadcrumbMixin
 
+from open_inwoner.utils.views import CommonPageMixin
+
 from .client import JaaropgaveClient, UitkeringClient
 from .forms import MonthlyReportsForm, YearlyReportsForm
 
 
-class BenefitsFormView(LoginRequiredMixin, BaseBreadcrumbMixin, FormView):
+class BenefitsFormView(
+    LoginRequiredMixin, BaseBreadcrumbMixin, CommonPageMixin, FormView
+):
     template_name: str
     form_class: forms.Form
 
     @cached_property
     def crumbs(self):
-        return [(_("Mijn uitkeringen"), reverse("ssd:uitkeringen"))]
+        current_page = self.request.current_page
+        title = current_page.get_title() if current_page else ("Mijn uitkeringen")
+        return [
+            (title, reverse("ssd:uitkeringen")),
+        ]
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -8,7 +8,7 @@
 {% block content %}
     <header class="oip-header-group">
         <h1 class="utrecht-heading-1">
-            {% trans "Samenwerken" %}
+            {{ page_title }}
         </h1>
         {% button href="collaborate:plan_create" text=_("Start nieuwe samenwerking") primary=True icon="group" icon_outlined=True %}
     </header>

--- a/src/open_inwoner/templates/pages/ssd/reports_base.html
+++ b/src/open_inwoner/templates/pages/ssd/reports_base.html
@@ -5,7 +5,7 @@
     {% render_grid %}
         {% render_column span=9 %}
             <h1 class="utrecht-heading-1" id="title">
-                {% trans "Mijn uitkeringen" %}
+                {{ page_title }}
             </h1>
             <p>
                 {% blocktrans with mijn_uitkeringen_text=client.config.mijn_uitkeringen_text|ckeditor_content|safe %}


### PR DESCRIPTION
Made it so that the browser tab title as well as the header of the 'Benefits', 'Collaboration' and 'Mijn Vragen' pages change with the page title configured in the cms.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/3076

Note that for the 'Mijn Vragen' page, the way that the Page object is retrieved is kind of iffy, though it does seem to work. See the comment above it.

Edit: As per the discussion in the weekly, 'Mijn vragen' is kept hardcoded for this issue and will be addressed in a separate issue. See Taiga.