### PR TITLE
Bump mozilla django oidc to 0.23.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -407,7 +407,7 @@ messagebird==2.1.0
     # via -r requirements/base.in
 mozilla-django-oidc==4.0.1
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.22.0
+mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -752,7 +752,7 @@ mozilla-django-oidc==4.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.22.0
+mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -852,7 +852,7 @@ mozilla-django-oidc==4.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.22.0
+mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -279,6 +279,7 @@ MIDDLEWARE = [
     "open_inwoner.accounts.middleware.NecessaryFieldsMiddleware",
     "open_inwoner.accounts.middleware.EmailVerificationMiddleware",
     "open_inwoner.cms.utils.middleware.AnonymousHomePageRedirectMiddleware",
+    "mozilla_django_oidc_db.middleware.SessionRefresh",
 ]
 
 ROOT_URLCONF = "open_inwoner.urls"
@@ -518,16 +519,6 @@ SESSION_COOKIE_AGE = 900  # Set to 15 minutes or less for testing
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
 
-# The SessionRefresh middleware is currently broken if multiple OIDC configurations
-# are active. As a workaround until this is fixed, we use this flag to optionally disable
-# it.
-# TODO: Remove when https://github.com/maykinmedia/mozilla-django-oidc-db/issues/136
-# has been resolved.
-USE_OIDC_SESSION_REFRESH_MIDDLEWARE = config(
-    "USE_OIDC_SESSION_REFRESH_MIDDLEWARE", default=True
-)
-if USE_OIDC_SESSION_REFRESH_MIDDLEWARE:
-    MIDDLEWARE.append("mozilla_django_oidc_db.middleware.SessionRefresh")
 
 #
 # SECURITY settings


### PR DESCRIPTION
The latest version of mozilla-django-oidc-db now should
properly apply the middleware for a dynamic config backend,
meaning the feature flag and gating is no longer needed.