### PR TITLE
Integrate vestiging-users into eHerkenning OIDC/SAML and branch selection

### DIFF
--- a/src/eherkenning/backends.py
+++ b/src/eherkenning/backends.py
@@ -4,7 +4,7 @@ from digid_eherkenning.backends import eHerkenningBackend as _eHerkenningBackend
 from digid_eherkenning.exceptions import eHerkenningError
 from digid_eherkenning.utils import get_client_ip
 
-from open_inwoner.kvk.branches import KVK_BRANCH_SESSION_VARIABLE
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 
 UserModel = get_user_model()
 
@@ -13,6 +13,14 @@ class eHerkenningBackend(_eHerkenningBackend):
     """
     Custom backend to identify users based on the KvK number instead of RSIN
     """
+
+    def _persist_eherkenning_params_to_session(self, request, user):
+        session_context = EHerkenningSessionContext(request)
+        session_context.persist_eherkenning_state_for_user(
+            user=user,
+            is_branch_restricted=bool(user.vestiging),
+            initial_branch_selection_done=False,
+        )
 
     def get_company_branch_number(self, attributes):
         company_branch_number = attributes.get(
@@ -27,16 +35,20 @@ class eHerkenningBackend(_eHerkenningBackend):
                 "Login failed due to no KvK being returned by eHerkenning."
             )
 
+        vestigingsnummer = self.get_company_branch_number(saml_attributes)
+
         created = False
         try:
-            user = UserModel.eherkenning_objects.get_by_kvk(kvk)
+            user = UserModel.eherkenning_objects.get_by_kvk_and_vestiging(
+                kvk=kvk, vestiging=vestigingsnummer
+            )
         except UserModel.DoesNotExist:
-            user = UserModel.eherkenning_objects.create(kvk=kvk)
+            user = UserModel.eherkenning_objects.create(
+                kvk=kvk, vestiging=vestigingsnummer
+            )
             created = True
 
-        if vestigingsnummer := self.get_company_branch_number(saml_attributes):
-            self.request.session[KVK_BRANCH_SESSION_VARIABLE] = vestigingsnummer
-            self.request.session.save()
+        self._persist_eherkenning_params_to_session(request, user)
 
         success_message = self.error_messages["login_success"] % {
             "user": str(user),

--- a/src/eherkenning/mock/backends.py
+++ b/src/eherkenning/mock/backends.py
@@ -6,6 +6,8 @@ from django.contrib.auth import get_user_model
 from digid_eherkenning.backends import BaseBackend
 from digid_eherkenning.utils import get_client_ip
 
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+
 logger = logging.getLogger(__name__)
 
 UserModel = get_user_model()
@@ -22,6 +24,14 @@ class eHerkenningBackend(BaseBackend):
         }
     )
 
+    def _persist_eherkenning_params_to_session(self, request, user):
+        session_context = EHerkenningSessionContext(request)
+        session_context.persist_eherkenning_state_for_user(
+            user=user,
+            is_branch_restricted=bool(user.vestiging),
+            initial_branch_selection_done=False,
+        )
+
     def get_or_create_user(self, request, kvk):
         created = False
         try:
@@ -37,6 +47,7 @@ class eHerkenningBackend(BaseBackend):
             "service": self.service_name,
         }
 
+        self._persist_eherkenning_params_to_session(request, user)
         self.log_success(request, success_message)
 
         return user, created

--- a/src/eherkenning/tests/test_mock_views.py
+++ b/src/eherkenning/tests/test_mock_views.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase, modify_settings, override_settings
 from django.urls import reverse
 

--- a/src/eherkenning/tests/test_mock_views.py
+++ b/src/eherkenning/tests/test_mock_views.py
@@ -158,10 +158,9 @@ class PasswordLoginViewTests(eHerkenningMockTestCase):
         self.assertRedirects(response, reverse("profile:registration_necessary"))
 
         # check user kvk
-        User = get_user_model()
-        self.assertEqual(
-            response.context["user"].kvk, User.eherkenning_objects.get().kvk
-        )
+        created_user = response.context["user"]
+        self.assertEqual(created_user.kvk, "29664887")
+        self.assertEqual(created_user.vestiging, "1234")
 
     @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")

--- a/src/open_inwoner/accounts/backends.py
+++ b/src/open_inwoner/accounts/backends.py
@@ -1,27 +1,29 @@
 import logging
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import AbstractUser
+from django.core.exceptions import SuspiciousOperation
 from django.urls import reverse, reverse_lazy
 
 from axes.backends import AxesBackend
 from digid_eherkenning.oidc.backends import BaseBackend
+from glom import Path, glom
 from mozilla_django_oidc_db.backends import OIDCAuthenticationBackend
 from mozilla_django_oidc_db.config import dynamic_setting
 from mozilla_django_oidc_db.typing import JSONObject
 from oath import accept_totp
 
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.kvk.branches import KVK_BRANCH_SESSION_VARIABLE
 from open_inwoner.utils.hash import generate_email_from_string
 from open_inwoner.utils.views import LogMixin
 
 from .choices import LoginTypeChoices
-from .models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
+from .models import OpenIDDigiDConfig, OpenIDEHerkenningConfig, User
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +193,11 @@ class DigiDOIDCBackend(LogMixin, BaseBackend):
         return user
 
 
+class KvkEntityInformation(NamedTuple):
+    kvk: str
+    vestigingsnummer: str | None
+
+
 class EHerkenningOIDCBackend(LogMixin, BaseBackend):
     OIP_UNIQUE_ID_USER_FIELDNAME = dynamic_setting[Literal["kvk"]]()
     OIP_LOGIN_TYPE = dynamic_setting[LoginTypeChoices]()
@@ -199,34 +206,76 @@ class EHerkenningOIDCBackend(LogMixin, BaseBackend):
         parent = super()._check_candidate_backend()
         return parent and self.config_class is OpenIDEHerkenningConfig
 
-    def _store_vestigingsnummer_in_session(self, claims: JSONObject):
+    def _get_kvk_entity_information_from_claims(
+        self, claims: JSONObject
+    ) -> KvkEntityInformation | None:
         """Get company vestigingsnummer from OIDC claims & store in session"""
-
         eherkenning_config = self.config_class.get_solo()
 
