### PR TITLE
Fix prev-login check failing on create_or_update

### DIFF
--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -617,7 +617,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
         if update_fields and "last_login" in update_fields:
-            update_fields.append("previous_login")
+            if not isinstance(update_fields, set):
+                update_fields = set(update_fields)
+
+            update_fields.add("previous_login")
 
         return super().save(
             force_insert, force_update, using, update_fields=update_fields


### PR DESCRIPTION
Added a check that verifies that `update_fields` argument is a list (and not a set).

The `update_or_create` method converts some of its arguments to a `set` before passing it to the `update_fields` parameter. Because of this, the snippet of code I put in the override of the save() method in `accounts/models.py` fails because it tries to call `append` on a set. Currently this doesn't seem to have affected anything yet (except stuff I'm currently working on that uses update_or_create).