### PR TITLE
[#3218] Use correct anchors and titles in profile navigation menu

### DIFF
--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -102,11 +102,17 @@ class MyProfileView(
         user = self.request.user
         today = date.today()
 
+        if user.is_eherkenning_user:
+            overview_anchor = ("#business-overview", _("Bedrijfsgegevens"))
+        else:
+            overview_anchor = ("#personal-info", _("Persoonlijke gegevens"))
+
         context["anchors"] = [
-            ("#personal-info", _("Persoonlijke gegevens")),
-            ("#overview", _("Overzicht")),
+            overview_anchor,
             ("#profile-remove", _("Profiel verwijderen")),
         ]
+        if self.config and self.config.selected_categories:
+            context["anchors"].insert(1, ("#overview", _("Overzicht")))
         if config.any_notifications_enabled:
             context["anchors"].insert(
                 1, ("#notifications", _("Voorkeuren voor meldingen"))


### PR DESCRIPTION
The PR fixes two issues with the navigation menu in the profile:

- the navigation anchor for eherkenning users uses the wrong tile (is: 'Persoonlijke gegevens', should be: 'Bedrijfsgegevens')
- the navigation anchor 'Overzicht' should only be displayed if there are selected categories to be displayed (configurable via the CMS profile app)

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3218