### PR TITLE
Use correct variable name for questions in list template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,8 @@ Nieuwe features
 Bugfixes
 --------
 
-* ...
+* [:taiga-is:`3480`, :pr:`1934`]: De paginering van de contactmomenten lijstweergave
+  ontbrak, maar is nu toegevoegd.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -81,7 +81,7 @@
         {% endrender_grid %}
     </div>
 
-    {% if vragen %}
+    {% if questions %}
         {% pagination page_obj=page_obj paginator=paginator request=request %}
     {% endif %}
 


### PR DESCRIPTION
The pagination for the contactmomenten list page is broken because of inconsistent variable naming

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3480