-        branch_number_claim = eherkenning_config.branch_number_claim[0]
-        if not (vestigingsnummer := claims.get(branch_number_claim)):
-            return
-
-        self.request.session[KVK_BRANCH_SESSION_VARIABLE] = vestigingsnummer
-        self.request.session.save()
-
-        identifier_claim = eherkenning_config.identifier_type_claim[0]
-        kvk_or_rsin = claims.get(identifier_claim)
-
-        self.log_system_action(
-            f"Vestigingsnummer {vestigingsnummer} retrieved from IdP for "
-            f"eHerkenning user (KVK/RSIN: {kvk_or_rsin})"
+        vestigingsnummer = glom(
+            claims, Path(*eherkenning_config.branch_number_claim), default=None
         )
+        kvk_or_rsin = glom(
+            claims, Path(*eherkenning_config.legal_subject_claim), default=None
+        )
+        identifier_type = glom(
+            claims, Path(*eherkenning_config.identifier_type_claim), default=None
+        )
+
+        if not kvk_or_rsin:
+            raise SuspiciousOperation(
+                "Claims did not include a value for the configured legal subject claim"
+            )
+
+        # TODO: The user may be using a broker which provides RSIN rather than KvK,
+        # a scenario for which we are not equipped. Our usual model just assumes that
+        # the identifier claim is KvK, even if it's actually an RSIN. This is hard to
+        # check for, because there is no fixed convention as to the naming of the OIDC
+        # claims. In theory, they should match the SAML claims verbatim:
+        #
+        #   urn:etoegang:1.9:EntityConcernedID:KvKnr
+        #   urn:etoegang:1.9:EntityConcernedID:RSIN
+        #
+        # But there is no guarantee this mapping will be used, so it's difficult to
+        # raise confidently. Instead, for now, we log this so we can detect it early.
+        #
+        # The proper solution would be to directly support RSIN as the identifier, hence
+        # the TODO.
+        if identifier_type and "kvk" not in identifier_type.lower():
+            # TODO: We don't really support this
+            logger.warning(
+                "eHerkenning OIDC backend possibly configured to use an identifier "
+                "type claim which does not point to KvK",
+                extra={"identifier_type": identifier_type},
+            )
+
+        return KvkEntityInformation(kvk=kvk_or_rsin, vestigingsnummer=vestigingsnummer)
+
+    def _log_successful_authenticate(self, user: User):
+        log_msg = (
+            f"Successful OIDC eHerkenning login for kvk/rsin={user.kvk} and "
+            f"vestiging={user.vestiging}"
+        )
+        self.log_system_action(log_msg)
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the specified subject."""
-        unique_id = self._extract_username(claims)
-
-        if not unique_id:
+        entity_info = self._get_kvk_entity_information_from_claims(claims)
+        if not entity_info:
             return self.UserModel.objects.none()
-        return self.UserModel.objects.filter(
-            **{f"{self.OIP_UNIQUE_ID_USER_FIELDNAME}__iexact": unique_id}
+
+        return self.UserModel.eherkenning_objects.filter_by_kvk_and_vestiging(
+            kvk=entity_info.kvk, vestiging=entity_info.vestigingsnummer
+        )
+
+    def _persist_eherkenning_params_to_session(self, user):
+        session_context = EHerkenningSessionContext(self.request)
+        session_context.persist_eherkenning_state_for_user(
+            user=user,
+            # If a branch claim was provided, mark the session as restricted and
+            # set the branchs selection flag to done so we skip the selection form.
+            is_branch_restricted=bool(user.vestiging),
+            initial_branch_selection_done=bool(user.vestiging),
         )
 
     def create_user(self, claims):
@@ -236,24 +285,28 @@ class EHerkenningOIDCBackend(LogMixin, BaseBackend):
         Get vestigingsnummer from OIDC claims & store in session
         """
 
-        unique_id = self._extract_username(claims)
+        entity_info = self._get_kvk_entity_information_from_claims(claims)
+        if not entity_info:
+            return None
 
-        logger.debug("Creating OIDC user: %s", unique_id)
+        email_seed = entity_info.kvk + (entity_info.vestigingsnummer or "")
+        create_kwargs = {
+            self.UserModel.USERNAME_FIELD: generate_email_from_string(
+                email_seed, domain="localhost"
+            ),
+            "login_type": self.OIP_LOGIN_TYPE,
+            "kvk": entity_info.kvk,
+        }
 
-        user = self.UserModel.objects.create_user(
-            **{
-                self.UserModel.USERNAME_FIELD: generate_email_from_string(
-                    unique_id, domain="localhost"
-                ),
-                self.OIP_UNIQUE_ID_USER_FIELDNAME: unique_id,
-                "login_type": self.OIP_LOGIN_TYPE,
-            }
-        )
+        if entity_info.vestigingsnummer:
+            create_kwargs["vestiging"] = entity_info.vestigingsnummer
 
-        self._store_vestigingsnummer_in_session(claims)
-
+        user = self.UserModel.objects.create_user(**create_kwargs)
+        self._persist_eherkenning_params_to_session(user)
+        self._log_successful_authenticate(user)
         return user
 
     def update_user(self, user: AbstractUser, claims: JSONObject):
-        self._store_vestigingsnummer_in_session(claims)
+        self._persist_eherkenning_params_to_session(user)
+        self._log_successful_authenticate(user)
         return super().update_user(user, claims)

--- a/src/open_inwoner/accounts/eherkenning_session.py
+++ b/src/open_inwoner/accounts/eherkenning_session.py
@@ -1,0 +1,155 @@
+from django.conf import settings
+from django.contrib.auth import login as django_login, logout as django_logout
+from django.http import HttpRequest
+
+from open_inwoner.accounts.models import User
+
+
+class EHerkenningSessionContext:
+    """Helper service to manage eHerkenning state in a request session."""
+
+    _request: HttpRequest
+    KVK_BRANCH_RESTRICTION_SESSION_KEY = "kvk_has_branch_restriction"
+    KVK_INITIAL_BRANCH_SELECTION_DONE_KEY = "kvk_initial_branch_selection_done"
+
+    def __init__(self, request: HttpRequest):
+        self._request = request
+
+    @classmethod
+    def _expected_auth_backends(cls) -> tuple[str, ...]:
+        expected_backends = (
+            "open_inwoner.accounts.backends.EHerkenningOIDCBackend",
+            "eherkenning.backends.eHerkenningBackend",
+        )
+        mock_backends = ("eherkenning.mock.backends.eHerkenningBackend",)
+
+        return expected_backends + tuple(
+            backend
+            for backend in mock_backends
+            if backend in settings.AUTHENTICATION_BACKENDS
+        )
+
+    @staticmethod
+    def assert_valid_eherkenning_user(user: User) -> None:
+        if (
+            not isinstance(user, User)
+            or (not user.is_eherkenning_user)
+            or (not user.kvk)
+        ):
+            raise ValueError("User is not an eHerkenning user")
+
+    @staticmethod
+    def assert_valid_eherkenning_request(request: HttpRequest) -> None:
+        if (
+            request.session.get("_auth_user_backend", None)
+            not in EHerkenningSessionContext._expected_auth_backends()
+        ):
+            raise ValueError(
+                "The user in this session was not authenticated via the expected "
+                f"EHerkenning backends: {', '.join(EHerkenningSessionContext._expected_auth_backends())}"
+            )
+
+    def _set_session_flag(self, key: str, flag: bool) -> None:
+        if not isinstance(flag, bool):
+            raise ValueError("`flag` must be a boolean")
+
+        self._request.session[key] = flag
+        self._request.session.save()
+
+    def _get_session_flag(self, key: str) -> bool:
+        if key not in self._request.session:
+            return False
+
+        flag = self._request.session.get(
+            key,
+        )
+        if not isinstance(flag, bool):
+            raise ValueError(f'session["{key}"] must be bool')
+
+        return flag
+
+    def _set_initial_branch_selection(self, done: bool) -> None:
+        self._set_session_flag(self.KVK_INITIAL_BRANCH_SELECTION_DONE_KEY, done)
+
+    def _set_branch_restriction(self, restriction: bool) -> None:
+        self._request.session[self.KVK_BRANCH_RESTRICTION_SESSION_KEY] = bool(
+            restriction
+        )
+        self._request.session.save()
+
+    def is_branch_restricted(self) -> bool:
+        return self._get_session_flag(self.KVK_BRANCH_RESTRICTION_SESSION_KEY)
+
+    def is_initial_branch_selection_done(self) -> bool:
+        return self._get_session_flag(self.KVK_INITIAL_BRANCH_SELECTION_DONE_KEY)
+
+    def mark_initial_branch_selection_done(self) -> None:
+        self._set_initial_branch_selection(True)
+
+    def persist_eherkenning_state_for_user(
+        self,
+        *,
+        user: User,
+        is_branch_restricted: bool,
+        initial_branch_selection_done: bool = False,
+    ) -> None:
+        # Note we do not validate the authentication backend here because this likely to
+        # be called _within_ an authentication backend handler and thus the user will
+        # not yet be authenticated.
+        self.assert_valid_eherkenning_user(user)
+        self._set_session_flag(
+            self.KVK_BRANCH_RESTRICTION_SESSION_KEY, is_branch_restricted
+        )
+        self._set_session_flag(
+            self.KVK_INITIAL_BRANCH_SELECTION_DONE_KEY, initial_branch_selection_done
+        )
+
+    def change_authenticated_user(
+        self,
+        *,
+        kvk: str,
+        vestiging: str | None,
+    ) -> None:
+        self.assert_valid_eherkenning_request(self._request)
+        self.assert_valid_eherkenning_user(self._request.user)
+
+        if self.is_branch_restricted():
+            raise ValueError(
+                "This session is branch restricted: you cannot switch to a different "
+                "eherkenning user"
+            )
+
+        if self._request.user.kvk != kvk:
+            raise ValueError(
+                "You cannot change the authenticated user to the rechtspersoon or "
+                "vestiging of a different kvk number"
+            )
+
+        try:
+            target_user = User.eherkenning_objects.get_by_kvk_and_vestiging(
+                kvk=kvk, vestiging=vestiging
+            )
+        except User.DoesNotExist:
+            target_user = User.eherkenning_objects.create(kvk=kvk, vestiging=vestiging)
+
+        if target_user == self._request.user:
+            return  # Nothing to do
+
+        # Persist these values before the session is cleared
+        previous_backend = self._request.session["_auth_user_backend"]
+        previous_initial_branch_selection_done = self.is_initial_branch_selection_done()
+
+        # Clear the session
+        django_logout(self._request)
+
+        # Login and re-sync the previous values
+        django_login(
+            request=self._request,
+            user=target_user,
+            backend=previous_backend,
+        )
+        self.persist_eherkenning_state_for_user(
+            user=target_user,
+            is_branch_restricted=False,
+            initial_branch_selection_done=previous_initial_branch_selection_done,
+        )

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -955,6 +955,9 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
 
         user = eHerkenningUserFactory.create(kvk="12345678", email="example@localhost")
 
+        self.client.force_login(
+            user, backend=EHerkenningSessionContext._expected_auth_backends()[0]
+        )
         response = self.app.get(reverse("pages-root"), user=user)
 
         # redirect to /kvk/branches/

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -14,6 +14,7 @@ from furl import furl
 from pyquery import PyQuery
 
 from open_inwoner.accounts.choices import NotificationChannelChoice
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 from open_inwoner.accounts.signals import KvKClient, update_user_on_login
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.tests.mixins import HaalCentraalMixin
@@ -932,6 +933,11 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
             response,
             reverse("profile:registration_necessary"),
         )
