### PR TITLE
[#3352] Fix error handling in Mijn Uitkeringen

### DIFF
--- a/src/open_inwoner/ssd/tests/files/jaaropgave_empty_body.xml
+++ b/src/open_inwoner/ssd/tests/files/jaaropgave_empty_body.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:gwsd="http://www.centric.nl/GWS/Diensten/JaarOpgaveClient/v0400" xmlns:fwi="http://www.centric.nl/GWS/FWI/v0200" xmlns:ns3="http://www.centric.nl/GWS/Header/v0201" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsa="http://www.w3.org/2005/08/addressing" xsi:schemaLocation="http://www.centric.nl/GWS/Diensten/JaarOpgaveClient/v0400 Diensten\JaarOpgaveClient\v0400-b01\BodyReaction_resolved.xsd">
+ <SOAP-ENV:Header>
+  <wsa:MessageID>739ABF07-3828-4477-9D2A-584045771D24</wsa:MessageID>
+  <wsa:Action>http://www.centric.nl/GWS/Diensten/JaarOpgaveClient-v0400/JaarOpgaveInfoResponse</wsa:Action>
+  <wsa:RelatesTo>urn:uuid:6be8d30a-7590-43de-9731-7c8dcbde91ad</wsa:RelatesTo>
+  <wsa:From>
+   <wsa:Address>https://rfor-2securet1.rfor.local:8443/ENSC/Intern/SSD/JaarOpgaveClient-v0400</wsa:Address>
+  </wsa:From>
+  <ns3:Header>
+   <RouteInformatie>
+    <Bron>
+     <Gemeentecode>0153</Gemeentecode>
+     <ApplicatieNaam>GWS4all</ApplicatieNaam>
+    </Bron>
+    <Bestemming>
+     <Gemeentecode>0153</Gemeentecode>
+     <ApplicatieNaam>Open Inwoner</ApplicatieNaam>
+    </Bestemming>
+   </RouteInformatie>
+   <BerichtIdentificatie>
+    <DatTijdAanmaakRequest>2023-08-17T09:09:26+0200</DatTijdAanmaakRequest>
+    <DatTijdOntvangstRequest>2023-08-17T09:09:26+02:00</DatTijdOntvangstRequest>
+    <DatTijdAanmaakResponse>2023-08-17T09:09:28+02:00</DatTijdAanmaakResponse>
+   </BerichtIdentificatie>
+  </ns3:Header>
+ </SOAP-ENV:Header>
+ <SOAP-ENV:Body>
+  <gwsd:JaarOpgaveInfoResponse>
+    <fwi:NietsGevonden/>
+  </gwsd:JaarOpgaveInfoResponse>
+ </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/open_inwoner/ssd/tests/files/uitkering_empty_body.xml
+++ b/src/open_inwoner/ssd/tests/files/uitkering_empty_body.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:fwi="http://www.centric.nl/GWS/FWI/v0200" xmlns:gwsd="http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient/v0600" xmlns:ns3="http://www.centric.nl/GWS/Header/v0201" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsa="http://www.w3.org/2005/08/addressing" xsi:schemaLocation="http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient/v0600 Diensten\UitkeringsSpecificatieClient\v0600-b01\BodyReaction_resolved.xsd">
+ <SOAP-ENV:Header>
+  <wsa:MessageID>447B2E69-F59E-4949-B31F-F1B6A0C80CDD</wsa:MessageID>
+  <wsa:Action>http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient-v0600/UitkeringsSpecificatieInfoResponse</wsa:Action>
+  <wsa:RelatesTo>urn:uuid:28d8fcc8-15fa-41de-b03e-b70b3349748a</wsa:RelatesTo>
+  <wsa:From>
+   <wsa:Address>https://rfor-2securet1.rfor.local:8443/ENSC/Intern/SSD/UitkeringsSpecificatieClient-v0600</wsa:Address>
+  </wsa:From>
+  <ns3:Header>
+   <RouteInformatie>
+    <Bron>
+     <Gemeentecode>0014</Gemeentecode>
+     <ApplicatieNaam>GWS4ALL</ApplicatieNaam>
+    </Bron>
+    <Bestemming>
+     <Gemeentecode>0014</Gemeentecode>
+     <ApplicatieNaam>Open Inwoner</ApplicatieNaam>
+    </Bestemming>
+   </RouteInformatie>
+   <BerichtIdentificatie>
+    <DatTijdAanmaakRequest>2025-07-08T13:41:45+0200</DatTijdAanmaakRequest>
+    <DatTijdOntvangstRequest>2025-07-08T13:41:46+02:00</DatTijdOntvangstRequest>
+    <DatTijdAanmaakResponse>2025-07-08T13:41:48+02:00</DatTijdAanmaakResponse>
+   </BerichtIdentificatie>
+  </ns3:Header>
+ </SOAP-ENV:Header>
+ <SOAP-ENV:Body>
+  <gwsd:UitkeringsSpecificatieInfoResponse>
+   <fwi:NietsGevonden/>
+  </gwsd:UitkeringsSpecificatieInfoResponse>
+ </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/open_inwoner/ssd/tests/test_xml.py
+++ b/src/open_inwoner/ssd/tests/test_xml.py
@@ -82,6 +82,17 @@ class JaaropgaveDataTest(TestCase):
             self.assertEqual(spec.werkgeversheffing_premie_zvw.waarde_bedrag, 494)
             self.assertEqual(spec.cd_premie_volksverzekering, "250")
 
+    @patch("open_inwoner.ssd.xml._get_report_info")
+    def test_jaaropgave_empty(self, m):
+        jaaropgave_path = FILES_DIR / "jaaropgave_empty_body.xml"
+        m.return_value = mock_get_report_info(
+            jaaropgave_path, JAAROPGAVE_INFO_RESPONSE_NODE, JaarOpgaveInfoResponse
+        )
+
+        jaaropgaven = get_jaaropgaven(None)
+
+        self.assertEqual(len(jaaropgaven), 0)
+
 
 class UitkeringDataTest(TestCase):
     @patch("open_inwoner.ssd.xml._get_report_info")
@@ -203,6 +214,17 @@ class UitkeringDataTest(TestCase):
 
             self.assertEqual(vakantiegeld, totaal_netto)
             self.assertEqual(totaal_netto, uit_te_betalen)
+
+    @patch("open_inwoner.ssd.xml._get_report_info")
+    def test_uitkering_empty(self, m):
+        uitkering_path = FILES_DIR / "uitkering_empty_body.xml"
+        m.return_value = mock_get_report_info(
+            uitkering_path, UITKERING_INFO_RESPONSE_NODE, UitkeringInfoResponse
+        )
+
+        uitkeringen = get_uitkeringen(None)
+
+        self.assertEqual(len(uitkeringen), 0)
 
 
 class SSDTagTest(TestCase):

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -58,6 +58,7 @@ class BenefitsFormView(
                         "Please try again later"
                     ),
                 )
