### PR TITLE
build(deps): add maykin-common dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Onderhoud
 * [:taiga-us:`3461`, :taiga-ta:`3472`, :pr:`1834`]: Python versie bijgewerkt naar
   ``v3.12``.
 * [:taiga-us:`3450`, :pr:`1927`]: ``maykin-django-prosemirror`` dependency toegevoegd.
+* [:taiga-ta:`3473`, :pr:`1931`]: ``maykin-common`` dependency toegevoegd.
 
 1.35.0 (2025-09-18)
 ===================

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,6 +25,7 @@ django-treebeard
 maykin-2fa
 phonenumbers
 maykin-django-prosemirror[images]
+maykin-common[otel]
 django-localflavor
 django-privates
 django-cors-headers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -144,6 +144,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-common
     #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
@@ -366,8 +367,14 @@ glom==20.11.0
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db
+googleapis-common-protos==1.70.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 greenlet==3.1.1
     # via playwright
+grpcio==1.74.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 html5lib==1.1
     # via
     #   djangocms-text-ckeditor
@@ -378,6 +385,8 @@ idna==3.7
     # via
     #   email-validator
     #   requests
+importlib-metadata==8.7.0
+    # via opentelemetry-api
 inflection==0.5.1
     # via drf-spectacular
 isodate==0.6.1
@@ -406,6 +415,8 @@ markuppy==1.14
     # via tablib
 maykin-2fa==1.0.2
     # via -r requirements/base.in
+maykin-common[otel]==0.10.0
+    # via -r requirements/base.in
 maykin-django-prosemirror[images]==0.1.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
@@ -430,12 +441,64 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.0.9
     # via tablib
+opentelemetry-api==1.37.0
+    # via
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.37.0
+    # via maykin-common
+opentelemetry-exporter-otlp-proto-common==1.37.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.37.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.37.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.58b0
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-django==0.58b0
+    # via maykin-common
+opentelemetry-instrumentation-wsgi==0.58b0
+    # via opentelemetry-instrumentation-django
+opentelemetry-proto==1.37.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-resource-detector-containerid==0.58b0
+    # via maykin-common
+opentelemetry-sdk==1.37.0
+    # via
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-resource-detector-containerid
+opentelemetry-semantic-conventions==0.58b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.58b0
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1
     # via furl
 packaging==23.0
     # via
     #   djangocms-text-ckeditor
     #   kombu
+    #   opentelemetry-instrumentation
 phonenumbers==8.13.29
     # via -r requirements/base.in
 phonenumberslite==8.13.29
@@ -453,6 +516,10 @@ prompt-toolkit==3.0.36
     # via click-repl
 prosemirror==0.5.2
     # via maykin-django-prosemirror
+protobuf==6.32.1
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psycopg2==2.9.9
     # via -r requirements/base.in
 pycparser==2.20
@@ -535,6 +602,7 @@ requests==2.32.5
     #   messagebird
     #   mozilla-django-oidc
     #   objects-api-client-django
+    #   opentelemetry-exporter-otlp-proto-http
     #   zgw-consumers
 ruamel-yaml==0.18.10
     # via django-setup-configuration
@@ -574,6 +642,11 @@ typing-extensions==4.10.0
     #   -r requirements/base.in
     #   elasticsearch
     #   mozilla-django-oidc-db
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   prosemirror
     #   pydantic
     #   pydantic-core
@@ -612,7 +685,9 @@ webencodings==0.5.1
     #   html5lib
     #   tinycss2
 wrapt==1.14.1
-    # via elastic-apm
+    # via
+    #   elastic-apm
+    #   opentelemetry-instrumentation
 xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
@@ -628,6 +703,8 @@ zgw-consumers==0.38.1
     #   objects-api-client-django
 zgw-consumers-oas==1.0.0
     # via -r requirements/base.in
+zipp==3.23.0
+    # via importlib-metadata
 zopfli==0.1.9
     # via fonttools
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -227,6 +227,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-common
     #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
@@ -632,11 +633,22 @@ glom==20.11.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
+googleapis-common-protos==1.70.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 greenlet==3.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   playwright
+grpcio==1.74.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 html5lib==1.1
     # via
     #   -c requirements/base.txt
@@ -656,6 +668,11 @@ idna==3.7
     #   yarl
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==8.7.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 inflection==0.5.1
     # via
     #   -c requirements/base.txt
@@ -721,6 +738,10 @@ maykin-2fa==1.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+maykin-common[otel]==0.10.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 maykin-django-prosemirror[images]==0.1.0
     # via
     #   -c requirements/base.txt
@@ -744,7 +765,7 @@ mozilla-django-oidc-db[setup-configuration]==0.23.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-multidict==6.0.5
+multidict==6.6.4
     # via yarl
 notifications-api-common==0.2.2
     # via
@@ -768,6 +789,89 @@ openpyxl==3.0.9
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
+opentelemetry-api==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-common
+opentelemetry-exporter-otlp-proto-common==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-django==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-common
+opentelemetry-instrumentation-wsgi==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-instrumentation-django
+opentelemetry-proto==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-resource-detector-containerid==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-common
+opentelemetry-sdk==1.37.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-resource-detector-containerid
+opentelemetry-semantic-conventions==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.58b0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1
     # via
     #   -c requirements/base.txt
