### PR TITLE
[#3459] Fetch CMS page for contactformulier based on template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,9 @@ Bugfixes
 * [:taiga-is:`3445`, :pr:`1898`]: De sjabloontag field_as_widget ging er onterecht
   vanuit dat het primaire argument een formulierveld was en veroorzaakte daardoor
   sporadisch fouten.
+* [:taiga-is:`3459`: :pr:`1908`]: Haal de CMS-pagina voor het contactformulier op basis
+  van de sjabloon in plaats van de plug-in (zodat de pagina in de voettekst wordt gekoppeld
+  zodra deze is aangemaakt).
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/footer/cms_plugins.py
+++ b/src/open_inwoner/cms/footer/cms_plugins.py
@@ -4,7 +4,7 @@ from django import forms
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy as _
 
-from cms.models import CMSPlugin, Page
+from cms.models import Page
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from djangocms_text_ckeditor.widgets import TextEditorWidget
@@ -37,15 +37,8 @@ class FooterPagesPlugin(CMSPluginBase):
                 ):
                     cms_pages.remove(page)
 
-        # Get ContactFormPlugin instances
-        contact_form_plugins = CMSPlugin.objects.filter(plugin_type="ContactFormPlugin")
-
-        # Get placeholders containing the plugins
-        placeholder_ids = contact_form_plugins.values_list("placeholder_id", flat=True)
-
-        # Get the CMS pages containing the placeholders
         contact_form_pages = Page.objects.filter(
-            placeholders__id__in=placeholder_ids, publisher_is_draft=False
+            template="cms/contactform/form_outer.html", publisher_is_draft=False
         )
 
         # Use the first page if it exists


### PR DESCRIPTION
The CMS page for the contact form is fetched by first getting the CMS plugin and the associated placeholders. However, if no plugin has been created yet, the link to the contact form page won't show up in the footer; it is only accessible by manually entering the URL. This is fixed by fetching the CMS page based on the template, which works because we have a dedicated template for the contact form.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3459

