### PR TITLE
Bump requests and urllib3 packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Onderhoud
   naar versie ``2.32.5``.
 * [:cve:`CVE-2024-37891`, :cve:`CVE-2024-35195`, :pr:`1905`] ``urllib3`` bijgewerkt
   naar versie ``2.5.0``.
+* [:pr:`1905`] ``vcrpy`` bijgewerkt naar versie ``7.0.0``.
 
 1.34.0 (2025-09-03)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Onderhoud
 * [:cve:`CVE-2024-53899`, :pr:`1892`] ``virtualenv`` bijgewerkt naar versie ``20.34.0``.
 * [:pr:`1897`] Het legacy management commando ``zgw_dev_status`` is verwijderd, alsmede
   legacy code voor het beheren van een "default" ZGW API Group.
+* [:cve:`CVE-2024-47081`, :cve:`CVE-2024-35195`, :pr:`1905`] ``requests`` bijgewerkt
+  naar versie ``2.32.5``.
 
 1.34.0 (2025-09-03)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,8 @@ Onderhoud
   legacy code voor het beheren van een "default" ZGW API Group.
 * [:cve:`CVE-2024-47081`, :cve:`CVE-2024-35195`, :pr:`1905`] ``requests`` bijgewerkt
   naar versie ``2.32.5``.
+* [:cve:`CVE-2024-37891`, :cve:`CVE-2024-35195`, :pr:`1905`] ``urllib3`` bijgewerkt
+  naar versie ``2.5.0``.
 
 1.34.0 (2025-09-03)
 ===================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -515,7 +515,7 @@ reportlab==3.6.13
     # via
     #   easy-thumbnails
     #   svglib
-requests==2.31.0
+requests==2.32.5
     # via
     #   ape-pie
     #   django-log-outgoing-requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -577,7 +577,7 @@ tzdata==2025.2
     #   kombu
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.18
+urllib3==2.5.0
     # via
     #   elastic-apm
     #   elastic-transport

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1074,7 +1074,7 @@ uritemplate==4.1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   drf-spectacular
-urllib3==1.26.18
+urllib3==2.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1082,11 +1082,12 @@ urllib3==2.5.0
     #   elastic-transport
     #   requests
     #   sentry-sdk
+    #   vcrpy
 uwsgi==2.0.23
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-vcrpy==6.0.1
+vcrpy==7.0.0
     # via
     #   -r requirements/test-tools.in
     #   pytest-recording

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -940,7 +940,7 @@ reportlab==3.6.13
     #   -r requirements/base.txt
     #   easy-thumbnails
     #   svglib
-requests==2.31.0
+requests==2.32.5
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1061,7 +1061,7 @@ reportlab==3.6.13
     #   -r requirements/ci.txt
     #   easy-thumbnails
     #   svglib
-requests==2.31.0
+requests==2.32.5
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1242,7 +1242,7 @@ uritemplate==4.1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   drf-spectacular
-urllib3==1.26.18
+urllib3==2.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1250,11 +1250,12 @@ urllib3==2.5.0
     #   elastic-transport
     #   requests
     #   sentry-sdk
+    #   vcrpy
 uwsgi==2.0.23
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-vcrpy==6.0.1
+vcrpy==7.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

Bump `requests` and `urllib3` to address [Dependabot issues](https://github.com/maykinmedia/open-inwoner/security/dependabot?q=is%3Aopen+sort%3Anewest+package%3Aurllib3%2Crequests).

## Checklist

- [x] CHANGELOG.rst updated


