### PR TITLE
[#2497] Add config step that adds default staff user

### DIFF
--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -140,3 +140,12 @@ sites_config:
   items:
     - domain: test-site
       name: The Django Sites default
+
+# Set default (staff) users
+default_user_configuration_enable: true
+default_user_configuration_config:
+  users:
+    - email: admin@user.nl
+      is_staff: True
+      is_superuser: True
+      password: change_me

--- a/src/open_inwoner/conf/app/setup_configuration.py
+++ b/src/open_inwoner/conf/app/setup_configuration.py
@@ -6,6 +6,7 @@ SETUP_CONFIGURATION_STEPS = [
     "open_inwoner.configurations.bootstrap.zgw.OpenZaakConfigurationStep",
     "open_inwoner.configurations.bootstrap.openklant.ESuiteKlantConfigurationStep",
     "open_inwoner.configurations.bootstrap.openklant.OpenKlant2ConfigurationStep",
+    "open_inwoner.configurations.bootstrap.default_users.UserConfigurationStep",
     "django_setup_configuration.contrib.sites.steps.SitesConfigurationStep",
 ]
 OIP_ORGANIZATION = config("OIP_ORGANIZATION", "")

--- a/src/open_inwoner/configurations/bootstrap/default_users.py
+++ b/src/open_inwoner/configurations/bootstrap/default_users.py
@@ -1,0 +1,62 @@
+import warnings
+
+from django_setup_configuration.configuration import BaseConfigurationStep
+from django_setup_configuration.models import ConfigurationModel
+
+from open_inwoner.accounts.models import User
+
+
+class UserConfigurationItem(ConfigurationModel):
+    """
+    Configuration model for a setting standard default users.
+    """
+
+    class Meta:
+        django_model_refs = {
+            User: (
+                "email",
+                "password",
+                "is_staff",
+                "is_superuser",
+            )
+        }
+
+
+class UserConfigurationModel(ConfigurationModel):
+    users: list[UserConfigurationItem]
+
+
+class UserConfigurationStep(BaseConfigurationStep):
+    """
+    Creates or updates a one or more default users based on
+    YAML settings. Note that a provided password
+    will only be used if the user does not exist yet.
+    """
+
+    verbose_name = "User Configuration Step"
+    enable_setting = "default_user_configuration_enable"
+    config_model = UserConfigurationModel
+    namespace = "default_user_configuration_config"
+
+    def execute(self, model):
+        for user_item in model.users:
+            user, created = User.objects.update_or_create(
+                email=user_item.email,
+                defaults={
+                    "email": user_item.email,
+                    "is_staff": user_item.is_staff,
+                    "is_superuser": user_item.is_superuser,
+                },
+            )
+
+            if created:
+                user.set_password(user_item.password)
+
+            user.save()
+
+            if user.check_password(user_item.password):
+                warnings.warn(
+                    "\nThe password for the automatically created "
+                    f"user '{user_item.email}' is currently set to a hardcoded default. "
+                    "Make sure to change the password in the admin panel.\n\n"
+                )

--- a/src/open_inwoner/configurations/tests/test_default_user_configuration.py
+++ b/src/open_inwoner/configurations/tests/test_default_user_configuration.py
@@ -1,0 +1,85 @@
+from django.conf import settings
+from django.test import TestCase
+
+from django_setup_configuration.test_utils import execute_single_step
+
+from open_inwoner.accounts.models import User
+from open_inwoner.configurations.bootstrap.default_users import UserConfigurationStep
+
+
+class TestDefaultUsersStep(TestCase):
+    def test_default_user_was_created(self):
+        email = "admin@user.nl"
+        password = "change_me"
+
+        config = {
+            "default_user_configuration_enable": True,
+            "default_user_configuration_config": {
+                "users": [
+                    {
+                        "email": email,
+                        "is_staff": True,
+                        "is_superuser": True,
+                        "password": password,
+                    }
+                ]
+            },
+        }
+
+        execute_single_step(UserConfigurationStep, object_source=config)
+
+        self.assertEqual(User.objects.count(), 1)
+
+        user = User.objects.get(email=email)
+        self.assertTrue(user.check_password(password))
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+
+    def test_default_user_was_updated(self):
+        email = "someuser@bar.com"
+        default_password = "change_me"
+        actual_password = "12345"
+        existing_user = User(email=email, first_name="Foo", last_name="Bar")
+        existing_user.set_password(actual_password)
+        existing_user.save()
+
+        self.assertTrue(existing_user.check_password(actual_password))
+        self.assertFalse(existing_user.is_staff)
+        self.assertFalse(existing_user.is_superuser)
+
+        existing_user.is_staff = True
+        existing_user.save()
+
+        config = {
+            "default_user_configuration_enable": True,
+            "default_user_configuration_config": {
+                "users": [
+                    {
+                        "email": email,
+                        "is_staff": True,
+                        "is_superuser": True,
+                        "password": default_password,
+                    }
+                ]
+            },
+        }
+
+        execute_single_step(UserConfigurationStep, object_source=config)
+        existing_user.refresh_from_db()
+
+        self.assertFalse(
+            existing_user.check_password(default_password)
+        )  # Should not have updated
+        self.assertTrue(existing_user.is_staff)
+        self.assertTrue(existing_user.is_superuser)
+
+    def test_verify_current_configuration(self):
+        try:
+            execute_single_step(
+                UserConfigurationStep,
+                yaml_source=f"{settings.BASE_DIR}/docker/setup_configuration/data.yaml",
+            )
+        except Exception as e:
+            self.fail(
+                f"Failed to execute UserConfigurationStep with the current configuration. Error: {e}"
+            )


### PR DESCRIPTION
Added a django-setup-configuration step that adds a default staff user.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/2497

Note that this is dependent on: https://github.com/maykinmedia/django-setup-configuration/pull/79

EDIT: On suggestion of @swrichards , I made this implementation separately from the one on django-setup-configuration.