### PR TITLE
Bump django-csp-reports to 1.9.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,8 +12,6 @@ asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via webauthn
-async-timeout==4.0.3
-    # via redis
 attrs==21.2.0
     # via
     #   glom
@@ -143,8 +141,8 @@ django==4.2.20
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   sentry-sdk
     #   objects-api-client-django
+    #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
 django-admin-index==3.1.0
@@ -187,7 +185,7 @@ django-cors-headers==3.10.0
     # via -r requirements/base.in
 django-csp==3.7
     # via -r requirements/base.in
-django-csp-reports==1.8.1
+django-csp-reports==1.9.1
     # via -r requirements/base.in
 django-digid-eherkenning[oidc]==0.19.2
     # via -r requirements/base.in
@@ -415,7 +413,7 @@ notifications-api-common==0.2.2
     # via -r requirements/base.in
 oath==1.4.4
     # via -r requirements/base.in
-objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git
+objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git@f3ed1be7dea30fe2eced6c5f2d33305ca011d03c#egg=objects-api-client-django
     # via -r requirements/base.in
 odfpy==1.4.1
     # via tablib

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -33,11 +33,6 @@ asn1crypto==1.5.1
     #   webauthn
 astroid==2.15.8
     # via pylint
-async-timeout==4.0.3
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   redis
 attrs==21.2.0
     # via
     #   -c requirements/base.txt
@@ -238,8 +233,8 @@ django==4.2.20
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   sentry-sdk
     #   objects-api-client-django
+    #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
 django-admin-index==3.1.0
@@ -312,7 +307,7 @@ django-csp==3.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-csp-reports==1.8.1
+django-csp-reports==1.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -769,7 +764,7 @@ oath==1.4.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git
+objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git@f3ed1be7dea30fe2eced6c5f2d33305ca011d03c#egg=objects-api-client-django
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,11 +39,6 @@ astroid==2.15.8
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pylint
-async-timeout==4.0.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   redis
 attrs==21.2.0
     # via
     #   -c requirements/ci.txt
@@ -278,8 +273,8 @@ django==4.2.20
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   sentry-sdk
     #   objects-api-client-django
+    #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
 django-admin-index==3.1.0
@@ -352,7 +347,7 @@ django-csp==3.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-csp-reports==1.8.1
+django-csp-reports==1.9.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -877,7 +872,7 @@ oath==1.4.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git
+objects-api-client-django @ git+https://github.com/maykinmedia/objects-api-client-django.git@f3ed1be7dea30fe2eced6c5f2d33305ca011d03c#egg=objects-api-client-django
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
`description-file` (with a dash) in `setup.cfg` of older versions of `django-csp-reports` is deprecated as it doesn't conform to PEP naming conventions, causing CI to tail. It is replaced with `description_file` in newer versions. 