### PR TITLE
[#3134] Explicitly handle ES timeouts in search view

### DIFF
--- a/src/open_inwoner/search/tests/test_views.py
+++ b/src/open_inwoner/search/tests/test_views.py
@@ -1,9 +1,13 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
+from django.contrib.messages import get_messages
 from django.test import TransactionTestCase, override_settings, tag
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 import requests_mock
+from elasticsearch.exceptions import ConnectionTimeout
 from furl import furl
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
@@ -373,3 +377,22 @@ class TestSearchView(ESMixin, TransactionTestCase):
                 },
             ),
         )
+
+    @patch("open_inwoner.search.views.search_products")
+    def test_search_shows_error_on_connection_timeout(
+        self, request_mocker, mock_search
+    ):
+        mock_search.side_effect = ConnectionTimeout()
+        self.client.force_login(self.user)
+        params = urlencode({"query": "stuff"}, doseq=True)
+        response = self.client.get(f'{reverse("search:search")}?{params}')
+
+        self.assertEqual(response.status_code, 200)
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        expected = _(
+            "The search functionality is temporarily unavailable. "
+            "Please try again at a later moment."
+        )
+        self.assertEqual(str(messages[0]), expected)

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -9,6 +9,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext as _
 from django.views.generic import FormView
 
+from elasticsearch.exceptions import ConnectionTimeout
 from furl import furl
 
 from open_inwoner.configurations.models import SiteConfiguration
@@ -110,15 +111,27 @@ class SearchView(
                             )
 
         # perform search
-        results = search_products(query, filters=data)
+        try:
+            results = search_products(query, filters=data)
 
-        # update form fields with choices
-        for facet in results.facets:
-            if facet.name in form.fields:
-                form.fields[facet.name].choices = facet.choices()
+            # update form fields with choices
+            for facet in results.facets:
+                if facet.name in form.fields:
+                    form.fields[facet.name].choices = facet.choices()
 
-        # paginate
-        paginator_dict = self.paginate_with_context(results.results)
+            # paginate
+            paginator_dict = self.paginate_with_context(results.results)
+        except ConnectionTimeout:
+            logger.exception("Elasticsearch timeout on performing search query")
+            paginator_dict = self.paginate_with_context([])
+            messages.add_message(
+                self.request,
+                messages.ERROR,
+                _(
+                    "The search functionality is temporarily unavailable. "
+                    "Please try again at a later moment."
+                ),
+            )
 
         context.update(paginator_dict)
 


### PR DESCRIPTION
Elasticsearch is resource-hungry, and frequently fails on test environments due to timeouts. Providing an explicit error message rather than a generic 500 is more user-friendly, and also helps us separate out timeouts from more critical errors.