### PR TITLE
build(deps): add maykin-django-prosemirror 0.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Onderhoud
 
 * [:taiga-us:`3461`, :taiga-ta:`3472`, :pr:`1834`]: Python versie bijgewerkt naar
   ``v3.12``.
+* [:taiga-us:`3450`, :pr:`1927`]: ``maykin-django-prosemirror`` dependency toegevoegd.
 
 1.35.0 (2025-09-18)
 ===================

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -24,6 +24,7 @@ django-sniplates
 django-treebeard
 maykin-2fa
 phonenumbers
+maykin-django-prosemirror[images]
 django-localflavor
 django-privates
 django-cors-headers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -83,6 +83,8 @@ css-inline==0.13.0
     # via
     #   -r requirements/base.in
     #   mail-editor
+cssselect==1.3.0
+    # via prosemirror
 cssselect2==0.4.1
     # via
     #   svglib
@@ -142,6 +144,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -203,6 +206,7 @@ django-filer==3.1.1
     #   djangocms-file
     #   djangocms-link
     #   djangocms-picture
+    #   maykin-django-prosemirror
 django-filter==21.1
     # via -r requirements/base.in
 django-formtools==2.3
@@ -389,6 +393,7 @@ lxml==6.0.0
     #   django-digid-eherkenning
     #   mail-editor
     #   maykin-python3-saml
+    #   prosemirror
     #   svglib
     #   xmlsec
 mail-editor==0.3.8
@@ -400,6 +405,8 @@ markdown==3.3.6
 markuppy==1.14
     # via tablib
 maykin-2fa==1.0.2
+    # via -r requirements/base.in
+maykin-django-prosemirror[images]==0.1.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via
@@ -444,6 +451,8 @@ playwright==1.50.0
     # via -r requirements/base.in
 prompt-toolkit==3.0.36
     # via click-repl
+prosemirror==0.5.2
+    # via maykin-django-prosemirror
 psycopg2==2.9.9
     # via -r requirements/base.in
 pycparser==2.20
@@ -565,6 +574,7 @@ typing-extensions==4.10.0
     #   -r requirements/base.in
     #   elasticsearch
     #   mozilla-django-oidc-db
+    #   prosemirror
     #   pydantic
     #   pydantic-core
     #   pyee

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -152,8 +152,12 @@ css-inline==0.13.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mail-editor
-cssselect==1.1.0
-    # via pyquery
+cssselect==1.3.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   prosemirror
+    #   pyquery
 cssselect2==0.4.1
     # via
     #   -c requirements/base.txt
@@ -223,6 +227,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -325,6 +330,7 @@ django-filer==3.1.1
     #   djangocms-file
     #   djangocms-link
     #   djangocms-picture
+    #   maykin-django-prosemirror
 django-filter==21.1
     # via
     #   -c requirements/base.txt
@@ -686,6 +692,7 @@ lxml==6.0.0
     #   django-digid-eherkenning
     #   mail-editor
     #   maykin-python3-saml
+    #   prosemirror
     #   pyquery
     #   svglib
     #   xmlsec
@@ -711,6 +718,10 @@ markuppy==1.14
 markupsafe==2.1.5
     # via jinja2
 maykin-2fa==1.0.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+maykin-django-prosemirror[images]==0.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -800,6 +811,11 @@ prompt-toolkit==3.0.36
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   click-repl
+prosemirror==0.5.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-django-prosemirror
 psycopg2==2.9.9
     # via
     #   -c requirements/base.txt
@@ -1053,6 +1069,7 @@ typing-extensions==4.10.0
     #   elasticsearch
     #   mozilla-django-oidc-db
     #   polyfactory
+    #   prosemirror
     #   pydantic
     #   pydantic-core
     #   pyee

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -177,10 +177,11 @@ css-inline==0.13.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mail-editor
-cssselect==1.1.0
+cssselect==1.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   prosemirror
     #   pyquery
 cssselect2==0.4.1
     # via
@@ -255,6 +256,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
@@ -361,6 +363,7 @@ django-filer==3.1.1
     #   djangocms-file
     #   djangocms-link
     #   djangocms-picture
+    #   maykin-django-prosemirror
 django-filter==21.1
     # via
     #   -c requirements/ci.txt
@@ -766,6 +769,7 @@ lxml==6.0.0
     #   django-digid-eherkenning
     #   mail-editor
     #   maykin-python3-saml
+    #   prosemirror
     #   pyquery
     #   svglib
     #   xmlsec
@@ -795,6 +799,10 @@ markupsafe==2.1.5
     #   jinja2
     #   werkzeug
 maykin-2fa==1.0.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+maykin-django-prosemirror[images]==0.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -905,6 +913,11 @@ prompt-toolkit==3.0.36
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   click-repl
+prosemirror==0.5.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-django-prosemirror
 psutil==5.9.7
     # via locust
 psycopg2==2.9.9
@@ -1221,6 +1234,7 @@ typing-extensions==4.10.0
     #   elasticsearch
     #   mozilla-django-oidc-db
     #   polyfactory
+    #   prosemirror
     #   pydantic
     #   pydantic-core
     #   pyee


### PR DESCRIPTION
## Summary

Added the `maykin-django-prosemirror` dependency so we can start the CKEditor migration story.

## Issue References

- Taiga User Story: [#3450](https://taiga.maykinmedia.nl/project/open-inwoner/us/3450)

## Checklist

- [x] CHANGELOG.rst updated
