### PR TITLE
[#2864] Replace notification-red with a more accessible variant 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@emotion/styled": "^11.3.0",
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@joeattardi/emoji-button": "^4.6.4",
-        "@open-inwoner/design-tokens": "^0.0.3-alpha.0",
+        "@open-inwoner/design-tokens": "^0.0.10-alpha.0",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "bem.js": "^1.0.10",
         "emojibase-data": "^7.0.1",
@@ -4139,9 +4139,9 @@
       }
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.7-alpha.2.tgz",
-      "integrity": "sha512-AEK4epmcim1CeQkTWyXU1eh2AynzSZiEGtRtB2RxBOpb9E/l2qBWsvqF+Efr5nHC0klBAZimgDCMUkNZAbG/Og=="
+      "version": "0.0.10-alpha.0",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.10-alpha.0.tgz",
+      "integrity": "sha512-YM+eaKD81zgSn4XbZ5VDNJVIx1dcmXLXtD1CZcBujQe9G+Lw2ZKign1D18jSGA5DYM933Skwh8i5QIx4Zizzog=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.5",
@@ -22711,9 +22711,9 @@
       }
     },
     "@open-inwoner/design-tokens": {
-      "version": "0.0.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.7-alpha.2.tgz",
-      "integrity": "sha512-AEK4epmcim1CeQkTWyXU1eh2AynzSZiEGtRtB2RxBOpb9E/l2qBWsvqF+Efr5nHC0klBAZimgDCMUkNZAbG/Og=="
+      "version": "0.0.10-alpha.0",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.10-alpha.0.tgz",
+      "integrity": "sha512-YM+eaKD81zgSn4XbZ5VDNJVIx1dcmXLXtD1CZcBujQe9G+Lw2ZKign1D18jSGA5DYM933Skwh8i5QIx4Zizzog=="
     },
     "@popperjs/core": {
       "version": "2.11.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@joeattardi/emoji-button": "^4.6.4",
-    "@open-inwoner/design-tokens": "^0.0.7-alpha.2",
+    "@open-inwoner/design-tokens": "^0.0.10-alpha.0",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "bem.js": "^1.0.10",
     "emojibase-data": "^7.0.1",

--- a/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
+++ b/src/open_inwoner/scss/components/CardContainer/CardContainer.scss
@@ -56,7 +56,7 @@
     .form {
       /// Make required asterisk visible for this component
       .label__label--required {
-        color: var(--color-red);
+        color: var(--color-red-notification);
         padding-left: var(--spacing-tiny);
         //make asterisks invisible by default, only make them visible if component has the caption
         display: inline;

--- a/src/open_inwoner/scss/components/Cases/CaseDetail.scss
+++ b/src/open_inwoner/scss/components/Cases/CaseDetail.scss
@@ -118,7 +118,7 @@
 
     /// Make required asterisk visible for this component
     .label__label--required {
-      color: var(--color-red);
+      color: var(--color-red-notification);
       padding-left: var(--spacing-tiny);
       //make asterisks invisible by default, only make them visible if component has the caption
       display: inline;

--- a/src/open_inwoner/scss/components/Condition/Condition.scss
+++ b/src/open_inwoner/scss/components/Condition/Condition.scss
@@ -20,6 +20,6 @@
   }
 
   &--negative {
-    color: var(--color-red);
+    color: var(--color-red-notification);
   }
 }

--- a/src/open_inwoner/scss/components/ContactForm/ContactForm.scss
+++ b/src/open_inwoner/scss/components/ContactForm/ContactForm.scss
@@ -2,7 +2,7 @@
   .form {
     /// Make required asterisk visible for this component
     .label__label--required {
-      color: var(--color-red);
+      color: var(--color-red-notification);
       padding-left: var(--spacing-tiny);
       //make asterisks invisible by default, only make them visible if component has the caption
       display: inline;

--- a/src/open_inwoner/scss/components/Form/Form.scss
+++ b/src/open_inwoner/scss/components/Form/Form.scss
@@ -172,7 +172,7 @@
 
   .label__label--required {
     font-size: var(--font-size-body-large);
-    color: var(--color-red);
+    color: var(--color-red-notification);
     padding-left: var(--spacing-tiny);
     vertical-align: sub;
     //make asterisks invisible by default, only make them visible if component has the caption

--- a/src/open_inwoner/scss/components/Form/Input.scss
+++ b/src/open_inwoner/scss/components/Form/Input.scss
@@ -32,7 +32,7 @@
 
 .label__label--required {
   font-size: var(--font-size-body-large);
-  color: var(--color-red);
+  color: var(--color-red-notification);
   padding-left: var(--spacing-tiny);
   vertical-align: sub;
 }

--- a/src/open_inwoner/scss/components/Plan/PlanFile.scss
+++ b/src/open_inwoner/scss/components/Plan/PlanFile.scss
@@ -1,7 +1,7 @@
 #document-create {
   /// Make required asterisk visible for this component
   .label__label--required {
-    color: var(--color-red);
+    color: var(--color-red-notification);
     padding-left: var(--spacing-tiny);
     //make asterisks invisible by default, only make them visible if component has the caption
     display: inline;

--- a/src/open_inwoner/scss/components/TabPanel/TabPanel.scss
+++ b/src/open_inwoner/scss/components/TabPanel/TabPanel.scss
@@ -126,7 +126,7 @@
   .form {
     /// Make required asterisk visible for this component
     .label__label--required {
-      color: var(--color-red);
+      color: var(--color-red-notification);
       padding-left: var(--spacing-tiny);
       //make asterisks invisible by default, only make them visible if component has the caption
       display: inline;

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -36,7 +36,6 @@
   --color-gray-lightest: #f3f3f3;
   --color-green: #d5e7d4;
   --color-green-dark: #248641;
-  --color-red: #e50026;
   --color-red-notification: var(--oip-color-red-notification);
   --color-white: #fff;
   --color-yellow: #f8d62d;

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -56,7 +56,7 @@
 
   &---django_registration_register {
     .label__label--required {
-      color: var(--color-red);
+      color: var(--color-red-notification);
       padding-left: var(--spacing-tiny);
       //make asterisks invisible by default, only make them visible if component has the caption
       display: inline;


### PR DESCRIPTION
(Needed for OIP release 1.29). The OIP notification-red does not have sufficient accessible contrast, so replacing it with the type of red we use for "required" asterisks. Also removing the old way to set colors and replacing it with just one NL-Design-Token.

Issue and all effected components: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2864 

When running this, you will actually use the code published from this PR:
https://github.com/maykinmedia/open-inwoner-design-tokens/pull/14

So:
$ npm ci --legacy-peer-deps
$ npm run build

in order to see the new :red_circle: red pop up everywhere.