### PR TITLE
[#3321] Only show CMS pages in sitemap if enabled via CMS AppHookConfig

### DIFF
--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import urlencode
 
 from django.shortcuts import render
@@ -6,6 +7,7 @@ from django.urls import reverse
 from cms.models import Title
 
 from open_inwoner.accounts.models import User
+from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
 from open_inwoner.cms.utils.page_display import (
     benefits_page_is_published,
     case_page_is_published,
@@ -15,7 +17,11 @@ from open_inwoner.cms.utils.page_display import (
     profile_page_is_published,
 )
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.pdc.models.category import Category
+from open_inwoner.questionnaire.models import QuestionnaireStep
+
+logger = logging.getLogger(__name__)
 
 
 def _get_category_data_for_user(cat: Category, user: User) -> dict:
@@ -71,29 +77,99 @@ def sitemap(request):
             {"url_name": "products:questionnaire_list", "link_text": "Zelftest"}
         )
     if profile_page_is_published():
-        base_url = reverse("profile:contact_list")
-        begeleiders_url = f"{base_url}?{urlencode({'type': 'begeleider'})}"
-
         context["cms_profile_pages"] = [
             {"url_name": "profile:detail", "link_text": "Mijn profiel"},
-            {
-                "url_name": "profile:categories",
-                "link_text": "Mijn interessegebieden",
-            },
-            {
-                "url": begeleiders_url,
-                "link_text": "Mijn begeleiders",
-            },
-            {"url_name": "profile:contact_list", "link_text": "Mijn contacten"},
-            {"url_name": "profile:appointments", "link_text": "Mijn afspraken"},
-            {"url_name": "profile:action_list", "link_text": "Openstaande acties"},
         ]
+
+        # conditionally add cms pages based on apphook configuration
+        cms_pages = context["cms_profile_pages"]
+        try:
+            profile_config = ProfileConfig.objects.get()
+        except ProfileConfig.MultipleObjectsReturned:
+            logger.warning("Multiple instances of ProfileConfig apphook found")
+            profile_config = ProfileConfig.objects.first()
+        if profile_config.selected_categories:
+            cms_pages.append(
+                {
+                    "url_name": "profile:categories",
+                    "link_text": "Mijn Interessegebieden",
+                },
+            )
+        if profile_config.mentors:
+            base_url = reverse("profile:contact_list")
+            begeleiders_url = f"{base_url}?{urlencode({'type': 'begeleider'})}"
+            cms_pages.append(
+                {
+                    "url": begeleiders_url,
+                    "link_text": "Mijn begeleiders",
+                },
+            )
+        if profile_config.my_contacts:
+            cms_pages.append(
+                {
+                    "url_name": "profile:contact_list",
+                    "link_text": "Mijn contacten",
+                },
+            )
+        if (
+            profile_config.selfdiagnose
+            and QuestionnaireStep.objects.filter(published=True).exists()
+        ):
+            cms_pages.append(
+                {
+                    "url_name": "products:questionnaire_list",
+                    "link_text": "Zelfdiagnose",
+                }
+            )
+        if profile_config.actions:
+            cms_pages.append(
+                {
+                    "url_name": "profile:action_list",
+                    "link_text": "Openstaande acties",
+                },
+            )
+        if profile_config.notifications:
+            cms_pages.append(
+                {
+                    "url_name": "profile:notifications",
+                    "link_text": "Notificatievoorkeuren",
+                }
+            )
+        if profile_config.questions:
+            cms_pages.append(
+                {
+                    "url_name": "cases:contactmoment_list",
+                    "link_text": "Mijn vragen",
+                }
+            )
+        if profile_config.ssd:
+            cms_pages.append(
+                {
+                    "url_name": "ssd:uitkeringen",
+                    "link_text": "Mijn uitkeringen",
+                }
+            )
+        if profile_config.appointments:
+            cms_pages.append(
+                {
+                    "url_name": "profile:appointments",
+                    "link_text": "Mijn afspraken",
+                },
+            )
 
     # add "platform pages" (conditional login/register page, cookie info etc.)
     context["platform_pages"] = [
         {"url_name": "pages-root", "link_text": "Home page"},
-        {"url_name": "contactform", "link_text": "Contactformulier"},
     ]
+
+    klant_config = KlantenSysteemConfig.get_solo()
+    if klant_config.has_contactform_configuration:
+        context["platform_pages"].append(
+            {
+                "url_name": "contactform",
+                "link_text": "Contactformulier",
+            },
+        )
 
     # hide login links for users that are logged in
     if not request.user.is_authenticated:

--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from cms.models import Title
 
@@ -55,30 +56,30 @@ def sitemap(request):
     context["cms_pages"] = []
     if benefits_page_is_published():
         context["cms_pages"].append(
-            {"url_name": "ssd:uitkeringen", "link_text": "Mijn uitkeringen"}
+            {"url_name": "ssd:uitkeringen", "link_text": _("Mijn uitkeringen")}
         )
     if case_page_is_published():
         context["cms_pages"].append(
-            {"url_name": "cases:index", "link_text": "Mijn zaken"}
+            {"url_name": "cases:index", "link_text": _("Mijn zaken")}
         )
         context["cms_pages"].append(
-            {"url_name": "cases:contactmoment_list", "link_text": "Mijn vragen"}
+            {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
         )
     if collaborate_page_is_published():
         context["cms_pages"].append(
-            {"url_name": "collaborate:plan_list", "link_text": "Mijn samenwerkingen"}
+            {"url_name": "collaborate:plan_list", "link_text": _("Mijn samenwerkingen")}
         )
     if inbox_page_is_published():
         context["cms_pages"].append(
-            {"url_name": "inbox:index", "link_text": "Mijn berichten"}
+            {"url_name": "inbox:index", "link_text": _("Mijn berichten")}
         )
     if products_page_is_published():
         context["cms_pages"].append(
-            {"url_name": "products:questionnaire_list", "link_text": "Zelftest"}
+            {"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}
         )
     if profile_page_is_published():
         context["cms_profile_pages"] = [
-            {"url_name": "profile:detail", "link_text": "Mijn profiel"},
+            {"url_name": "profile:detail", "link_text": _("Mijn profiel")},
         ]
 
         # conditionally add cms pages based on apphook configuration
@@ -92,7 +93,7 @@ def sitemap(request):
             cms_pages.append(
                 {
                     "url_name": "profile:categories",
-                    "link_text": "Mijn Interessegebieden",
+                    "link_text": _("Mijn Interessegebieden"),
                 },
             )
         if profile_config.mentors:
@@ -101,14 +102,14 @@ def sitemap(request):
             cms_pages.append(
                 {
                     "url": begeleiders_url,
-                    "link_text": "Mijn begeleiders",
+                    "link_text": _("Mijn begeleiders"),
                 },
             )
         if profile_config.my_contacts:
             cms_pages.append(
                 {
                     "url_name": "profile:contact_list",
-                    "link_text": "Mijn contacten",
+                    "link_text": _("Mijn contacten"),
                 },
             )
         if (
@@ -118,48 +119,48 @@ def sitemap(request):
             cms_pages.append(
                 {
                     "url_name": "products:questionnaire_list",
-                    "link_text": "Zelfdiagnose",
+                    "link_text": _("Zelfdiagnose"),
                 }
             )
         if profile_config.actions:
             cms_pages.append(
                 {
                     "url_name": "profile:action_list",
-                    "link_text": "Openstaande acties",
+                    "link_text": _("Openstaande acties"),
                 },
             )
         if profile_config.notifications:
             cms_pages.append(
                 {
                     "url_name": "profile:notifications",
-                    "link_text": "Notificatievoorkeuren",
+                    "link_text": _("Notificatievoorkeuren"),
                 }
             )
         if profile_config.questions:
             cms_pages.append(
                 {
                     "url_name": "cases:contactmoment_list",
-                    "link_text": "Mijn vragen",
+                    "link_text": _("Mijn vragen"),
                 }
             )
         if profile_config.ssd:
             cms_pages.append(
                 {
                     "url_name": "ssd:uitkeringen",
-                    "link_text": "Mijn uitkeringen",
+                    "link_text": _("Mijn uitkeringen"),
                 }
             )
         if profile_config.appointments:
             cms_pages.append(
                 {
                     "url_name": "profile:appointments",
-                    "link_text": "Mijn afspraken",
+                    "link_text": _("Mijn afspraken"),
                 },
             )
 
     # add "platform pages" (conditional login/register page, cookie info etc.)
     context["platform_pages"] = [
-        {"url_name": "pages-root", "link_text": "Home page"},
+        {"url_name": "pages-root", "link_text": _("Home page")},
     ]
 
     klant_config = KlantenSysteemConfig.get_solo()
@@ -167,14 +168,14 @@ def sitemap(request):
         context["platform_pages"].append(
             {
                 "url_name": "contactform",
-                "link_text": "Contactformulier",
+                "link_text": _("Contactformulier"),
             },
         )
 
     # hide login links for users that are logged in
     if not request.user.is_authenticated:
         context["platform_pages"].append(
-            {"url_name": "login", "link_text": "Login or create an account"}
+            {"url_name": "login", "link_text": _("Login or create an account")}
         )
 
     # add cms_pages to platform_pages

--- a/src/open_inwoner/templates/pages/sitemap/sitemap.html
+++ b/src/open_inwoner/templates/pages/sitemap/sitemap.html
@@ -40,14 +40,16 @@
         </section>
 
         {# onderwerpen #}
-        <section class="sitemap__section">
-            <h2 class="utrecht-heading-2"><a class="link" href="{% url 'products:category_list' %}">{% trans "Onderwerpen" %}</a></h2>
-            <ul class="utrecht-unordered-list">
-                {% for node in category_nodes %}
-                    {% include "pages/sitemap/category_item.html" with node=node %}
-                {% endfor %}
-            </ul>
-        </section>
+        {% if category_nodes %}
+            <section class="sitemap__section">
+                <h2 class="utrecht-heading-2"><a class="link" href="{% url 'products:category_list' %}">{% trans "Onderwerpen" %}</a></h2>
+                <ul class="utrecht-unordered-list">
+                    {% for node in category_nodes %}
+                        {% include "pages/sitemap/category_item.html" with node=node %}
+                    {% endfor %}
+                </ul>
+            </section>
+        {% endif %}
 
         {% if request.user.is_authenticated %}
             <section class="sitemap__section">


### PR DESCRIPTION
`Mijn profiel` can be configured via a CMS apphook so that only certain elements are enabled/disabled. This is picked up in the view + template for the profile, but not in the sitemap, which now incorrectly includes links to all elements of `Mijn profiel`, irrespective of whether they're enabled or not.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3321