### PR TITLE
[#3039] Remove error suppression in synchronous API based flows

### DIFF
--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.dispatch import receiver
 from django.urls import reverse
@@ -9,6 +10,7 @@ from open_inwoner.accounts.models import User
 from open_inwoner.haalcentraal.models import HaalCentraalConfig
 from open_inwoner.haalcentraal.utils import update_brp_data_in_db
 from open_inwoner.kvk.client import KvKClient
+from open_inwoner.kvk.exceptions import KVKAPIException
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
@@ -42,7 +44,16 @@ def update_user_on_login(sender, user, request, *args, **kwargs):
     # to the klanten APIs, because e.g. RSIN or company name will be a required input
     # for certain sync operations.
     if user.is_eherkenning_user:
-        _update_eherkenning_user_from_kvk_api(user=user)
+        try:
+            _update_eherkenning_user_from_kvk_api(user=user)
+        except KVKAPIException:
+            messages.warning(
+                request=request,
+                message=_(
+                    "We're experiencing technical difficulties. "
+                    "Your profile information may not be up-to-date."
+                ),
+            )
 
     # update brp fields when login with digid and brp is configured
     if user.is_digid_user and HaalCentraalConfig.get_solo().service:
@@ -90,56 +101,49 @@ def _update_user_from_esuite(
 
 def _update_eherkenning_user_from_kvk_api(user: User):
     extra_exc_params = {"kvk": user.kvk, "vestiging": user.vestiging}
-    try:
-        kvk_client = KvKClient()
-        updated_fields = []
+    kvk_client = KvKClient()
+    updated_fields = []
 
-        # Update company name. We want this to run on every login because it may
-        # change (if infrequently)
-        basisprofiel = kvk_client.get_basisprofiel(kvk=user.kvk)
-        company_name = basisprofiel.get("naam")
-        if company_name and user.company_name != company_name:
-            user.company_name = company_name
-            user.save(update_fields=["company_name"])
-            updated_fields.append("company_name")
+    # Update company name. We want this to run on every login because it may
+    # change (if infrequently)
+    basisprofiel = kvk_client.get_basisprofiel(kvk=user.kvk)
+    company_name = basisprofiel.get("naam")
+    if company_name and user.company_name != company_name:
+        user.company_name = company_name
+        user.save(update_fields=["company_name"])
+        updated_fields.append("company_name")
 
-        # Update branch name (leave empty for rechtspersoon)
-        if user.vestiging:
-            branch_profile = kvk_client.get_vestigingsprofiel(vestiging=user.vestiging)
-            branch_name = branch_profile.get("eersteHandelsnaam")
-            if branch_name and user.branch_name != branch_name:
-                user.branch_name = branch_name
-                user.save()
-                updated_fields.append("branch_name")
+    # Update branch name (leave empty for rechtspersoon)
+    if user.vestiging:
+        branch_profile = kvk_client.get_vestigingsprofiel(vestiging=user.vestiging)
+        branch_name = branch_profile.get("eersteHandelsnaam")
+        if branch_name and user.branch_name != branch_name:
+            user.branch_name = branch_name
+            user.save()
+            updated_fields.append("branch_name")
 
-        # Optionally update RSIN. Unlike company name, RSIN should be immutable, so we
-        # only have to fetch it if it's not set.
-        if not user.rsin:
-            rsin = kvk_client.retrieve_rsin_with_kvk(kvk=user.kvk)
+    # Optionally update RSIN. Unlike company name, RSIN should be immutable, so we
+    # only have to fetch it if it's not set.
+    if not user.rsin:
+        rsin = kvk_client.retrieve_rsin_with_kvk(kvk=user.kvk)
 
-            if rsin:
-                user.rsin = rsin
-                user.save(update_fields=["rsin"])
-                updated_fields.append("rsin")
-            else:
-                logger.error(
-                    "Unable to sync rsin from KvK API",
-                    extra=extra_exc_params,
-                )
-
-        if updated_fields:
-            system_action(
-                _(
-                    "user attributes were updated from KvK API: %(fields)s"
-                    % {"fields": ", ".join(updated_fields)}
-                ),
-                content_object=user,
+        if rsin:
+            user.rsin = rsin
+            user.save(update_fields=["rsin"])
+            updated_fields.append("rsin")
+        else:
+            logger.error(
+                "Unable to sync rsin from KvK API",
+                extra=extra_exc_params,
             )
 
-    except Exception:
-        logger.exception(
-            "Unable to update eHerkenning user from KvK API",
-            extra=extra_exc_params,
+    if updated_fields:
+        system_action(
+            _(
+                "user attributes were updated from KvK API: %(fields)s"
+                % {"fields": ", ".join(updated_fields)}
+            ),
+            content_object=user,
         )
 
 

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1418,11 +1418,13 @@ class DuplicateEmailRegistrationTest(WebTest):
 
         self.assertEqual(users.count(), 1)
 
-    def test_digid_user_can_edit_profile(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_digid_user_can_edit_profile(self, mock_update):
         """
         Assert that digid user can edit their profile (the email of the same user
         is not counted as duplicate)
         """
+        mock_update.return_value = True
         url = reverse("digid-mock:password")
 
         # create profile
@@ -1556,11 +1558,13 @@ class DuplicateEmailRegistrationTest(WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["form"].errors, expected_errors)
 
-    def test_non_digid_user_can_edit_profile(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_non_digid_user_can_edit_profile(self, mock_update):
         """
         Assert that non-digid users can edit their profile (the email of the same user
         is not counted as duplicate)
         """
+        mock_update.return_value = True
 
         url = reverse("profile:edit")
         test_user = User.objects.create(

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -944,17 +944,19 @@ class eHerkenningRegistrationTest(AssertRedirectsMixin, WebTest):
             ).is_initial_branch_selection_done()
         )
 
+    @patch("open_inwoner.kvk.client.KvKClient.get_basisprofiel")
     @patch("open_inwoner.kvk.client.KvKClient.get_all_company_branches")
     @patch(
         "open_inwoner.kvk.models.KvKConfig.get_solo",
     )
     def test_eherkenning_user_is_redirected_to_necessary_registration(
-        self, mock_solo, mock_kvk
+        self, mock_solo, mock_kvk, mock_get_basisprofiel
     ):
         """
         eHerkenning users that do not have their email filled in should be redirected to
         the registration form
         """
+        mock_get_basisprofiel.return_value = {}
         mock_kvk.return_value = [
             {"kvkNummer": "12345678", "vestigingsnummer": "1234"},
         ]

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -72,7 +72,10 @@ class TestProfile(WebTest):
             },
         )
 
-    def test_users_modification_is_logged(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_users_modification_is_logged(self, mock_update):
+        mock_update.return_value = True
+
         form = self.app.get(reverse("profile:edit"), user=self.user).forms[
             "profile-edit"
         ]

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -365,7 +365,10 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         }
         self.assertEqual(base_response.context["form"].errors, expected_errors)
 
-    def test_save_filled_form(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_save_filled_form(self, mock_update):
+        mock_update.return_value = True
+
         response = self.app.get(self.url, user=self.user, status=200)
         form = response.forms["profile-edit"]
         form["first_name"] = "First name"
@@ -378,6 +381,7 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         form["postcode"] = "1013 RM"
         form["city"] = "Amsterdam"
         base_response = form.submit()
+
         self.assertEqual(base_response.url, self.return_url)
         followed_response = base_response.follow()
         self.assertEqual(followed_response.status_code, 200)
@@ -422,16 +426,23 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
                 }
                 self.assertEqual(response.context["form"].errors, expected_errors)
 
-    def test_modify_email_succeeds(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_modify_email_succeeds(self, mock_update):
+        mock_update.return_value = True
+
         response = self.app.get(self.url, user=self.user)
         form = response.forms["profile-edit"]
         form["email"] = "user@example.com"
         response = form.submit()
+
         self.user.refresh_from_db()
         self.assertEqual(response.url, self.return_url)
         self.assertEqual(self.user.email, "user@example.com")
 
-    def test_modify_contact_details_eherkenning_succeeds(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_modify_contact_details_eherkenning_succeeds(self, mock_update):
+        mock_update.return_value = True
+
         eherkenning_user = eHerkenningUserFactory()
         response = self.app.get(self.url, user=eherkenning_user)
         form = response.forms["profile-edit"]
@@ -439,26 +450,34 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         form["phonenumber"] = "0612345678"
         form["phonenumber_alternative"] = "0687654321"
         response = form.submit()
+
         eherkenning_user.refresh_from_db()
         self.assertEqual(response.url, self.return_url)
         self.assertEqual(eherkenning_user.email, "user@example.com")
         self.assertEqual(eherkenning_user.phonenumber, "0612345678")
         self.assertEqual(eherkenning_user.phonenumber_alternative, "0687654321")
 
-    def test_updating_a_field_without_modifying_email_succeeds(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_updating_a_field_without_modifying_email_succeeds(self, mock_update):
+        mock_update.return_value = True
+
         initial_email = self.user.email
         initial_first_name = self.user.first_name
+
         response = self.app.get(self.url, user=self.user)
         form = response.forms["profile-edit"]
         form["first_name"] = "Testing"
         response = form.submit()
+
         self.assertEqual(self.user.first_name, initial_first_name)
         self.user.refresh_from_db()
         self.assertEqual(response.url, self.return_url)
         self.assertEqual(self.user.email, initial_email)
         self.assertEqual(self.user.first_name, "Testing")
 
-    def test_form_for_digid_brp_user_saves_data(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_form_for_digid_brp_user_saves_data(self, mock_update):
+        mock_update.return_value = True
         user = UserFactory(
             bsn="999993847",
             first_name="name",
@@ -507,7 +526,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertEqual(type(form), BrpUserForm)
 
-    def test_image_is_saved_when_begeleider_and_default_login(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_image_is_saved_when_begeleider_and_default_login(self, mock_update):
+        mock_update.return_value = True
         self.user.contact_type = ContactTypeChoices.begeleider
         self.user.save()
 
@@ -524,7 +545,10 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertIsNotNone(self.user.image.file)
 
-    def test_image_is_saved_when_begeleider_and_digid_login(self):
+    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    def test_image_is_saved_when_begeleider_and_digid_login(self, mock_update):
+        mock_update.return_value = True
+
         self.user.contact_type = ContactTypeChoices.begeleider
         self.user.login_type = LoginTypeChoices.digid
         self.user.save()

--- a/src/open_inwoner/accounts/views/auth.py
+++ b/src/open_inwoner/accounts/views/auth.py
@@ -26,6 +26,7 @@ from eherkenning.mock.views.eherkenning import (
 )
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.kvk.client import KvKClient
+from open_inwoner.kvk.exceptions import KVKAPIException
 from open_inwoner.utils.views import LogMixin
 
 from ..choices import LoginTypeChoices
@@ -149,26 +150,26 @@ class BlockEenmanszaakLoginMixin:
         failure_url = self.get_failure_url()
 
         client = KvKClient()
-        basisprofiel = client.get_basisprofiel(kvk=kvk)
 
-        if not basisprofiel:
-            auth.logout(request)
+        try:
+            basisprofiel = client.get_basisprofiel(kvk=kvk)
+        except KVKAPIException:
             messages.error(
-                request, _("We could not log you in. Please try again later.")
+                request=request,
+                message=_(
+                    "We're experiencing technical difficulties. Please try again later"
+                ),
             )
-            return HttpResponseRedirect(failure_url)
-
-        if basisprofiel.get("fout"):
             auth.logout(request)
-            message = basisprofiel["fout"][0]["omschrijving"]
-            messages.error(request, message)
             return HttpResponseRedirect(failure_url)
 
         rechtsvorm = glom(basisprofiel, "_embedded.eigenaar.rechtsvorm", default="")
         if rechtsvorm == "Eenmanszaak":
+            messages.error(
+                request,
+                _("Use DigiD to log in as a sole proprietor."),
+            )
             auth.logout(request)
-            message = _("Use DigiD to log in as a sole proprietor.")
-            messages.error(request, message)
             return HttpResponseRedirect(failure_url)
         return response
 

--- a/src/open_inwoner/accounts/views/auth.py
+++ b/src/open_inwoner/accounts/views/auth.py
@@ -146,14 +146,22 @@ class BlockEenmanszaakLoginMixin:
         if not (kvk := request.user.kvk):
             return response
 
+        failure_url = self.get_failure_url()
+
         client = KvKClient()
         basisprofiel = client.get_basisprofiel(kvk=kvk)
+
+        if not basisprofiel:
+            auth.logout(request)
+            messages.error(
+                request, _("We could not log you in. Please try again later.")
+            )
+            return HttpResponseRedirect(failure_url)
 
         if basisprofiel.get("fout"):
             auth.logout(request)
             message = basisprofiel["fout"][0]["omschrijving"]
             messages.error(request, message)
-            failure_url = self.get_failure_url()
             return HttpResponseRedirect(failure_url)
 
         rechtsvorm = glom(basisprofiel, "_embedded.eigenaar.rechtsvorm", default="")
@@ -161,7 +169,6 @@ class BlockEenmanszaakLoginMixin:
             auth.logout(request)
             message = _("Use DigiD to log in as a sole proprietor.")
             messages.error(request, message)
-            failure_url = self.get_failure_url()
             return HttpResponseRedirect(failure_url)
         return response
 

--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Iterable, Protocol
 
+from django.contrib import messages
 from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.generic import TemplateView
 
@@ -197,14 +198,27 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
             raise ImproperlyConfigured("Unknown KlantenServiceType")
 
         origin = self.request.headers.get("Referer")
-        question, zaak_with_api_group = service.retrieve_question(
+        question, zaken_with_api_group = service.retrieve_question(
             self.get_fetch_params(service),
             question_uuid=kwargs["kcm_uuid"],
             user=self.request.user,
         )
         if not question:
             raise Http404()
+        if zaken_with_api_group and len(zaken_with_api_group) > 1:
+            # In principle this should not happen, a zaak should be stored in
+            # exactly one backend. But: https://www.xkcd.com/2200/
+            # We should at least receive a ping if this happens and warn the user.
+            logger.error("Found one zaak in multiple backends")
+            messages.warning(
+                self.request,
+                _(
+                    "Your question was connected to multiple cases, we are showing you the first."
+                ),
+            )
+
         self.question = question
+        zaak_with_api_group = zaken_with_api_group[0] if zaken_with_api_group else None
         QuestionValidator.validate_python(question)
 
         local_kcm, created = KlantContactMomentAnswer.objects.get_or_create(  # noqa

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -28,6 +28,7 @@ from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.utils import fetch_brp
 from open_inwoner.laposta.forms import NewsletterSubscriptionForm
 from open_inwoner.laposta.models import LapostaConfig
+from open_inwoner.openklant.api_models import Klant
 from open_inwoner.openklant.services import eSuiteKlantenService
 from open_inwoner.plans.models import Plan
 from open_inwoner.qmatic.client import NoServiceConfigured, qmatic_client_factory
@@ -230,18 +231,35 @@ class EditProfileView(
         return self.request.user
 
     def form_valid(self, form):
-        form.save()
         user: User = self.get_object()
 
-        self.update_esuite_klant(
+        klant = self.update_esuite_klant(
             {k: form.cleaned_data[k] for k in form.changed_data}, user
         )
 
-        messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-        self.log_change(self.get_object(), _("profile was modified"))
+        # only save the form if changes have been written to Klanten API or
+        # changes do not require writing to API
+        if klant or not any(
+            key in form.changed_data
+            for key in ("email", "phonenumber", "phonenumber_alternative")
+        ):
+            form.save()
+            messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
+            self.log_change(self.get_object(), _("profile was modified"))
+        else:
+            messages.error(
+                request=self.request,
+                message=_(
+                    "Your changes could not be saved due to technical problems. "
+                    "Please try again later"
+                ),
+            )
+            self.log_change(
+                self.get_object(), _("profile changes not saved due to Klant API error")
+            )
         return HttpResponseRedirect(self.get_success_url())
 
-    def update_esuite_klant(self, user_form_data: dict, user: User):
+    def update_esuite_klant(self, user_form_data: dict, user: User) -> Klant | None:
         field_mapping = {
             "emailadres": "email",
             "telefoonnummer": "phonenumber",
@@ -266,7 +284,7 @@ class EditProfileView(
                 fetch_params=fetch_params, user=user
             )
             if klant and not created:
-                service.update_klant_from_user(
+                return service.update_klant_from_user(
                     klant, user, update_fields=list(update_data.keys())
                 )
 

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -1147,6 +1147,10 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
             self.log_system_action(
                 "error while registering contactmoment by API", user=self.request.user
             )
+            messages.error(
+                request=self.request,
+                message=_("Your question could not be saved. Please try again later."),
+            )
             return False
 
         self.log_system_action(

--- a/src/open_inwoner/kvk/client.py
+++ b/src/open_inwoner/kvk/client.py
@@ -3,11 +3,12 @@ from functools import cached_property
 from urllib.parse import urlencode
 
 import requests
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import InvalidJSONError, JSONDecodeError
 
 from open_inwoner.utils.decorators import cache as cache_result
 
 from .constants import CompanyType
+from .exceptions import KVKAPIException
 from .models import KvKConfig
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class KvKClient:
 
         return request_kwargs
 
-    def _request(self, endpoint: str, params: dict | None = None) -> dict:
+    def _request(self, endpoint: str, params: dict | None = None) -> dict | None:
         if not self.config or not self.config.api_root:
             return {}
 
@@ -56,15 +57,19 @@ class KvKClient:
 
         try:
             response = requests.get(url, **request_kwargs)
-        except requests.RequestException as ex:
-            logger.exception("Unable to retrieve information from the KVK API: %s", ex)
-            return {}
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            logger.warning("Error response while making request to KVK API")
+            raise KVKAPIException.from_error_response(exc.response) from exc
+        except requests.RequestException as exc:
+            logger.warning("Error while making request to KVK API")
+            raise KVKAPIException from exc
 
         try:
             data = response.json()
-        except (AttributeError, JSONDecodeError, requests.RequestException) as ex:
-            logger.exception("Unable to parse information from the KVK API: %s", ex)
-            return {}
+        except (InvalidJSONError, JSONDecodeError, ValueError) as exc:
+            logger.exception("Unable to parse information from the KVK API")
+            raise KVKAPIException from exc
 
         return data
 
@@ -140,8 +145,7 @@ class KvKClient:
 
     @cache_result("kvk:{kvk}")
     def get_basisprofiel(self, kvk: str) -> dict:
-        basisprofiel = self._request(f"{self.basisprofielen_endpoint}/{kvk}") or {}
-        return basisprofiel
+        return self._request(f"{self.basisprofielen_endpoint}/{kvk}")
 
     def get_vestigingsprofiel(self, vestiging: str) -> dict:
         vestigingsprofiel = (

--- a/src/open_inwoner/kvk/exceptions.py
+++ b/src/open_inwoner/kvk/exceptions.py
@@ -1,0 +1,26 @@
+import contextlib
+from typing import Self
+
+from requests import Response
+
+
+class KVKAPIException(Exception):
+    response: Response | None
+    message: str
+
+    def __init__(self, message=None, *, response: Response | None = None):
+        super().__init__()
+        self.message = (
+            message or "An error occurred while communicating with the KVK API"
+        )
+        self.response = response
+
+    @classmethod
+    def from_error_response(cls, response: Response) -> Self:
+        api_error_message: str | None = None
+
+        with contextlib.suppress(BaseException):
+            data = response.json()
+            api_error_message = data.get("fout", [{}])[0].get("omschrijving", "")
+
+        return cls(message=api_error_message, response=response)

--- a/src/open_inwoner/kvk/tests/test_api.py
+++ b/src/open_inwoner/kvk/tests/test_api.py
@@ -2,10 +2,12 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+import requests
 import requests_mock
 from requests.exceptions import InvalidJSONError, SSLError
 
 from ..client import KvKClient
+from ..exceptions import KVKAPIException
 from ..models import KvKConfig
 from . import mocks
 from .factories import CLIENT_CERT, CLIENT_CERT_PAIR, SERVER_CERT
@@ -305,33 +307,40 @@ class KvKRequestsInterfaceTest(TestCase):
     def test_kvk_response_not_ok(self, mocker):
         patch.stopall()  # use custom requests mock for this test
 
-        for code in [300, 400, 500]:
+        scenarios = [
+            (400, requests.HTTPError),
+            (500, requests.HTTPError),
+        ]
+        for code, error in scenarios:
             with self.subTest(code=code):
                 mocker.get(
                     f"{self.kvk_client.search_endpoint}?kvkNummer=69599084&resultatenPerPagina=100",
                     status_code=code,
+                    json={
+                        "fout": [
+                            {
+                                "code": "IPD0005",
+                                "omschrijving": "Op basis van het KVK-nummer 69599084 kan het product niet worden geleverd.",
+                            }
+                        ]
+                    },
                 )
 
-                company = self.kvk_client.search(kvkNummer="69599084")
-                self.assertEqual(company, {})
+                with self.assertRaises(KVKAPIException) as cm:
+                    self.kvk_client.search(kvkNummer="69599084")
+                self.assertEqual(
+                    cm.exception.message,
+                    "Op basis van het KVK-nummer 69599084 kan het product niet worden geleverd.",
+                )
 
     def test_kvk_api_error(self):
         self.mocked_requests.side_effect = SSLError
 
-        company = self.kvk_client.search(kvkNummer="69599084")
-
-        self.assertEqual(company, {})
+        with self.assertRaises(KVKAPIException):
+            self.kvk_client.search(kvkNummer="69599084")
 
     def test_kvk_invalid_json(self):
         self.mocked_requests.return_value.json.side_effect = InvalidJSONError
 
-        company = self.kvk_client.search(kvkNummer="69599084")
-
-        self.assertEqual(company, {})
-
-    def test_kvk_no_response(self):
-        self.mocked_requests.return_value = None
-
-        company = self.kvk_client.search(kvkNummer="69599084")
-
-        self.assertEqual(company, {})
+        with self.assertRaises(KVKAPIException):
+            self.kvk_client.search(kvkNummer="69599084")

--- a/src/open_inwoner/kvk/views.py
+++ b/src/open_inwoner/kvk/views.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from django.contrib import messages
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -14,6 +15,7 @@ from open_inwoner.utils.views import LogMixin
 
 from ..utils.url import get_next_url_from
 from .client import KvKClient
+from .exceptions import KVKAPIException
 from .forms import CompanyBranchChoiceForm
 
 
@@ -33,9 +35,19 @@ class CompanyBranchChoiceView(LogMixin, FormView):
 
         kvk_client = KvKClient()
 
-        company_branches = kvk_client.get_all_company_branches(
-            kvk=self.request.user.kvk
-        )
+        try:
+            company_branches = kvk_client.get_all_company_branches(
+                kvk=self.request.user.kvk
+            )
+        except KVKAPIException:
+            messages.error(
+                request=self.request,
+                message=_(
+                    "We are temporarily unable to show your branches, please try again at a later point."
+                ),
+            )
+            company_branches = []
+
         # create pseudo-branch representing the company as a whole (the "rechtspersoon").
         # technically, the compnay as a legal entity is represented as "rechtspersoon",
         # but this is not always included in query results

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -750,7 +750,7 @@ class eSuiteVragenService(KlantenService):
             local_kcm.is_seen = True
             local_kcm.save()
 
-        zaak_with_api_group = None
+        zaken_with_api_group = []
 
         ocm = self.retrieve_objectcontactmoment(kcm.contactmoment, "zaak")
         if ocm and ocm.object_type == "zaak":
@@ -766,18 +766,17 @@ class eSuiteVragenService(KlantenService):
                     "Unable to find matched contactmomenten zaak in any zgw backend"
                 )
             else:
-                zaak, client = cases_found[0].result, cases_found[0].client
-                group = ZGWApiGroupConfig.objects.resolve_group_from_hints(
-                    client=client
-                )
-                zaak_with_api_group = ZaakWithApiGroup(zaak=zaak, api_group=group)
-                if case_count > 1:
-                    # In principle this should not happen, a zaak should be stored in
-                    # exactly one backend. But: https://www.xkcd.com/2200/
-                    # We should at least receive a ping if this happens.
-                    logger.error("Found one zaak in multiple backends")
+                zaken_with_api_group = [
+                    ZaakWithApiGroup(
+                        zaak=case.result,
+                        api_group=ZGWApiGroupConfig.objects.resolve_group_from_hints(
+                            case.client
+                        ),
+                    )
+                    for case in cases_found
+                ]
 
-        return self._build_question_dto(kcm), zaak_with_api_group
+        return self._build_question_dto(kcm), zaken_with_api_group
 
     def list_questions_for_zaak(self, zaak: Zaak, user: User) -> list[Question]:
         objectcontactmomenten = self.retrieve_objectcontactmomenten_for_zaak(zaak)

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -770,7 +770,7 @@ class eSuiteVragenService(KlantenService):
                     ZaakWithApiGroup(
                         zaak=case.result,
                         api_group=ZGWApiGroupConfig.objects.resolve_group_from_hints(
-                            case.client
+                            client=case.client
                         ),
                     )
                     for case in cases_found

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -409,11 +409,12 @@ class eSuiteKlantenService(
                 if field not in update_fields:
                     del update_data[field]
 
-        self.partial_update_klant(klant, update_data)
+        klant = self.partial_update_klant(klant, update_data)
         system_action(
             f"patched klant from user profile edit with fields: {', '.join(sorted(update_data.keys()))}",
             user=user,
         )
+        return klant
 
 
 class eSuiteVragenService(KlantenService):

--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -42,6 +42,10 @@ class SSDBaseClient(ABC):
         }
 
     def _get_auth_kwargs(self) -> dict:
+        if not self.config.service:
+            logger.error("SSD client used without SOAP service")
+            return {}
+
         cert = self.config.service.get_cert()
         verify = self.config.service.get_verify()
         return {
@@ -64,7 +68,7 @@ class SSDBaseClient(ABC):
         context = {**self._get_base_context(), **kwargs}
         return loader.render_to_string(self.request_template, context)
 
-    def templated_request(self, **kwargs) -> Response:
+    def templated_request(self, **kwargs) -> Response | None:
         """Wrap around `requests.post` with headers, auth details, request body"""
 
         auth_kwargs = self._get_auth_kwargs()
@@ -78,8 +82,16 @@ class SSDBaseClient(ABC):
                 headers=headers,
                 **auth_kwargs,
             )
-        except requests.exceptions.RequestException as e:
-            logger.exception("Requests exception: %s", e)
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response else None
+            if status_code and 400 <= status_code < 500:
+                logger.exception("Client error from SSD client")
+            elif status_code and 500 <= status_code < 600:
+                logger.exception("Server error from SSD client")
+            return
+        except requests.exceptions.RequestException as exc:
+            logger.exception("Requests exception: %s", exc)
             return
 
         return response

--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -12,6 +12,7 @@ import requests
 from requests import Response
 
 from ..utils.export import render_pdf
+from .exceptions import SSDClientException
 from .models import SSDConfig
 from .xml import get_jaaropgaven, get_uitkeringen
 
@@ -83,16 +84,9 @@ class SSDBaseClient(ABC):
                 **auth_kwargs,
             )
             response.raise_for_status()
-        except requests.HTTPError as exc:
-            status_code = exc.response.status_code if exc.response else None
-            if status_code and 400 <= status_code < 500:
-                logger.exception("Client error from SSD client")
-            elif status_code and 500 <= status_code < 600:
-                logger.exception("Server error from SSD client")
-            return
-        except requests.exceptions.RequestException as exc:
-            logger.exception("Requests exception: %s", exc)
-            return
+        except (requests.HTTPError, requests.RequestException) as exc:
+            logger.exception("Requests error from SSD client")
+            raise SSDClientException from exc
 
         return response
 
@@ -147,7 +141,7 @@ class JaaropgaveClient(SSDBaseClient):
         """
         return f"Jaaropgave {report_date}"
 
-    def get_reports(self, bsn: str, report_date: str, base_url: str) -> bytes | None:
+    def get_reports(self, bsn: str, report_date: str, request_url: str) -> bytes | None:
         response = self.templated_request(bsn=bsn, dienstjaar=report_date)
 
         if not response or response.status_code != 200:
@@ -168,7 +162,7 @@ class JaaropgaveClient(SSDBaseClient):
         pdf = render_pdf(
             self.html_template,
             context={"reports": jaaropgaven},
-            base_url=base_url,
+            base_url=request_url,
         )
         return pdf
 
@@ -200,9 +194,7 @@ class UitkeringClient(SSDBaseClient):
         dt_formatted = django_date(dt, "F Y").lower()
         return f"Maandspecificatie {dt_formatted}"
 
-    def get_reports(
-        self, bsn: str, report_date: str, request_base_url: str
-    ) -> bytes | None:
+    def get_reports(self, bsn: str, report_date: str, request_url: str) -> bytes | None:
         response = self.templated_request(bsn=bsn, period=report_date)
 
         if not response or response.status_code != 200:
@@ -225,7 +217,7 @@ class UitkeringClient(SSDBaseClient):
                 "reports": uitkeringen,
                 "comments": self.config.maandspecificatie_pdf_comments,
             },
-            base_url=request_base_url,
+            base_url=request_url,
         )
         return pdf
 

--- a/src/open_inwoner/ssd/exceptions.py
+++ b/src/open_inwoner/ssd/exceptions.py
@@ -1,0 +1,25 @@
+from typing import Self
+
+from .service.jaaropgave import JaarOpgaveInfoResponse
+from .service.uitkering import (
+    UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
+)
+
+
+class SSDClientException(Exception):
+    response: JaarOpgaveInfoResponse | UitkeringInfoResponse | None
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or "SSD client error")
+
+    @classmethod
+    def from_xml_response(
+        cls, xml_response: JaarOpgaveInfoResponse | UitkeringInfoResponse
+    ) -> Self:
+        # fout, waarschuwing, informatie
+        fwi = xml_response.fwi
+        error_messages = ", ".join(
+            e.tekst for e in (fwi.fout or fwi.waarshuwing or fwi.informatie,) if e
+        )
+
+        return cls(message=error_messages)

--- a/src/open_inwoner/ssd/tests/test_client.py
+++ b/src/open_inwoner/ssd/tests/test_client.py
@@ -9,6 +9,7 @@ from lxml import etree
 from requests.exceptions import ConnectionError
 
 from ..client import JaaropgaveClient, UitkeringClient
+from ..exceptions import SSDClientException
 from .factories import ConcreteSSDClient, SSDConfigFactory
 
 FILES_DIR = Path(__file__).parent.resolve() / "files"
@@ -134,9 +135,9 @@ class SSDClientRequestInterfaceTest(TestCase):
         )
 
         context = {"bsn": "dummy", "period": "dummy"}
-        response = ssd_client.templated_request(**context)
 
-        self.assertIsNone(response)
+        with self.assertRaises(SSDClientException):
+            ssd_client.templated_request(**context)
 
 
 class UitkeringClientTest(TestCase):
@@ -147,18 +148,29 @@ class UitkeringClientTest(TestCase):
             service__url="https://example.com/soap-service/",
         )
 
-        for code in [300, 400, 500]:
+        mock_request.post(
+            "https://example.com/soap-service/maandspecificatie/",
+            status_code=300,
+        )
+        res = ssd_client.get_reports(
+            bsn="12345",
+            report_date="198507",
+            request_url="https://dummy.com",
+        )
+        self.assertIsNone(res)
+
+        for code in [400, 500]:
             with self.subTest(code=code):
                 mock_request.post(
                     "https://example.com/soap-service/maandspecificatie/",
                     status_code=code,
                 )
-                res = ssd_client.get_reports(
-                    bsn="12345",
-                    report_date="198507",
-                    request_base_url="https://dummy.com",
-                )
-                self.assertIsNone(res)
+                with self.assertRaises(SSDClientException):
+                    ssd_client.get_reports(
+                        bsn="12345",
+                        report_date="198507",
+                        request_url="https://dummy.com",
+                    )
 
     @patch("django.utils.timezone.localtime", return_value=datetime(2023, 7, 12, 11, 0))
     @requests_mock.Mocker()
@@ -170,11 +182,13 @@ class UitkeringClientTest(TestCase):
 
         mock_request.post("https://example.com/soap-service/maandspecificatie/")
 
-        ssd_client.get_reports(
-            bsn="12345",
-            report_date="198507",
-            request_base_url="https://dummy.com",
-        )
+        # error due to missing response content; we only test the request body
+        with self.assertRaises(SSDClientException):
+            ssd_client.get_reports(
+                bsn="12345",
+                report_date="198507",
+                request_url="https://dummy.com",
+            )
 
         # get request body and parse XML
         body = mock_request.last_request.body
@@ -204,18 +218,29 @@ class JaaropgaveClientTest(TestCase):
             service__url="https://example.com/soap-service/",
         )
 
-        for code in [300, 400, 500]:
+        mock_request.post(
+            "https://example.com/soap-service/jaaropgave/",
+            status_code=300,
+        )
+        res = ssd_client.get_reports(
+            bsn="12345",
+            report_date="198507",
+            request_url="https://dummy.com",
+        )
+        self.assertIsNone(res)
+
+        for code in [400, 500]:
             with self.subTest(code=code):
                 mock_request.post(
                     "https://example.com/soap-service/jaaropgave/",
                     status_code=code,
                 )
-                res = ssd_client.get_reports(
-                    bsn="12345",
-                    report_date="1985-12-24",
-                    base_url="https://dummy.com",
-                )
-                self.assertIsNone(res)
+                with self.assertRaises(SSDClientException):
+                    ssd_client.get_reports(
+                        bsn="12345",
+                        report_date="198507",
+                        request_url="https://dummy.com",
+                    )
 
     @patch("django.utils.timezone.localtime", return_value=datetime(2023, 7, 12, 11, 0))
     @requests_mock.Mocker()
@@ -227,11 +252,13 @@ class JaaropgaveClientTest(TestCase):
 
         mock_request.post("https://example.com/soap-service/jaaropgave/")
 
-        ssd_client.get_reports(
-            bsn="12345",
-            report_date="1985",
-            base_url="https://dummy.com",
-        )
+        # error due to missing response content; we only test the request body
+        with self.assertRaises(SSDClientException):
+            ssd_client.get_reports(
+                bsn="12345",
+                report_date="1985",
+                request_url="https://dummy.com",
+            )
 
         # get request body and parse XML
         body = mock_request.last_request.body

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -1,11 +1,14 @@
+import logging
 from datetime import datetime
 
 from django import forms
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.translation import gettext as _
 from django.views.generic.edit import FormView
 
 from furl import furl
@@ -14,7 +17,10 @@ from view_breadcrumbs import BaseBreadcrumbMixin
 from open_inwoner.utils.views import CommonPageMixin
 
 from .client import JaaropgaveClient, UitkeringClient
+from .exceptions import SSDClientException
 from .forms import MonthlyReportsForm, YearlyReportsForm
+
+logger = logging.getLogger(__name__)
 
 
 class BenefitsFormView(
@@ -39,9 +45,19 @@ class BenefitsFormView(
 
             bsn = request.user.bsn
             report_date = ssd_client.format_report_date(form.data["report_date"])
-            request_base_url = request.build_absolute_uri()
+            request_url = request.build_absolute_uri()
 
-            pdf_content = ssd_client.get_reports(bsn, report_date, request_base_url)
+            try:
+                pdf_content = ssd_client.get_reports(bsn, report_date, request_url)
+            except SSDClientException:
+                logger.exception("SSD client error")
+                messages.error(
+                    request=request,
+                    message=_(
+                        "Your report(s) could not be retrieved due to technical problems. "
+                        "Please try again later"
+                    ),
+                )
 
             if not pdf_content:
                 return_path = request.get_full_path()

--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -14,6 +14,7 @@ from open_inwoner.ssd.service.jaaropgave.body_reaction_resolved import (
     SpecificatieJaarOpgave,
 )
 
+from .exceptions import SSDClientException
 from .service.jaaropgave import Client, JaarOpgaveInfoResponse
 from .service.uitkering import (
     UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
@@ -29,6 +30,8 @@ UITKERING_INFO_RESPONSE_NODE = (
     "UitkeringsSpecificatieInfoResponse"
 )
 
+FAULT_NODE = "//{http://schemas.xmlsoap.org/soap/envelope/}Fault"
+
 
 def _get_report_info(
     response: requests.Response,
@@ -36,30 +39,41 @@ def _get_report_info(
     info_type: Any,
 ) -> JaarOpgaveInfoResponse | UitkeringInfoResponse | None:
     """
-    Return the `info_type` (e.g. JaarOpgaveInfoResponse) from the request
-    response, or `None` if a parsing error occurs
+    Return the `info_response` (e.g. `JaarOpgaveInfoResponse`) from the request
+    response, raise `SSDClientException` if an error occurs
 
     Note: bandit identifies the use of `lxml.etree.fromstring` as a security issue
     because the parser is vulnerable to certain XML attacks. We count the origin of the
     `response` as a trusted source, hence the warning is considered a false positive
     """
     if not response.content:
-        return None
+        raise SSDClientException("response had no content")
 
     try:
         tree = etree.fromstring(response.content).getroottree()
-        node = tree.find(info_response_node)
-    except (LxmlError, XMLSyntaxError):
-        return None
+    except (LxmlError, XMLSyntaxError) as exc:
+        raise SSDClientException("error generating XML from content") from exc
+
+    if not (info_node := tree.find(info_response_node)):
+        raise SSDClientException(
+            "XML node %s not found in response", info_response_node
+        )
 
     parser = XmlParser(context=XmlContext(), handler=LxmlEventHandler)
 
     try:
-        info = parser.parse(node, info_type)
-    except ParserError:
-        return None
+        info_response = parser.parse(info_node, info_type)
+    except ParserError as exc:
+        raise SSDClientException("failed to parse XML for %s", info_response) from exc
 
-    return info
+    # fout, waarschuwing, informatie
+    if info_response.fwi:
+        raise SSDClientException.from_xml_response(xml_response=info_response)
+
+    if info_response.niets_gevonden:
+        raise SSDClientException("unexpected error occured")
+
+    return info_response
 
 
 class JaaropgaveReturn(TypedDict):
@@ -76,20 +90,12 @@ def get_jaaropgaven(response: requests.Response) -> list[JaaropgaveReturn] | Non
         response, JAAROPGAVE_INFO_RESPONSE_NODE, JaarOpgaveInfoResponse
     )
 
-    if not jaaropgave_info or not isinstance(jaaropgave_info, JaarOpgaveInfoResponse):
-        return None
-
-    try:
-        client = cast(Client, jaaropgave_info.jaar_opgave_client.client)
-        jaar_opgave = cast(
-            JaarOpgave, jaaropgave_info.jaar_opgave_client.jaar_opgave[0]
-        )
-        inhoudingsplichtige = cast(Inhoudingsplichtige, jaar_opgave.inhoudingsplichtige)
-        specificatien = cast(
-            list[SpecificatieJaarOpgave], jaar_opgave.specificatie_jaar_opgave
-        )
-    except AttributeError:
-        return None
+    client = cast(Client, jaaropgave_info.jaar_opgave_client.client)
+    jaar_opgave = cast(JaarOpgave, jaaropgave_info.jaar_opgave_client.jaar_opgave[0])
+    inhoudingsplichtige = cast(Inhoudingsplichtige, jaar_opgave.inhoudingsplichtige)
+    specificatien = cast(
+        list[SpecificatieJaarOpgave], jaar_opgave.specificatie_jaar_opgave
+    )
 
     return [
         {
@@ -109,18 +115,12 @@ def get_uitkeringen(response: requests.Response) -> list[dict] | None:
         response, UITKERING_INFO_RESPONSE_NODE, UitkeringInfoResponse
     )
 
-    if not uitkeringen_info or not isinstance(uitkeringen_info, UitkeringInfoResponse):
-        return None
-
-    try:
-        uitkeringsspecificatie = (
-            uitkeringen_info.uitkerings_specificatie_client.uitkeringsspecificatie[0]
-        )
-        uitkeringsinstantie = uitkeringsspecificatie.uitkeringsinstantie
-        client = uitkeringen_info.uitkerings_specificatie_client.client
-        dossierhistorien = uitkeringsspecificatie.dossierhistorie
-    except AttributeError:
-        return None
+    uitkeringsspecificatie = (
+        uitkeringen_info.uitkerings_specificatie_client.uitkeringsspecificatie[0]
+    )
+    uitkeringsinstantie = uitkeringsspecificatie.uitkeringsinstantie
+    client = uitkeringen_info.uitkerings_specificatie_client.client
+    dossierhistorien = uitkeringsspecificatie.dossierhistorie
 
     return [
         {


### PR DESCRIPTION
A couple of improvements to our error handling in API calls.

~~- [x] Warn users on "Mijn Aanvragen" if one or more ZGW backends failed to respond~~
- [x] Display a user error if we are unable to sync a user's saved profile fields to the klanten API
- [x] Error if digid-based eenmanszaak login cannot reach KvK
- [x] Warn user if more than one zaak was found for a question
- [x] Gracefully handle misconfigured SSD clients
- [x] Display an error message if we were unable to create a Question via API

In addition, error handling for the KVK and SSD clients was improved by introducing custom exceptions which are handled closer to the views.
> [!NOTE]  
>Tthe change to the `BlockEenmanszaakLoginMixin` is a change in behavior, not merely a refactor: if there is an error when fetching the basisprofiel from the KVK API, eherkenning login is down for everyone, and an error message is displayed to the user. The potential inconvenience for eherkenning users who are not eenmanszaken is preferable to the risk of allowing eenmanszaken to login via eherkenning (instead of digid).

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/3039