### PR TITLE
[dimpact #297] Prevent deletion of primary website

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Bugfixes
   OpenKlant gebeurt nu ook direct na registratie, niet alleen na inloggen.
 * [:taiga-is:`3375`, :pr:`1852`, :pr:`1868` ]: Correct afbreken van lange woorden en
   e-mailadressen in smalle tegels, zoals bij productlocaties.
+* [:taiga-dimpact:`297`, :pr:`1866`]: Het verwijderen van websites en het toevoegen van
+  sites naast de primaire website wordt voorkomen.
 
 Onderhoud
 ---------
@@ -29,4 +31,4 @@ Onderhoud
   teksten B1-conform te maken.
 * [:pr:`1878`]: Aanpassen pipeline for het bijhouden en publiceren van de changelog
   op de documentatie pagina.
-  
+

--- a/docs/beheerhandleiding/12_configuratie.rst
+++ b/docs/beheerhandleiding/12_configuratie.rst
@@ -600,3 +600,5 @@ Wanneer u een of meerdere platte pagina’s wilt verwijderen, kikt u in de check
 ==============
 
 Hier vult de beheerder de domeinnaam en weergavenaam van de website(s) in. Deze kunnen indien noodzakelijk worden aangepast. Dit is ter inrichting van het systeem. De domeinnaam moet overeenkomen met de domeinnaam van de omgeving.
+
+Voor het gebruik van Open Inwoner is een website vereist. Aangezien er geen gebruiksscenario is voor meerdere sites, is het niet mogelijk om de primaire website te verwijderen of extra sites toe te voegen.

--- a/src/open_inwoner/configurations/admin.py
+++ b/src/open_inwoner/configurations/admin.py
@@ -1,15 +1,12 @@
 from django import forms
 from django.contrib import admin, messages
-from django.contrib.admin.actions import delete_selected as default_delete_selected
 from django.contrib.flatpages.admin import FlatPageAdmin
 from django.contrib.sites.admin import SiteAdmin
 from django.contrib.sites.models import Site
 from django.core import exceptions
+from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
-from django.forms import ValidationError
-from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
-from django.urls import resolve, reverse
+from django.urls import resolve
 from django.urls.exceptions import Resolver404
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
@@ -26,40 +23,14 @@ from ..utils.iteration import split
 from .models import CustomFontSet, SiteConfiguration, SiteConfigurationPage
 
 
-@admin.action(description=_("Delete selected websites"))
-def delete_selected(modeladmin, request, queryset):
-    """
-    Override `delete_selected` action to prevent accidental deletion of all websites
-    """
-    if queryset.count() == Site.objects.all().count():
-        messages.add_message(
-            request,
-            messages.WARNING,
-            _("You cannot delete all websites; at least one site must remain."),
-        )
-        return HttpResponseRedirect(reverse("admin:sites_site_changelist"))
-    return default_delete_selected(modeladmin, request, queryset)
-
-
 class CustomSiteAdmin(SiteAdmin):
-    """
-    Overrides `SiteAdmin` to prevent deletion of last website
-    """
-
     model = Site
-    actions = [delete_selected]
 
-    def delete_model(self, request, obj):
-        if self.model.objects.count() < 2:
-            messages.add_message(
-                request, messages.WARNING, _("You cannot delete the last site.")
-            )
-            return redirect("admin:sites_site_changelist")
-        else:
-            super().delete_model(request, obj)
+    def has_add_permission(self, request):
+        return not Site.objects.exists()
 
-    class Media:
-        css = {"all": ("css/admin/admin_overrides.css",)}
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 # re-register `Site` with our CustomSiteAdmin

--- a/src/open_inwoner/configurations/tests/test_admin.py
+++ b/src/open_inwoner/configurations/tests/test_admin.py
@@ -4,7 +4,6 @@ from django.utils.translation import gettext_lazy as _
 
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
-from pyquery import PyQuery
 
 from open_inwoner.accounts.tests.factories import UserFactory
 
@@ -19,89 +18,39 @@ class TestAdminSite(WebTest):
     def setUpTestData(cls):
         cls.user = UserFactory(is_superuser=True, is_staff=True)
 
-    def test_delete_site_success(self):
-        site2 = Site.objects.create(id=2, domain="example2.com", name="example2")
+    def test_site_add_prevented_if_one_exists(self):
+        """Test that adding a site is prevented if one already exists."""
+        # Make sure we have exactly one site
+        initial_site_count = Site.objects.count()
+        self.assertEqual(initial_site_count, 1)
 
-        # delete site
         response = self.app.get(
-            reverse("admin:sites_site_delete", kwargs={"object_id": site2.id}),
-            user=self.user,
+            reverse("admin:sites_site_add"), user=self.user, expect_errors=True
         )
-        response = response.form.submit().follow()
 
-        # check sites
-        sites = Site.objects.all()
-        self.assertEqual(len(sites), 1)
+        self.assertEqual(response.status_code, 403)
 
-        # check message
-        doc = PyQuery(response.content)
+        self.assertEqual(Site.objects.count(), initial_site_count)
 
-        success_msg = doc.find(".success").text()
-        self.assertIn("met succes verwijderd.", success_msg)
+    def test_site_deletion_prevented(self):
+        """Test that site deletion is prevented."""
+        site = Site.objects.get()
 
-    def test_delete_last_site_fail(self):
-        # attempt to delete site
         response = self.app.get(
-            reverse("admin:sites_site_delete", kwargs={"object_id": 1}), user=self.user
+            reverse("admin:sites_site_change", args=[site.pk]), user=self.user
         )
-        response = response.form.submit().follow()
 
-        # check sites
-        sites = Site.objects.all()
-        self.assertEqual(len(sites), 1)
+        # Verify the delete button is not present (text or link)
+        self.assertNotIn("Delete", response.text)
+        delete_url = reverse("admin:sites_site_delete", args=[site.pk])
+        self.assertNotIn(delete_url, response.text)
 
-        # check message
-        doc = PyQuery(response.content)
+        # Try to access the delete page directly - should return 403 Forbidden
+        response = self.app.get(delete_url, user=self.user, expect_errors=True)
+        self.assertEqual(response.status_code, 403)
 
-        warning_msg = doc.find(".warning").text()
-        self.assertEqual(warning_msg, _("You cannot delete the last site."))
-
-    def test_bulk_delete_success(self):
-        site2 = Site.objects.create(id=2, domain="example2.com", name="example2")
-        site3 = Site.objects.create(id=3, domain="example3.com", name="example3")
-
-        # delete sites
-        data = {"action": "delete_selected", "_selected_action": [site2.pk, site3.pk]}
-        response = self.app.post(
-            reverse("admin:sites_site_changelist"), data, user=self.user
-        )
-        response = response.form.submit().follow()  # confirmation form
-
-        # check sites
-        sites = Site.objects.all()
-        self.assertEqual(len(sites), 1)
-
-        # check message
-        doc = PyQuery(response.content)
-
-        success_msg = doc.find(".success").text()
-        self.assertEqual(success_msg, "2 websites met succes verwijderd.")
-
-    def test_bulk_delete_fail(self):
-        Site.objects.create(id=2, domain="example2.com", name="example2")
-        Site.objects.create(id=3, domain="example3.com", name="example3")
-
-        # attempt to delete sites
-        data = {
-            "action": "delete_selected",
-            "_selected_action": [site.pk for site in Site.objects.all()],
-        }
-        response = self.app.post(
-            reverse("admin:sites_site_changelist"), data, user=self.user
-        ).follow()
-
-        # check sites
-        sites = Site.objects.all()
-        self.assertEqual(len(sites), 3)
-
-        # check message
-        doc = PyQuery(response.content)
-
-        warning_msg = doc.find(".warning").text()
-        self.assertEqual(
-            warning_msg,
-            _("You cannot delete all websites; at least one site must remain."),
-        )
+        # Verify the site still exists
+        self.assertTrue(Site.objects.filter(pk=site.pk).exists())
 
 
 @disable_admin_mfa()


### PR DESCRIPTION
Instead of preventing deletion of the last website, we now prevent adding sites if one already exists (there is no use case for multiple sites) and prevent deletion altogether.

Refs: https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/297