### PR TITLE
ci: ignore failing linkcheck for npmjs.com

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,8 +116,10 @@ linkcheck_ignore = [
     r"https://www\.omg\.org/*",  # incredibly unstable domain...
     r"https://www\.jccsoftware\.nl/.*",  # looks like the requests user agent is blocked...
     r"https://hub\.docker\.com/r/.*",  # HTTP 429, presumably docker hub is blocking/limiting Github CI runners
-    r"https?://stackoverflow\.com/.*",  # SO 403s when running on github actions :/
     r"http://es6-features\.org.*",  # old link
+    # 403s when running on github actions:
+    r"https?://stackoverflow\.com/.*",
+    r"https?://www\.npmjs\.com/.*",
 ]
 
 extlinks = {


### PR DESCRIPTION
The npmjs website appears to also return a 403 from GH action (like SO), so we add it to the ignore list for the checklink module.