### PR TITLE
:sparkles: Update page titles for several pages

### DIFF
--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -6,6 +6,7 @@
     {% static_placeholder 'login_banner' %}
 {% endblock header_image %}
 
+{# {% block title %}{% with site_name=site_name page_title=_("Log in") %}{{ block.super }}{% endwith %}{% endblock %} #}
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans 'Welkom' %}</h1>

--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -176,7 +176,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
         return [(_("Mijn vragen"), reverse("cases:contactmoment_list"))]
 
     def page_title(self):
-        return _("Mijn vraag")
+        return f"{_('Mijn vraag')} {self.question['identification']}"
 
     def get_anchors(self) -> list:
         return [
@@ -204,7 +204,7 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
         )
         if not question:
             raise Http404()
-
+        self.question = question
         QuestionValidator.validate_python(question)
 
         local_kcm, created = KlantContactMomentAnswer.objects.get_or_create(  # noqa

--- a/src/open_inwoner/accounts/views/login.py
+++ b/src/open_inwoner/accounts/views/login.py
@@ -90,6 +90,15 @@ class CustomLoginView(LogMixin, LoginView):
 
         return redirect(furl(reverse("verify_token")).add(params).url)
 
+    # Manually overwrite the context site_name and page_title for the LoginView.
+    # A wrong default is set in django.contrib.auth.LoginView.
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        config = SiteConfiguration.get_solo()
+        context["site_name"] = config.name
+        context["page_title"] = _("Log in")
+        return context
+
 
 class VerifyTokenView(ThrottleMixin, FormView):
     throttle_visits = 3

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -87,19 +87,39 @@ class VragenService(Protocol):
 
 
 class OuterCaseDetailView(
-    OuterCaseAccessMixin, CommonPageMixin, BaseBreadcrumbMixin, TemplateView
+    OuterCaseAccessMixin,
+    CommonPageMixin,
+    BaseBreadcrumbMixin,
+    CaseAccessMixin,
+    TemplateView,
 ):
     template_name = "pages/cases/status_outer.html"
+    case: Zaak | None = None
 
     @cached_property
     def crumbs(self):
+        # case is retrieved via CaseAccessMixin
+        if self.case:
+            return [
+                (_("Mijn zaken"), reverse("cases:index")),
+                (
+                    f"{self.case.description} - {_('Status')}",
+                    reverse("cases:case_detail", kwargs=self.kwargs),
+                ),
+            ]
         return [
             (_("Mijn zaken"), reverse("cases:index")),
             (
-                _("Status"),
+                f"{_('Zaak')} - {_('Status')}",
                 reverse("cases:case_detail", kwargs=self.kwargs),
             ),
         ]
+
+    def page_title(self):
+        if self.case:
+            return f"{self.case.description} {self.case.identification} - {_('Status')}"
+        else:
+            return f"{_('Zaak')} - {_('Status')}"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -163,16 +183,25 @@ class InnerCaseDetailView(
 
     @cached_property
     def crumbs(self):
+        # case is retrieved via CaseAccessMixin
+        if self.case:
+            return [
+                (_("Mijn zaken"), reverse("cases:index")),
+                (
+                    f"{self.case.description} - {_('Status')}",
+                    reverse("cases:case_detail", kwargs=self.kwargs),
+                ),
+            ]
         return [
             (_("Mijn zaken"), reverse("cases:index")),
             (
-                _("Status"),
+                f"{_('Zaak')} - {_('Status')}",
                 reverse("cases:case_detail", kwargs=self.kwargs),
             ),
         ]
 
     def page_title(self):
-        return _("Status")
+        return f"{self.case.description} {self.case.identification} - {_('Status')}"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/src/open_inwoner/questionnaire/views.py
+++ b/src/open_inwoner/questionnaire/views.py
@@ -47,14 +47,31 @@ class QuestionnaireStepView(CommonPageMixin, BaseBreadcrumbMixin, FormView):
 
     @cached_property
     def crumbs(self):
+        root_object = self.get_object().get_root()
         if self.request.user.is_authenticated:
             return [
                 (_("Mijn profiel"), reverse("profile:detail")),
                 (_("Zelfdiagnose"), reverse("products:questionnaire_list")),
+                (
+                    f"{root_object.question} - {_('Zelfdiagnose')}",
+                    reverse("products:descendent_step", kwargs=self.kwargs)
+                    if self.kwargs.get("root_slug")
+                    else reverse("products:root_step", kwargs=self.kwargs),
+                ),
             ]
         return [
             (_("Zelfdiagnose"), reverse("products:questionnaire_list")),
+            (
+                f"{root_object.question} - {_('Zelfdiagnose')}",
+                reverse("products:descendent_step", kwargs=self.kwargs)
+                if self.kwargs.get("root_slug")
+                else reverse("products:root_step", kwargs=self.kwargs),
+            ),
         ]
+
+    def page_title(self):
+        object = self.get_object()
+        return f"{object.depth} - {object.get_root().question} - {_('Zelfdiagnose')}"
 
     def get_object(self) -> QuestionnaireStep:
         slug = self.kwargs.get(

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -35,7 +35,14 @@ class SearchView(
     success_url = reverse_lazy("search:search")
 
     def page_title(self):
-        return _("Zoeken")
+        form = self.get_form()
+        if form.is_valid():
+            data = form.cleaned_data.copy()
+            query = data.pop("query")
+            if query:
+                return f"{query} - {_('Zoeken')}"
+
+        return f"{_('Zoeken')}"
 
     def get(self, request, *args, **kwargs):
         # SearchForm

--- a/src/open_inwoner/templates/flatpages/default.html
+++ b/src/open_inwoner/templates/flatpages/default.html
@@ -1,7 +1,7 @@
 {% extends 'master.html' %}
 {% load render_tags %}
 
-{% block title %}{{ flatpage.title }}{% endblock %}
+{% block title %}{% with page_title=flatpage.title %}{{ block.super }}{% endwith %}{% endblock %}
 
 {% block content %}
   <h1 class="utrecht-heading-1">{{ flatpage.title }}</h1>


### PR DESCRIPTION
Story:
https://taiga.maykinmedia.nl/project/open-inwoner/us/3025

---

✅ Login page - "OpenInwoner Testomgeving" ->  “Inloggen - Mijn Groningen”
✅ Mijn zaken, zaakdetailpage title - "Status - Mijn Groningen" -> "Zaaknaam 511-2021 - Status - Mijn Groningen"
✅ Mijn vragen - "Mijn vraag - Mijn Groningen" -> "Mijn vraag 103-2244 - Mijn Groningen”
✅ Zelftest, test naam in titel - "Zelftest - Mijn Groningen" -> “1 - Naam test - Zelftest - Mijn Groningen”.
✅ Zoeken query in tite - "Zoeken - Mijn Groningen" -> “DFAFDD - Zoeken - Mijn Groningen”

> Mijn Groningen is configurable in de admin (Nothin changed).