+        self.assertTrue(
+            EHerkenningSessionContext(
+                response.wsgi_request
+            ).is_initial_branch_selection_done()
+        )
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
@@ -965,10 +971,16 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
             response, reverse("kvk:branches"), fetch_redirect_response=False
         )
 
-        res = self.app.post(response["Location"], {"branch_number": "1234"})
+        res = self.client.post(response["Location"], {"branch_number": "1234"})
 
         # redirect to /register/necessary/
         self.assertRedirects(res, reverse("profile:registration_necessary"))
+
+        self.assertTrue(
+            EHerkenningSessionContext(
+                res.wsgi_request
+            ).is_initial_branch_selection_done()
+        )
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
@@ -1276,27 +1288,11 @@ class DuplicateEmailRegistrationTest(WebTest):
         return_value="123456789",
         autospec=True,
     )
-    @patch(
-        "open_inwoner.kvk.client.KvKClient.get_all_company_branches",
-        autospec=True,
-    )
     def test_eherkenning_user_success(
-        self, mock_kvk, mock_retrieve_rsin_with_kvk, mock_get_basisprofiel
+        self, mock_retrieve_rsin_with_kvk, mock_get_basisprofiel
     ):
         """Assert that eHerkenning users can register with duplicate emails"""
 
-        mock_kvk.return_value = [
-            {
-                "kvkNummer": "12345678",
-                "vestigingsnummer": "1234",
-                "naam": "Mijn bedrijf",
-            },
-            {
-                "kvkNummer": "12345678",
-                "vestigingsnummer": "5678",
-                "naam": "Mijn bedrijf",
-            },
-        ]
         mock_get_basisprofiel.return_value = {
             "_embedded": {"eigenaar": {"rechtsvorm": "Stichting"}}
         }
@@ -1310,7 +1306,7 @@ class DuplicateEmailRegistrationTest(WebTest):
         url = reverse("eherkenning-mock:password")
         params = {
             "acs": reverse("eherkenning:acs"),
-            "next": reverse("kvk:branches"),
+            "next": reverse("profile:registration_necessary"),
         }
         url = f"{url}?{urlencode(params)}"
 
@@ -1319,13 +1315,7 @@ class DuplicateEmailRegistrationTest(WebTest):
             "auth_name": "12345678",
             "auth_pass": "bar",
         }
-        response = self.app.post(url, data).follow()
-
-        # select company branch
-        response = self.app.get(response["Location"])
-        form = response.forms["eherkenning-branch-form"]
-        form["branch_number"] = "5678"
-        response = form.submit().follow()
+        response = self.app.post(url, data).follow().follow()
 
         # fill in necessary fields form
         form = response.forms["necessary-form"]

--- a/src/open_inwoner/accounts/tests/test_backends.py
+++ b/src/open_inwoner/accounts/tests/test_backends.py
@@ -7,7 +7,16 @@ from django.urls import reverse
 from furl import furl
 from mozilla_django_oidc_db.config import store_config
 
-from .factories import UserFactory
+from eherkenning.backends import eHerkenningBackend
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.models import User
+from open_inwoner.utils.test import SessionMiddleware
+
+from .factories import (
+    UserFactory,
+    eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
+)
 
 
 class OIDCBackendTestCase(TestCase):
@@ -92,3 +101,94 @@ class OIDCBackendTestCase(TestCase):
         self.assertEqual(
             result.backend, "open_inwoner.accounts.backends.CustomOIDCBackend"
         )
