### PR TITLE
feat: make SECRET_KEY_FALLBACKS environment configurable

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -29,6 +29,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config("SECRET_KEY")
 
+# To facilitate key rotation and migrations. We currently only allow a single value
+# (hence the singular `SECRET_KEY_FALLBACK` config attribute).
+if secret_key_fallback := config("SECRET_KEY_FALLBACK", default=""):
+    SECRET_KEY_FALLBACKS = [secret_key_fallback]
+
 # NEVER run with DEBUG=True in production-like environments
 DEBUG = config("DEBUG", default=False)
 


### PR DESCRIPTION
Apart from allowing key rotation as a general best practice,
making the SECRET_KEY_FALLBACKS configurable can facilitate
instance migrations which keep existing sessions intact (using
the fallback) whilst progressively phasing these ciphertexts
out on the basis of the new primary SECRET_KEY.

We only allow a single value to avoid commas intended to be
part of a high-entropy SECRET_KEY being interpreted as a
list (and thereby giving several low-entropy secret keys).

This is in anticipation of some planned OIP migrations, to
give us the option to migrate crypto-verified state if we
need to.