### PR TITLE
Expand user admin display items and filters

### DIFF
--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -169,7 +169,7 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
         "login_type",
     )
     search_fields = ("first_name", "infix", "last_name", "email")
-    ordering = ("email",)
+    ordering = ("last_login",)
     filter_horizontal = (
         "user_contacts",
         "contacts_for_approval",

--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -159,6 +159,8 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
         "is_staff",
         "is_active",
         "contact_type",
+        "last_login",
+    )
     )
     search_fields = ("first_name", "infix", "last_name", "email")
     ordering = ("email",)

--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -161,6 +161,12 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
         "contact_type",
         "last_login",
     )
+    list_filter = (
+        "is_staff",
+        "is_superuser",
+        "is_active",
+        "groups",
+        "login_type",
     )
     search_fields = ("first_name", "infix", "last_name", "email")
     ordering = ("email",)


### PR DESCRIPTION
While working on the vestigingen branch, I noticed it was quite hard to get a sense of user activity and creation from the admin panel: especially `last_login` and `login_type` are tucked away on the detail page. It makes sense to add a few more fields here.