### PR TITLE
feat: upgrade Elasticsearch version and libraries to 9.x/8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
           --name postgres
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2
+        image: bitnami/elasticsearch:9.0.3-debian-12-r1
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -150,7 +150,7 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
           --name postgres
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2
+        image: bitnami/elasticsearch:9.0.3-debian-12-r1
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'

--- a/bin/start_elasticsearch.sh
+++ b/bin/start_elasticsearch.sh
@@ -1,2 +1,11 @@
-docker pull docker.elastic.co/elasticsearch/elasticsearch:7.15.2
-docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -m=1g docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+#!/bin/bash
+
+ES_IMAGE=bitnami/elasticsearch:9.0.3-debian-12-r1
+
+docker pull $ES_IMAGE
+docker run --rm \
+    -p 9200:9200 -p 9300:9300 \
+    -e "discovery.type=single-node" \
+    -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+    -m=1g \
+    $ES_IMAGE

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ celery-once==3.0.1
 certifi==2023.11.17
     # via
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 cffi==1.15.0
@@ -193,7 +193,7 @@ django-csp-reports==1.9.1
     # via -r requirements/base.in
 django-digid-eherkenning[oidc]==0.19.2
     # via -r requirements/base.in
-django-elasticsearch-dsl==7.4
+django-elasticsearch-dsl==8.2
     # via -r requirements/base.in
 django-extra-fields==3.0.2
     # via -r requirements/base.in
@@ -331,9 +331,9 @@ ecs-logging==2.1.0
     # via elastic-apm
 elastic-apm==6.20.0
     # via -r requirements/base.in
-elasticsearch==7.15.1
-    # via elasticsearch-dsl
-elasticsearch-dsl==7.4.0
+elastic-transport==8.17.1
+    # via elasticsearch
+elasticsearch==8.18.1
     # via django-elasticsearch-dsl
 email-validator==2.1.1
     # via pydantic
@@ -479,7 +479,7 @@ python-dateutil==2.8.2
     # via
     #   celery
     #   django-relativedelta
-    #   elasticsearch-dsl
+    #   elasticsearch
     #   faker
     #   messagebird
     #   python-crontab
@@ -537,7 +537,6 @@ six==1.16.0
     # via
     #   click-repl
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
     #   furl
     #   html5lib
     #   isodate
@@ -562,6 +561,7 @@ tinycss2==1.1.1
 typing-extensions==4.10.0
     # via
     #   -r requirements/base.in
+    #   elasticsearch
     #   mozilla-django-oidc-db
     #   pydantic
     #   pydantic-core
@@ -579,7 +579,7 @@ uritemplate==4.1.1
 urllib3==1.26.18
     # via
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 uwsgi==2.0.23

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -89,7 +89,7 @@ certifi==2023.11.17
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 cffi==1.15.0
@@ -312,7 +312,7 @@ django-digid-eherkenning[oidc]==0.19.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-elasticsearch-dsl==7.4
+django-elasticsearch-dsl==8.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -560,12 +560,12 @@ elastic-apm==6.20.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-elasticsearch==7.15.1
+elastic-transport==8.17.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elasticsearch-dsl
-elasticsearch-dsl==7.4.0
+    #   elasticsearch
+elasticsearch==8.18.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -885,7 +885,7 @@ python-dateutil==2.8.2
     #   -r requirements/base.txt
     #   celery
     #   django-relativedelta
-    #   elasticsearch-dsl
+    #   elasticsearch
     #   faker
     #   freezegun
     #   messagebird
@@ -984,7 +984,6 @@ six==1.16.0
     #   -r requirements/base.txt
     #   click-repl
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
     #   furl
     #   html5lib
     #   isodate
@@ -1054,6 +1053,7 @@ typing-extensions==4.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   elasticsearch
     #   mozilla-django-oidc-db
     #   polyfactory
     #   pydantic
@@ -1079,7 +1079,7 @@ urllib3==1.26.18
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 uwsgi==2.0.23

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -104,7 +104,7 @@ certifi==2023.11.17
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   geventhttpclient
     #   requests
     #   sentry-sdk
@@ -348,7 +348,7 @@ django-digid-eherkenning[oidc]==0.19.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-elasticsearch-dsl==7.4
+django-elasticsearch-dsl==8.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -602,12 +602,12 @@ elastic-apm==6.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-elasticsearch==7.15.1
+elastic-transport==8.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elasticsearch-dsl
-elasticsearch-dsl==7.4.0
+    #   elasticsearch
+elasticsearch==8.18.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1009,7 +1009,7 @@ python-dateutil==2.8.2
     #   -r requirements/ci.txt
     #   celery
     #   django-relativedelta
