### PR TITLE
Bump kombu to 5.5.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -380,7 +380,7 @@ josepy==1.13.0
     # via mozilla-django-oidc
 jsonschema==4.1.0
     # via drf-spectacular
-kombu==5.3.7
+kombu==5.5.1
     # via celery
 lxml==4.9.1
     # via
@@ -567,10 +567,11 @@ typing-extensions==4.10.0
     #   xsdata
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.1
     # via
     #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.18

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -692,7 +692,7 @@ jsonschema==4.1.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   drf-spectacular
-kombu==5.3.7
+kombu==5.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1102,12 +1102,13 @@ typing-extensions==4.10.0
     #   xsdata
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -781,7 +781,7 @@ jsonschema==4.1.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   drf-spectacular
-kombu==5.3.7
+kombu==5.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1305,12 +1305,13 @@ typing-extensions==4.10.0
     #   xsdata
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
This is to deal with the issue mentioned in:
https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/229

TLDR, Celery would sometimes be unable to reconnect to redis upon connection
loss. This will be fixed in Celery 5.5, but we can get an advance by
bumping Kombu to 5.5, which doesn't appear to have any breaking changes
relevant to our setup.