### PR TITLE
Persist full session on eHerkenning user switch

### DIFF
--- a/src/open_inwoner/accounts/eherkenning_session.py
+++ b/src/open_inwoner/accounts/eherkenning_session.py
@@ -1,5 +1,11 @@
 from django.conf import settings
-from django.contrib.auth import login as django_login, logout as django_logout
+from django.contrib.auth import (
+    BACKEND_SESSION_KEY,
+    HASH_SESSION_KEY,
+    SESSION_KEY,
+    login as django_login,
+    logout as django_logout,
+)
 from django.http import HttpRequest
 
 from open_inwoner.accounts.models import User
@@ -138,6 +144,7 @@ class EHerkenningSessionContext:
         # Persist these values before the session is cleared
         previous_backend = self._request.session["_auth_user_backend"]
         previous_initial_branch_selection_done = self.is_initial_branch_selection_done()
+        previous_session = dict(self._request.session)
 
         # Clear the session
         django_logout(self._request)
@@ -148,6 +155,18 @@ class EHerkenningSessionContext:
             user=target_user,
             backend=previous_backend,
         )
+
+        # We want to preserve as much as possible from the previous session values
+        # as possible. This is especially important because various flows in the
+        # mozilla_django_oidc_db depend on the presence of various session variables
+        # to work properly (e.g. SSO via the OIDC IdP).
+        skip = (SESSION_KEY, BACKEND_SESSION_KEY, HASH_SESSION_KEY)
+        for key, val in previous_session.items():
+            if key not in skip:
+                self._request.session[key] = val
+
+        self._request.session.save()
+
         self.persist_eherkenning_state_for_user(
             user=target_user,
             is_branch_restricted=False,

--- a/src/open_inwoner/accounts/tests/test_eherkenning_session.py
+++ b/src/open_inwoner/accounts/tests/test_eherkenning_session.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.contrib.auth import HASH_SESSION_KEY, SESSION_KEY, login as django_login
 from django.test import RequestFactory, TestCase
 
 from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
@@ -232,3 +233,45 @@ class EHerkenningSessionContextTests(TestCase):
                 )
                 self.assertEqual(context.is_branch_restricted(), False)
                 self.assertFalse(context.is_initial_branch_selection_done())
+
+    def test_change_authenticated_user_persists_session_variables(self):
+        request = self.make_request_with_session()
+        request.session[
+            "_auth_user_backend"
+        ] = EHerkenningSessionContext._expected_auth_backends()[0]
+        request.user = self.user
+        context = EHerkenningSessionContext(request)
+        context._set_branch_restriction(False)
+        session = request.session
+        session["foo"] = "bar"
+        session["baz"] = 42
+        session.save()
+
+        # To add session and auth keys to the session
+        django_login(
+            request,
+            user=self.user,
+            backend=EHerkenningSessionContext._expected_auth_backends()[0],
+        )
+        initial_session_dict = dict(session)
+
+        context.change_authenticated_user(
+            kvk=self.vestiging_user.kvk,
+            vestiging=self.vestiging_user.vestiging,
+        )
+
+        self.assertEqual(request.user, self.vestiging_user)
+        self.assertEqual(
+            request.session["_auth_user_backend"],
+            EHerkenningSessionContext._expected_auth_backends()[0],
+        )
+        self.assertEqual(context.is_branch_restricted(), False)
+        self.assertFalse(context.is_initial_branch_selection_done())
+        self.assertEqual(context._request.session["foo"], "bar")
+        self.assertEqual(context._request.session["baz"], 42)
+        self.assertNotEqual(
+            initial_session_dict[SESSION_KEY], request.session[SESSION_KEY]
+        )
+        self.assertNotEqual(
+            initial_session_dict[HASH_SESSION_KEY], request.session[HASH_SESSION_KEY]
+        )


### PR DESCRIPTION
When switching users for a different vestiging, the user will initially have authenticated through SAML or OIDC. In the latter case especially, there will be a number of session variables on which the OIDC flows depend. For instance, the ID token may be persisted and this will be used for the logout flow.

When a user switches to a different vestiging-user, we do not want to break any of these flows. Essentially, it should be as if the session was not changed _except_ for the user (and possible the branch selection flag).

To address this, we copy over all session variables, apart from the Django auth session keys which obviously will change, because we now have a new user.

The alternative was to copy over the specific variables which the OIDC backend expects, but that leaves us vulnerable to breaking interface changes in these packages. More generally, other modules might depend on the existence of certain session variables. In that light, simply copying over as much as we can seems like the safest path forward.