### PR TITLE
Bump maykin-2fa to 1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,7 @@ Onderhoud
   versie ``2.5.0``.
 * [:pr:`1905`] ``vcrpy`` bijgewerkt naar versie ``7.0.0``.
 * [:pr:`1907`, :cve:`CVE-2025-7783`]: ``form-data`` bijgewerkt naar versie ``3.0.4``.
+* [:pr:`1918`]: ``maykin-2fa`` bijgewerkt naar versie ``1.0.2``.
 
 1.34.0 (2025-09-03)
 ===================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -399,7 +399,7 @@ markdown==3.3.6
     # via -r requirements/base.in
 markuppy==1.14
     # via tablib
-maykin-2fa==1.0.0
+maykin-2fa==1.0.2
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -714,7 +714,7 @@ markuppy==1.14
     #   tablib
 markupsafe==2.1.5
     # via jinja2
-maykin-2fa==1.0.0
+maykin-2fa==1.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -798,7 +798,7 @@ markupsafe==2.1.5
     #   -r requirements/ci.txt
     #   jinja2
     #   werkzeug
-maykin-2fa==1.0.0
+maykin-2fa==1.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
The new version fixes redirects for admin login when 2fa is disabled