@@ -779,6 +883,7 @@ packaging==23.0
     #   -r requirements/base.txt
     #   djangocms-text-ckeditor
     #   kombu
+    #   opentelemetry-instrumentation
     #   pytest
     #   sphinx
 phonenumbers==8.13.29
@@ -811,11 +916,19 @@ prompt-toolkit==3.0.36
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   click-repl
+propcache==0.3.2
+    # via yarl
 prosemirror==0.5.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-django-prosemirror
+protobuf==6.32.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psycopg2==2.9.9
     # via
     #   -c requirements/base.txt
@@ -965,6 +1078,7 @@ requests==2.32.5
     #   messagebird
     #   mozilla-django-oidc
     #   objects-api-client-django
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-mock
     #   sphinx
     #   zgw-consumers
@@ -1068,6 +1182,11 @@ typing-extensions==4.10.0
     #   -r requirements/base.txt
     #   elasticsearch
     #   mozilla-django-oidc-db
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   polyfactory
     #   prosemirror
     #   pydantic
@@ -1143,6 +1262,7 @@ wrapt==1.14.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   elastic-apm
+    #   opentelemetry-instrumentation
     #   vcrpy
 xlrd==2.0.1
     # via
@@ -1163,7 +1283,7 @@ xsdata==23.8
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-yarl==1.9.8
+yarl==1.20.1
     # via vcrpy
 zgw-consumers==0.38.1
     # via
@@ -1175,6 +1295,11 @@ zgw-consumers-oas==1.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+zipp==3.23.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   importlib-metadata
 zopfli==0.1.9
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -256,6 +256,7 @@ django==4.2.24
     #   easy-thumbnails
     #   mail-editor
     #   maykin-2fa
+    #   maykin-common
     #   maykin-django-prosemirror
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
@@ -690,6 +691,12 @@ glom==20.11.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
+googleapis-common-protos==1.70.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 gprof2dot==2022.7.29
     # via django-silk
 greenlet==3.1.1
@@ -698,6 +705,11 @@ greenlet==3.1.1
     #   -r requirements/ci.txt
     #   gevent
     #   playwright
+grpcio==1.74.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 html5lib==1.1
     # via
     #   -c requirements/ci.txt
@@ -722,6 +734,11 @@ imagesize==1.4.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
+importlib-metadata==8.7.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-api
 inflection==0.5.1
     # via
     #   -c requirements/ci.txt
@@ -802,6 +819,10 @@ maykin-2fa==1.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+maykin-common[otel]==0.10.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 maykin-django-prosemirror[images]==0.1.0
     # via
     #   -c requirements/ci.txt
@@ -827,7 +848,7 @@ mozilla-django-oidc-db[setup-configuration]==0.23.0
     #   django-digid-eherkenning
 msgpack==1.0.7
     # via locust
-multidict==6.0.5
+multidict==6.6.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -856,6 +877,89 @@ openpyxl==3.0.9
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   tablib
+opentelemetry-api==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-common
+opentelemetry-exporter-otlp-proto-common==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-django==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-common
+opentelemetry-instrumentation-wsgi==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-instrumentation-django
+opentelemetry-proto==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-resource-detector-containerid==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-common
+opentelemetry-sdk==1.37.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   maykin-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-resource-detector-containerid
+opentelemetry-semantic-conventions==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.58b0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1
     # via
     #   -c requirements/ci.txt
@@ -868,6 +972,7 @@ packaging==23.0
     #   build
     #   djangocms-text-ckeditor
     #   kombu
+    #   opentelemetry-instrumentation
     #   pytest
     #   sphinx
 pep517==0.11.0
@@ -913,11 +1018,22 @@ prompt-toolkit==3.0.36
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   click-repl
+propcache==0.3.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   yarl
 prosemirror==0.5.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-django-prosemirror
+protobuf==6.32.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.7
     # via locust
 psycopg2==2.9.9
@@ -1084,6 +1200,7 @@ requests==2.32.5
     #   messagebird
     #   mozilla-django-oidc
     #   objects-api-client-django
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-mock
     #   sphinx
     #   zgw-consumers
@@ -1233,6 +1350,11 @@ typing-extensions==4.10.0
     #   -r requirements/ci.txt
     #   elasticsearch
     #   mozilla-django-oidc-db
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   polyfactory
     #   prosemirror
     #   pydantic
@@ -1327,6 +1449,7 @@ wrapt==1.14.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   elastic-apm
+    #   opentelemetry-instrumentation
     #   vcrpy
 xlrd==2.0.1
     # via
@@ -1347,7 +1470,7 @@ xsdata==23.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-yarl==1.9.8
+yarl==1.20.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1362,6 +1485,11 @@ zgw-consumers-oas==1.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+zipp==3.23.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   importlib-metadata
 zope-event==5.0
     # via gevent
 zope-interface==6.1


### PR DESCRIPTION
## Summary

Generally an important dependency, which means we can deprecate some of our own code in favour of the common approach (e.g. around PDF generation, 2FA). But immediately this is to get the otel dependencies working.

## Issue References

- Taiga User Story: [#3461](https://taiga.maykinmedia.nl/project/open-inwoner/us/3461)
- Taiga Task: [#3463](https://taiga.maykinmedia.nl/project/open-inwoner/task/3473)

## Checklist

- [x] CHANGELOG.rst updated

