### PR TITLE
Ensure the KlantenService correctly sends vestigingen params

### DIFF
--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -24,7 +24,10 @@ logger = logging.getLogger(__name__)
 
 class KlantenClient(APIClient):
     def retrieve_klant(
-        self, user_bsn: str | None = None, user_kvk_or_rsin: str | None = None
+        self,
+        user_bsn: str | None = None,
+        user_kvk_or_rsin: str | None = None,
+        vestigingsnummer: str | None = None,
     ) -> Klant | None:
         if not user_bsn and not user_kvk_or_rsin:
             return
@@ -33,7 +36,9 @@ class KlantenClient(APIClient):
         if user_bsn:
             klanten = self.retrieve_klanten_for_bsn(user_bsn)
         elif user_kvk_or_rsin:
-            klanten = self.retrieve_klanten_for_kvk_or_rsin(user_kvk_or_rsin)
+            klanten = self.retrieve_klanten_for_kvk_or_rsin(
+                user_kvk_or_rsin=user_kvk_or_rsin, vestigingsnummer=vestigingsnummer
+            )
 
         if klanten:
             # let's use the first one
@@ -58,14 +63,15 @@ class KlantenClient(APIClient):
         return klanten
 
     def retrieve_klanten_for_kvk_or_rsin(
-        self, user_kvk_or_rsin: str, *, vestigingsnummer=None
+        self, user_kvk_or_rsin: str, *, vestigingsnummer: str | None = None
     ) -> list[Klant]:
-        params = {"subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin}
-
-        if vestigingsnummer:
-            params = {
+        params = (
+            {
                 "subjectVestiging__vestigingsNummer": vestigingsnummer,
             }
+            if vestigingsnummer
+            else {"subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin}
+        )
 
         try:
             response = self.get(

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -269,10 +269,14 @@ class eSuiteKlantenService(
         if user_bsn:
             payload = payload | {"subjectIdentificatie": {"inpBsn": user_bsn}}
         elif user_kvk_or_rsin:
-            payload = payload | {"subjectIdentificatie": {"innNnpId": user_kvk_or_rsin}}
             if vestigingsnummer:
-                payload["subjectIdentificatie"] = payload["subjectIdentificatie"] | {
-                    "vestigingsNummer": vestigingsnummer
+                payload = payload | {
+                    "subjectIdentificatie": {"vestigingsNummer": vestigingsnummer}
+                }
+
+            else:
+                payload = payload | {
+                    "subjectIdentificatie": {"innNnpId": user_kvk_or_rsin}
                 }
 
         try:

--- a/src/open_inwoner/openklant/tests/test_esuite_service.py
+++ b/src/open_inwoner/openklant/tests/test_esuite_service.py
@@ -123,7 +123,8 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
             m.request_history[0].json(),
             {
                 "subjectIdentificatie": {
-                    "innNnpId": "87654321",
+                    # Note: the innNnpId is not sent for vestiging, it's either innNnpId
+                    # or vestigingsNummer
                     "vestigingsNummer": "123456789000",
                 }
             },


### PR DESCRIPTION
The Klanten API expects either the innNnpId or the vestigingsNummer parameter is sent, but not both. This commit fixes this at the client level.