### PR TITLE
[#3389] Sync user profiles with OpenKlant

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 from django.contrib.auth.signals import user_logged_in
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext as _
@@ -22,6 +23,10 @@ from open_inwoner.kvk.tests.factories import CertificateFactory
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.openklant.tests.data import MockAPIReadPatchData
+from open_inwoner.openklant.tests.factories import (
+    ESuiteConfigFactory,
+    OpenKlant2ConfigFactory,
+)
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
 
 from ...cms.collaborate.cms_apps import CollaborateApphook
@@ -1818,6 +1823,221 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
                     ]
                 }
                 self.assertEqual(response.context["form"].errors, expected_errors)
+
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    def test_update_klant_via_openklant_successful(self, mock_service_class):
+        """Test successful update of user data via OpenKlant"""
+        OpenKlant2ConfigFactory()
+
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            phonenumber="",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        # Mock the service
+        mock_service = mock_service_class.return_value
+        mock_partij = {
+            "uuid": "12345678-1234-1234-1234-123456789012",
+            "id": "123",
+            "naam": "Test User",
+        }
+        mock_service.get_or_create_partij_for_user.return_value = (mock_partij, True)
+
+        # Submit the form
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        # Assertions
+        self.assertEqual(response.status_code, 302)
+        mock_service.get_or_create_partij_for_user.assert_called_once_with(user=user)
+        mock_service.update_partij_from_user.assert_called_once_with(
+            partij_uuid="12345678-1234-1234-1234-123456789012",
+            user=user,
+            user_form_data={
+                "email": "new@example.com",
+            },
+        )
+
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    def test_update_klant_via_openklant_with_existing_partij(self, mock_service_class):
+        """Test update when partij already exists (not created)"""
+        OpenKlant2ConfigFactory()
+
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        # Mock the service - partij already exists
+        mock_service = mock_service_class.return_value
+        mock_partij = {
+            "uuid": "12345678-1234-1234-1234-123456789012",
+            "id": "123",
+            "naam": "Test User",
+        }
+        # Return False for created to indicate partij already exists
+        mock_service.get_or_create_partij_for_user.return_value = (mock_partij, False)
+
+        # Submit the form
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        # Assertions
+        self.assertEqual(response.status_code, 302)
+        mock_service.update_partij_from_user.assert_called_once_with(
+            partij_uuid="12345678-1234-1234-1234-123456789012",
+            user=user,
+            user_form_data={
+                "email": "new@example.com",
+            },
+        )
+
+    @patch("open_inwoner.accounts.views.registration.eSuiteKlantenService")
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    def test_both_esuite_and_openklant_services_called(
+        self, mock_openklant_class, mock_esuite_class
+    ):
+        """Test that both eSuite and OpenKlant services are called when both are configured"""
+        ESuiteConfigFactory()
+        OpenKlant2ConfigFactory()
+
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.ESUITE.value
+        config.save()
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        # Mock eSuite service
+        mock_esuite = mock_esuite_class.return_value
+        mock_klant = {"id": "esuite-123"}
+        mock_esuite.get_or_create_klant.return_value = (mock_klant, True)
+        mock_esuite.get_fetch_parameters.return_value = {}
+
+        # Mock OpenKlant service
+        mock_openklant = mock_openklant_class.return_value
+        mock_partij = {
+            "uuid": "12345678-1234-1234-1234-123456789012",
+            "id": "openklant-123",
+        }
+        mock_openklant.get_or_create_partij_for_user.return_value = (mock_partij, True)
+
+        # Submit the form
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        # Assertions
+        self.assertEqual(response.status_code, 302)
+        mock_esuite.get_or_create_klant.assert_called_once()
+        mock_esuite.update_klant_from_user.assert_called_once()
+        mock_openklant.get_or_create_partij_for_user.assert_called_once()
+        mock_openklant.update_partij_from_user.assert_called_once()
+
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    @patch("open_inwoner.accounts.views.registration.logger")
+    def test_update_klant_via_openklant_service_not_configured(
+        self, mock_logger, mock_service_class
+    ):
+        """Test handling when OpenKlant service is not properly configured"""
+        OpenKlant2ConfigFactory()
+
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        # Mock the service to raise ImproperlyConfigured
+        mock_service_class.side_effect = ImproperlyConfigured("Service not configured")
+
+        # Submit the form
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        # Assertions - form should still submit successfully
+        self.assertEqual(response.status_code, 302)
+        mock_logger.info.assert_called_once_with("Unable to build KlantenService")
+
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    @patch("open_inwoner.accounts.views.registration.logger")
+    def test_update_klant_via_openklant_partij_creation_fails(
+        self, mock_logger, mock_service_class
+    ):
+        """Test error handling when partij creation fails"""
+        OpenKlant2ConfigFactory()
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        # Mock the service to return None for partij
+        mock_service = mock_service_class.return_value
+        mock_service.get_or_create_partij_for_user.return_value = (None, False)
+
+        # Submit the form
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        # Assertions
+        self.assertEqual(response.status_code, 302)
+        mock_service.get_or_create_partij_for_user.assert_called_once_with(user=user)
+        mock_service.update_partij_from_user.assert_not_called()
+        mock_logger.error.assert_called_once_with(
+            "Unable to create partij during post-registration sync",
+            extra={"user": user},
+        )
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1420,7 +1420,9 @@ class DuplicateEmailRegistrationTest(WebTest):
 
         self.assertEqual(users.count(), 1)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_digid_user_can_edit_profile(self, mock_update):
         """
         Assert that digid user can edit their profile (the email of the same user
@@ -1560,7 +1562,9 @@ class DuplicateEmailRegistrationTest(WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["form"].errors, expected_errors)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_non_digid_user_can_edit_profile(self, mock_update):
         """
         Assert that non-digid users can edit their profile (the email of the same user

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -72,7 +72,9 @@ class TestProfile(WebTest):
             },
         )
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_users_modification_is_logged(self, mock_update):
         mock_update.return_value = True
 

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -21,6 +21,7 @@ from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.tests.mixins import HaalCentraalMixin
 from open_inwoner.laposta.models import LapostaConfig
 from open_inwoner.laposta.tests.factories import LapostaListFactory, MemberFactory