+
+
+class EHerkenningSAMLBackendTestCase(TestCase):
+    def setUp(self):
+        self.user = eHerkenningUserFactory()
+        self.vestiging_user = eHerkenningVestigingUserFactory(kvk=self.user.kvk)
+
+    def make_request_with_session(self):
+        request = RequestFactory().get("/")
+        middleware = SessionMiddleware(get_response=lambda r: None)
+        middleware.process_request(request)
+        request.session.save()  # Save to trigger session creation
+        return request
+
+    def test_kvk_claim_without_vestigingen_claim_returns_kvk_user(self):
+        backend = eHerkenningBackend()
+        request = self.make_request_with_session()
+        context = EHerkenningSessionContext(request)
+
+        user, created = backend.get_or_create_user(
+            request,
+            None,
+            saml_attributes={
+                "urn:etoegang:1.11:attribute-represented:KvKnr": [self.user.kvk]
+            },
+        )
+
+        self.assertEqual(user, self.user)
+        self.assertFalse(created)
+        self.assertFalse(context.is_branch_restricted())
+
+    def test_kvk_claim_with_vestigingen_claim_returns_vestiging_user(self):
+        backend = eHerkenningBackend()
+        request = self.make_request_with_session()
+        context = EHerkenningSessionContext(request)
+
+        user, created = backend.get_or_create_user(
+            request,
+            None,
+            saml_attributes={
+                "urn:etoegang:1.11:attribute-represented:KvKnr": [
+                    self.vestiging_user.kvk
+                ],
+                "urn:etoegang:1.9:ServiceRestriction:Vestigingsnr": self.vestiging_user.vestiging,
+            },
+        )
+
+        self.assertEqual(user, self.vestiging_user)
+        self.assertFalse(created)
+        self.assertTrue(context.is_branch_restricted())
+
+    def test_kvk_claim_without_vestigingen_claim_creates_kvk_user(self):
+        User.objects.all().delete()
+        backend = eHerkenningBackend()
+        request = self.make_request_with_session()
+        context = EHerkenningSessionContext(request)
+
+        user, created = backend.get_or_create_user(
+            request,
+            None,
+            saml_attributes={
+                "urn:etoegang:1.11:attribute-represented:KvKnr": ["12345678"]
+            },
+        )
+
+        user = User.objects.get()
+        self.assertEqual(user.kvk, "12345678")
+        self.assertEqual(user.vestiging, "")
+        self.assertTrue(created)
+        self.assertFalse(context.is_branch_restricted())
+
+    def test_kvk_claim_with_vestigingen_claim_creates_vestiging_user(self):
+        User.objects.all().delete()
+        backend = eHerkenningBackend()
+        request = self.make_request_with_session()
+        context = EHerkenningSessionContext(request)
+
+        user, created = backend.get_or_create_user(
+            request,
+            None,
+            saml_attributes={
+                "urn:etoegang:1.11:attribute-represented:KvKnr": ["12345678"],
+                "urn:etoegang:1.9:ServiceRestriction:Vestigingsnr": "123456789012",
+            },
+        )
+
+        user = User.objects.get()
+        self.assertEqual(user.kvk, "12345678")
+        self.assertEqual(user.vestiging, "123456789012")
+        self.assertTrue(created)
+        self.assertTrue(context.is_branch_restricted())

