### PR TITLE
build: add static files volume support to Docker start script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,8 @@ Bugfixes
 Onderhoud
 ---------
 
+* [:taiga-ta:`3465`, :pr:`1919`] Het Docker start script ondersteunt optioneel het
+  kopieren van static files naar een daarvoor aangewezen volume.
 * [:cve:`CVE-2024-53899`, :pr:`1892`] ``virtualenv`` bijgewerkt naar versie ``20.34.0``.
 * [:pr:`1897`] Het legacy management commando ``zgw_dev_status`` is verwijderd, alsmede
   legacy code voor het beheren van een "default" ZGW API Group.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ Bugfixes
   vervangen met de officiële Elasticsearch images.
 * [:taiga-ta:`3460`, :taiga-us:`3449`, :pr:`1904`]: Het indienen van lege tekstwaarden tijdens
   het bijwerken van het profiel, wat leidde tot fouten in eSuite klant, is opgelost.
+* [:pr:`1919`] De docker-compose variabelen voor de Elasticsearch verbinding gebruiken
+  nu de verplichte, volledig gekwalificeerde versie van de URL.
 
 Onderhoud
 ---------

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -6,6 +6,11 @@ set -ex
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
+# Copy static root to volume, if required
+if [ -n "$STATIC_ROOT_VOLUME" ]; then
+    cp -r /app/static/* "$STATIC_ROOT_VOLUME"
+fi
+
 # wait for required services
 # See: https://docs.docker.com/compose/startup-order/
 ${SCRIPTPATH}/wait_for_db.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,12 @@ services:
     volumes:
       - data:/data
 
-  busybox:
+  prepare-volumes:
     image: busybox
-    command: /bin/chown -R 1000 /private-media
+    command: /bin/chown -R 1000 /private-media /srv/static
     volumes:
       - private_media:/private-media
+      - static:/srv/static
 
   web: &web-service
     build: &web_build
@@ -94,6 +95,7 @@ services:
       - UWSGI_MAX_REQUESTS
       - UWSGI_POST_BUFFERING
       - UWSGI_BUFFER_SIZE
+      - STATIC_ROOT_VOLUME=/srv/static
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; exit(requests.head('http://localhost:8000/admin/').status_code not in [200, 302])"]
       interval: 30s
@@ -106,11 +108,13 @@ services:
     volumes: &web_volumes
       - media:/app/media
       - private_media:/app/private_media
+      - static:/srv/static
     ports:
       - 8000:8000
     depends_on:
       - db
       - redis
+      - prepare-volumes
     networks:
       - openinwoner-dev
 
@@ -127,6 +131,7 @@ services:
     volumes:
       - ./docker-nginx-default.conf:/etc/nginx/conf.d/default.conf
       - private_media:/private-media
+      - static:/srv/static
     ports:
       - '9000:80'
     depends_on:
@@ -184,6 +189,7 @@ volumes:
   db:
   media:
   private_media:
+  static:
   data:
   es_data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - CELERY_LOGLEVEL=DEBUG
-      - ES_HOST=elasticsearch
+      - ES_HOST=http://elasticsearch:9200
       # Needed for Celery Flower to match the TIME_ZONE configured in the
       # settings used by workers and beat containers.
       - TZ=Europe/Amsterdam

--- a/docker-nginx-default.conf
+++ b/docker-nginx-default.conf
@@ -7,6 +7,11 @@ server {
         alias /private-media;
     }
 
+    location /static {
+        expires max;
+        alias /srv/static;
+    }
+
     location / {
         client_max_body_size 100M;
         proxy_pass   http://web:8000;


### PR DESCRIPTION
## Summary

Add optional support to the `docker_start.sh` script for copying the static files to a mounted volume, so that static files can optionally be served by nginx.

## Issue References

- Taiga Task: [#3465](https://taiga.maykinmedia.nl/project/open-inwoner/task/3465)

## Checklist

- [x] CHANGELOG.rst updated
