### PR TITLE
feat: fix Service connected to CatalogusConfig on zgw_import_data

### DIFF
--- a/src/open_inwoner/openzaak/tests/test_zgw_imports.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports.py
@@ -5,6 +5,7 @@ import requests_mock
 from open_inwoner.openzaak.models import CatalogusConfig, OpenZaakConfig, ZaakTypeConfig
 from open_inwoner.openzaak.tests.factories import (
     CatalogusConfigFactory,
+    ServiceFactory,
     ZGWApiGroupConfigFactory,
 )
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
@@ -139,8 +140,9 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
         super().setUpTestData()
         cls.config = OpenZaakConfig.get_solo()
         cls.roots = (CATALOGI_ROOT, ANOTHER_CATALOGI_ROOT)
-        for root in cls.roots:
-            ZGWApiGroupConfigFactory(ztc_service__api_root=root)
+        cls.api_groups = [
+            ZGWApiGroupConfigFactory(ztc_service__api_root=root) for root in cls.roots
+        ]
 
     def test_import_catalogs(self, m):
         data = {root: CatalogMockData(root).install_mocks(m) for root in self.roots}
@@ -186,6 +188,32 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
                     "url", "domein", "rsin"
                 )[:2]
             ),
+        )
+
+    def test_import_catalogs_updates_service(self, m):
+        self.api_groups[1].delete()  # We'll use a single set of mocks for simplicity
+        configured_catalogi_service = self.api_groups[0].ztc_service
+        data = CatalogMockData(configured_catalogi_service.api_root).install_mocks(m)
+
+        another_service = ServiceFactory()
+        existing_catalogus_with_same_url_but_different_service = CatalogusConfigFactory(
+            service=another_service, url=data.catalogs[0]["url"]
+        )
+
+        self.assertNotEqual(
+            existing_catalogus_with_same_url_but_different_service.service,
+            configured_catalogi_service,
+            msg="Existing catalogusconfig service differs from client that will sync",
+        )
+
+        import_catalog_configs()
+
+        existing_catalogus_with_same_url_but_different_service.refresh_from_db()
+        self.assertEqual(
+            existing_catalogus_with_same_url_but_different_service.service,
+            configured_catalogi_service,
+            msg="Existing catalog with matching URL but differing Service should "
+            "be updated",
         )
 
     def test_import_zaaktype_configs_with_catalogs(self, m):

--- a/src/open_inwoner/openzaak/zgw_imports.py
+++ b/src/open_inwoner/openzaak/zgw_imports.py
@@ -66,27 +66,40 @@ def import_catalog_configs() -> list[CatalogusConfig]:
     if not result.join_results():
         return []
 
-    create = []
-
+    to_create = []
+    to_update = []
     with transaction.atomic():
-        known = set(CatalogusConfig.objects.values_list("url", flat=True))
+        existing_configs = {
+            config.url: config for config in CatalogusConfig.objects.all()
+        }
+
         for response in result:
             for catalog in response.result:
-                if catalog.url in known:
-                    continue
-                create.append(
-                    CatalogusConfig(
-                        url=catalog.url,
-                        rsin=catalog.rsin or "",
-                        domein=catalog.domein,
-                        service=response.client.configured_from,
+                if catalog.url in existing_configs:
+                    # Ensure the connected Service still matches: we always want this
+                    # to match the Service backing the client that did the syncing
+                    existing = existing_configs[catalog.url]
+                    if existing.service != response.client.configured_from:
+                        existing.service = response.client.configured_from
+                        to_update.append(existing)
+                else:
+                    to_create.append(
+                        CatalogusConfig(
+                            url=catalog.url,
+                            rsin=catalog.rsin or "",
+                            domein=catalog.domein,
+                            service=response.client.configured_from,
+                        )
                     )
-                )
 
-        if create:
-            CatalogusConfig.objects.bulk_create(create)
+        if to_update:
+            CatalogusConfig.objects.bulk_update(to_update, ["service"])
+            logger.info("Updated service on %d catalogs", len(to_update))
 
-    return create
+        if to_create:
+            CatalogusConfig.objects.bulk_create(to_create)
+
+    return to_create
 
 
 def import_zaaktype_configs() -> list[ZaakTypeConfig]:


### PR DESCRIPTION
Previously, when syncing catalogus configs, we would match only on URLs but not check the connected Service. This means that certain CatalogusConfig objects may have gotten into a broken state, due to existing prior to introducing the service attribute on the CatalogusConfig model. In that case, there is a chance the field was never properly updated, or that the value was set to an incorrect service.

This is important becaus we use the Service to configure clients for all nested types (zaaktypes, resultaattypes, etc.), and we might get InvalidURL exceptions from ape_pie, because the api_root of the client does not match that of the resource being fetched.