### PR TITLE
Revert "chore(deps): bump lxml to 5.3.0 and xmlsec to 1.3.14"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         uses: maykinmedia/setup-django-backend@v1.3
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
-          python-version: '3.11'
+          python-version: '3.12'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
           setup-node: 'yes'
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install coverage.py
         # We only need coverage, but we need to match the version that was used
         # to generate the coverage files. Grab it from the dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up backend environment
-        uses: maykinmedia/setup-django-backend@v1
+        uses: maykinmedia/setup-django-backend@v1.3
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client libgdal-dev gdal-bin'
           python-version: '3.12'
@@ -196,7 +196,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Set up backend environment
-        uses: maykinmedia/setup-django-backend@v1
+        uses: maykinmedia/setup-django-backend@v1.3
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext libgdal-dev gdal-bin graphviz'
           python-version: '3.12'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -384,7 +384,7 @@ jsonschema==4.1.0
     # via drf-spectacular
 kombu==5.5.1
     # via celery
-lxml==5.3.0
+lxml==4.9.1
     # via
     #   django-digid-eherkenning
     #   mail-editor
@@ -606,7 +606,7 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via maykin-python3-saml
 xsdata==23.8
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -679,7 +679,7 @@ kombu==5.5.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-lxml==5.3.0
+lxml==4.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1136,7 +1136,7 @@ xlwt==1.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -759,7 +759,7 @@ kombu==5.5.1
     #   celery
 locust==2.20.0
     # via -r requirements/dev.in
-lxml==5.3.0
+lxml==4.9.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1323,7 +1323,7 @@ xlwt==1.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   tablib
-xmlsec==1.3.14
+xmlsec==1.3.12
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
This reverts commit 327fd06db03feb088876df29a6c6be1dd0519ec5.

The familiar version mismatch bug is appearing in the test environment. Switching back to a known working pair.