### PR TITLE
Apply ruff bandit

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -97,24 +97,3 @@ jobs:
           grep ^ruff requirements/ci.txt | uv pip install --system -r /dev/stdin
       - name: Run ruff format on all files
         run: ruff format --diff --target-version py311 src
-
-  bandit:
-    name: Python security check using Bandit
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install libxml
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          pip install uv
-          uv pip install --system -r requirements/dev.txt
-      - name: Run Bandit
-        run: |
-          bandit -r ./src/ -x tests,conf/utils.py -s B101

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,9 +4,6 @@
 pip-tools
 pre-commit
 
-# Code formatting
-bandit
-
 # Debug tooling
 django-debug-toolbar
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -53,8 +53,6 @@ babel==2.15.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
-bandit==1.7.4
-    # via -r requirements/dev.in
 beautifulsoup4==4.12.3
     # via
     #   -c requirements/ci.txt
@@ -688,10 +686,6 @@ gevent==23.9.1
     #   locust
 geventhttpclient==2.0.11
     # via locust
-gitdb==4.0.9
-    # via gitpython
-gitpython==3.1.41
-    # via bandit
 glom==20.11.0
     # via
     #   -c requirements/ci.txt
@@ -871,8 +865,6 @@ packaging==23.0
     #   djangocms-text-ckeditor
     #   pytest
     #   sphinx
-pbr==5.9.0
-    # via stevedore
 pep517==0.11.0
     # via build
 phonenumbers==8.13.29
@@ -1038,7 +1030,6 @@ pyyaml==6.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   bandit
     #   drf-spectacular
     #   gemma-zds-client
     #   pre-commit
@@ -1129,8 +1120,6 @@ six==1.16.0
     #   orderedmultidict
     #   python-dateutil
     #   qrcode
-smmap==5.0.0
-    # via gitdb
 snowballstemmer==2.2.0
     # via
     #   -c requirements/ci.txt
@@ -1203,8 +1192,6 @@ sqlparse==0.4.4
     #   django
     #   django-debug-toolbar
     #   django-silk
