### PR TITLE
[#1169] Remove xml-related packages from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     build-essential \
     git \
     libpq-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
     libxmlsec1-openssl \
     libgdk-pixbuf2.0-0 \
     libffi-dev \
@@ -68,7 +66,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libgdal32 \
     libgeos-c1v5 \
     libproj25 \
-    libxmlsec1-dev \
     libxmlsec1-openssl \
     libgdk-pixbuf2.0-0 \
     libffi-dev \


### PR DESCRIPTION
When `libxml` is installed (which it is through installing libxml2-dev), then pip compiles `lxml` from source against the system `libxml`. This has caused a mismatch between the system `libxml` available at runtime and the `libxml` that `lxml` was compiled against during the build stage. Without `libxml` on the system, pip falls back on pre-built binary wheels, which have their own version of `libxml` built in.

Taiga: https://taiga.maykinmedia.nl/project/maykin-intranet/issue/1169