### PR TITLE
Small refactors of kvk/vestigingen params in API queries

### DIFF
--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -220,12 +220,15 @@ class eSuiteKlantenService(
     def _retrieve_klanten_for_kvk_or_rsin(
         self, user_kvk_or_rsin: str, *, vestigingsnummer=None
     ) -> list[Klant]:
-        params = {"subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin}
-
-        if vestigingsnummer:
-            params = {
+        params = (
+            {
                 "subjectVestiging__vestigingsNummer": vestigingsnummer,
             }
+            if vestigingsnummer
+            else {
+                "subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin,
+            }
+        )
 
         try:
             response = self.client.get(

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -95,7 +95,8 @@ class ZakenClient(ZgwAPIClient):
             return fetch_cases_for_company(
                 kvk_or_rsin=user_kvk_or_rsin,
             )
-        return []
+
+        raise ValueError("You must supply either a bsn or kvk/rsin/vestigingsnummer")
 
     @cache_result(
         "{self.base_url}:cases:{user_bsn}:{max_requests}:{identificatie}",

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -1,5 +1,6 @@
 import base64
 import concurrent.futures
+import functools
 import logging
 import warnings
 from dataclasses import dataclass
@@ -79,18 +80,20 @@ class ZakenClient(ZgwAPIClient):
             return self.fetch_cases_by_bsn(
                 user_bsn, max_requests=max_requests, identificatie=identificatie
             )
+
+        fetch_cases_for_company = functools.partial(
+            self.fetch_cases_for_company,
+            max_requests=max_requests,
+            zaak_identificatie=identificatie,
+        )
         if vestigingsnummer:
-            return self.fetch_cases_for_company(
-                max_requests=max_requests,
-                zaak_identificatie=identificatie,
+            return fetch_cases_for_company(
                 vestigingsnummer=vestigingsnummer,
             )
         if user_kvk or user_rsin:
             user_kvk_or_rsin = user_rsin if user_rsin else user_kvk
-            return self.fetch_cases_for_company(
+            return fetch_cases_for_company(
                 kvk_or_rsin=user_kvk_or_rsin,
-                max_requests=max_requests,
-                zaak_identificatie=identificatie,
             )
         return []
 


### PR DESCRIPTION
For DImpact I had to check how we use `kvk`/`vestigingsnummer` for different APIs (basically: both or either?), and I made these small refactors for readability.