### PR TITLE
feat: disable the Django sites framework

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -22,8 +22,6 @@ BASE_DIR = os.path.abspath(
 #
 # Core Django settings
 #
-SITE_ID = config("SITE_ID", default=1)
-
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -127,9 +125,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
-    # NOTE: If enabled, at least one Site object is required and
-    # uncomment SITE_ID above.
-    "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.flatpages",


### PR DESCRIPTION
The Django sites framework frequently causes deployment issues in new environments due to lacking a proper setup flow. We could obviously add that (django setup configuration has a built-in step for this), but given that nothing else uses the framework, it makes more sense just to disable it as a vestigial bit of functionality that we have no use for.

BREAKING CHANGE: Removes the Sites framework