### PR TITLE
Revert "build(docker): ensure npm run collect target directory exists…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,6 @@ Bugfixes
   e-mailadressen in smalle tegels, zoals bij productlocaties.
 * [:taiga-dimpact:`297`, :pr:`1866`]: Het verwijderen van websites en het toevoegen van
   sites naast de primaire website wordt voorkomen.
-* [:taiga-is:`3377`,  :pr:`1882`]: De static/bundles/images map wordt nu correct 
-  opgebouwd in de Docker container.
 
 Onderhoud
 ---------

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,6 @@ RUN npm ci
 # copy source code
 COPY ./src /app/src
 
-# Ensure the target directory for npm run collect exists
-RUN mkdir -p /app/src/open_inwoner/static/bundles/
-
 # build frontend
 RUN npm run build
 


### PR DESCRIPTION
… (#1882)"

This reverts commit add97e4081b76eca085b78ac1b768d8ab2d94117, reversing changes made to 1cbfe31263a3697587e19d420d7485414322552b.

The fix appears not to have worked in our test environments. Reverting in favour of a new approach.