### PR TITLE
Add a running changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,32 @@
-==============
-Change history
-==============
+1.34 (2025-??-??) [Unreleased]
+==============================
 
+Voor een volledig overzicht van alle commits, zie ...
 
-See the Github releases: https://github.com/maykinmedia/open-inwoner/releases
+Nieuwe features
+---------------
 
+* [:taiga-us:`3368`, :pr:`1839`]: Een anoniem ingevuld contactformulier wordt nu ook in de
+  OpenKlant2 backend opgeslagen.
+* [:taiga-us:`3370`, :pr:`1837`, :pr:`1869`]: Het navigatiemenu is nu conform het NL Design
+  System op de meeste pagina's aan de linkerkant van het scherm geplaatst. Sommige
+  detailpagina's behouden voorlopig het dropdownmenu in afwachting van nieuwe designs.
+
+Bugfixes
+--------
+
+* [:taiga-is:`3396`, :taiga-is:`3395`, :pr:`1852`, :pr:`1853`]: Verschillende problemen
+  bij het ophalen van contactmomenten uit OpenKlant2 zijn opgelost.
+* [:taiga-is:`3389`, :pr:`1845`]: De synchronisatie van gebruikersprofielen met
+  OpenKlant gebeurt nu ook direct na registratie, niet alleen na inloggen.
+* [:taiga-is:`3375`, :pr:`1852`, :pr:`1868` ]: Correct afbreken van lange woorden en
+  e-mailadressen in smalle tegels, zoals bij productlocaties.
+
+Onderhoud
+---------
+
+* [:taiga-us:`3393`, :pr:`1871`]: Kleine tekstuele verbeteringen zijn doorgevoerd om de
+  teksten B1-conform te maken.
+* [:pr:`1878`]: Aanpassen pipeline for het bijhouden en publiceren van de changelog
+  op de documentatie pagina.
+  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,31 @@ repository and create a pull request to the `develop` branch of this project's
 repository. Your pull request will be reviewed, if applicable, feedback will be
 given and if everything is approved, it will be merged.
 
+### Updating the changelog
+
+In most cases, you should also update the CHANGELOG.rst file to document your changes.
+Add an entry under the current release section in the appropriate category:
+
+- **Nieuwe features** - New functionality, features, or significant enhancements. This
+  will usually map to a Taiga story in the current sprint.
+- **Bugfixes** - Bug fixes, error corrections, or issue resolutions, which will usually
+  be in response to Taiga issues raised separately from the current sprint.
+- **Onderhoud** - Maintenance work, dependency updates, refactoring, or technical
+  improvements
+
+Each entry should reference both the GitHub pull request and related Taiga issue using
+Sphinx extlink shortcodes: `` :pr:`123` `` for pull requests, `` :taiga-us:`456` `` for
+Taiga user stories, `` :taiga-is:`789` `` for Taiga issues and  `` :taiga-dimpact:`123`
+`` for Taiga Dimpact issues. See the root `CHANGELOG.rst` file for examples of the
+proper format. 
+
+The entry should preferably be written in Dutch, though English is fine if you are not
+comfortable in Dutch. The English issues will be translated as part of preparing the
+release.
+
+If your PR contains multiple commits, add a separate commit for the changelog update.
+Otherwise, feel free to include in a single commit for minor changes.
+
 ### Reviews on releases
 
 All pull requests will be reviewed by a project member before they are merged

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,5 @@
+=========
 Changelog
 =========
 
-.. toctree::
-   :maxdepth: 1
-
-   De volledige changelogs zijn per release te vinden op GitHub <https://github.com/maykinmedia/open-inwoner/releases>
-   Een meer algemene omschrijving van de toegevoegde functionaliteit is terug te vinden binnen de release aankondigingen in de mailing list archive <https://mailing.maykinmedia.nl/archive>
+.. include:: ../CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.graphviz",
     "sphinx_tabs.tabs",
+    "sphinx.ext.extlinks",
     "recommonmark",
     # "sphinx_markdown_tables",
     "django_setup_configuration.documentation.setup_config_example",
@@ -118,3 +119,15 @@ linkcheck_ignore = [
     r"https?://stackoverflow\.com/.*",  # SO 403s when running on github actions :/
     r"http://es6-features\.org.*",  # old link
 ]
+
+extlinks = {
+    "taiga-us": ("https://taiga.maykinmedia.nl/project/open-inwoner/us/%s", "#%s"),
+    "taiga-is": ("https://taiga.maykinmedia.nl/project/open-inwoner/issue/%s", "#%s"),
+    "taiga-dimpact": (
+        "https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/%s",
+        "#dimpact-%s",
+    ),
+    "pr": ("https://github.com/maykinmedia/open-inwoner/pull/%s", "PR %s"),
+    "release": ("https://github.com/maykinmedia/open-inwoner/releases/tag/%s", "%s"),
+    "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", "%s"),
+}


### PR DESCRIPTION
Our release notes are often written in one go when we prepare the actual release. This is a lot of work, because a lot of context is lacking and inevitably the quality and completeness suffers somewhat due to having to write up the whole sprint in a single batch.

Starting in the current sprint (upcoming release 1.35), I would like us to distribute the workload of keeping the Changelog current and complete amongst the team. Writing up a changelog entry as part of a PR should give you better context and more bandwidth to properly describe what's going on.

I've updated the `CONTRIBUTING.md` file with some basic guidelines for this. I've back-filled the notes for the current, about to be released `v1.34` for a template. Note the shortcodes for referring to Taiga issues and PRs.