### PR TITLE
fix: typo in BRP headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Bugfixes
 
 * [:taiga-is:`3480`, :pr:`1934`]: De paginering van de contactmomenten lijstweergave
   ontbrak, maar is nu toegevoegd.
+* [:taiga-is:`3483`,  :pr:`1937`]: Typo's in BRP API request headers verholpen
+  (``x-requets-*`` naar ``x-requests-*``).
 
 Onderhoud
 ---------

--- a/src/open_inwoner/haalcentraal/api.py
+++ b/src/open_inwoner/haalcentraal/api.py
@@ -135,13 +135,13 @@ class BRP_2_1(BRPAPI):
 
         # Centric headers
         if self.config.x_request_organization:
-            headers["x-requets-organization"] = self.config.x_request_organization
+            headers["x-requests-organization"] = self.config.x_request_organization
         if self.config.x_request_application:
-            headers["x-requets-application"] = self.config.x_request_application
+            headers["x-requests-application"] = self.config.x_request_application
         if self.config.x_request_afnemerscode:
-            headers["x-requets-afnemerscode"] = self.config.x_request_afnemerscode
+            headers["x-requests-afnemerscode"] = self.config.x_request_afnemerscode
         if self.config.x_request_user:
-            headers["x-requets-user"] = self.config.x_request_user
+            headers["x-requests-user"] = self.config.x_request_user
 
         response = self.client.post(
             url=url,


### PR DESCRIPTION
## Summary

There was a typo in the Centric BRP headers.

## Issue References

- Taiga Issue: [#3483](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3483)


## Checklist

- [x] CHANGELOG.rst updated

