### PR TITLE
feat: validate ES connection settings at startup

### DIFF
--- a/src/open_inwoner/search/apps.py
+++ b/src/open_inwoner/search/apps.py
@@ -1,0 +1,35 @@
+import logging
+
+from django.apps import AppConfig
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from elasticsearch.dsl.connections import connections
+
+logger = logging.getLogger(__name__)
+
+
+class SearchAppConfig(AppConfig):
+    name = "open_inwoner.search"
+
+    def ready(self):
+        es_settings = getattr(settings, "ELASTICSEARCH_DSL", None)
+        if not es_settings:
+            logger.info("No elasticsearch configured")
+            return
+
+        connections.configure(**es_settings)
+
+        try:
+            connections.get_connection()
+        except BaseException as exc:
+            # This check serves two purposes:
+            #
+            # - Detect elasticsearch errors on start-up, and not when running the
+            #   index rebuild or an actual search query and;
+            # - Give context to exceptions raised for e.g. incomplete connecting strings
+            #   which might otherwise be a bit opaque for end-users.
+            raise ImproperlyConfigured(
+                "Unable to configure elasticsearch client, which failed with error: "
+                f"{exc}"
+            ) from exc

--- a/src/open_inwoner/search/tests/test_config.py
+++ b/src/open_inwoner/search/tests/test_config.py
@@ -1,0 +1,20 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
+
+from open_inwoner.search.apps import SearchAppConfig
+
+
+class ElasticsearchConfigTest(TestCase):
+    @override_settings(ELASTICSEARCH_DSL={"default": {"hosts": "localhost"}})
+    def test_search_app_ready_hook_raises_error_with_unqualified_host(self):
+        app_config = SearchAppConfig.create("open_inwoner.search")
+
+        with self.assertRaises(ImproperlyConfigured) as cm:
+            app_config.ready()
+
+        self.assertIn("Unable to configure elasticsearch client", str(cm.exception))
+
+    @override_settings(ELASTICSEARCH_DSL=None)
+    def test_search_app_ready_hook_does_not_raise_without_config(self):
+        app_config = SearchAppConfig.create("open_inwoner.search")
+        app_config.ready()


### PR DESCRIPTION
Due to bumping the underlying elasticsearch libraries, the ES host string now requires a scheme and a port, which many of our production deploys do not include. Adding this runtime check means this issue will be detected early and given some clearer context so it can be dealt with at deploy time.