### PR TITLE
build(deps): override npm form-data to >4.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,7 +63,8 @@ Onderhoud
 * [:cve:`CVE-2024-37891`, :cve:`CVE-2024-35195`, :pr:`1905`] ``urllib3`` bijgewerkt naar
   versie ``2.5.0``.
 * [:pr:`1905`] ``vcrpy`` bijgewerkt naar versie ``7.0.0``.
-* [:pr:`1907`, :cve:`CVE-2025-7783`]: ``form-data`` bijgewerkt naar versie ``3.0.4``.
+* [:pr:`1915`, :cve:`CVE-2025-7783`]: ``form-data`` override bijgewerkt naar versie
+  ``>4.0.3``.
 
 1.34.0 (2025-09-03)
 ===================

--- a/package-lock.json
+++ b/package-lock.json
@@ -10403,23 +10403,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -15958,15 +15941,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
+        "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
@@ -28534,19 +28517,6 @@
         }
       }
     },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/superagent/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -38336,23 +38306,8 @@
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": ">=3.0.4",
+        "form-data": ">4.0.3",
         "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-          "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "es-set-tostringtag": "^2.1.0",
-            "hasown": "^2.0.2",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "babel-core": {
@@ -42414,15 +42369,15 @@
       }
     },
     "form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
+        "mime-types": "^2.1.12"
       }
     },
     "formatjs": {
@@ -45144,7 +45099,7 @@
         "decimal.js": "^10.2.1",
         "domexception": "^2.0.1",
         "escodegen": "^2.0.0",
-        "form-data": ">=3.0.4",
+        "form-data": ">4.0.3",
         "html-encoding-sniffer": "^2.0.1",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -51482,7 +51437,7 @@
         "cookiejar": "^2.1.3",
         "debug": "^4.3.3",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": ">=3.0.4",
+        "form-data": ">4.0.3",
         "formidable": "^2.0.1",
         "methods": "^1.1.2",
         "mime": "^2.5.0",
@@ -51497,16 +51452,6 @@
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,6 @@
     "yargs": "latest"
   },
   "overrides": {
-    "form-data": ">=3.0.4"
+    "form-data": ">4.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Pin the `form-data` override to `>4.0.3` to avoid [security issues](https://github.com/maykinmedia/open-inwoner/security/dependabot/437).

## Checklist

- [x] CHANGELOG.rst updated


