### PR TITLE
[#3316] Limited CSRF cookie age to end of session

### DIFF
--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -533,6 +533,7 @@ SESSION_COOKIE_SECURE = IS_HTTPS
 SESSION_COOKIE_HTTPONLY = True
 
 CSRF_COOKIE_SECURE = IS_HTTPS
+CSRF_USE_SESSIONS = True  # Because cookie csrf makes pen testers uncomfortable
 CSRF_FAILURE_VIEW = "open_inwoner.accounts.views.csrf_failure"
 
 if IS_HTTPS:


### PR DESCRIPTION
Added a setting that limits the CSRF token until the end of the session.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/us/3316?milestone=535

One of the recommendations was that CSRF tokens should rotate on every new session, but this is already done by default. See:
https://docs.djangoproject.com/en/5.2/ref/csrf/#why-might-a-user-encounter-a-csrf-validation-failure-after-logging-in