### PR TITLE
fix: ensure JS static assets are properly copied to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,61 @@
-node_modules
 Dockerfile*
 docker-compose*
 .dockerignore
+
+# From .gitignore:
+# Developers
+.hg
 .git
-.vscode
-env/
+.svn
+.idea/
+.vscode/
+.sass-cache/
+*.db
+*.pyc
+__pycache__
+*~
+
+# Javascript libraries
+/node_modules/
+
+# Generated files
+/docs/_build
+
+# Coverage reports
+/reports/
+/htmlcov/
+.coverage
+coverage.xml
+
+# Environment
+#/deployment/app.*.yml
+#/deployment/hosts.*
 local.py
-media/
-private_media/
+/env/
+/media/
+/private_media/
+/static/
+/mail/
+/log/*.log*
+/log/nginx/*.log*
+/.env
+.DS_STORE
+
+# Static files
+src/open_inwoner/static/bundles/
+src/open_inwoner/static/webfonts/
+src/open_inwoner/fonts/
+src/open_inwoner/static/webfonts/fa-brands-400.ttf
+src/open_inwoner/static/webfonts/fa-brands-400.woff2
+src/open_inwoner/static/webfonts/fa-regular-400.ttf
+src/open_inwoner/static/webfonts/fa-regular-400.woff2
+src/open_inwoner/static/webfonts/fa-solid-900.ttf
+src/open_inwoner/static/webfonts/fa-solid-900.woff2
+src/open_inwoner/static/webfonts/fa-v4compatibility.ttf
+src/open_inwoner/static/webfonts/fa-v4compatibility.woff2
+src/open_inwoner/static/fonts/material-icons/
+
+# Storybook files
+*storybook.log
+storybook-static/
+coverage/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,9 @@ Bugfixes
 * [:taiga-is:`3459`: :pr:`1908`]: Haal de CMS-pagina voor het contactformulier op basis
   van de sjabloon in plaats van de plug-in (zodat de pagina in de voettekst wordt
   gekoppeld zodra deze is aangemaakt).
+* [:taiga-is:`3377`,  :pr:`1917`]: De ``static/bundles/images`` map wordt nu correct
+  opgebouwd in de Docker container, waardoor o.m. `marker-icon.png` bestanden correct
+  ontsloten worden.
 
 Onderhoud
 ---------

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ WORKDIR /app
 COPY ./build /app/build/
 COPY ./*.json ./*.js ./*.mjs ./*.ts ./.babelrc /app/
 
+# Ensure the target directory for npm run collect exists
+RUN mkdir -p /app/src/open_inwoner/static/bundles/images
+
 # install WITH dev tooling
 RUN npm ci
 


### PR DESCRIPTION
## Summary

The `npm run collect` task does not work properly on our CI Docker build because the `src/open_inwoner/static/bundles/images` directory does not exist in the isolated frontend build. This was not noticed locally, because due to `COPY src` these files were typically included from the local developer build. This PR ensures the necessary folders are created in the Docker container, and updates `.dockerignore` to ensure that, when building locally, the build is clean.

## Issue References

- Taiga Issue:[ #3377 ](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3377)

## Checklist

- [x] CHANGELOG.rst updated
