### PR TITLE
[#3445] Check argument type for template tag 'field_as_widget'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,9 @@ Nieuwe features
 Bugfixes
 --------
 
-* ...
+* [:taiga-is: `3445`, :pr: `1898`]: De sjabloontag field_as_widget ging er onterecht
+  vanuit dat het primaire argument een formulierveld was en veroorzaakte daardoor
+  sporadisch fouten.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/components/templatetags/form_tags.py
+++ b/src/open_inwoner/components/templatetags/form_tags.py
@@ -520,10 +520,15 @@ def field_as_widget(field, class_string, form_id):
     if form_id:
         attrs["form"] = form_id
 
-    if autocomplete := HTML_NAME_TO_AUTOCOMPLETE.get(field.html_name):
-        attrs["autocomplete"] = autocomplete
+    # Check if field is actually a form field object with html_name attribute
+    # and not a string or other type
+    if hasattr(field, "html_name"):
+        if autocomplete := HTML_NAME_TO_AUTOCOMPLETE.get(field.html_name):
+            attrs["autocomplete"] = autocomplete
+        return field.as_widget(attrs=attrs)
 
-    return field.as_widget(attrs=attrs)
+    # Return as is if field is not a form field object
+    return field
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
The template tag `field_as_widget` naively assumed that its primary argument is a form field. In some cases, however, it can be a string, and then the tag produced an `AttributeError` ([Sentry](https://sentry.maykinmedia.nl/organizations/maykin-media/issues/451093/?project=427&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0))

Refs: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3445