### PR TITLE
[#3242] Replace 'welcome' with icon and add firstname/businessname in authenticated menu

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -9,31 +9,29 @@
         <div class="header__menu">
         {% if request.user.is_authenticated or not config.hide_categories_from_anonymous_users %}
             <button class="header__button" aria-expanded="false">
-                <div class="header__menu-icon">
+                <span class="header__menu-icon">
                     <span class="closed">{% trans "Menu" %}</span>
                     <span class="open">{% trans "Sluiten" %}</span>
-                </div>
+                </span>
             </button>
         {% endif %}
         {% firstof config.logo.default_alt_text config.name as logo_alt_text %}
         {% include "components/Logo/Logo.html" with src=config.logo.file.url alt=logo_alt_text svg_height=75 only %}
 
         {% if request.user.is_authenticated %}
-            <span class="nav-login--icon">{% icon icon="how_to_reg" icon_position="before" outlined=True %}
-                <span class="sr-only">{% trans "U bent ingelogd." %}</span>
-            </span>
+        <span class="nav-login__icon nav-login__icon--authenticated">
+            {% button text="" title=_("U bent ingelogd.") href="profile:detail" icon="how_to_reg" icon_position="before" transparent=True icon_outlined=True %}
+        <span class="sr-only">{% trans "U bent ingelogd." %}</span>
+        </span>
         {% elif config.login_show %}
-            <span class="nav-login--icon">
-                {% url 'login' as login_url %}
-                {% trans "Inloggen" as login %}
-                {% button text="" title="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True %}
-            </span>
+        <span class="nav-login__icon">
+            {% button text="" title=_("Inloggen") href="login" icon="person" icon_position="before" primary=True icon_outlined=True %}
+        </span>
         {% endif %}
         </div>
         {# end of mobile header-menu with logo #}
 
         <div class="header--mobile header__submenu">
-        
             <div class="header--mobile__close">
                 {% button icon="close" text=_("Sluiten") hide_text=True icon_outlined=True transparent=True id="closeMobileNav" %}
             </div>
@@ -92,9 +90,8 @@
                     {% elif config.login_show %}
                         <ul class="header__list">
                             <li class="header__list-item">
-                                {% url 'login' as login_url %}
                                 {% trans "Log in" as loginmobile %}
-                                {% link text=loginmobile title=loginmobile href=login_url icon="account_circle" icon_position="before" primary=True icon_outlined=True %}
+                                {% link text=loginmobile title=loginmobile href="login" icon="account_circle" icon_position="before" primary=True icon_outlined=True %}
                             </li>
                         </ul>
                     {% endif %}

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -7,7 +7,14 @@
     <nav class="primary-navigation primary-navigation--desktop primary-navigation__authenticated" aria-label="Navigatie na inloggen">
         <ul class="primary-navigation__list">
             <li class="primary-navigation__list-item">
-            {% button text=_('Welkom ')|addstr:request.user.display_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+                <span class="nav-login__icon">{% icon icon="how_to_reg" icon_position="before" outlined=True %}</span>
+                {% if user.is_eherkenning_user and user.vestiging %}
+                    {% button text=user.branch_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+                {% elif user.is_eherkenning_user %}
+                    {% button text=user.company_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+                {% else %}
+                    {% button text=user.display_name type="button" icon="expand_more" icon_position="after" icon_outlined=True transparent=True extra_classes="primary-navigation--toggle" %}
+                {% endif %}
 
                 {% if request.user.num_indicators %}
                     {# num_indicators is set from a modifier in show_menu_below_id #}
@@ -34,9 +41,7 @@
 {% elif config.login_show %}
     <div class="desktop-login">
         <span class="desktop-login__link">
-            {% url 'login' as login_url %}
-            {% trans "Inloggen" as login %}
-            {% button text="Inloggen" href=login_url icon="person" icon_position="before" primary=True icon_outlined=True %}
+            {% button text=_("Inloggen") href="login" icon="person" icon_position="before" primary=True icon_outlined=True %}
         </span>
     </div>
 {% endif %}

--- a/src/open_inwoner/js/components/siteimprove/tracking.js
+++ b/src/open_inwoner/js/components/siteimprove/tracking.js
@@ -400,11 +400,20 @@ const partialClickSelectors = {
     {
       category: 'Dropdown navigatie',
     },
+  '.header .header__container > nav.primary-navigation.primary-navigation--desktop.primary-navigation__authenticated > ul > li > span > span':
+    {
+      category: 'Dropdown navigatie desktop',
+      label: 'Click op persoons-icoon',
+    },
   '.header--mobile.header__submenu > nav > ul > li a span': {
     category: 'Mobiel menu',
   },
   '.header--mobile__close *': {
     category: 'Mobiel menu',
+  },
+  '.header .header__container > .header__menu > span > a': {
+    category: 'Mobiel menu',
+    label: 'Click op persoons-icoon',
   },
   '.userfeed .card *': {
     category: 'Homepage openstaande acties',
@@ -541,10 +550,7 @@ const keydownSelectors = {
       // Check if the target or any of its ancestors has a class we do not wish to track
       let doNotTrackElement = target
       while (doNotTrackElement) {
-        if (
-          doNotTrackElement.matches('#registration-form') ||
-          doNotTrackElement.classList.contains('login-tab--container')
-        ) {
+        if (doNotTrackElement.classList.contains('login-tab--container')) {
           return
         }
         doNotTrackElement = doNotTrackElement.parentElement

--- a/src/open_inwoner/scss/components/Filter/FilterModal.scss
+++ b/src/open_inwoner/scss/components/Filter/FilterModal.scss
@@ -72,9 +72,9 @@
     align-items: flex-end;
 
     *[class*='icons'] {
-      font-size: 32px;
-      width: 32px;
-      max-width: 32px;
+      font-size: var(--font-size-icon-large);
+      width: var(--font-size-icon-large);
+      max-width: var(--font-size-icon-large);
     }
 
     .button--textless {

--- a/src/open_inwoner/scss/components/FilterBar/FilterBar.scss
+++ b/src/open_inwoner/scss/components/FilterBar/FilterBar.scss
@@ -147,7 +147,7 @@
         padding: 0;
 
         [class*='icons'] {
-          font-size: 32px;
+          font-size: var(--font-size-icon-large);
         }
       }
 

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -83,7 +83,7 @@ $vm: var(--spacing-large);
         position: initial;
         grid-row: 1;
         grid-column: 6 / span 5;
-        margin-left: var(--spacing-large);
+        margin-left: 0;
       }
 
       > .primary-navigation {
@@ -123,7 +123,7 @@ $vm: var(--spacing-large);
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
-        grid-column: 11 / span 2;
+        grid-column: 12;
         grid-row: 1;
       }
 
@@ -170,11 +170,22 @@ $vm: var(--spacing-large);
       display: none;
     }
 
-    .nav-login--icon {
+    .nav-login__icon {
       display: flex;
       justify-content: center;
       align-items: center;
       height: calc(var(--row-height) * 2);
+
+      &--authenticated {
+        .button--transparent {
+          padding-right: var(--spacing-medium);
+        }
+
+        [class*='icons'] {
+          color: var(--color-black);
+          font-size: var(--font-size-icon-large);
+        }
+      }
     }
   }
 
@@ -260,9 +271,11 @@ $vm: var(--spacing-large);
   .header__button .header__menu-icon {
     background-color: var(--color-primary);
   }
+
   .header__button .header__menu-icon .open {
     display: none;
   }
+
   .header__button .header__menu-icon .closed {
     height: var(--font-size-body);
     width: 100%;
@@ -285,14 +298,13 @@ $vm: var(--spacing-large);
       &__main {
         grid-row: 1;
         grid-column: 4 / span 2;
-        width: 180px;
       }
 
       &__authenticated {
-        display: flex;
+        display: grid;
         flex-direction: row;
         grid-row: 1;
-        grid-column: 11 / span 2;
+        grid-column: 12;
 
         // Tablet menu
         @media (min-width: 768px) and (max-width: 910px) {
@@ -330,7 +342,7 @@ $vm: var(--spacing-large);
     left: 0;
     margin: 0;
     max-width: 100%;
-    padding: 0 var(--spacing-medium) 0 var(--spacing-medium);
+    padding: 0;
     position: initial;
     right: 0;
     top: calc(2 * var(--row-height));
@@ -339,6 +351,15 @@ $vm: var(--spacing-large);
 
     .form {
       padding: 0;
+      max-width: var(--mobile-xs-width);
+
+      // Tablet view
+      @media (min-width: 768px) and (max-width: 910px) {
+        max-width: 100%;
+        .form__control {
+          max-width: 100%;
+        }
+      }
     }
 
     @media (min-width: 768px) {

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -23,7 +23,6 @@
     font-size: var(--font-size-body-larger);
     margin: 0;
     padding: 0;
-    overflow-x: hidden;
 
     @media (min-width: 768px) {
       flex-direction: row;
@@ -37,7 +36,6 @@
     flex-direction: column;
     justify-content: flex-start;
     min-height: var(--row-height);
-    overflow: hidden;
     padding: 0;
 
     .link {
@@ -104,44 +102,75 @@
 
   /// Dropdown triangles
 
-  &.primary-navigation__main .subpage-list {
-    left: -11px;
-
+  &.primary-navigation__main {
+    // Align Products dropdown when Dyslexia-font is toggled
     @media (min-width: 768px) {
-      &::before {
-        box-sizing: border-box;
-        border-bottom: 6px solid var(--color-primary);
-        border-left: 6px solid var(--color-white);
-        border-right: 6px solid var(--color-white);
-        content: '';
-        display: block;
-        height: 6px;
-        left: 135px;
-        position: absolute;
-        top: -7px;
-        width: 11px;
-      }
-      &::after {
-        box-sizing: border-box;
-        border-bottom: 6px solid var(--color-white);
-        border-left: 6px solid transparent;
-        border-right: 6px solid transparent;
-        content: '';
-        display: block;
-        height: 6px;
-        left: 135px;
-        position: absolute;
-        top: -6px;
-        width: 11px;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    // Remove ellipsis only for Products dropdown
+    .button.button--transparent.primary-navigation--toggle {
+      white-space: initial;
+      overflow: initial;
+      text-overflow: initial;
+    }
+
+    .subpage-list {
+      left: -11px;
+
+      @media (min-width: 768px) {
+        &::before {
+          box-sizing: border-box;
+          border-bottom: 6px solid var(--color-primary);
+          border-left: 6px solid var(--color-white);
+          border-right: 6px solid var(--color-white);
+          content: '';
+          display: block;
+          height: 6px;
+          left: 135px;
+          position: absolute;
+          top: -7px;
+          width: 11px;
+        }
+        &::after {
+          box-sizing: border-box;
+          border-bottom: 6px solid var(--color-white);
+          border-left: 6px solid transparent;
+          border-right: 6px solid transparent;
+          content: '';
+          display: block;
+          height: 6px;
+          left: 135px;
+          position: absolute;
+          top: -6px;
+          width: 11px;
+        }
       }
     }
   }
 
   &.primary-navigation__authenticated {
+    .primary-navigation__list .primary-navigation__list-item {
+      justify-content: flex-end;
+
+      .nav-login__icon {
+        [class*='icons'] {
+          pointer-events: all;
+        }
+      }
+    }
+
     .button.button--transparent.primary-navigation--toggle {
       display: inline-block;
+      padding-left: 6px;
       padding-right: var(--spacing-giant);
-      width: 170px;
+      text-align: left;
+      max-width: 150px;
+
+      @media (min-width: 768px) and (max-width: 910px) {
+        max-width: var(--mobile-xs-width);
+      }
 
       & [class*='icons'] {
         position: absolute;
@@ -149,6 +178,7 @@
         right: 13px;
       }
     }
+
     .subpage-list {
       @media (min-width: 768px) {
         &::before {
@@ -235,6 +265,7 @@
     @media (min-width: 768px) {
       right: 0;
     }
+
     [class*='icons'] {
       margin-right: var(--spacing-large);
     }
@@ -254,7 +285,8 @@
 
   &:not(#{&}--dismissed)[class*='--open'] &__list-item {
     // Open subpages
-    .button.primary-navigation--toggle {
+    .button.primary-navigation--toggle,
+    .nav-login__icon .material-icons-outlined {
       color: var(--color-primary);
     }
   }

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -236,6 +236,7 @@
   --font-size-body-small: var(--utrecht-paragraph-small-font-size);
   --font-size-body-larger: 18px;
   --font-size-body-large: 20px;
+  --font-size-icon-large: 32px;
   --font-line-height-body-small: 20px;
   --font-line-height-body-medium: 24px;
   --font-line-height-body-large: 28px;


### PR DESCRIPTION
Taiga story:
https://taiga.maykinmedia.nl/project/open-inwoner/us/3222

separated issue:
https://taiga.maykinmedia.nl/project/open-inwoner/task/3242

- [x] remove Welkom texts in menu's
- [x] also add vestigingen or business names in desktop
- [x] add how_to_reg icon before names on desktop
- [x] due to new spacing because of extra icon: correct all spacing (including for Dyslexia styles etc.)
- [x] check tablet styles
- [ ] ~~change how_to_reg icon on mobile into Account_Circle~~ Keep as is
- [x] make mobile icon only link to Profiel page
- [x] keep/add tracking with Siteimprove
- [x] change icon color on Desktop into secondary color when dropdown is opened (? not sure if that is needed)