--- a/src/open_inwoner/accounts/tests/test_eherkenning_session.py
+++ b/src/open_inwoner/accounts/tests/test_eherkenning_session.py
@@ -1,0 +1,234 @@
+from unittest import mock
+
+from django.test import RequestFactory, TestCase
+
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.tests.factories import (
+    DigidUserFactory,
+    eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
+)
+from open_inwoner.utils.test import SessionMiddleware
+
+
+class EHerkenningSessionContextTests(TestCase):
+    def setUp(self):
+        self.user = eHerkenningUserFactory()
+        self.vestiging_user = eHerkenningVestigingUserFactory(kvk=self.user.kvk)
+
+    def make_request_with_session(self):
+        request = RequestFactory().get("/")
+        middleware = SessionMiddleware(get_response=lambda r: None)
+        middleware.process_request(request)
+        request.session.save()  # Save to trigger session creation
+        return request
+
+    def test_persisted_state_generates_expected_branch_restriction_state(self):
+        for branch_restriction in (True, False):
+            with self.subTest(branch_restriction):
+                request = self.make_request_with_session()
+                request.user = self.user
+
+                context = EHerkenningSessionContext(request)
+                context.persist_eherkenning_state_for_user(
+                    user=self.user, is_branch_restricted=branch_restriction
+                )
+
+                self.assertEqual(context.is_branch_restricted(), branch_restriction)
+                self.assertFalse(context.is_initial_branch_selection_done())
+
+    def test_branch_restriction_check_fails_on_non_bool(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+
+        for val in (1, "foo", object(), None):
+            with self.subTest(val):
+                request.session[
+                    EHerkenningSessionContext.KVK_BRANCH_RESTRICTION_SESSION_KEY
+                ] = val
+
+                context = EHerkenningSessionContext(request)
+                with self.assertRaises(ValueError) as ctx:
+                    context.is_branch_restricted()
+
+                self.assertEqual(
+                    str(ctx.exception),
+                    'session["kvk_has_branch_restriction"] must be bool',
+                )
+
+    def test_change_authenticated_user_raises_on_missing_backend(self):
+        request = self.make_request_with_session()
+
+        context = EHerkenningSessionContext(request)
+        with self.assertRaises(ValueError) as ctx:
+            context.change_authenticated_user(kvk=self.user.kvk, vestiging=None)
+
+        self.assertEqual(
+            str(ctx.exception),
+            "The user in this session was not authenticated via the expected "
+            "EHerkenning backends: open_inwoner.accounts.backends."
+            "EHerkenningOIDCBackend, eherkenning.backends.eHerkenningBackend, "
+            "eherkenning.mock.backends.eHerkenningBackend",
+        )
+
+    def test_change_authenticated_user_raises_on_incorrect_backend(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = "open_inwoner.accounts.backends.DigiDOIDCBackend"
+
+        context = EHerkenningSessionContext(request)
+        with self.assertRaises(ValueError) as ctx:
+            context.change_authenticated_user(kvk=self.user.kvk, vestiging=None)
+
+        self.assertEqual(
+            str(ctx.exception),
+            "The user in this session was not authenticated via the expected "
+            "EHerkenning backends: open_inwoner.accounts.backends."
+            "EHerkenningOIDCBackend, eherkenning.backends.eHerkenningBackend, "
+            "eherkenning.mock.backends.eHerkenningBackend",
+        )
+
+    def test_change_authenticated_user_raises_on_non_eherkenning_user(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = DigidUserFactory()
+
+        context = EHerkenningSessionContext(request)
+        with self.assertRaises(ValueError) as ctx:
+            context.change_authenticated_user(kvk=self.user.kvk, vestiging=None)
+
+        self.assertEqual(str(ctx.exception), "User is not an eHerkenning user")
+
+    def test_change_authenticated_user_with_branch_restriction_raises(
+        self,
+    ):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.user
+
+        context = EHerkenningSessionContext(request)
+        context._set_branch_restriction(True)
+
+        with self.assertRaises(ValueError) as ctx:
+            context.change_authenticated_user(
+                kvk=self.user.kvk, vestiging=self.vestiging_user.vestiging
+            )
+
+        self.assertEqual(
+            str(ctx.exception),
+            "This session is branch restricted: you cannot switch "
+            "to a different eherkenning user",
+        )
+        self.assertEqual(request.user, self.user)
+
+    def test_change_authenticated_user_raises_on_target_user_with_different_kvk(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.user
+        different_kvk_user = eHerkenningUserFactory(kvk="38804926")
+
+        context = EHerkenningSessionContext(request)
+        with self.assertRaises(ValueError) as ctx:
+            context.change_authenticated_user(
+                kvk=different_kvk_user.kvk, vestiging=None
+            )
+
+        self.assertEqual(
+            str(ctx.exception),
+            "You cannot change the authenticated user to the rechtspersoon or "
+            "vestiging of a different kvk number",
+        )
+        self.assertEqual(request.user, self.user)
+
+    def test_change_authenticated_user_from_kvk_to_kvk_and_vestiging(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.user
+
+        context = EHerkenningSessionContext(request)
+        context.change_authenticated_user(
+            kvk=self.user.kvk, vestiging=self.vestiging_user.vestiging
+        )
+
+        self.assertEqual(request.user, self.vestiging_user)
+        self.assertEqual(
+            request.session["_auth_user_backend"],
+            EHerkenningSessionContext._expected_auth_backends()[0],
+        )
+        self.assertFalse(context.is_branch_restricted())
+        self.assertFalse(context.is_initial_branch_selection_done())
+
+    def test_change_authenticated_user_from_vestiging_and_kvk_to_only_kvk(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.vestiging_user
+
+        context = EHerkenningSessionContext(request)
+        context.change_authenticated_user(kvk=self.user.kvk, vestiging=None)
+
+        self.assertEqual(request.user, self.user)
+        self.assertEqual(
+            request.session["_auth_user_backend"],
+            EHerkenningSessionContext._expected_auth_backends()[0],
+        )
+        self.assertFalse(context.is_branch_restricted())
+        self.assertFalse(context.is_initial_branch_selection_done())
+
+    def test_change_authenticated_user_to_same_user_does_not_mutate_session(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.user
+
+        context = EHerkenningSessionContext(request)
+
+        with mock.patch(
+            "open_inwoner.accounts.eherkenning_session.django_logout"
+        ) as mock_logout:
+            context.change_authenticated_user(kvk=self.user.kvk, vestiging=None)
+
+        mock_logout.assert_not_called()
+        self.assertEqual(request.user, self.user)
+        self.assertEqual(
+            request.session["_auth_user_backend"],
+            EHerkenningSessionContext._expected_auth_backends()[0],
+        )
+        self.assertFalse(context.is_branch_restricted())
+        self.assertFalse(context.is_initial_branch_selection_done())
+
+    def test_change_authenticated_user_maintains_branch_restriction_and_backend(self):
+        for expected_backend in EHerkenningSessionContext._expected_auth_backends():
+
+            with self.subTest(expected_backend):
+                request = self.make_request_with_session()
+                request.session["_auth_user_backend"] = expected_backend
+                request.user = self.user
+                context = EHerkenningSessionContext(request)
+                context._set_branch_restriction(False)
+
+                context.change_authenticated_user(
+                    kvk=self.vestiging_user.kvk,
+                    vestiging=self.vestiging_user.vestiging,
+                )
+
+                self.assertEqual(request.user, self.vestiging_user)
+                self.assertEqual(
+                    request.session["_auth_user_backend"],
+                    expected_backend,
+                )
+                self.assertEqual(context.is_branch_restricted(), False)
+                self.assertFalse(context.is_initial_branch_selection_done())

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -31,7 +31,12 @@ from ...cms.profile.cms_apps import ProfileApphook
 from ...cms.tests import cms_tools
 from ..choices import LoginTypeChoices
 from ..models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
-from .factories import DigidUserFactory, UserFactory, eHerkenningUserFactory
+from .factories import (
+    DigidUserFactory,
+    UserFactory,
+    eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
+)
 
 User = get_user_model()
 
@@ -2260,9 +2265,11 @@ class eHerkenningOIDCFlowTests(WebTest):
         mock_get_basisprofiel,
     ):
         """
-        KVK branch selection should be skipped if KVK_BRANCH_SESSION_VARIABLE is present in session
+        KVK branch selection should be skipped
         """
-        user = eHerkenningUserFactory.create(kvk="12345678", rsin="123456789")
+        user = eHerkenningVestigingUserFactory.create(
+            kvk="12345678", rsin="123456789", vestiging="123456789000"
+        )
         mock_get_userinfo.return_value = {
             "sub": "some_username",
             "kvk": "12345678",
@@ -2289,9 +2296,7 @@ class eHerkenningOIDCFlowTests(WebTest):
 
         self.assertEqual(user.pk, int(self.app.session.get("_auth_user_id")))
         self.assertEqual(user.kvk, "12345678")
-        self.assertEqual(
-            self.app.session.get(KVK_BRANCH_SESSION_VARIABLE), "123456789000"
-        )
+        self.assertEqual(user.vestiging, "123456789000")
 
         self.assertRedirects(
             callback_response, reverse("profile:detail"), fetch_redirect_response=False

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -1,5 +1,6 @@
 from hashlib import md5
 from typing import Literal
+from unittest import skip
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -17,6 +18,7 @@ from furl import furl
 from mozilla_django_oidc_db.models import OpenIDConnectConfig
 from pyquery import PyQuery
 
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 from open_inwoner.accounts.views.auth_oidc import (
     GENERIC_DIGID_ERROR_MSG,
     GENERIC_EHERKENNING_ERROR_MSG,
@@ -1067,10 +1069,113 @@ class eHerkenningOIDCFlowTests(WebTest):
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.verify_token")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_token")
+    @patch("open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo")
+    def test_missing_claims_in_configuration_raises_exception(
+        self,
+        mock_get_solo,
+        mock_get_token,
+        mock_verify_token,
+        mock_store_tokens,
+        mock_get_userinfo,
+        mock_retrieve_rsin_with_kvk,
+        mock_kvk,
+        mock_get_basisprofiel,
+    ):
+        config = OpenIDEHerkenningConfig(id=1, enabled=True)
+
+        for empty_claim in (
+            "branch_number_claim",
+            "identifier_type_claim",
+            "legal_subject_claim",
+        ):
+            with self.subTest(empty_claim):
+                setattr(config, empty_claim, [])
+                config.save()
+                mock_get_solo.return_value = config
+
+                session = self.client.session
+                session["oidc_states"] = {
+                    "mock": {
+                        "nonce": "nonce",
+                        "config_class": "accounts.OpenIDEHerkenningConfig",
+                    }
+                }
+                session.save()
+
+                callback_url = reverse("eherkenning_oidc:callback")
+
+                # Note this is raised by django mozilla oidc db, but it's useful to have
+                # a guard against that behavior changing, because our custom
+                # implementation assumes these claims are configured and does not handle
+                # the case where they're missing (because the base class already does
+                # that).
+                with self.assertRaises(ValueError):
+                    self.client.get(callback_url, {"code": "mock", "state": "mock"})
+
+                self.assertEqual(User.objects.count(), 0)
+
+    @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
+    @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
+    @patch("open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.verify_token")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_token")
     @patch(
         "open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo",
         return_value=OpenIDEHerkenningConfig(
             id=1, enabled=True, legal_subject_claim=["sub"]
+        ),
+    )
+    def test_missing_claim_in_token_redirects_to_error_page(
+        self,
+        mock_get_solo,
+        mock_get_token,
+        mock_verify_token,
+        mock_store_tokens,
+        mock_get_userinfo,
+        mock_retrieve_rsin_with_kvk,
+        mock_kvk,
+        mock_get_basisprofiel,
+    ):
+        mock_get_userinfo.return_value = {
+            "email": "existing_user@example.com",
+        }
+
+        session = self.client.session
+        session["oidc_states"] = {
+            "mock": {
+                "nonce": "nonce",
+                "config_class": "accounts.OpenIDEHerkenningConfig",
+            }
+        }
+        session.save()
+        callback_url = reverse("eherkenning_oidc:callback")
+
+        # enter the login flow
+        callback_response = self.client.get(
+            callback_url, {"code": "mock", "state": "mock"}
+        )
+
+        self.assertRedirects(
+            callback_response, reverse("oidc-error"), fetch_redirect_response=False
+        )
+        self.assertEqual(User.objects.count(), 0)
+
+    @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
+    @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
+    @patch("open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.verify_token")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_token")
+    @patch(
+        "open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo",
+        return_value=OpenIDEHerkenningConfig(
+            id=1,
+            enabled=True,
+            legal_subject_claim=["sub"],
+            branch_number_claim=["branch"],
         ),
     )
     def test_existing_kvk_creates_no_new_user(
@@ -1139,6 +1244,13 @@ class eHerkenningOIDCFlowTests(WebTest):
         self.assertEqual(db_user.first_name, "John")
         self.assertEqual(db_user.last_name, "Doe")
 
+        self.assertEqual(callback_response.wsgi_request.user, db_user)
+        self.assertFalse(
+            EHerkenningSessionContext(
+                callback_response.wsgi_request
+            ).is_branch_restricted()
+        )
+
     @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
     @patch("open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
@@ -1200,6 +1312,168 @@ class eHerkenningOIDCFlowTests(WebTest):
         self.assertEqual(new_user.email, f"{hashed_bsn}@localhost")
         self.assertEqual(new_user.rsin, "123456789")
         self.assertEqual(new_user.login_type, LoginTypeChoices.eherkenning)
+
+        self.assertEqual(callback_response.wsgi_request.user, new_user)
+        self.assertFalse(
+            EHerkenningSessionContext(
+                callback_response.wsgi_request
+            ).is_branch_restricted()
+        )
+
+    @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
+    @patch("open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.verify_token")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_token")
+    @patch(
+        "open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo",
+        return_value=OpenIDEHerkenningConfig(
+            id=1,
+            enabled=True,
+            legal_subject_claim=["sub"],
+            branch_number_claim=["urn:etoegang:1.9:ServiceRestriction:Vestigingsnr"],
+        ),
+    )
+    def test_new_user_is_created_when_existing_kvk_without_vestiging(
+        self,
+        mock_get_solo,
+        mock_get_token,
+        mock_verify_token,
+        mock_store_tokens,
+        mock_get_userinfo,
+        mock_retrieve_rsin_with_kvk,
+        mock_get_basisprofiel,
+    ):
+        mock_get_basisprofiel.return_value = {
+            "_embedded": {"eigenaar": {"rechtsvorm": "Stichting"}}
+        }
+        mock_retrieve_rsin_with_kvk.return_value = "123456789"
+        # set up a user with a non existing email address
+        mock_get_userinfo.return_value = {
+            "sub": "12345678",
+            "urn:etoegang:1.9:ServiceRestriction:Vestigingsnr": "849586958473",
+        }
+        existing_user = eHerkenningUserFactory.create(
+            kvk="12345678", rsin="123456789", email="existing_user@example.com"
+        )
+        session = self.client.session
+        session["oidc_states"] = {
+            "mock": {
+                "nonce": "nonce",
+                "config_class": "accounts.OpenIDEHerkenningConfig",
+            }
+        }
+        session.save()
+        callback_url = reverse("eherkenning_oidc:callback")
+
+        self.assertFalse(User.objects.filter(email="new_user@example.com").exists())
+
+        # enter the login flow
+        callback_response = self.client.get(
+            callback_url, {"code": "mock", "state": "mock"}
+        )
+
+        self.assertRedirects(
+            callback_response, reverse("pages-root"), fetch_redirect_response=False
+        )
+        new_user = User.objects.get(kvk="12345678", vestiging="849586958473")
+
+        mock_retrieve_rsin_with_kvk.assert_called_with("12345678")
+        salt = "generate_email_from_bsn"
+        hashed_bsn = md5(
+            (salt + "12345678" + "849586958473").encode(), usedforsecurity=False
+        ).hexdigest()
+        self.assertEqual(new_user.email, f"{hashed_bsn}@localhost")
+        self.assertEqual(new_user.rsin, "123456789")
+        self.assertEqual(new_user.vestiging, "849586958473")
+        self.assertEqual(new_user.login_type, LoginTypeChoices.eherkenning)
+
+        self.assertEqual(existing_user.kvk, new_user.kvk)
+        self.assertEqual(existing_user.vestiging, "")
+
+        self.assertEqual(list(User.objects.all()), [existing_user, new_user])
+
+        self.assertEqual(callback_response.wsgi_request.user, new_user)
+        self.assertTrue(
+            EHerkenningSessionContext(
+                callback_response.wsgi_request
+            ).is_branch_restricted()
+        )
+
+    @patch("open_inwoner.accounts.signals.KvKClient.get_basisprofiel", autospec=True)
+    @patch("open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.verify_token")
+    @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_token")
+    @patch(
+        "open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo",
+        return_value=OpenIDEHerkenningConfig(
+            id=1,
+            enabled=True,
+            legal_subject_claim=["sub"],
+            branch_number_claim=["urn:etoegang:1.9:ServiceRestriction:Vestigingsnr"],
+        ),
+    )
+    def test_existing_user_is_returned_for_already_existing_kvk_and_vestiging(
+        self,
+        mock_get_solo,
+        mock_get_token,
+        mock_verify_token,
+        mock_store_tokens,
+        mock_get_userinfo,
+        mock_retrieve_rsin_with_kvk,
+        mock_get_basisprofiel,
+    ):
+        mock_get_basisprofiel.return_value = {
+            "_embedded": {"eigenaar": {"rechtsvorm": "Stichting"}}
+        }
+        mock_retrieve_rsin_with_kvk.return_value = "123456789"
+        # set up a user with a non existing email address
+        mock_get_userinfo.return_value = {
+            "sub": "12345678",
+            "urn:etoegang:1.9:ServiceRestriction:Vestigingsnr": "849586958473",
+        }
+        existing_user = eHerkenningUserFactory.create(
+            kvk="12345678",
+            rsin="123456789",
+            email="existing_user@example.com",
+            vestiging="849586958473",
+        )
+        session = self.client.session
+        session["oidc_states"] = {
+            "mock": {
+                "nonce": "nonce",
+                "config_class": "accounts.OpenIDEHerkenningConfig",
+            }
+        }
+        session.save()
+        callback_url = reverse("eherkenning_oidc:callback")
+
+        self.assertFalse(User.objects.filter(email="new_user@example.com").exists())
+
+        # enter the login flow
+        callback_response = self.client.get(
+            callback_url, {"code": "mock", "state": "mock"}
+        )
+
+        self.assertRedirects(
+            callback_response, reverse("pages-root"), fetch_redirect_response=False
+        )
+        db_user = User.objects.get()
+
+        mock_retrieve_rsin_with_kvk.assert_not_called()
+        self.assertEqual(db_user.pk, existing_user.pk)
+        self.assertEqual(db_user.kvk, existing_user.kvk)
+        self.assertEqual(db_user.rsin, existing_user.rsin)
+
+        self.assertEqual(callback_response.wsgi_request.user, db_user)
+        self.assertTrue(
+            EHerkenningSessionContext(
+                callback_response.wsgi_request
+            ).is_branch_restricted()
+        )
 
     @patch(
         "open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo",
@@ -1638,6 +1912,7 @@ class eHerkenningOIDCFlowTests(WebTest):
 
         self.assertContains(response, _("Use DigiD to log in as a sole proprietor."))
 
+    @skip("Slated for deprecation")
     @patch(
         "open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk",
         return_value="123456789",
@@ -1762,6 +2037,7 @@ class eHerkenningOIDCFlowTests(WebTest):
 
         self.assertEqual(profile_response.status_code, 200)
 
+    @skip("Slated for deprecation")
     @patch(
         "open_inwoner.accounts.signals.KvKClient.retrieve_rsin_with_kvk",
         autospec=True,

--- a/src/open_inwoner/cms/cases/tests/test_contactform.py
+++ b/src/open_inwoner/cms/cases/tests/test_contactform.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, patch
 from django.conf import settings
 from django.contrib.auth import signals
 from django.core import mail
-from django.test import Client, TestCase, override_settings, tag
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
@@ -703,7 +703,6 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
 
         mock_send_confirm.assert_called_once_with("foo@example.com", ANY)
 
-    @tag("user_model_with_vestiging")
     def test_form_success_with_api_eherkenning_user(
         self, m, mock_contactmoment, mock_send_confirm
     ):

--- a/src/open_inwoner/components/tests/test_header.py
+++ b/src/open_inwoner/components/tests/test_header.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from pyquery import PyQuery
 
@@ -129,6 +129,7 @@ class HeaderTest(TestCase):
         self.assertEqual(links[2].attr("href"), self.published2.get_absolute_url())
         self.assertEqual(links[3].attr("href"), self.published4.get_absolute_url())
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session()
     def test_categories_visibility_for_eherkenning_users(self):
         config = SiteConfiguration.get_solo()

--- a/src/open_inwoner/kvk/middleware.py
+++ b/src/open_inwoner/kvk/middleware.py
@@ -1,6 +1,6 @@
 from django.urls import NoReverseMatch, reverse
 
-from open_inwoner.kvk.branches import kvk_branch_selected_done
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 from open_inwoner.utils.middleware import BaseConditionalUserRedirectMiddleware
 
 
@@ -8,10 +8,11 @@ class KvKLoginMiddleware(BaseConditionalUserRedirectMiddleware):
     """Redirect authenticated eHerkenning users to select a company branch"""
 
     def requires_redirect(self, request):
-        user = request.user
-        return user.is_eherkenning_user and not kvk_branch_selected_done(
-            request.session
-        )
+        if not request.user.is_eherkenning_user:
+            return False
+
+        context = EHerkenningSessionContext(request)
+        return not context.is_initial_branch_selection_done()
 
     def get_redirect_url(self, request):
         try:

--- a/src/open_inwoner/kvk/tests/test_views.py
+++ b/src/open_inwoner/kvk/tests/test_views.py
@@ -5,10 +5,12 @@ from django.urls import reverse, reverse_lazy
 
 from pyquery import PyQuery
 
-from open_inwoner.accounts.tests.factories import eHerkenningUserFactory
-from open_inwoner.kvk.branches import (
-    KVK_BRANCH_SESSION_VARIABLE,
-    kvk_branch_selected_done,
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.models import User
+from open_inwoner.accounts.tests.factories import (
+    DigidUserFactory,
+    eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
 )
 from open_inwoner.kvk.tests.factories import CertificateFactory
 
@@ -35,6 +37,27 @@ class KvKViewsTestCase(TestCase):
 
         self.assertEqual(response.status_code, 401)
 
+    def test_post_as_non_eherkenning_user_throws_401(self):
+        self.client.force_login(DigidUserFactory())
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_post_as_branch_restricted_user_throws_401(self):
+        self.client.force_login(eHerkenningVestigingUserFactory())
+
+        # Note: we have to persist the session in a separate variable because every
+        # property access on self.client insantiates a new session
+        session = self.client.session
+        session.update(
+            {EHerkenningSessionContext.KVK_BRANCH_RESTRICTION_SESSION_KEY: True}
+        )
+        session.save()
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 401)
+
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
         "open_inwoner.kvk.models.KvKConfig.get_solo",
@@ -52,12 +75,26 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
+        self.client.force_login(
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
 
-        response = self.client.post(self.url, data={"branch_number": "1234"})
+        vestiging = "1234"
+        self.assertEqual(
+            User.eherkenning_objects.filter_by_kvk_and_vestiging(
+                kvk=self.user.kvk, vestiging=vestiging
+            ).count(),
+            0,
+        )
+        response = self.client.post(self.url, data={"branch_number": vestiging})
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(kvk_branch_selected_done(self.client.session), True)
+        self.assertTrue(
+            EHerkenningSessionContext(
+                response.wsgi_request
+            ).is_initial_branch_selection_done()
+        )
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
@@ -74,12 +111,26 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
+        vestiging_user = eHerkenningVestigingUserFactory(kvk=self.user.kvk)
+        self.client.force_login(
+            user=vestiging_user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
 
         response = self.client.post(self.url, data={"branch_number": ""})
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(kvk_branch_selected_done(self.client.session), True)
+        self.assertEqual(
+            response.wsgi_request.user,
+            self.user,
+            msg="Empty branch number interpreted as a change to the legal entity user",
+        )
+        self.assertEqual(response.wsgi_request.user.vestiging, "")
+        self.assertTrue(
+            EHerkenningSessionContext(
+                response.wsgi_request
+            ).is_initial_branch_selection_done()
+        )
 
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
@@ -98,13 +149,18 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
-
+        self.client.force_login(
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
         response = self.client.post(self.url, data={"branch_number": "4321"})
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(kvk_branch_selected_done(self.client.session), False)
-        self.assertNotIn(KVK_BRANCH_SESSION_VARIABLE, self.client.session)
+        self.assertEqual(
+            response.wsgi_request.user,
+            self.user,
+            msg="Branch matched existing user, no user change required",
+        )
 
         doc = PyQuery(response.content)
         branch_inputs = doc.find("[name='branch_number']")
@@ -129,7 +185,10 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
+        self.client.force_login(
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
 
         response = self.client.get(self.url)
 
@@ -137,7 +196,12 @@ class KvKViewsTestCase(TestCase):
         self.assertEqual(response.url, reverse("pages-root"))
         # Because no branches were found, the branch check should be skipped in the future
         # and no branch number should be set
-        self.assertEqual(kvk_branch_selected_done(self.client.session), True)
+        self.assertEqual(response.wsgi_request.user, self.user)
+        self.assertTrue(
+            EHerkenningSessionContext(
+                response.wsgi_request
+            ).is_initial_branch_selection_done()
+        )
 
         response = self.client.get(response.url)
 
@@ -172,7 +236,10 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
+        self.client.force_login(
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
 
         response = self.client.get(self.url)
 
@@ -220,7 +287,10 @@ class KvKViewsTestCase(TestCase):
         mock_solo.return_value.client_certificate = CertificateFactory()
         mock_solo.return_value.server_certificate = CertificateFactory()
 
-        self.client.force_login(user=self.user)
+        self.client.force_login(
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)

--- a/src/open_inwoner/kvk/views.py
+++ b/src/open_inwoner/kvk/views.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -6,7 +8,8 @@ from django.views.generic import FormView
 
 from furl import furl
 
-from open_inwoner.kvk.branches import KVK_BRANCH_SESSION_VARIABLE
+from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.models import User
 from open_inwoner.utils.views import LogMixin
 
 from ..utils.url import get_next_url_from
@@ -57,10 +60,34 @@ class CompanyBranchChoiceView(LogMixin, FormView):
             redirect = furl(reverse("pages-root"))
         return redirect.url
 
-    def get(self, request, *args, **kwargs):
-        if not getattr(request.user, "kvk", None):
+    def check_permissions(self, request):
+        user = cast(User, request.user)
+        context = EHerkenningSessionContext(request)
+
+        # Only eHerkenning users can potentially switch to a vestiging
+        try:
+            context.assert_valid_eherkenning_user(user)
+        except ValueError:
             return HttpResponse(_("Unauthorized"), status=401)
 
+        if context.is_branch_restricted():
+            return HttpResponse(
+                _("Your eHerkenning account cannot access other branches."),
+                status=401,
+            )
+
+    def dispatch(self, request, *args, **kwargs):
+        if bad_auth_response := self.check_permissions(request):
+            return bad_auth_response
+
+        # Assume we can access this page, we mark the branch selection is done if the
+        # page is visited
+        eherkenning_context = EHerkenningSessionContext(request)
+        eherkenning_context.mark_initial_branch_selection_done()
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
         redirect = self.get_redirect()
         context = super().get_context_data()
 
@@ -73,18 +100,14 @@ class CompanyBranchChoiceView(LogMixin, FormView):
                 f"List of company branches for KVK number {request.user.kvk} contains "
                 "no branch with vestigingsnummer"
             )
-            request.session[KVK_BRANCH_SESSION_VARIABLE] = None
-            request.session.save()
+
             return HttpResponseRedirect(redirect)
 
         context["company_branches"] = form.company_branches
 
         return render(request, self.template_name, context)
 
-    def post(self, request):
-        if not getattr(request.user, "kvk", None):
-            return HttpResponse(_("Unauthorized"), status=401)
-
+    def post(self, request, *args, **kwargs):
         redirect = self.get_redirect()
         context = self.get_context_data()
 
@@ -98,7 +121,14 @@ class CompanyBranchChoiceView(LogMixin, FormView):
         # empty string for KVK_BRANCH_SESSION_VARIABLE is interpreted as
         # "interact as the rechtspersoon, not as any specific branch"
         branch_number = request.POST["branch_number"]
-        request.session[KVK_BRANCH_SESSION_VARIABLE] = branch_number
+
+        # Change the user
+        eherkenning_context = EHerkenningSessionContext(request)
+        eherkenning_context.change_authenticated_user(
+            kvk=request.user.kvk,
+            vestiging=branch_number or None,
+        )
+
         self.log_user_action(
             request.user,
             (

--- a/src/open_inwoner/openklant/tests/test_contactform.py
+++ b/src/open_inwoner/openklant/tests/test_contactform.py
@@ -639,6 +639,7 @@ class ContactFormIntegrationTest(
             },
         )
 
+    @tag("user_model_with_vestiging")
     def test_register_contactmoment_for_kvk_or_rsin_user_via_api(
         self, _m, mock_captcha, mock_send_confirm
     ):
@@ -846,6 +847,7 @@ class ContactFormIntegrationTest(
         mock_send_confirm.assert_called_once_with(data.user.email, subject.subject)
         mock_send_confirm.reset_mock()
 
+    @tag("user_model_with_vestiging")
     @patch("open_inwoner.openklant.forms.generate_question_answer_pair")
     def test_register_contactmoment_for_kvk_or_rsin_user_via_api_and_update_klant(
         self, m, mock_captcha2, mock_captcha, mock_send_confirm

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -315,6 +315,7 @@ class ContactMomentViewsTestCase(
                     },
                 )
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session("1234")
     def test_contactmoment_list_vestiging(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
@@ -735,6 +736,7 @@ class ContactMomentViewsTestCase(
             },
         )
 
+    @tag("user_model_with_vestiging")
     def test_contactmoment_detail_esuite_for_kvk_or_rsin(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
     ):
@@ -783,6 +785,7 @@ class ContactMomentViewsTestCase(
                     },
                 )
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session("1234")
     def test_contactmoment_detail_esuite_vestiging(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
@@ -830,6 +833,7 @@ class ContactMomentViewsTestCase(
                     },
                 )
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session("1234")
     def test_cannot_access_detail_for_hoofdvestiging_as_vestiging(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
+from django.test import RequestFactory, tag
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -1522,6 +1522,7 @@ class TestCaseDetailView(
                 self.assertContains(response, "ZAAK-2022-0000000025")
                 self.assertContains(response, "Coffee zaaktype")
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session("1234")
     @patch.object(
         eSuiteVragenService,
@@ -1797,6 +1798,7 @@ class TestCaseDetailView(
                     response, _("Sorry, you don't have access to this page (403)")
                 )
 
+    @tag("user_model_with_vestiging")
     @set_kvk_branch_number_in_session(value=None)
     def test_no_access_if_fetch_eherkenning_zaken_with_rsin_and_user_has_no_rsin(
         self, m

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, tag
 from django.test.utils import override_settings
 from django.urls import reverse_lazy
 
@@ -1311,6 +1311,7 @@ class CaseSubmissionTest(TransactionWebTest):
             data.submission_2["datumLaatsteWijziging"],
         )
 
+    @tag("user_model_with_vestiging")
     @requests_mock.Mocker()
     @patch("open_inwoner.kvk.middleware.kvk_branch_selected_done")
     def test_get_open_submissions_by_kvk(self, m, kvk_branch_selected):

--- a/src/open_inwoner/pdc/tests/test_views.py
+++ b/src/open_inwoner/pdc/tests/test_views.py
@@ -6,9 +6,9 @@ from open_inwoner.accounts.tests.factories import (
     DigidUserFactory,
     UserFactory,
     eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
 )
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.utils.test import set_kvk_branch_number_in_session
 
 from .factories import CategoryFactory
 
@@ -20,7 +20,9 @@ PATCHED_MIDDLEWARE = [
 ]
 
 
-@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+@override_settings(
+    ROOT_URLCONF="open_inwoner.cms.tests.urls", MIDDLEWARE=PATCHED_MIDDLEWARE
+)
 class CategoryListViewTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -150,7 +152,9 @@ class CategoryListViewTest(TestCase):
         )
 
 
-@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+@override_settings(
+    ROOT_URLCONF="open_inwoner.cms.tests.urls", MIDDLEWARE=PATCHED_MIDDLEWARE
+)
 class CategoryDetailViewTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -212,14 +216,13 @@ class CategoryDetailViewTest(TestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    @set_kvk_branch_number_in_session()
     def test_category_detail_view_access_restricted_for_eherkenning_user(self):
         category = CategoryFactory.create(
             name="test cat2",
             description="A <em>descriptive</em> description",
             visible_for_companies=False,
         )
-        user = eHerkenningUserFactory()
+        user = eHerkenningVestigingUserFactory()
         self.client.force_login(user)
 
         url = reverse("products:category_detail", kwargs={"slug": category.slug})


### PR DESCRIPTION
This is the core of the vestiging-user change and breaks down into three parts:

- Updating the OIDC auth backend to handle vestiging-users
- Ibid, for the SAML (and SAML mock!) backends
- Managing branch selection and switching between vestiging-users

You'll want to go commit-by-commit, hopefully it's easy enough to follow. I created a helper (`EHerkenningSessionContext`) which does a lot of the heavy lifting. Specifically, it enforces that:

1. _If_ a vestiging was provided via OIDC/SAML claims, the user _cannot_ switch to either another vestiging _or_ the rechtsperson itself. This might ultimately not be the desired behavior, but let's be restrictive until we hear otherwise.
2. It tries to maintain parity with the existing branch selection behavior, basically: you are only redirected to the selection screen if your eHerkenning does not indicate a specific branch (meaning you _also_ shouldn't see it when you switch vestiging-users!).

The functionality whereby a vestiging is provided via OIDC/SAML is hard to test locally (our mocks don't support passing a vestiging right now), but you can still login with one of the KvK Test users and select one of the vestigingen. On your profile page, you'll see the currently selected vestiging (or not if you are the rechtspersoon itself).