+from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import ESuiteKlantConfig
 from open_inwoner.pdc.tests.factories import CategoryFactory
 from open_inwoner.plans.tests.factories import PlanFactory
@@ -365,7 +366,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         }
         self.assertEqual(base_response.context["form"].errors, expected_errors)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_save_filled_form(self, mock_update):
         mock_update.return_value = True
 
@@ -426,7 +429,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
                 }
                 self.assertEqual(response.context["form"].errors, expected_errors)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_modify_email_succeeds(self, mock_update):
         mock_update.return_value = True
 
@@ -439,7 +444,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         self.assertEqual(response.url, self.return_url)
         self.assertEqual(self.user.email, "user@example.com")
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_modify_contact_details_eherkenning_succeeds(self, mock_update):
         mock_update.return_value = True
 
@@ -457,7 +464,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         self.assertEqual(eherkenning_user.phonenumber, "0612345678")
         self.assertEqual(eherkenning_user.phonenumber_alternative, "0687654321")
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_updating_a_field_without_modifying_email_succeeds(self, mock_update):
         mock_update.return_value = True
 
@@ -475,7 +484,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         self.assertEqual(self.user.email, initial_email)
         self.assertEqual(self.user.first_name, "Testing")
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_form_for_digid_brp_user_saves_data(self, mock_update):
         mock_update.return_value = True
         user = UserFactory(
@@ -526,7 +537,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertEqual(type(form), BrpUserForm)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_image_is_saved_when_begeleider_and_default_login(self, mock_update):
         mock_update.return_value = True
         self.user.contact_type = ContactTypeChoices.begeleider
@@ -545,7 +558,9 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertIsNotNone(self.user.image.file)
 
-    @patch("open_inwoner.accounts.views.profile.EditProfileView.update_esuite_klant")
+    @patch(
+        "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
+    )
     def test_image_is_saved_when_begeleider_and_digid_login(self, mock_update):
         mock_update.return_value = True
 
@@ -749,6 +764,86 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         self.assertTimelineLog("retrieved klant for user")
         self.assertTimelineLog(
             "patched klant from user profile edit with fields: emailadres"
+        )
+
+    @requests_mock.Mocker()
+    def test_update_via_openklant(self, m):
+        MockAPIReadPatchData.setUpServices(
+            klanten_service_type=KlantenServiceType.OPENKLANT2
+        )
+        data = MockAPIReadPatchData().install_mocks_openklant(m)
+
+        response = self.app.get(self.url, user=data.digid_user)
+
+        # reset noise from signals
+        m.reset_mock()
+        self.clearTimelineLogs()
+
+        form = response.forms["profile-edit"]
+        form["email"] = "new@example.com"
+        form["phonenumber"] = "0612345678"
+        form["phonenumber_alternative"] = "0687654321"
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+
+        digitale_adressen_requests = [
+            r for r in m.request_history if "digitaleadressen" in r.path
+        ]
+
+        # 1. email update
+        email_requests = [
+            r
+            for r in digitale_adressen_requests
+            if r.method in ["POST"]
+            and r.json()
+            and r.json().get("soortDigitaalAdres") == "email"
+        ]
+        self.assertEqual(len(email_requests), 1)
+
+        email_req = email_requests[0]
+        self.assertEqual(email_req.json()["adres"], "new@example.com")
+        self.assertEqual(email_req.json()["soortDigitaalAdres"], "email")
+        self.assertEqual(
+            email_req.json()["verstrektDoorPartij"],
+            {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
+        )
+
+        # 2. phone number updates
+        phone_requests = [
+            r
+            for r in digitale_adressen_requests
+            if r.method in ["POST"]
+            and r.json()
+            and r.json().get("soortDigitaalAdres") == "telefoonnummer"
+        ]
+        self.assertEqual(len(phone_requests), 2)
+
+        phone_numbers = [r.json() for r in phone_requests]
+        standard_number = next(num for num in phone_numbers if num["isStandaardAdres"])
+        self.assertEqual(
+            standard_number,
+            {
+                "adres": "0612345678",
+                "soortDigitaalAdres": "telefoonnummer",
+                "isStandaardAdres": True,
+                "verstrektDoorPartij": {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
+                "verstrektDoorBetrokkene": None,
+                "omschrijving": "OIP profiel",
+            },
+        )
+
+        alt_number = next(num for num in phone_numbers if not num["isStandaardAdres"])
+        self.assertEqual(
+            alt_number,
+            {
+                "adres": "0687654321",
+                "soortDigitaalAdres": "telefoonnummer",
+                "isStandaardAdres": False,
+                "verstrektDoorPartij": {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
+                "verstrektDoorBetrokkene": None,
+                "omschrijving": "OIP profiel",
+            },
         )
 
 

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -28,8 +28,10 @@ from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.utils import fetch_brp
 from open_inwoner.laposta.forms import NewsletterSubscriptionForm
 from open_inwoner.laposta.models import LapostaConfig
-from open_inwoner.openklant.api_models import Klant
-from open_inwoner.openklant.services import eSuiteKlantenService
+from open_inwoner.openklant.constants import KlantenServiceType
+from open_inwoner.openklant.models import KlantenSysteemConfig
+from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
+from open_inwoner.openklant.types import PartijUpdateData
 from open_inwoner.plans.models import Plan
 from open_inwoner.qmatic.client import NoServiceConfigured, qmatic_client_factory
 from open_inwoner.questionnaire.models import QuestionnaireStep
@@ -233,20 +235,29 @@ class EditProfileView(
     def form_valid(self, form):
         user: User = self.get_object()
 
-        klant = self.update_esuite_klant(
-            {k: form.cleaned_data[k] for k in form.changed_data}, user
-        )
-
-        # only save the form if changes have been written to Klanten API or
-        # changes do not require writing to API
-        if klant or not any(
+        # immediately save form if changes don't require writing to API
+        if not any(
             key in form.changed_data
             for key in ("email", "phonenumber", "phonenumber_alternative")
         ):
             form.save()
             messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
             self.log_change(self.get_object(), _("profile was modified"))
-        else:
+            return HttpResponseRedirect(self.get_success_url())
+
+        # write changes to API's; abort saving if write fails
+        # we treat `api_update_ok` as True if the relevant service is not configured at all
+        esuite_update_ok, openklant_update_ok = True, True
+        klanten_config = KlantenSysteemConfig.get_solo()
+        if klanten_config.has_api_service_configured(KlantenServiceType.ESUITE):
+            esuite_update_ok = self.update_klant_via_esuite(
+                {k: form.cleaned_data[k] for k in form.changed_data}, user
+            )
+        if klanten_config.has_api_service_configured(KlantenServiceType.OPENKLANT2):
+            openklant_update_ok = self.update_klant_via_openklant(
+                {k: form.cleaned_data[k] for k in form.changed_data}, user
+            )
+        if not esuite_update_ok or not openklant_update_ok:
             messages.error(
                 request=self.request,
                 message=_(
@@ -257,9 +268,31 @@ class EditProfileView(
             self.log_change(
                 self.get_object(), _("profile changes not saved due to Klant API error")
             )
+            return HttpResponseRedirect(self.get_success_url())
+
+        form.save()
+        messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
+        self.log_change(self.get_object(), _("profile was modified"))
         return HttpResponseRedirect(self.get_success_url())
 
-    def update_esuite_klant(self, user_form_data: dict, user: User) -> Klant | None:
+    def update_klant_via_openklant(self, user_form_data: dict, user: User) -> bool:
+        try:
+            service = OpenKlant2Service()
+        except Exception:
+            logger.warning("OpenKlant2Service failed to build")
+            return False
+
+        partij, created = service.get_or_create_partij_for_user(user)
+
+        if partij and not created:
+            return service.update_partij_from_user_data(
+                partij_uuid=partij["uuid"],
+                update_data=PartijUpdateData(**user_form_data),
+            )
+
+        return bool(partij)
+
+    def update_klant_via_esuite(self, user_form_data: dict, user: User) -> bool:
         field_mapping = {
             "emailadres": "email",
             "telefoonnummer": "phonenumber",
@@ -270,26 +303,25 @@ class EditProfileView(
             for api_name, local_name in field_mapping.items()
             if user_form_data.get(local_name)
         }
-        if not update_data:
-            return None
 
         try:
             service = eSuiteKlantenService()
         except Exception:
             logger.warning("eSuiteKlantenService failed to build")
-            return None
+            return False
 
         if fetch_params := service.get_fetch_parameters(user):
             klant, created = service.get_or_create_klant(
                 fetch_params=fetch_params, user=user
             )
             if klant and not created:
-                return service.update_klant_from_user(
-                    klant, user, update_fields=list(update_data.keys())
+                return bool(
+                    service.update_klant_from_user(
+                        klant, user, update_fields=list(update_data.keys())
+                    )
                 )
-            return klant
 
-        return None
+        return bool(klant)
 
     def get_form_class(self):
         user = self.request.user
@@ -396,13 +428,13 @@ class MyNotificationsView(
         user: User = self.get_object()
 
         if "case_notification_channel" in form.changed_data:
-            self.update_esuite_klant(user)
+            self.update_klant_via_esuite(user)
 
         messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
         self.log_change(self.object, _("users notifications were modified"))
         return HttpResponseRedirect(self.get_success_url())
 
-    def update_esuite_klant(self, user: User):
+    def update_klant_via_esuite(self, user: User):
         try:
             service = eSuiteKlantenService()
         except Exception:

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -271,13 +271,13 @@ class EditProfileView(
             if user_form_data.get(local_name)
         }
         if not update_data:
-            return
+            return None
 
         try:
             service = eSuiteKlantenService()
         except Exception:
             logger.warning("eSuiteKlantenService failed to build")
-            return
+            return None
 
         if fetch_params := service.get_fetch_parameters(user):
             klant, created = service.get_or_create_klant(
@@ -287,6 +287,9 @@ class EditProfileView(
                 return service.update_klant_from_user(
                     klant, user, update_fields=list(update_data.keys())
                 )
+            return klant
+
+        return None
 
     def get_form_class(self):
         user = self.request.user

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -13,7 +13,9 @@ from django.views.generic import TemplateView, UpdateView
 from django_registration.backends.one_step.views import RegistrationView
 from furl import furl
 
-from open_inwoner.openklant.services import eSuiteKlantenService
+from open_inwoner.openklant.constants import KlantenServiceType
+from open_inwoner.openklant.models import KlantenSysteemConfig
+from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
 
 from ...mail.verification import send_user_email_verification_mail
@@ -165,7 +167,11 @@ class NecessaryFieldsUserView(
     def form_valid(self, form):
         user = form.save()
 
-        self.update_klant(form)
+        klanten_config = KlantenSysteemConfig.get_solo()
+        if klanten_config.has_api_service_configured(KlantenServiceType.ESUITE):
+            self.update_klant_via_esuite(form)
+        if klanten_config.has_api_service_configured(KlantenServiceType.OPENKLANT2):
+            self.update_klant_via_openklant(form)
 
         invite = form.cleaned_data["invite"]
         if invite:
@@ -187,7 +193,37 @@ class NecessaryFieldsUserView(
 
         return initial
 
-    def update_klant(self, form: NecessaryUserForm):
+    def update_klant_via_openklant(self, form: NecessaryUserForm):
+        try:
+            service = OpenKlant2Service()
+        except ImproperlyConfigured:
+            logger.info("Unable to build KlantenService")
+            return
+
+        user = form.instance
+
+        partij, _ = service.get_or_create_partij_for_user(user=user)
+
+        if not partij:
+            logger.error(
+                "Unable to create partij during post-registration sync",
+                extra={"user": user},
+            )
+            return
+
+        update_data = {}
+        if "email" in form.cleaned_data:
+            update_data["email"] = form.cleaned_data["email"]
+        if "phonenumber" in form.cleaned_data:
+            update_data["phonenumber"] = form.cleaned_data["phonenumber"]
+
+        service.update_partij_from_user(
+            partij_uuid=partij["uuid"],
+            user=user,
+            user_form_data=update_data,
+        )
+
+    def update_klant_via_esuite(self, form: NecessaryUserForm):
         try:
             service = eSuiteKlantenService()
         except ImproperlyConfigured:

--- a/src/open_inwoner/openklant/models.py
+++ b/src/open_inwoner/openklant/models.py
@@ -351,3 +351,16 @@ class KlantenSysteemConfig(SingletonModel):
             != KlantenServiceType.ESUITE.value
         )
         return self.contact_registration_enabled and contactform_subjects.exists()
+
+    def has_api_service_configured(
+        self, klanten_service_type: KlantenServiceType
+    ) -> bool:
+        match klanten_service_type:
+            case KlantenServiceType.ESUITE:
+                config = ESuiteKlantConfig.get_solo()
+                return getattr(config, "klanten_service", None) is not None
+            case KlantenServiceType.OPENKLANT2:
+                config = OpenKlant2Config.get_solo()
+                return getattr(config, "service", None) is not None
+            case _:
+                return False

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -49,6 +49,7 @@ from open_inwoner.openklant.models import (
     KlantContactMomentAnswer,
     OpenKlant2Config,
 )
+from open_inwoner.openklant.types import PartijUpdateData
 from open_inwoner.openklant.wrap import (
     contactmoment_has_new_answer,
     fetch_klantcontactmoment,
@@ -1295,36 +1296,59 @@ class OpenKlant2Service(
                 content_object=user,
             )
 
-    def update_partij_from_user(self, partij_uuid: str, user: User):
+    def _update_partij(
+        self,
+        partij_uuid: str,
+        user: User | None = None,
+        update_data: PartijUpdateData | None = None,
+    ) -> bool:
+        if user:
+            update_data = PartijUpdateData(
+                email=user.email,
+                phonenumber=user.phonenumber,
+                phonenumber_alternative=user.phonenumber_alternative,
+            )
+
         updated_fields = []
 
-        _, created = self.get_or_create_digitaal_adres(
-            partij_uuid=partij_uuid,
-            soort_adres="telefoonnummer",
-            adres=user.phonenumber,
-            is_standaard_adres=True,
-        )
-        if created:
-            updated_fields.append("digitaleAddresen.telefoonnummer")
+        if phonenumber := update_data.get("phonenumber"):
+            _, created = self.get_or_create_digitaal_adres(
+                partij_uuid=partij_uuid,
+                soort_adres="telefoonnummer",
+                adres=phonenumber,
+                is_standaard_adres=True,
+            )
+            if created:
+                updated_fields.append("digitaleAddresen.telefoonnummer")
 
         for attr, soort_adres in (
             ("email", "email"),
             ("phonenumber_alternative", "telefoonnummer"),
         ):
-            _, created = self.get_or_create_digitaal_adres(
-                partij_uuid=partij_uuid,
-                soort_adres=soort_adres,
-                adres=getattr(user, attr),
-                is_standaard_adres=False,
-            )
-            if created:
-                updated_fields.append(f"digitaleAddresen.{soort_adres}")
+            if adres := update_data.get(attr):
+                _, created = self.get_or_create_digitaal_adres(
+                    partij_uuid=partij_uuid,
+                    soort_adres=soort_adres,
+                    adres=adres,
+                    is_standaard_adres=False,
+                )
+                if created:
+                    updated_fields.append(f"digitaleAddresen.{soort_adres}")
 
         if updated_fields:
             system_action(
-                f"updated Partij from user with fields: {', '.join(sorted(updated_fields))}",
-                content_object=user,
+                f"updated Partij from user {update_data['email']} with fields: {', '.join(sorted(updated_fields))}",
             )
+
+        return any(updated_fields)
+
+    def update_partij_from_user(self, partij_uuid: str, user: User) -> bool:
+        return self._update_partij(partij_uuid=partij_uuid, user=user)
+
+    def update_partij_from_user_data(
+        self, partij_uuid: str, update_data: PartijUpdateData
+    ) -> bool:
+        return self._update_partij(partij_uuid=partij_uuid, update_data=update_data)
 
     def create_question(
         self, partij_uuid: str, question: str, subject: str

--- a/src/open_inwoner/openklant/tests/data.py
+++ b/src/open_inwoner/openklant/tests/data.py
@@ -6,8 +6,11 @@ from open_inwoner.accounts.tests.factories import (
     eHerkenningUserFactory,
     eHerkenningVestigingUserFactory,
 )
-from open_inwoner.openklant.constants import Status
-from open_inwoner.openklant.models import ESuiteKlantConfig
+from open_inwoner.openklant.constants import KlantenServiceType, Status
+from open_inwoner.openklant.models import (
+    ESuiteKlantConfig,
+    OpenKlant2Config,
+)
 from open_inwoner.openzaak.tests.factories import (
     ServiceFactory,
     ZGWApiGroupConfigFactory,
@@ -23,15 +26,24 @@ CONTACTMOMENTEN_ROOT = "https://contactmomenten.nl/api/v1/"
 
 class MockAPIData:
     @classmethod
-    def setUpServices(cls):
-        config = ESuiteKlantConfig.get_solo()
-        config.klanten_service = ServiceFactory(
-            api_root=KLANTEN_ROOT, api_type=APITypes.kc
-        )
-        config.contactmomenten_service = ServiceFactory(
-            api_root=CONTACTMOMENTEN_ROOT, api_type=APITypes.cmc
-        )
-        config.save()
+    def setUpServices(
+        cls, klanten_service_type: KlantenServiceType = KlantenServiceType.ESUITE
+    ):
+        if klanten_service_type == KlantenServiceType.OPENKLANT2:
+            cls.config = OpenKlant2Config.get_solo()
+            cls.config.service = ServiceFactory(
+                api_root=OPENKLANT2_ROOT, api_type=APITypes.kc
+            )
+            cls.config.save()
+        else:
+            config = ESuiteKlantConfig.get_solo()
+            config.klanten_service = ServiceFactory(
+                api_root=KLANTEN_ROOT, api_type=APITypes.kc
+            )
+            config.contactmomenten_service = ServiceFactory(
+                api_root=CONTACTMOMENTEN_ROOT, api_type=APITypes.cmc
+            )
+            config.save()
 
         # services
         ZGWApiGroupConfigFactory(
@@ -185,6 +197,146 @@ class MockAPIReadPatchData(MockAPIData):
                 f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 json=self.klant_eherkenning_updated,
                 status_code=200,
+            ),
+        ]
+        return self
+
+    def install_mocks_openklant(self, m) -> "MockAPIReadPatchData":
+        self.digid_user = DigidUserFactory()
+        m.get(
+            "http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon",
+            headers={"Content-Type": "application/json"},
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "uuid": "7260ea01-12c0-4750-8fd1-dfa777818837",
+                    },
+                ],
+            },
+            status_code=200,
+        )
+        m.get(
+            "http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=100000001&soortPartij=persoon",
+            headers={"Content-Type": "application/json"},
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "uuid": "7260ea01-12c0-4750-8fd1-dfa777818837",
+                    },
+                ],
+            },
+            status_code=200,
+        )
+
+        m.get(
+            "http://localhost:8338/klantinteracties/api/v1/partijen/7260ea01-12c0-4750-8fd1-dfa777818837?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact",
+            headers={"Content-Type": "application/json"},
+            json={
+                "uuid": "7260ea01-12c0-4750-8fd1-dfa777818837",
+                "digitaleAdressen": None,
+                "voorkeursDigitaalAdres": None,
+                "rekeningnummers": None,
+                "voorkeursRekeningnummer": None,
+                "indicatieGeheimhouding": False,
+                "indicatieActief": True,
+                "voorkeurstaal": "crp",
+                "soortPartij": "persoon",
+                "partijIdentificatie": {
+                    "contactnaam": {
+                        "voorletters": "Dr.",
+                        "voornaam": "Test Persoon",
+                        "voorvoegselAchternaam": "Mrs.",
+                        "achternaam": "Gamble",
+                    }
+                },
+            },
+        )
+        m.get(
+            "http://localhost:8338/klantinteracties/api/v1/partijen/7260ea01-12c0-4750-8fd1-dfa777818837?expand=digitaleAdressen",
+            headers={"Content-Type": "application/json"},
+            json={
+                "count": 0,
+                "next": None,
+                "previous": None,
+                "results": [],
+            },
+        )
+        m.post(
+            f"{OPENKLANT2_ROOT}/digitaleadressen",
+            headers={"Content-Type": "application/json"},
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [],
+            },
+        )
+
+        klantcontact = {
+            "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "url": "http://example.com",
+            "gingOverOnderwerpobjecten": [],
+            "hadBetrokkenActoren": [],
+            "omvatteBijlagen": [],
+            "hadBetrokkenen": [],
+            "leiddeTotInterneTaken": [],
+            "nummer": "007",
+            "kanaal": "email",
+            "onderwerp": "Aanvraag",
+            "inhoud": "Hoe gaat het?",
+            "taal": "nl",
+            "vertrouwelijk": False,
+            "plaatsgevondenOp": "2019-08-24T14:15:22Z",
+        }
+        betrokkene = {
+            "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "url": "http://example.com",
+            "wasPartij": {
+                "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+                "url": "http://example.com",
+            },
+            "hadKlantcontact": {
+                "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+                "url": "http://example.com",
+            },
+            "digitaleAdressen": [{}],
+            "volledigeNaam": "John Doe",
+            "rol": "medewerker",
+            "initiator": True,
+        }
+        interne_taak = {
+            "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "url": "http://example.com",
+            "gevraagdeHandeling": "",
+            "aanleidinggevendKlantcontact": {
+                "uuid": klantcontact["uuid"],
+                "url": "http://example.com",
+            },
+            "status": "te_verwerken",
+            "toegewezenOp": "2019-08-24T14:15:22Z",
+        }
+
+        self.matchers = [
+            m.post(
+                "http://localhost:8338/klantinteracties/api/v1/betrokkenen",
+                headers={"Content-Type": "application/json"},
+                json=betrokkene,
+            ),
+            m.post(
+                "http://localhost:8338/klantinteracties/api/v1/klantcontacten",
+                headers={"Content-Type": "application/json"},
+                json=klantcontact,
+            ),
+            m.post(
+                "http://localhost:8338/klantinteracties/api/v1/internetaken",
+                headers={"Content-Type": "application/json"},
+                json=interne_taak,
             ),
         ]
         return self

--- a/src/open_inwoner/openklant/types.py
+++ b/src/open_inwoner/openklant/types.py
@@ -1,0 +1,9 @@
+from typing import NotRequired
+
+from typing_extensions import TypedDict
+
+
+class PartijUpdateData(TypedDict):
+    email: NotRequired[str]
+    phonenumber: NotRequired[str]
+    phonenumber_alternative: NotRequired[str]


### PR DESCRIPTION
- [x] Sync user profile data (email, standard phone number, altternative phone number) with OpenKlant after profile edits
- [x] Sync user data with OpenKlant on registration

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3389

Note that in the current implementation, the handling of contact information is inconsistent between the registration form and the code for writing to the Klant API's. See https://taiga.maykinmedia.nl/project/open-inwoner/issue/3392