### PR TITLE
:bug: [#3371] FIX csp errors for NLDS React components

### DIFF
--- a/src/open_inwoner/components/templates/components/Sidenav/Sidenav.html
+++ b/src/open_inwoner/components/templates/components/Sidenav/Sidenav.html
@@ -1,10 +1,6 @@
 {% load i18n form_tags string_tags solo_tags custom_session_tags menu_tags button_tags side_navigation %}
 
 {% if request.user.is_authenticated %}
-    {% block extra_head %}
-        <!-- Set nonce for DenHaag components, or else styling from number-badge will cause CSP errors -->
-        <meta name="csp-nonce" content="{{ request.csp_nonce }}" />
-    {% endblock %}
 
     <div class="side-navigation--oip">
         <div class="" id="react-openinwoner-sidenav"></div>

--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -29,6 +29,10 @@
         {% endif %}
         <meta property="og:type" content="article">
 
+        <script nonce="{{ request.csp_nonce }}">
+            window.NONCE = "{{ request.csp_nonce }}";
+        </script>
+
 
         {% if favicon %}<link rel="icon" href="{{ favicon }}" />
         <link rel="apple-touch-icon" href="{{ favicon }}">{% endif %}


### PR DESCRIPTION
- :bug: [#3371] FIX csp errors for NLDS React components - issue for non admin users.

Description:
Non admin users can't see the injected NLDS component styling due to a block CSP.

Fix origin:
https://github.com/nl-design-system/denhaag/pull/1410