+                pdf_content = None
 
             if not pdf_content:
                 return_path = request.get_full_path()

--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -70,9 +70,6 @@ def _get_report_info(
     if info_response.fwi:
         raise SSDClientException.from_xml_response(xml_response=info_response)
 
-    if info_response.niets_gevonden:
-        raise SSDClientException("unexpected error occured")
-
     return info_response
 
 
@@ -89,6 +86,8 @@ def get_jaaropgaven(response: requests.Response) -> list[JaaropgaveReturn] | Non
     jaaropgave_info = _get_report_info(
         response, JAAROPGAVE_INFO_RESPONSE_NODE, JaarOpgaveInfoResponse
     )
+    if jaaropgave_info.niets_gevonden:
+        return []
 
     client = cast(Client, jaaropgave_info.jaar_opgave_client.client)
     jaar_opgave = cast(JaarOpgave, jaaropgave_info.jaar_opgave_client.jaar_opgave[0])
@@ -114,6 +113,8 @@ def get_uitkeringen(response: requests.Response) -> list[dict] | None:
     uitkeringen_info = _get_report_info(
         response, UITKERING_INFO_RESPONSE_NODE, UitkeringInfoResponse
     )
+    if uitkeringen_info.niets_gevonden:
+        return []
 
     uitkeringsspecificatie = (
         uitkeringen_info.uitkerings_specificatie_client.uitkeringsspecificatie[0]


### PR DESCRIPTION
Fixes two small bugs in the uitkeringen app:

- [x] Set `pdf_content` to `null` in case of SSD client error
- [x] Properly handle response contents with `fwi:NietsGevonden` (they are not errors)

https://taiga.maykinmedia.nl/project/open-inwoner/issue/3352