### PR TITLE
feat: add id and subscription fields to Subscription admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Nieuwe features
   In plaats van één beschrijving heeft het contactformulier nu twee beschrijvingen, één voor
   geauthenticeerde en één voor anonieme gebruikers. De oude beschrijving wordt naar beide
   nieuwe velden gekopieerd. Pas één of beide beschrijvingen naar behoefte aan.
+* [:pr:`1901`, :taiga-ta:`3447`]: ID en abonnement status toegevoegd als alleen-lezen
+  velden in de admin detailpagina van de Webhook abonnementen.
 
 Bugfixes
 --------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,11 +123,13 @@ linkcheck_ignore = [
 extlinks = {
     "taiga-us": ("https://taiga.maykinmedia.nl/project/open-inwoner/us/%s", "#%s"),
     "taiga-is": ("https://taiga.maykinmedia.nl/project/open-inwoner/issue/%s", "#%s"),
+    "taiga-ta": ("https://taiga.maykinmedia.nl/project/open-inwoner/task/%s", "#%s"),
     "taiga-dimpact": (
         "https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/%s",
         "#dimpact-%s",
     ),
     "pr": ("https://github.com/maykinmedia/open-inwoner/pull/%s", "PR %s"),
+    "gh": ("https://github.com/maykinmedia/open-inwoner/issues/%s", "#%s"),
     "release": ("https://github.com/maykinmedia/open-inwoner/releases/tag/%s", "%s"),
     "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", "%s"),
 }

--- a/src/notifications/admin.py
+++ b/src/notifications/admin.py
@@ -67,5 +67,26 @@ deregister_webhook.short_description = _("Deregister the webhooks")  # noqa
 
 @admin.register(Subscription)
 class SubscriptionAdmin(admin.ModelAdmin):
-    list_display = ("callback_url", "channels", "_subscription")
+    list_display = (
+        "id",
+        "callback_url",
+        "channels",
+        "client_id",
+        "_subscription",
+    )
+    list_display_links = (
+        "id",
+        "callback_url",
+    )
+    readonly_fields = (
+        "id",
+        "_subscription",
+    )
+    fields = (
+        "id",
+        "callback_url",
+        "channels",
+        "client_id",
+        "_subscription",
+    )
     actions = [register_webhook, deregister_webhook]


### PR DESCRIPTION
This helps troubleshooting subscription issues, as you can more easily tell subscriptions apart and match them to settings in eSuite/Openzaak by comparing the client ID.