### PR TITLE
:bug: [#3477] When CMS menu is empty, sidenav should not take space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Bugfixes
   ontbrak, maar is nu toegevoegd.
 * [:taiga-is:`3483`,  :pr:`1937`]: Typo's in BRP API request headers verholpen
   (``x-requets-*`` naar ``x-requests-*``).
+* [:taiga-is:`3477`: :pr:`1935`]: Wanneer er geen CMS-pagina's zijn en het menu leeg is,
+  dan wordt de zijnavigatie nu onzichtbaar, zodat de rest van de inhoud niet meer te smal
+  wordt weergegeven.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/products/cms_plugins.py
+++ b/src/open_inwoner/cms/products/cms_plugins.py
@@ -5,6 +5,7 @@ from cms.apphook_pool import apphook_pool
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from open_inwoner.components.templatetags.side_navigation import react_sidenav_data
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.pdc.forms import ProductFinderForm
 from open_inwoner.pdc.models import Category, ProductCondition, ProductLocation
@@ -30,6 +31,18 @@ def selected_categories_enabled() -> bool:
     return False
 
 
+def has_menu_items(context):
+    """Check if there are sidenav menu items available"""
+    if not context["request"].user.is_authenticated:
+        return False
+
+    try:
+        menu_data = react_sidenav_data(context)
+        return len(menu_data) > 0
+    except Exception:
+        return False
+
+
 @plugin_pool.register_plugin
 class CategoriesPlugin(CMSActiveAppMixin, CMSPluginBase):
     module = _("PDC")
@@ -42,7 +55,10 @@ class CategoriesPlugin(CMSActiveAppMixin, CMSPluginBase):
     def render(self, context, instance, placeholder):
         config = OpenZaakConfig.get_solo()
         request = context["request"]
-        self.limit = 3 if request.user.is_authenticated else 4
+
+        # Check if user has menu items instead of just authentication
+        has_menu = has_menu_items(context)
+        self.limit = 3 if has_menu else 4
 
         if (
             request.user.is_authenticated

--- a/src/open_inwoner/components/templates/components/Sidenav/Sidenav.html
+++ b/src/open_inwoner/components/templates/components/Sidenav/Sidenav.html
@@ -1,10 +1,12 @@
 {% load i18n form_tags string_tags solo_tags custom_session_tags menu_tags button_tags side_navigation %}
 
 {% if request.user.is_authenticated %}
-
-    <div class="side-navigation--oip">
-        <div class="" id="react-openinwoner-sidenav"></div>
-        {% react_sidenav_data as menu_data %}
-        {{ menu_data|json_script:"sidenav-menu-data" }}
-    </div>
+    {% has_sidenav_items as has_menu %}
+    {% if has_menu %}
+        <div class="side-navigation--oip">
+            <div class="" id="react-openinwoner-sidenav"></div>
+            {% react_sidenav_data as menu_data %}
+            {{ menu_data|json_script:"sidenav-menu-data" }}
+        </div>
+    {% endif %}
 {% endif %}

--- a/src/open_inwoner/components/templatetags/side_navigation.py
+++ b/src/open_inwoner/components/templatetags/side_navigation.py
@@ -234,3 +234,16 @@ def react_sidenav_data(context):
     except Exception as e:
         logger.exception("Error loading sidenav menu: %s", e)
         return []
+
+
+@register.simple_tag(takes_context=True)
+def has_sidenav_items(context):
+    """
+    Check if there are any menu items.
+    If False then sidebar should be hidden and main content should be fullwidth
+    """
+    if not context["request"].user.is_authenticated:
+        return False
+
+    menu_data = react_sidenav_data(context)
+    return len(menu_data) > 0

--- a/src/open_inwoner/templates/cms/fullwidth.html
+++ b/src/open_inwoner/templates/cms/fullwidth.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n cms_tags sekizai_tags static %}
+{% load i18n cms_tags sekizai_tags static side_navigation %}
 
 {% block mount_modules %} data-mount-modules='["sidenav"]'{% endblock %}
 
@@ -33,13 +33,16 @@
 {% block main_outer %}
     <main id="content" class="container container--fullwidth">
         {% block main_inner %}
-            <div class="grid{% block grid_class %}{% endblock %}">
+            {% has_sidenav_items as has_menu %}
+            <div class="grid{% if has_menu %} grid--with-sidebar{% else %} grid--no-sidebar{% endif %}{% block grid_class %}{% endblock %}">
                 {% spaceless %}
-                    <div class="grid__sidebar">
-                        {% block sidebar_content %}
-                            {% include "components/Sidenav/Sidenav.html" %}
-                        {% endblock sidebar_content %}
-                    </div>
+                    {% if has_menu %}
+                        <div class="grid__sidebar">
+                            {% block sidebar_content %}
+                                {% include "components/Sidenav/Sidenav.html" %}
+                            {% endblock sidebar_content %}
+                        </div>
+                    {% endif %}
                 {% endspaceless %}
 
                 <div class="grid__main">

--- a/src/open_inwoner/templates/cms/products/categories_plugin.html
+++ b/src/open_inwoner/templates/cms/products/categories_plugin.html
@@ -1,4 +1,4 @@
-{% load i18n button_tags %}
+{% load i18n button_tags side_navigation %}
 {% if categories %}
     <section class="plugin plugin__categories">
         <header class="oip-header-group">
@@ -9,8 +9,13 @@
 
         <p class="utrecht-paragraph">{{ configurable_text.home_page.home_theme_intro|linebreaksbr }}</p>
 
+        {% has_sidenav_items as has_menu %}
         {% if request.user.is_authenticated %}
-            {% include "components/Card/CardContainer.html" with categories=categories columns=3 image_object_fit="cover" only %}
+            {% if has_menu %}
+                {% include "components/Card/CardContainer.html" with categories=categories columns=3 image_object_fit="cover" only %}
+            {% else %}
+                {% include "components/Card/CardContainer.html" with categories=categories columns=4 image_object_fit="cover" only %}
+            {% endif %}
         {% else %}
             {% include "components/Card/CardContainer.html" with categories=categories columns=4 image_object_fit="cover" only %}
         {% endif %}


### PR DESCRIPTION
## Summary

When there are no pages in CMS menu, or when pages are taken out of the CMS menu, the Sidenavigation should not take visible space, and content should align to the utmost left of the container.

## Issue References

Bug issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3477

## Checklist

- [x] CHANGELOG.rst updated
- [ ] Codecov report reviewed for untested lines

