### PR TITLE
[#3375] Make long email adresses break properly in cards

### DIFF
--- a/src/open_inwoner/components/templates/components/Card/LocationCard.html
+++ b/src/open_inwoner/components/templates/components/Card/LocationCard.html
@@ -11,7 +11,7 @@
                 {% link href='tel:'|addstr:phonenumber secondary=True text=phonenumber %}
             {% endif %}
             {% if email %}
-                {% link href='mailto:'|addstr:email secondary=True text=email %}
+                {% link href='mailto:'|addstr:email secondary=True text=email extra_classes="link--mailto" %}
             {% endif %}
         </div>
     </div>

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -13,6 +13,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  hyphens: auto;
   min-height: 70px;
   min-width: var(--header-height);
   position: relative;

--- a/src/open_inwoner/scss/components/Typography/Link.scss
+++ b/src/open_inwoner/scss/components/Typography/Link.scss
@@ -25,6 +25,10 @@
     text-align: right;
   }
 
+  &--mailto {
+    word-break: break-all;
+  }
+
   *[class*='icons'],
   *[class*='Icons'] {
     font-size: 24px;


### PR DESCRIPTION
Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3375 

CSS 'hyphens' is perfect for adding a hyphen and breaking very long titles in the OIP location cards,
but: it is forbidden to be used in emailaddresses because adding a hyphen there. is bad for UX (if people see the address on desktop but want to type it on their phone e.g.):
https://ux.stackexchange.com/questions/31764/hyphenating-urls-and-email-addresses-that-would-overflow-their-container.

Also: hyphens do not work BEFORE an @ sign (IF we would not use break-all in mailaddresses):

<img width="961" height="336" alt="Screenshot 2025-08-28 at 11 39 06" src="https://github.com/user-attachments/assets/33ce76f9-13a6-40e3-b137-3aa92aa7e432" />