-stevedore==3.5.0
-    # via bandit
 svglib==1.5.1
     # via
     #   -c requirements/ci.txt

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,6 +66,8 @@ select = [
     "N",
     # https://docs.astral.sh/ruff/rules/#isort-i
     "I",
+    # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "S",
 ]
 ignore = [
     # Whitespace before ':' (conflicts with Black)
@@ -92,6 +94,8 @@ ignore = [
     "N815",
     # Exception name should be named with Error suffix
     "N818",
+    # Checks for uses of the Python requests or httpx module that omit the timeout parameter.
+    "S113"
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -115,6 +119,11 @@ ignore-names = [
     "*TimelineLog*",
     "innNnpId",
 ]
+
+[lint.per-file-ignores]
+# Ignore security rules in test files
+"**/test_*.py" = ["S"]
+"**/tests/**/*.py" = ["S"]
 
 # Import sorting configuration (equivalent to isort)
 [lint.isort]

--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -1,4 +1,5 @@
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -104,9 +105,8 @@ class Subscription(models.Model):
         """
         Registers the webhook with the notification component.
         """
-        assert self.notifications_api_config.notifications_api_service, (
-            "No service for Notifications API configured"
-        )
+        if not self.notifications_api_config.notifications_api_service:
+            raise ImproperlyConfigured("No service for Notifications API configured")
 
         client = self.notifications_api_config.get_client()
 

--- a/src/open_inwoner/accounts/views/auth_oidc.py
+++ b/src/open_inwoner/accounts/views/auth_oidc.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import auth, messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import resolve_url
@@ -96,7 +96,9 @@ class OIDCLogoutView(View):
         return resolve_url(settings.LOGOUT_REDIRECT_URL)
 
     def get(self, request):
-        assert self.config_class is not None
+        if self.config_class is None:
+            raise ImproperlyConfigured("Missing OIDCLogoutView config class")
+
         config = self.config_class.get_solo()
 
         id_token = request.session.get("oidc_id_token")

--- a/src/open_inwoner/api/pdc/views.py
+++ b/src/open_inwoner/api/pdc/views.py
@@ -25,12 +25,13 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
         # Perform the lookup filtering.
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
 
-        assert lookup_url_kwarg in self.kwargs, (
-            "Expected view %s to be called with a URL keyword argument "
-            'named "%s". Fix your URL conf, or set the `.lookup_field` '
-            "attribute on the view correctly."
-            % (self.__class__.__name__, lookup_url_kwarg)
-        )
+        if lookup_url_kwarg not in self.kwargs:
+            raise ValueError(
+                "Expected view %s to be called with a URL keyword argument "
+                'named "%s". Fix your URL conf, or set the `.lookup_field` '
+                "attribute on the view correctly."
+                % (self.__class__.__name__, lookup_url_kwarg)
+            )
 
         filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
         obj = get_object_or_404(queryset, **filter_kwargs)

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -1089,7 +1089,8 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
         return bool(question)
 
     def _register_via_esuite(self, form, config: ESuiteKlantConfig):
-        assert config.has_api_configuration
+        if not config.has_api_configuration:
+            raise ImproperlyConfigured("Missing eSuite API configuration")
 
         try:
             ztc = ZaakTypeConfig.objects.filter_case_type(self.case.zaaktype).get()

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -480,7 +480,7 @@ def form_actions(
         - primary: bool | If the primary styling should be used.
     """
     if (not primary_text and primary_icon is None) and kwargs.get("primary", True):
-        assert False, "provide primary_text or primary_icon"
+        raise ValueError("provide primary_text or primary_icon")
 
     primary = kwargs.get("primary", "transparent" not in kwargs)
 

--- a/src/open_inwoner/conf/utils.py
+++ b/src/open_inwoner/conf/utils.py
@@ -83,8 +83,9 @@ def _get_version_from_git():
     Returns the current tag or commit hash supplied by git
     """
     try:
-        tags = check_output(
-            ["git", "tag", "--points-at", "HEAD"], universal_newlines=True
+        tags = check_output(  # noqa: S603
+            ["git", "tag", "--points-at", "HEAD"],  # noqa: S607
+            universal_newlines=True,
         )
     except CalledProcessError:
         logger.warning("Unable to list tags")
@@ -94,7 +95,10 @@ def _get_version_from_git():
         return next(version for version in tags.splitlines())
 
     try:
-        commit = check_output(["git", "rev-parse", "HEAD"], universal_newlines=True)
+        commit = check_output(  # noqa: S603
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            universal_newlines=True,
+        )
     except CalledProcessError:
         logger.warning("Unable to list current commit hash")
         commit = None

--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -193,7 +193,9 @@ class ContactmomentenClient(APIClient):
         # resolve linked resources
         contactmoment_mapping = {}
         for ocm in object_contact_momenten:
-            assert ocm.object == zaak.url
+            if not ocm.object == zaak.url:
+                raise ValueError("objectcontactmoment not linked to zaak")
+
             ocm.object = zaak
 
             contactmoment_url = ocm.contactmoment
@@ -243,7 +245,9 @@ class ContactmomentenClient(APIClient):
 
         # resolve linked resources
         for kcm in klanten_contact_moments:
-            assert kcm.klant == klant.url
+            if not kcm.klant == klant.url:
+                raise ValueError("klantcontactmoment not linked to klant")
+
             kcm.klant = klant
             kcm.contactmoment = self.retrieve_contactmoment(kcm.contactmoment)
 

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -551,7 +551,9 @@ class eSuiteVragenService(KlantenService):
         # resolve linked resources
         contactmoment_mapping = {}
         for ocm in object_contact_momenten:
-            assert ocm.object == zaak.url
+            if not ocm.object == zaak.url:
+                raise ValueError("objectcontactmoment not linked to zaak")
+
             ocm.object = zaak
 
             contactmoment_url = ocm.contactmoment
@@ -601,7 +603,9 @@ class eSuiteVragenService(KlantenService):
 
         # resolve linked resources
         for kcm in klanten_contact_moments:
-            assert kcm.klant == klant.url
+            if not kcm.klant == klant.url:
+                raise ValueError("klantcontactmoment not linked to klant")
+
             kcm.klant = klant
             kcm.contactmoment = self.retrieve_contactmoment(kcm.contactmoment)
 

--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
@@ -221,7 +222,8 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
         form: ContactForm,
         esuite_config: ESuiteKlantConfig,
     ) -> tuple[bool, str]:
-        assert esuite_config.has_api_configuration
+        if not esuite_config.has_api_configuration:
+            raise ImproperlyConfigured("Missing API configuration for eSuite")
 
         klant = self._fetch_klant()
         if klant:

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -328,7 +328,9 @@ class ZakenClient(ZgwAPIClient):
             "zaak": case_url,
         }
         if role_desc_generic:
-            assert role_desc_generic in RolOmschrijving.values
+            if role_desc_generic not in RolOmschrijving.values:
+                raise ValueError(f"{role_desc_generic} is not a known RolOmschrijving")
+
             params["omschrijvingGeneriek"] = role_desc_generic
 
         try:

--- a/src/open_inwoner/openzaak/management/commands/zgw_dev_status.py
+++ b/src/open_inwoner/openzaak/management/commands/zgw_dev_status.py
@@ -165,7 +165,7 @@ class Command(BaseCommand):
 
             # if next status is end-status we need to result, so random select one
             if next_status_type.is_eindstatus and not case.resultaat:
-                next_result_type = random.choice(result_types)  # nosec
+                next_result_type = random.choice(result_types)  # noqa: S311
                 self.stdout.write(f"setting new result {next_result_type.omschrijving}")
                 zaken_client.create(
                     "resultaat",

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -1858,7 +1858,7 @@ class TestCaseDetailView(
 
                 response = self.client.get(self.case_detail_url)
 
-                self.assertEquals(response.status_code, 200)
+                self.assertEqual(response.status_code, 200)
                 self.assertContains(response, self.zaak["identificatie"])
 
     def test_no_access_as_vestiging_when_no_roles_are_found_for_vestigingsnummer(

--- a/src/open_inwoner/openzaak/utils.py
+++ b/src/open_inwoner/openzaak/utils.py
@@ -144,7 +144,11 @@ def get_zaak_type_info_object_type_config(
     case_type: ZaakType,
     info_object_type_url: str,
 ) -> ZaakTypeInformatieObjectTypeConfig | None:
-    assert isinstance(info_object_type_url, str)
+    if not isinstance(info_object_type_url, str):
+        raise ValueError(
+            f"info_object_type_url is a {type(info_object_type_url)}, not a str"
+        )
+
     try:
         return ZaakTypeInformatieObjectTypeConfig.objects.get_for_case_and_info_type(
             case_type, info_object_type_url

--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -50,7 +50,7 @@ def _get_report_info(
         raise SSDClientException("response had no content")
 
     try:
-        tree = etree.fromstring(response.content).getroottree()
+        tree = etree.fromstring(response.content).getroottree()  # noqa: S320
     except (LxmlError, XMLSyntaxError) as exc:
         raise SSDClientException("error generating XML from content") from exc
 

--- a/src/open_inwoner/utils/colors.py
+++ b/src/open_inwoner/utils/colors.py
@@ -55,7 +55,8 @@ def hex_to_luminance(hex_color):
     https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
     """
     color = re.sub(r"^0x|^#", "", hex_color)
-    assert len(color) == 6
+    if not len(color) == 6:
+        raise ValueError(f"Expected {color} to have length 6")
 
     def calc(c):
         if c <= 0.03928:

--- a/src/open_inwoner/utils/tests/test_colors.py
+++ b/src/open_inwoner/utils/tests/test_colors.py
@@ -34,6 +34,27 @@ class ColorUtilsTestCase(TestCase):
                 actual = hex_to_luminance(hex)
                 self.assertAlmostEqual(actual, expected, places=3)
 
+    def test_hex_to_luminance_invalid_length(self):
+        """Test that hex_to_luminance raises ValueError for invalid color lengths."""
+        invalid_colors = [
+            "#fff",  # 3 characters (too short)
+            "#ff",  # 2 characters (too short)
+            "#f",  # 1 character (too short)
+            "#fffffff",  # 7 characters (too long)
+            "#ffffffff",  # 8 characters (too long)
+            "fff",  # No # prefix, 3 characters
+            "0xfff",  # 0x prefix, 3 characters
+            "",  # Empty string
+        ]
+
+        for color in invalid_colors:
+            with self.subTest(color=color):
+                with self.assertRaises(ValueError) as cm:
+                    hex_to_luminance(color)
+
+                # Verify the error message mentions the expected length
+                self.assertIn("to have length 6", str(cm.exception))
+
     def test_get_contrast_ratio(self):
         tests = [
             ("#000000", "#ffffff", 21.0),

--- a/src/open_inwoner/utils/tests/test_glom.py
+++ b/src/open_inwoner/utils/tests/test_glom.py
@@ -9,6 +9,6 @@ class GlomTestCase(SimpleTestCase):
             "aa": {"bb": 1},
             "cc": {"dd": 2},
         }
-        self.assertEquals(glom_multiple(obj, ("aa.bb", "cc.dd")), 1)
-        self.assertEquals(glom_multiple(obj, ("aa.xyz", "cc.dd")), 2)
-        self.assertEquals(glom_multiple(obj, ("aa.xyz", "cc.xyz"), default=999), 999)
+        self.assertEqual(glom_multiple(obj, ("aa.bb", "cc.dd")), 1)
+        self.assertEqual(glom_multiple(obj, ("aa.xyz", "cc.dd")), 2)
+        self.assertEqual(glom_multiple(obj, ("aa.xyz", "cc.xyz"), default=999), 999)

--- a/src/open_inwoner/utils/text.py
+++ b/src/open_inwoner/utils/text.py
@@ -10,7 +10,8 @@ def middle_truncate(value: str, length: int, dots="...") -> str:
 
 
 def html_tag_wrap_format(format_str: str, tag: str, **kwargs) -> str:
-    assert kwargs, "expected replacment kwargs"
+    if not kwargs:
+        raise ValueError("expected replacement kwargs")
     html_tag = "<{}>{{}}</{}>".format(tag, tag)
     replace = {
         name: format_html(html_tag, force_str(value)) for name, value in kwargs.items()

--- a/src/openklant2/factories/digitaal_adres.py
+++ b/src/openklant2/factories/digitaal_adres.py
@@ -28,6 +28,8 @@ class CreateDigitaalAdresDataFactory(factory.Factory):
         )
     )
     omschrijving = factory.Faker("word")
-    soortDigitaalAdres = random.choice(["email", "telefoonnummer", "overig"])  # nosec
+    soortDigitaalAdres = random.choice(  # noqa: S311
+        ["email", "telefoonnummer", "overig"],
+    )
     verstrektDoorBetrokkene = factory.SubFactory(ForeignKeyRef)
     verstrektDoorPartij = factory.SubFactory(ForeignKeyRef)


### PR DESCRIPTION
We can deprecate the separate `bandit` pipeline by relying on `ruff` which incorporates all the relevant rules, making things faster and more maintainable.

<!-- readthedocs-preview open-inwoner start -->
----
📚 Documentation preview 📚: https://open-inwoner--1824.org.readthedocs.build/en/1824/

<!-- readthedocs-preview open-inwoner end -->