-    #   elasticsearch-dsl
+    #   elasticsearch
     #   faker
     #   freezegun
     #   messagebird
@@ -1121,7 +1121,6 @@ six==1.16.0
     #   -r requirements/ci.txt
     #   click-repl
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
     #   furl
     #   geventhttpclient
     #   html5lib
@@ -1235,6 +1234,7 @@ typing-extensions==4.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   elasticsearch
     #   mozilla-django-oidc-db
     #   polyfactory
     #   pydantic
@@ -1260,7 +1260,7 @@ urllib3==1.26.18
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   elastic-apm
-    #   elasticsearch
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 uwsgi==2.0.23

--- a/src/open_inwoner/cms/tests/cms_tools.py
+++ b/src/open_inwoner/cms/tests/cms_tools.py
@@ -159,7 +159,11 @@ def render_full_page(page: Page, *, as_user: User | None = None):
     # Use the render_page function
     rendered_response = render_page(request, page, current_language="nl", slug=None)
     rendered_response.render()
-    return rendered_response.content
+
+    content = rendered_response.content
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    return content
 
 
 def import_context_processors():

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -901,9 +901,7 @@ GEOCODER = "open_inwoner.utils.geocode.PdocLocatieserver"
 
 
 # ELASTICSEARCH CONFIG
-ELASTICSEARCH_DSL = {
-    "default": {"hosts": config("ES_HOST", "localhost:9200")},
-}
+ELASTICSEARCH_DSL = {"default": {"hosts": config("ES_HOST", "http://localhost:9200")}}
 ES_INDEX_PRODUCTS = config("ES_INDEX_PRODUCTS", "products")
 ES_INDEX_CMS_PAGES = config("ES_INDEX_CMS_PAGES", "cms_pages")
 ES_MAX_SIZE = 10000

--- a/src/open_inwoner/search/analyzers.py
+++ b/src/open_inwoner/search/analyzers.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import analyzer, token_filter
+from elasticsearch.dsl import analyzer, token_filter
 
 from .utils import load_synonyms
 

--- a/src/open_inwoner/search/results.py
+++ b/src/open_inwoner/search/results.py
@@ -6,8 +6,8 @@ from django.db import models
 from django.urls import reverse
 
 from django_elasticsearch_dsl import Document
-from elasticsearch_dsl import FacetedResponse
-from elasticsearch_dsl.response import Response
+from elasticsearch.dsl import FacetedResponse
+from elasticsearch.dsl.response import Response
 
 from open_inwoner.pdc.models import Product
 

--- a/src/open_inwoner/search/searches.py
+++ b/src/open_inwoner/search/searches.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 
-from elasticsearch_dsl import (
+from elasticsearch.dsl import (
     FacetedSearch,
     MultiSearch,
     NestedFacet,
@@ -11,7 +11,7 @@ from elasticsearch_dsl import (
     TermsFacet,
     query,
 )
-from elasticsearch_dsl.response import Response
+from elasticsearch.dsl.response import Response
 
 from .constants import FacetChoices
 from .documents import CMSPageDocument, ProductDocument

--- a/src/open_inwoner/search/tests/test_search_pages.py
+++ b/src/open_inwoner/search/tests/test_search_pages.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.test import TestCase, tag
 
-from elasticsearch_dsl import Search
+from elasticsearch.dsl import Search
 
 from open_inwoner.accounts.models import SiteConfiguration
 from open_inwoner.cms.tests.cms_tools import create_cms_page_with_content

--- a/src/open_inwoner/search/tests/test_views.py
+++ b/src/open_inwoner/search/tests/test_views.py
@@ -382,7 +382,7 @@ class TestSearchView(ESMixin, TransactionTestCase):
     def test_search_shows_error_on_connection_timeout(
         self, request_mocker, mock_search
     ):
-        mock_search.side_effect = ConnectionTimeout()
+        mock_search.side_effect = ConnectionTimeout(message="Connection was timed out.")
         self.client.force_login(self.user)
         params = urlencode({"query": "stuff"}, doseq=True)
         response = self.client.get(f"{reverse('search:search')}?{params}")


### PR DESCRIPTION
This also ensures we're using the same elasticsearch image that is used in production, via openinwoner-deployment and our helm charts. This ensures more consistency between environments.