### PR TITLE
feat: make rebuild_search_index task retryable

### DIFF
--- a/src/open_inwoner/search/tasks.py
+++ b/src/open_inwoner/search/tasks.py
@@ -3,12 +3,25 @@ import logging
 
 from django.core.management import call_command
 
+from elasticsearch.exceptions import ConnectionError, ConnectionTimeout
+
 from open_inwoner.celery import app
 
 logger = logging.getLogger(__name__)
 
 
-@app.task
+@app.task(
+    autoretry_for=(
+        ConnectionError,
+        ConnectionTimeout,
+    ),
+    # This is a periodic job that runs nightly, and especially on test environments is
+    # prone to timeouts. Hence the generous retry_backoff parameter to give us a bit of
+    # slack to let the JVM garbage collector do its work.
+    retry_kwargs={"max_retries": 5},
+    retry_backoff=120,
+    retry_jitter=True,
+)
 def rebuild_search_index():
     logger.info("starting rebuild_search_index() task")
 


### PR DESCRIPTION
Test instances often have elasticsearch containers with
limited resources, meaning that the daily index rebuild
fails frequently due to timeouts and memory issues. Given
that this task is meant as a daily job which is non
time critical, we can give it a generous retry schedule.

[Taiga 3217](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3217)