### PR TITLE
ci: replace bitnami with vanilla ES images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,11 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
           --name postgres
       elasticsearch:
-        image: bitnami/elasticsearch:9.0.3-debian-12-r1
+        image: elasticsearch:9.0.3
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+          xpack.security.enabled: false
         ports:
           - 9200:9200
           - 9300:9300
@@ -163,10 +164,11 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
           --name postgres
       elasticsearch:
-        image: bitnami/elasticsearch:9.0.3-debian-12-r1
+        image: elasticsearch:9.0.3
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+          xpack.security.enabled: false
         ports:
           - 9200:9200
           - 9300:9300

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Bugfixes
 * [:taiga-is:`3377`,  :pr:`1917`]: De ``static/bundles/images`` map wordt nu correct
   opgebouwd in de Docker container, waardoor o.m. `marker-icon.png` bestanden correct
   ontsloten worden.
+* [:taiga-is:`3466`, :pr:`1922`]: De bitnami images in CI en docker-compose zijn
+  vervangen met de officiële Elasticsearch images.
 
 Onderhoud
 ---------

--- a/bin/start_elasticsearch.sh
+++ b/bin/start_elasticsearch.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-ES_IMAGE=bitnami/elasticsearch:9.0.3-debian-12-r1
+ES_IMAGE=elasticsearch:9.0.3
 
 docker pull $ES_IMAGE
 docker run --rm \
     -p 9200:9200 -p 9300:9300 \
     -e "discovery.type=single-node" \
     -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+    -e "xpack.security.enabled=false" \
     -m=1g \
     $ES_IMAGE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - openinwoner-dev
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.3
     container_name: elasticsearch
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
## Summary

The bitnami images are being fased out: this PR replaces them with the official Docker images for elasticsearch.

## Issue References

- Taiga Issue: [#3466](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3466)

## Checklist

- [x] CHANGELOG.rst updated
