### PR TITLE
[#3404] NavigationAuthenticated - Onder mijn profiel icoon alleen mijn profiel, wissel van vestiging en uitloggen zien

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -23,16 +23,15 @@
 
                 <ul class="primary-navigation__list subpage-list">
                     {{ rendered_cms_menu__home }}
-
                     {% if user.is_eherkenning_user %}
                         {% session_is_branch_restricted as is_branch_restricted %}
                         {% if not is_branch_restricted %}
-                        <li class="header__list-item">
-                            {% link text=_("Wissel van vestiging") href="kvk:branches" icon="autorenew" icon_position="before" primary=True icon_outlined=True %}
-                        </li>
+                            <li class="primary-navigation__list-item primary-navigation__list-item--always-visible">
+                                {% link text=_("Wissel van vestiging") href="kvk:branches" icon="autorenew" icon_position="before" primary=True icon_outlined=True %}
+                            </li>
                         {% endif %}
                     {% endif %}
-                    <li class="header__list-item">
+                    <li class="primary-navigation__list-item primary-navigation__list-item--always-visible">
                         {% link text=_("Logout") href=request.user.get_logout_url icon="logout" icon_position="before" primary=True %}
                     </li>
                 </ul>

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -154,6 +154,13 @@
     .primary-navigation__list .primary-navigation__list-item {
       justify-content: flex-end;
 
+      /* Wide screens: show only first item */
+      @media (min-width: 1024px) {
+        &:not(:first-child, &--always-visible) {
+          display: none;
+        }
+      }
+
       .nav-login__icon {
         [class*='icons'] {
           cursor: pointer;

--- a/src/open_inwoner/templates/cms/menu/primary.html
+++ b/src/open_inwoner/templates/cms/menu/primary.html
@@ -1,22 +1,16 @@
 {% load menu_tags link_tags %}
 {% for child in children %}
-    {% if request.resolver_match.url_name == 'index' and 'cases' in request.resolver_match.app_names and not forloop.first %}
-        {# Skip non-first items on cases index #}
-    {% elif request.resolver_match.url_name in "pages-root,contactmoment_list,plan_list,uitkeringen,general_faq,category_list" and not forloop.first %}
-        {# Skip non-first items on hidden routes #}
-    {% else %}
-        {% with url=child.attr.redirect_url|default:child.get_absolute_url %}
-            <li class="primary-navigation__list-item">
-                {% link text=child.get_menu_title href=url icon=child.common.menu_icon icon_outlined=True icon_position="before" %}
-                {% if child.indicator %}
-                    <span class="indicator"><a class="link secondary indicator__link" href="{{ url }}">{{ child.indicator }}<span class="indicator__dot"></span></a></span>
-                {% endif %}
-                {% if child.children %}
-                <ul class="primary-navigation__list subpage-list">
-                    {% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
-                </ul>
-                {% endif %}
-            </li>
-        {% endwith %}
-    {% endif %}
+    {% with url=child.attr.redirect_url|default:child.get_absolute_url %}
+        <li class="primary-navigation__list-item {% if request.resolver_match.url_name not in "pages-root,contactmoment_list,plan_list,uitkeringen,general_faq,category_list" %}primary-navigation__list-item--always-visible{% endif %}">
+            {% link text=child.get_menu_title href=url icon=child.common.menu_icon icon_outlined=True icon_position="before" %}
+            {% if child.indicator %}
+                <span class="indicator"><a class="link secondary indicator__link" href="{{ url }}">{{ child.indicator }}<span class="indicator__dot"></span></a></span>
+            {% endif %}
+            {% if child.children %}
+            <ul class="primary-navigation__list subpage-list">
+                {% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
+            </ul>
+            {% endif %}
+        </li>
+    {% endwith %}
 {% endfor %}


### PR DESCRIPTION
### User story:
https://taiga.maykinmedia.nl/project/open-inwoner/task/3414

### Description:
Onder mijn profiel icoon alleen mijn profiel, wissel van vestiging en uitloggen zien

### Note:
The NavigationAuthenticated is only changed on the pages where the `SideNavigation` is implemented and on laptop screen sizes larger than 1024px (no room for the `SideNavigation`) - otherwise these pages would become unaccessible.