### PR TITLE
build(docker): ensure npm run collect target directory exists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Bugfixes
   e-mailadressen in smalle tegels, zoals bij productlocaties.
 * [:taiga-dimpact:`297`, :pr:`1866`]: Het verwijderen van websites en het toevoegen van
   sites naast de primaire website wordt voorkomen.
+* [:taiga-is:`3377`,  :pr:`1882`]: De static/bundles/images map wordt nu correct 
+  opgebouwd in de Docker container.
 
 Onderhoud
 ---------

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN npm ci
 # copy source code
 COPY ./src /app/src
 
+# Ensure the target directory for npm run collect exists
+RUN mkdir -p /app/src/open_inwoner/static/bundles/
+
 # build frontend
 RUN npm run build
 


### PR DESCRIPTION
Our frontend docker build, during `npm run collect`, tries to copy various static assets over the Django static files folder. We need to ensure the bundles directory exist before copying over files.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3377