### PR TITLE
fix: refactor menu generation logic for React sidenav

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Bugfixes
   wordt weergegeven.
 * [:taiga-is:`3484`]: De pagina voor contactmomenten crashte wanneer het contactformulier
   niet was geconfigureerd.
+* [:taiga-is:`3479`: :pr:`1940`]: Ongepubliceerde CMS pagina's worden niet meer
+  weergegeven in de zijnavigatie.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/products/tests/test_plugin_categories.py
+++ b/src/open_inwoner/cms/products/tests/test_plugin_categories.py
@@ -651,10 +651,11 @@ class TestCategoriesCaseFiltering(ClearCachesMixin, TransactionWebTest):
                     CategoriesPlugin, user=self.eherkenning_user
                 )
 
-                self.assertEqual(context["categories"].count(), 3)
+                self.assertEqual(context["categories"].count(), 4)
                 self.assertEqual(context["categories"][0], self.category2)
                 self.assertEqual(context["categories"][1], self.category3)
                 self.assertEqual(context["categories"][2], self.category6)
+                self.assertEqual(context["categories"][3], self.category7)
 
     @requests_mock.Mocker()
     def test_categories_based_on_cases_for_eherkenning_user_with_vestigingsnummer(
@@ -692,10 +693,11 @@ class TestCategoriesCaseFiltering(ClearCachesMixin, TransactionWebTest):
                     user=self.eherkenning_user_vestiging,
                 )
 
-                self.assertEqual(context["categories"].count(), 3)
+                self.assertEqual(context["categories"].count(), 4)
                 self.assertEqual(context["categories"][0], self.category2)
                 self.assertEqual(context["categories"][1], self.category3)
                 self.assertEqual(context["categories"][2], self.category6)
+                self.assertEqual(context["categories"][3], self.category7)
 
     @patch(
         "zgw_consumers.service.pagination_helper",

--- a/src/open_inwoner/components/templatetags/side_navigation.py
+++ b/src/open_inwoner/components/templatetags/side_navigation.py
@@ -1,207 +1,264 @@
-import contextlib
 import logging
+from typing import List, TypedDict
 
 from django import template
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, resolve, reverse
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _
 
+from cms.models import Page
+from menus.base import NavigationNode
 from menus.menu_pool import menu_pool
+
+from open_inwoner.cms.extensions.models import CommonExtension
 
 register = template.Library()
 logger = logging.getLogger(__name__)
 
 
-def get_extra_menu_items(context):
-    """Generate extra menu items based on context conditions"""
-    extra_items = []
-    request = context.get("request")
+class MenuItem(TypedDict):
+    href: str
+    label: str
+    icon: str | None
+    current: bool
+    counter: int | None
 
-    # FAQ item
-    if context.get("has_general_faq_questions", False):
+
+class SideNavMenuData:
+    """Generate data for the React side navigation meny."""
+
+    exclude_urls_from_menu = [
+        "profile:detail",
+    ]
+    """List of URL names that will be excluded from the sidenav menu."""
+
+    def __init__(self, context, root_id: str = "home"):
+        self.context = context
+        self.root_id = root_id
         try:
-            # Check if current request matches the FAQ route or its sub-routes
-            is_current = False
-            if request and hasattr(request, "path"):
-                try:
-                    # Get the FAQ URL pattern
-                    faq_url = reverse("general_faq")
-                    # Check if current path starts with the FAQ URL
-                    is_current = request.path.startswith(faq_url)
-                except NoReverseMatch:
-                    # Fallback to hardcoded path if reverse fails
-                    is_current = request.path.startswith("/faq/")
+            self.request = context["request"]
+        except KeyError as exc:
+            raise ValueError("Your context must include a request") from exc
 
-            extra_items.append(
-                {
-                    "href": reverse("general_faq"),
-                    "label": str(_("Veelgestelde vragen")),
-                    "icon": "question_answer",
-                    "current": is_current,
-                    "counter": None,
-                }
+    def get_menu_data(self) -> List[MenuItem]:
+        # NOTE: This logic is adopted from the ShowMenuBelowId class in menus. We follow
+        # the basic processing steps included there.
+        menu_renderer = self.context.get("cms_menu_renderer")
+        if not menu_renderer:
+            menu_renderer = menu_pool.get_renderer(self.request)
+
+        # Get nodes using the root_id
+        nodes = menu_renderer.get_nodes(namespace=None, root_id=self.root_id)
+        target_nodes: List[NavigationNode] = []
+
+        if not (
+            id_nodes := menu_pool.get_nodes_by_attribute(
+                nodes,
+                "reverse_id",
+                self.root_id,
             )
-            logger.debug("Added FAQ extra menu item")
+        ):
+            raise ImproperlyConfigured(
+                "You must define a root CMS page with reverse_id='home' to show the "
+                "side navigation menu"
+            )
+
+        # Flatten list to avoid recursion
+        node = id_nodes[0]
+        target_nodes = node.children
+        for remove_parent in target_nodes:
+            remove_parent.parent = None
+
+        # Apply modifiers
+        target_nodes = menu_renderer.apply_modifiers(
+            target_nodes, namespace=None, root_id=self.root_id, post_cut=True
+        )
+
+        return self._process_nodes_to_json(target_nodes)
+
+    def _extract_icon(self, node: NavigationNode) -> str | None:
+        if not (node_id := getattr(node, "id", None)):
+            return None
+
+        try:
+            page = Page.objects.get(pk=node_id)
+
+            def try_get_icon(page_obj, page_type=""):
+                """Helper to try getting icon from a page's CommonExtension"""
+                try:
+                    common_ext = CommonExtension.objects.get(extended_object=page_obj)
+                    if common_ext.menu_icon:
+                        logger.debug(
+                            "Found icon via CommonExtension%s: %s",
+                            page_type,
+                            common_ext.menu_icon,
+                        )
+                        return common_ext.menu_icon
+                except CommonExtension.DoesNotExist:
+                    pass
+                return None
+
+            # Try current page first
+            if icon := try_get_icon(page):
+                return icon
+
+            # If not found and this is a public page, try the draft version
+            if not page.publisher_is_draft and hasattr(page, "publisher_public"):
+                try:
+                    draft_page = page.publisher_public
+                    if icon := try_get_icon(draft_page, " on draft"):
+                        return icon
+                except AttributeError:
+                    pass
+
+            # If not found and this is a draft page, try the public version
+            if page.publisher_is_draft and getattr(page, "publisher_public_id", None):
+                try:
+                    public_page = Page.objects.get(
+                        pk=getattr(page, "publisher_public_id")
+                    )
+                    if icon := try_get_icon(public_page, " on public"):
+                        return icon
+                except Page.DoesNotExist:
+                    pass
+
+        except Exception:
+            logger.exception("Error extracting icon")
+
+        return None
+
+    def _extract_counter(self, node: NavigationNode) -> int | None:
+        # Check if the node already has a counter indicator
+        indicator = getattr(node, "indicator", None)
+        if indicator and str(indicator) != "0":
+            try:
+                return int(indicator)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Got a menu indicator value that cannot be coerced to int",
+                    extra={"indicator": indicator},
+                )
+
+        return None
+
+    def _is_current_page(self, node: NavigationNode) -> bool:
+        current = node.is_selected(self.request)
+
+        # Fallback to URL path matching if CMS selection isn't working. This is mostly
+        # needed to have some test coverage, because the test setup to get
+        # node.is_selected worked is too convoluted.
+        if not current:
+            current = self.request.path == node.get_absolute_url()
+
+        # Handle special case where route doesn't match CMS page URLs
+        try:
+            resolved = resolve(self.request.path)
+            if resolved.url_name == "contactmoment_list":
+                current = "contactmomenten" in node.get_absolute_url()
         except Exception as e:
-            logger.warning("Could not add FAQ menu item: %s", e)
+            logger.debug("Could not resolve current path for menu highlighting: %s", e)
 
-    # Add more conditional items here as needed:
-    # - User-specific items based on permissions
-    # - Context-specific items based on current page
-    # - Dynamic items based on user data/settings
+        return current
 
-    logger.debug("Generated %s extra menu items", len(extra_items))
-    return extra_items
+    def _is_visible_to_user(self, node: NavigationNode) -> bool:
+        try:
+            # Note how draft status works: there are typically two physical Page objects
+            # for the same logical page: one draft, one published. Which one is returned
+            # depends on the request context, and is handled by Django CMS, by selecting
+            # the appropriate node for that context. Thus, we can assume `node` will
+            # contain the relevant ID for the current context.
+            page = Page.objects.get(pk=node.id)
+            current_language = get_language()
+            is_published_for_language = page.is_published(current_language)
+            is_draft = page.publisher_is_draft
+            is_staff = self.request.user.is_staff
 
+            # Staff users can see all pages (including drafts) if published for language
+            # OR if it's a draft page with content in the current language
+            if is_staff:
+                if is_published_for_language:
+                    return True
 
-@register.simple_tag(takes_context=True)
-def react_sidenav_data(context):
-    """Template tag to provide menu data for React SideNavModule component"""
-    request = context["request"]
+                # For unpublished draft pages, check if they have content in current
+                # language as a hack to answer the question "Does the unpublished draft
+                # version have any content?". This allows staff users to still see the
+                # menu when they are in edit mode.
+                if is_draft:
+                    try:
+                        title = page.get_title_obj(
+                            language=current_language, fallback=False
+                        )
+                        if title:
+                            return True
+                    except Exception:
+                        logger.warning(
+                            "unable to get page title for the current node",
+                            extra={"page": page},
+                        )
 
-    try:
-        # Get the menu renderer
-        renderer = menu_pool.get_renderer(request)
+                logger.debug(
+                    "Skipping node %s for staff user: not published and no content for language %s",
+                    node.title,
+                    current_language,
+                )
+                return False
 
-        # Get all menu nodes
-        all_nodes = renderer.get_nodes()
-        all_nodes = renderer.apply_modifiers(all_nodes, post_cut=True)
-        logger.debug("Total nodes found: %s", len(all_nodes))
+            # Regular users only see published (non-draft) pages
+            if is_draft:
+                logger.debug(
+                    "Skipping node %s for regular user: page is draft", node.title
+                )
+                return False
 
-        # Find the "home" node first (preferred method)
-        home_node = None
-        for node in all_nodes:
-            # Check if this is the home page via node.attr.reverse_id
-            node_attr = getattr(node, "attr", {})
-            if node_attr.get("reverse_id", None) == "home":
-                home_node = node
-                logger.debug("Found home node: %s", node.title)
-                break
+            if not is_published_for_language:
+                logger.debug(
+                    "Skipping node %s for regular user: not published for language %s",
+                    node.title,
+                    current_language,
+                )
+                return False
 
-        # Determine which nodes to use
-        if home_node:
-            # Use children of home node (preferred)
-            target_nodes = getattr(home_node, "children", [])
-            logger.debug("Using home node children: %s items", len(target_nodes))
-        else:
-            # Fallback: use all visible nodes
+            return True
+
+        except (Page.DoesNotExist, AttributeError):
             logger.warning(
-                "Home node not found (reverse_id='home' not set). Using all visible pages as fallback."
+                "Unable to determine publication status for node %s (id=%s): page not found or missing attributes",
+                getattr(node, "title", "Unknown"),
+                getattr(node, "id", "Unknown"),
             )
+            return False
 
-            target_nodes = []
-            for node in all_nodes:
-                # Only include visible nodes
-                if getattr(node, "visible", True):
-                    target_nodes.append(node)
+    def _should_include_node(self, node: NavigationNode) -> bool:
+        url = node.get_absolute_url()
 
-            logger.debug(
-                "Using fallback nodes (all visible): %s items", len(target_nodes)
-            )
-
-        menu_items = []
-
-        # Process the target nodes
-        for node in target_nodes:
-            logger.debug("Processing node: %s", getattr(node, "title", "NO_TITLE"))
-
-            if node.title == "Mijn Profiel":
-                logger.debug("  Skipping my profile node in react nav")
+        for excluded_url in self.exclude_urls_from_menu:
+            try:
+                excluded_url_path = reverse(excluded_url)
+                if excluded_url_path in url:
+                    logger.debug("Excluding node %s with URL %s", node, url)
+                    return False
+            except Exception:
+                logger.debug("Failed to reverse URL %s", excluded_url, exc_info=True)
                 continue
 
-            # Skip hidden items
-            if not getattr(node, "visible", True):
-                logger.debug("  Skipping invisible node")
-                continue
+        if not self._is_visible_to_user(node):
+            logger.debug("Skipped node: not published %s", node)
+            return False
 
-            # Skip items without proper attributes
-            if not hasattr(node, "get_menu_title"):
-                logger.debug("Skipping node without get_menu_title")
-                continue
+        return True
 
-            # Extract URL
-            url = None
-            if (
-                hasattr(node, "attr")
-                and hasattr(node.attr, "redirect_url")
-                and node.attr.redirect_url
-            ):
-                url = node.attr.redirect_url
-            elif hasattr(node, "get_absolute_url"):
-                url = node.get_absolute_url()
-            else:
-                logger.debug("Skipping node without URL")
-                continue
+    def _process_nodes_to_json(
+        self, target_nodes: List[NavigationNode]
+    ) -> List[MenuItem]:
+        menu_items: List[MenuItem] = []
 
-            # Extract icon
-            icon = ""  # Default: empty (no icon) for municipalities that don't configure icons
+        for node in filter(self._should_include_node, target_nodes):
+            url = node.get_absolute_url()
+            icon = self._extract_icon(node)
+            counter = self._extract_counter(node)
+            current = self._is_current_page(node)
 
-            # Try multiple ways to get the icon
-            if hasattr(node, "common") and hasattr(node.common, "menu_icon"):
-                icon = node.common.menu_icon
-                logger.debug("Found icon via node.common.menu_icon: %s", icon)
-            elif hasattr(node, "menu_icon"):
-                icon = node.menu_icon
-                logger.debug("Found icon via node.menu_icon: %s", icon)
-            elif hasattr(node, "attr") and hasattr(node.attr, "menu_icon"):
-                icon = node.attr.menu_icon
-                logger.debug("Found icon via node.attr.menu_icon: %s", icon)
-            else:
-                # Try to get it from the page's CommonExtension
-                try:
-                    if hasattr(node, "id") and node.id:
-                        from cms.models import Page
-
-                        from open_inwoner.cms.extensions.models import CommonExtension
-
-                        page = Page.objects.get(pk=node.id)
-                        common_ext = CommonExtension.objects.get(extended_object=page)
-                        if common_ext.menu_icon:
-                            icon = common_ext.menu_icon
-                            logger.debug("  Found icon via CommonExtension: %s", icon)
-                except Exception as icon_error:
-                    logger.debug(
-                        "Could not get icon from CommonExtension: %s", icon_error
-                    )
-
-            # Extract indicator/counter
-            counter = None
-            if (
-                hasattr(node, "indicator")
-                and node.indicator
-                and str(node.indicator) != "0"
-            ):
-                with contextlib.suppress(ValueError, TypeError):
-                    counter = int(node.indicator)
-
-            # Check if current page
-            current = getattr(node, "selected", False)
-
-            # Handle specific routes that don't match CMS page URLs
-            # This is needed since the configured route does not match
-            # the hardcoded url specified in `cms/cases/urls.py`
-            if request and hasattr(request, "path"):
-                try:
-                    resolved = resolve(request.path)
-                    # Define routes that need special handling
-                    special_routes = {
-                        "contactmoment_list": "contactmomenten",
-                    }
-
-                    if resolved.url_name in special_routes:
-                        keyword = special_routes[resolved.url_name]
-                        # Reset all items to not current first
-                        current = False
-
-                        redirect_url = node.attr.get("redirect_url") or None
-                        # Set current=True only for menu items containing the keyword
-                        if redirect_url and keyword in redirect_url:
-                            current = True
-                except Exception as e:
-                    logger.debug(
-                        "Could not resolve current path for menu highlighting: %s", e
-                    )
-
-            menu_item = {
+            menu_item: MenuItem = {
                 "href": url,
                 "label": node.get_menu_title(),
                 "icon": icon,
@@ -210,17 +267,9 @@ def react_sidenav_data(context):
             }
 
             menu_items.append(menu_item)
-            logger.debug(
-                "Added menu item: %s -> %s (icon: %s)",
-                menu_item["label"],
-                menu_item["href"],
-                menu_item["icon"],
-            )
+            logger.debug("Added menu item: %s", menu_item)
 
-        # Add extra items based on context/conditions
-        extra_items = get_extra_menu_items(context)
-
-        # Combine base menu with extra items
+        extra_items = self.get_extra_menu_items()
         complete_menu = menu_items + extra_items
 
         logger.debug(
@@ -231,8 +280,48 @@ def react_sidenav_data(context):
         )
         return complete_menu
 
-    except Exception as e:
-        logger.exception("Error loading sidenav menu: %s", e)
+    def get_extra_menu_items(self) -> List[MenuItem]:
+        extra_items: List[MenuItem] = []
+        request = self.context.get("request")
+        if not request and hasattr(request, "path"):
+            return extra_items
+
+        if not self.context.get("has_general_faq_questions", False):
+            return extra_items
+
+        # FAQ item
+        is_current = False
+
+        try:
+            faq_url = reverse("general_faq")
+            is_current = request.path.startswith(faq_url)
+        except NoReverseMatch:
+            logger.warning("Could not add FAQ menu item: %s", exc_info=True)
+            return extra_items
+
+        extra_items.append(
+            {
+                "href": faq_url,
+                "label": str(_("Veelgestelde vragen")),
+                "icon": "question_answer",
+                "current": is_current,
+                "counter": None,
+            }
+        )
+
+        logger.debug("Generated %s extra menu items", len(extra_items))
+        return extra_items
+
+
+@register.simple_tag(takes_context=True)
+def react_sidenav_data(context):
+    """Template tag to provide menu data for React SideNavModule component"""
+
+    try:
+        side_nav_menu = SideNavMenuData(context, root_id="home")
+        return side_nav_menu.get_menu_data()
+    except Exception:
+        logger.exception("Error loading sidenav menu")
         return []
 
 

--- a/src/open_inwoner/components/tests/test_side_navigation.py
+++ b/src/open_inwoner/components/tests/test_side_navigation.py
@@ -1,1088 +1,538 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+from django.contrib.sessions.backends.db import SessionStore
+from django.core.exceptions import ImproperlyConfigured
 from django.template import Context
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import NoReverseMatch
+from django.utils import translation
 
+from cms import api
+from cms.test_utils.testcases import CMSTestCase
+
+from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.extensions.constants import IndicatorChoices
+from open_inwoner.cms.extensions.models import CommonExtension
 from open_inwoner.components.templatetags.side_navigation import (
-    get_extra_menu_items,
+    SideNavMenuData,
     react_sidenav_data,
 )
 
 
-class TestReactSidenavData(TestCase):
+@override_settings(
+    CMS_PERMISSION=False,
+    ROOT_URLCONF="open_inwoner.components.tests.test_urls",
+    LANGUAGE_CODE="nl",
+    LANGUAGES=[("nl", "Dutch"), ("en", "English")],
+    USE_I18N=True,
+)
+class TestSideNavigationMenuFactory(CMSTestCase):
     def setUp(self):
+        super().setUp()
         self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.context = Context({"request": self.request})
+        self.regular_user = UserFactory(is_staff=False)
+        self.staff_user = UserFactory(is_staff=True)
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_no_nodes_found(self, mock_menu_pool):
-        """Test when no menu nodes are found"""
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = []
-        mock_renderer.apply_modifiers.return_value = []
-        mock_menu_pool.get_renderer.return_value = mock_renderer
+        # Create home page with correct reverse_id
+        self.home_page = api.create_page(
+            "Home",
+            "cms/fullwidth.html",
+            "nl",
+            reverse_id="home",
+            in_navigation=True,
+            slug="home",
+        )
+        self.home_page.publish("nl")
 
-        result = react_sidenav_data(self.context)
+    def _get_menu_data(self, user, path="/"):
+        with translation.override("nl"):
+            request = self.factory.get(path)
+            request.user = user
+            request.session = SessionStore()
+            request.session.create()
 
-        self.assertEqual(result, [])
-        mock_menu_pool.get_renderer.assert_called_once_with(self.request)
-        mock_renderer.get_nodes.assert_called_once()
+            context = Context({"request": request})
+            return react_sidenav_data(context)
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_home_node_found_by_reverse_id(self, mock_menu_pool):
-        """Test finding home node by reverse_id in node.attr"""
-        home_node = Mock()
-        home_node.title = "Home"
-        home_node.children = []
-        # Set up attr with reverse_id
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")
+    def test_draft_page_visibility_differs_for_staff_and_regular_users(self):
+        published_page = api.create_page(
+            "Published Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        published_page.publish("nl")
 
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
+        draft_page = api.create_page(
+            "Draft Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        # Don't publish this page - keep it as true draft
 
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])  # No children
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_home_node_not_found_uses_fallback(self, mock_menu_pool):
-        """Test fallback to all visible nodes when no reverse_id='home' is found"""
-        # Node without reverse_id="home"
-        other_node = Mock()
-        other_node.title = "Other Page"
-        other_node.visible = True
-        other_node.get_menu_title.return_value = "Other Menu"
-        other_node.get_absolute_url.return_value = "/other/"
-        other_node.selected = False
-        # Set up attr without reverse_id="home" - this should use fallback
-        other_node.attr = Mock()
-        other_node.attr.reverse_id = "other"
-        other_node.attr.get = Mock(
-            return_value="other"
-        )  # Not "home", triggers fallback
-        delattr(other_node, "indicator")
-        # Remove common and menu_icon to get empty icon
-        delattr(other_node, "common")
-        delattr(other_node, "menu_icon")
-        # Make sure attr doesn't have menu_icon or redirect_url
-        delattr(other_node.attr, "menu_icon")
-        delattr(other_node.attr, "redirect_url")
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [other_node]
-        mock_renderer.apply_modifiers.return_value = [other_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        # Should use fallback and include the visible node
-        expected = [
+        # Regular user should only see the published page
+        regular_user_menu = self._get_menu_data(self.regular_user)
+        expected_regular_menu = [
             {
-                "href": "/other/",
-                "label": "Other Menu",
-                "icon": "",
+                "href": published_page.get_absolute_url(),
+                "label": "Published Page",
+                "icon": None,
                 "current": False,
                 "counter": None,
             }
         ]
-        self.assertEqual(result, expected)
+        self.assertEqual(regular_user_menu, expected_regular_menu)
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_home_node_without_attr(self, mock_menu_pool):
-        """Test node without attr attribute uses fallback"""
-        node_without_attr = Mock()
-        node_without_attr.title = "No Attr"
-        node_without_attr.visible = True
-        node_without_attr.get_menu_title.return_value = "No Attr Menu"
-        node_without_attr.get_absolute_url.return_value = "/no-attr/"
-        node_without_attr.selected = False
-        # Remove attr attribute entirely
-        delattr(node_without_attr, "attr")
-        delattr(node_without_attr, "indicator")
-        # Remove common and menu_icon to get empty icon
-        delattr(node_without_attr, "common")
-        delattr(node_without_attr, "menu_icon")
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [node_without_attr]
-        mock_renderer.apply_modifiers.return_value = [node_without_attr]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        # Should use fallback
-        expected = [
+        # Staff user should see both published and draft pages
+        staff_user_menu = self._get_menu_data(self.staff_user)
+        expected_staff_menu = [
             {
-                "href": "/no-attr/",
-                "label": "No Attr Menu",
-                "icon": "",
+                "href": published_page.get_absolute_url(),
+                "label": "Published Page",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            },
+            {
+                "href": draft_page.get_absolute_url(),
+                "label": "Draft Page",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            },
+        ]
+        self.assertEqual(staff_user_menu, expected_staff_menu)
+
+    def test_menu_icons_from_draft_page_common_extension(self):
+        page_with_icon = api.create_page(
+            "Page With Icon",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        page_with_icon.publish("nl")
+
+        # Add CommonExtension to the draft version
+        CommonExtension.objects.create(
+            extended_object=page_with_icon,  # This is the draft version
+            menu_icon="person",
+        )
+
+        # Regular user should see published page with icon
+        regular_menu = self._get_menu_data(self.regular_user)
+        expected_regular_menu = [
+            {
+                "href": page_with_icon.get_absolute_url(),
+                "label": "Page With Icon",
+                "icon": "person",
                 "current": False,
                 "counter": None,
             }
         ]
-        self.assertEqual(result, expected)
+        self.assertEqual(
+            regular_menu,
+            expected_regular_menu,
+            msg="Regular user should see published page with icon from draft version CommonExtension",
+        )
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_invisible_child_node_skipped(self, mock_menu_pool):
-        """Test that invisible child nodes are skipped"""
-        child_node = Mock()
-        child_node.visible = False
-        child_node.title = "Invisible"
-
-        home_node = Mock()
-        home_node.title = "Home"
-        home_node.children = [child_node]
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.visible = True
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_fallback_invisible_node_skipped(self, mock_menu_pool):
-        """Test that invisible nodes are skipped in fallback mode"""
-        invisible_node = Mock()
-        invisible_node.visible = False
-        invisible_node.title = "Invisible"
-        invisible_node.attr = Mock()
-        invisible_node.attr.reverse_id = "other"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [invisible_node]
-        mock_renderer.apply_modifiers.return_value = [invisible_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_without_get_menu_title_skipped(self, mock_menu_pool):
-        """Test that nodes without get_menu_title are skipped"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "No Menu Title"
-        # Remove get_menu_title method to test the skipping behavior
-        delattr(child_node, "get_menu_title")
-        # Remove all other attributes that could cause fallback processing
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        delattr(child_node, "selected")
-        delattr(child_node, "get_absolute_url")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.title = "Home"
-        home_node.children = [child_node]
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.visible = True
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_with_redirect_url(self, mock_menu_pool):
-        """Test node with redirect_url in attr"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Child"
-        child_node.get_menu_title.return_value = "Child Menu"
-        child_node.selected = False
-        child_node.attr = Mock()
-        child_node.attr.redirect_url = "https://external.com"
-        child_node.attr.get = Mock(return_value="https://external.com")
-        # No indicator
-        delattr(child_node, "indicator")
-        # Remove common, menu_icon, and attr.menu_icon to get empty icon
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        # Make sure attr doesn't have menu_icon
-        delattr(child_node.attr, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        expected = [
+        # Staff user should see the same
+        staff_menu = self._get_menu_data(self.staff_user)
+        expected_staff_menu = [
             {
-                "href": "https://external.com",
-                "label": "Child Menu",
-                "icon": "",
+                "href": page_with_icon.get_absolute_url(),
+                "label": "Page With Icon",
+                "icon": "person",
                 "current": False,
                 "counter": None,
             }
         ]
-        self.assertEqual(result, expected)
+        self.assertEqual(
+            staff_menu,
+            expected_staff_menu,
+            msg="Staff user should see same icon from draft version",
+        )
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_with_absolute_url(self, mock_menu_pool):
-        """Test node using get_absolute_url when no redirect_url"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Child"
-        child_node.get_menu_title.return_value = "Child Menu"
-        child_node.selected = True
-        child_node.get_absolute_url.return_value = "/child/"
-        # No attr or redirect_url
-        delattr(child_node, "attr")
-        delattr(child_node, "indicator")
-        # Remove common and menu_icon to get empty icon
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
+    def test_menu_icons_on_draft_only_pages_for_staff(self):
+        draft_page = api.create_page(
+            "Draft Page With Icon",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        # Don't publish this page - keep as draft only
 
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
+        CommonExtension.objects.create(
+            extended_object=draft_page,
+            menu_icon="edit",
+        )
 
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
+        # Regular user should not see any pages
+        regular_menu = self._get_menu_data(self.regular_user)
+        self.assertEqual(regular_menu, [])
 
-        result = react_sidenav_data(self.context)
-
-        expected = [
+        # Staff user should see the draft page with complete menu structure
+        staff_menu = self._get_menu_data(self.staff_user)
+        expected_staff_menu = [
             {
-                "href": "/child/",
-                "label": "Child Menu",
-                "icon": "",
+                "href": draft_page.get_absolute_url(),
+                "label": "Draft Page With Icon",
+                "icon": "edit",
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            staff_menu,
+            expected_staff_menu,
+            msg="Staff user should see draft page with icon from CommonExtension",
+        )
+
+    def test_menu_pages_without_common_extension_show_no_icon(self):
+        page_without_icon = api.create_page(
+            "Page Without Icon",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        page_without_icon.publish("nl")
+        # Intentionally avoid creating a CommonExtension
+
+        # Regular user should see page with null icon
+        regular_menu = self._get_menu_data(self.regular_user)
+        expected_regular_menu = [
+            {
+                "href": page_without_icon.get_absolute_url(),
+                "label": "Page Without Icon",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            regular_menu,
+            expected_regular_menu,
+            msg="Page without CommonExtension should show no icon",
+        )
+
+        # Staff user should see the same structure
+        staff_menu = self._get_menu_data(self.staff_user)
+        expected_staff_menu = [
+            {
+                "href": page_without_icon.get_absolute_url(),
+                "label": "Page Without Icon",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            staff_menu,
+            expected_staff_menu,
+            msg="Staff should see same structure with no icon",
+        )
+
+    def test_menu_icon_fallback_between_draft_and_public_versions(self):
+        # Create page with icon on draft (most common)
+        page_draft_icon = api.create_page(
+            "Page Draft Icon",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        page_draft_icon.publish("nl")
+
+        CommonExtension.objects.create(
+            extended_object=page_draft_icon,
+            menu_icon="draft_icon",
+        )
+
+        # Regular user should see icon from draft version CommonExtension
+        regular_menu = self._get_menu_data(self.regular_user)
+        expected_regular_menu = [
+            {
+                "href": page_draft_icon.get_absolute_url(),
+                "label": "Page Draft Icon",
+                "icon": "draft_icon",
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            regular_menu,
+            expected_regular_menu,
+            msg="Regular user should see icon found via fallback to draft version",
+        )
+
+        # Staff user should see the same complete structure
+        staff_menu = self._get_menu_data(self.staff_user)
+        expected_staff_menu = [
+            {
+                "href": page_draft_icon.get_absolute_url(),
+                "label": "Page Draft Icon",
+                "icon": "draft_icon",
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            staff_menu,
+            expected_staff_menu,
+            msg="Staff user should see same fallback behavior as regular user",
+        )
+
+    def test_menu_counters_are_calculated_from_user_specific_data(self):
+        # Create page with inbox message indicator
+        inbox_page = api.create_page(
+            "My Messages",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        inbox_page.publish("nl")
+
+        # Get the published version of the page
+        published_page = inbox_page.get_public_object()
+
+        CommonExtension.objects.create(
+            extended_object=published_page,
+            menu_indicator=IndicatorChoices.inbox_new_messages,
+        )
+
+        # Set up user to have 7 new messages
+        self.regular_user.get_new_messages_total = lambda: 7
+
+        menu_data = self._get_menu_data(self.regular_user)
+        expected_menu = [
+            {
+                "href": published_page.get_absolute_url(),
+                "label": "My Messages",
+                "icon": None,
+                "current": False,
+                "counter": 7,
+            }
+        ]
+        self.assertEqual(
+            menu_data,
+            expected_menu,
+            msg="Counter should match user's message count",
+        )
+
+    def test_current_page_is_highlighted_when_user_visits_that_page(self):
+        # Create two pages to test current detection
+        visited_page = api.create_page(
+            "Visited Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+            slug="visited-page",
+        )
+        visited_page.publish("nl")
+
+        other_page = api.create_page(
+            "Other Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+            slug="other-page",
+        )
+        other_page.publish("nl")
+
+        published_visited_page = visited_page.get_public_object()
+        published_other_page = other_page.get_public_object()
+
+        visited_page_url = published_visited_page.get_absolute_url()
+        menu_data = self._get_menu_data(self.regular_user, path=visited_page_url)
+
+        expected_menu = [
+            {
+                "href": published_visited_page.get_absolute_url(),
+                "label": "Visited Page",
+                "icon": None,
                 "current": True,
                 "counter": None,
-            }
-        ]
-        self.assertEqual(result, expected)
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_without_url_skipped(self, mock_menu_pool):
-        """Test that nodes without URL are skipped"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Child"
-        child_node.get_menu_title.return_value = "Child Menu"
-        # No attr, redirect_url, or get_absolute_url - should be skipped
-        delattr(child_node, "attr")
-        delattr(child_node, "get_absolute_url")
-        # Remove all other attributes that could provide URLs
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        delattr(child_node, "selected")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-        # Make sure home node itself is invisible
-        home_node.visible = False
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_icon_from_common_menu_icon(self, mock_menu_pool):
-        """Test getting icon from node.common.menu_icon"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.common = Mock()
-        child_node.common.menu_icon = "icon-home"
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["icon"], "icon-home")
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_icon_from_menu_icon_attribute(self, mock_menu_pool):
-        """Test getting icon from node.menu_icon when common doesn't have it"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.menu_icon = "icon-settings"
-        # No common attribute
-        delattr(child_node, "common")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["icon"], "icon-settings")
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_icon_from_attr_menu_icon(self, mock_menu_pool):
-        """Test getting icon from node.attr.menu_icon"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.attr = Mock()
-        child_node.attr.menu_icon = "icon-user"
-        # No redirect_url in attr
-        delattr(child_node.attr, "redirect_url")
-        # No common or menu_icon
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["icon"], "icon-user")
-
-    @patch("open_inwoner.cms.extensions.models.CommonExtension")
-    @patch("cms.models.Page")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_icon_from_common_extension(
-        self, mock_menu_pool, mock_page_model, mock_common_ext
-    ):
-        """Test getting icon from CommonExtension when other methods fail"""
-        # Set up mocks for database queries
-        mock_page = Mock()
-        mock_page_model.objects.get.return_value = mock_page
-
-        mock_ext_instance = Mock()
-        mock_ext_instance.menu_icon = "icon-database"
-        mock_common_ext.objects.get.return_value = mock_ext_instance
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.id = 123
-        # No other icon sources
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        delattr(child_node, "attr")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["icon"], "icon-database")
-        mock_page_model.objects.get.assert_called_once_with(pk=123)
-        mock_common_ext.objects.get.assert_called_once_with(extended_object=mock_page)
-
-    @patch("open_inwoner.cms.extensions.models.CommonExtension")
-    @patch("cms.models.Page")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_icon_common_extension_fails(
-        self, mock_menu_pool, mock_page_model, mock_common_ext
-    ):
-        """Test when CommonExtension lookup fails"""
-        mock_page_model.objects.get.side_effect = Exception("Page not found")
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.id = 123
-        # No other icon sources
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-        delattr(child_node, "attr")
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["icon"], "")  # Default empty icon
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_with_valid_counter(self, mock_menu_pool):
-        """Test node with valid indicator/counter"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.indicator = "5"  # String that can be converted to int
-        # Remove attributes that could interfere
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result[0]["counter"], 5)
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_with_zero_counter_ignored(self, mock_menu_pool):
-        """Test that zero counter is treated as None"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.indicator = "0"  # Zero should be ignored
-        # Remove attributes that could interfere
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertIsNone(result[0]["counter"])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_with_invalid_counter(self, mock_menu_pool):
-        """Test node with invalid indicator that can't be converted to int"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        child_node.selected = False
-        child_node.indicator = "invalid"  # Can't convert to int
-        # Remove attributes that could interfere
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertIsNone(result[0]["counter"])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_exception_handling(self, mock_menu_pool):
-        """Test that exceptions are caught and empty list is returned"""
-        mock_menu_pool.get_renderer.side_effect = Exception("Menu error")
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_complete_menu_item(self, mock_menu_pool):
-        """Test a complete menu item with all attributes"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Complete Child"
-        child_node.get_menu_title.return_value = "Complete Menu"
-        child_node.get_absolute_url.return_value = "/complete/"
-        child_node.selected = True
-        child_node.indicator = "3"
-        child_node.menu_icon = "icon-complete"
-        # Remove common attribute to ensure menu_icon is used
-        delattr(child_node, "common")
-        # Remove attr to ensure get_absolute_url is used
-        delattr(child_node, "attr")
-
-        home_node = Mock()
-        home_node.title = "Home"
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.children = [child_node]
-        # Make home node itself invisible so it doesn't get processed
-        home_node.visible = False
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        expected = [
+            },
             {
-                "href": "/complete/",
-                "label": "Complete Menu",
-                "icon": "icon-complete",
-                "current": True,
-                "counter": 3,
+                "href": published_other_page.get_absolute_url(),
+                "label": "Other Page",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            },
+        ]
+        self.assertEqual(
+            menu_data,
+            expected_menu,
+            msg="Visited page should be marked as current, other page should not",
+        )
+
+    def test_pages_only_published_in_other_languages_are_hidden_from_menu(self):
+        dutch_page = api.create_page(
+            "Dutch Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        dutch_page.publish("nl")
+
+        en_page = api.create_page(
+            "English Only Page",
+            "cms/fullwidth.html",
+            "en",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        en_page.publish("en")  # Only publish in English, not Dutch
+
+        # Menu in Dutch context should only contain Dutch page
+        menu_data = self._get_menu_data(self.regular_user)
+        expected_menu = [
+            {
+                "href": dutch_page.get_absolute_url(),
+                "label": "Dutch Page",
+                "icon": None,
+                "current": False,
+                "counter": None,
             }
         ]
-        self.assertEqual(result, [])
+        self.assertEqual(
+            menu_data,
+            expected_menu,
+            msg="Menu in Dutch context should only contain Dutch page",
+        )
+
+    def test_invalid_counter_values_are_handled_gracefully(self):
+        page_with_broken_counter = api.create_page(
+            "Broken Counter Page",
+            "cms/fullwidth.html",
+            "nl",
+            parent=self.home_page,
+            in_navigation=True,
+        )
+        page_with_broken_counter.publish("nl")
+
+        CommonExtension.objects.create(
+            extended_object=page_with_broken_counter,
+            menu_indicator=IndicatorChoices.inbox_new_messages,
+        )
+
+        # Set up user method to return invalid (non-integer) value
+        self.regular_user.get_new_messages_total = lambda: "not-a-number"
+
+        # Menu should still generate successfully with counter as None
+        menu_data = self._get_menu_data(self.regular_user)
+        expected_menu = [
+            {
+                "href": page_with_broken_counter.get_absolute_url(),
+                "label": "Broken Counter Page",
+                "icon": None,
+                "current": False,
+                "counter": None,
+            }
+        ]
+        self.assertEqual(
+            menu_data,
+            expected_menu,
+            msg="Counter should be None when conversion fails",
+        )
+
+    def test_missing_home_page_raises_configuration_error(self):
+        self.home_page.delete()
+
+        request = self.factory.get("/")
+        request.user = self.regular_user
+        context = Context({"request": request})
+
+        with self.assertRaisesRegex(
+            ImproperlyConfigured,
+            "You must define a root CMS page with reverse_id='home'",
+        ):
+            SideNavMenuData(context).get_menu_data()
 
 
-class TestReactSidenavDataEdgeCases(TestCase):
+class TestExtraMenuItemGeneration(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.context = Context({"request": self.request})
 
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_home_node_without_children_attribute(self, mock_menu_pool):
-        """Test home node that doesn't have children attribute"""
-        home_node = Mock()
-        home_node.title = "Home"
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        # Remove children attribute entirely
-        delattr(home_node, "children")
-        # Make sure the node itself won't be processed as a menu item by making it invisible
-        home_node.visible = False
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_node_without_selected_attribute(self, mock_menu_pool):
-        """Test node without selected attribute uses False as default"""
-        child_node = Mock()
-        child_node.visible = True
-        child_node.get_menu_title.return_value = "Child"
-        child_node.get_absolute_url.return_value = "/child/"
-        # Remove selected attribute - this will cause getattr(node, "selected", False) to return False
-        delattr(child_node, "selected")
-        delattr(child_node, "indicator")
-        # Remove attr and common to avoid unexpected mock values
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        # Remove menu_icon to avoid unexpected mock values
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-        # Make sure home node itself is invisible
-        home_node.visible = False
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        self.assertFalse(result[0]["current"])
-
-
-class TestGetExtraMenuItems(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.context = Context({"request": self.request})
-
-    def test_no_extra_items_when_no_faq_questions(self):
-        """Test that no extra items are returned when has_general_faq_questions is False"""
-        context = Context({"request": self.request, "has_general_faq_questions": False})
-        result = get_extra_menu_items(context)
-        self.assertEqual(result, [])
-
-    def test_no_extra_items_when_faq_context_missing(self):
-        """Test that no extra items are returned when has_general_faq_questions is not in context"""
-        context = Context({"request": self.request})
-        result = get_extra_menu_items(context)
-        self.assertEqual(result, [])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_added_with_current_false(self, mock_reverse):
-        """Test FAQ item is added when has_general_faq_questions is True"""
-        mock_reverse.return_value = "/faq/"
-        request = self.factory.get("/other-page/")
+    def test_faq_menu_item_is_added_when_context_indicates_faq_available(self):
+        request = self.factory.get("/some-other-page/")
         context = Context({"request": request, "has_general_faq_questions": True})
 
-        result = get_extra_menu_items(context)
+        extra_items = SideNavMenuData(context).get_extra_menu_items()
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["href"], "/faq/")
-        self.assertEqual(result[0]["label"], "Veelgestelde vragen")
-        self.assertEqual(result[0]["icon"], "question_answer")
-        self.assertFalse(result[0]["current"])
-        self.assertIsNone(result[0]["counter"])
+        expected_faq_item = {
+            "href": "/faq/",  # Based on reverse("general_faq")
+            "label": "Veelgestelde vragen",
+            "icon": "question_answer",
+            "current": False,
+            "counter": None,
+        }
+        self.assertEqual(
+            extra_items,
+            [expected_faq_item],
+            msg="FAQ item should be added when context indicates FAQ available",
+        )
 
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_added_with_current_true_when_on_faq_page(self, mock_reverse):
-        """Test FAQ item shows as current when on FAQ page"""
-        mock_reverse.return_value = "/faq/"
+    def test_faq_menu_item_is_marked_current_when_user_is_on_faq_page(self):
         request = self.factory.get("/faq/some-question/")
         context = Context({"request": request, "has_general_faq_questions": True})
 
-        result = get_extra_menu_items(context)
+        extra_items = SideNavMenuData(context).get_extra_menu_items()
 
-        self.assertEqual(len(result), 1)
-        self.assertTrue(result[0]["current"])
+        expected_faq_item = {
+            "href": "/faq/",
+            "label": "Veelgestelde vragen",
+            "icon": "question_answer",
+            "current": True,
+            "counter": None,
+        }
+        self.assertEqual(
+            extra_items,
+            [expected_faq_item],
+            msg="FAQ item should be marked current when user is on FAQ page",
+        )
 
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_added_with_current_true_when_exact_faq_path(self, mock_reverse):
-        """Test FAQ item shows as current when on exact FAQ path"""
-        mock_reverse.return_value = "/faq/"
-        request = self.factory.get("/faq/")
-        context = Context({"request": request, "has_general_faq_questions": True})
+    def test_no_extra_items_when_faq_not_available(self):
+        context_false = Context(
+            {"request": self.factory.get("/"), "has_general_faq_questions": False}
+        )
+        self.assertEqual(SideNavMenuData(context_false).get_extra_menu_items(), [])
 
-        result = get_extra_menu_items(context)
+        # Test with missing key
+        context_missing = Context({"request": self.factory.get("/")})
+        self.assertEqual(SideNavMenuData(context_missing).get_extra_menu_items(), [])
 
-        self.assertEqual(len(result), 1)
-        self.assertTrue(result[0]["current"])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_no_reverse_match_uses_fallback(self, mock_reverse):
-        """Test FAQ item uses fallback path when reverse fails"""
-        mock_reverse.side_effect = NoReverseMatch("general_faq not found")
-        request = self.factory.get("/faq/some-question/")
-        context = Context({"request": request, "has_general_faq_questions": True})
-
-        result = get_extra_menu_items(context)
-
-        # When reverse fails completely, no FAQ item should be created
-        self.assertEqual(len(result), 0)
-
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_no_reverse_match_uses_fallback_false(self, mock_reverse):
-        """Test FAQ item uses fallback path when reverse fails and not on faq"""
-        mock_reverse.side_effect = NoReverseMatch("general_faq not found")
-        request = self.factory.get("/other-page/")
-        context = Context({"request": request, "has_general_faq_questions": True})
-
-        result = get_extra_menu_items(context)
-
-        # When reverse fails completely, no FAQ item should be created
-        self.assertEqual(len(result), 0)
-
-    def test_faq_item_no_request_in_context(self):
-        """Test FAQ item when no request in context"""
+    def test_faq_item_without_request_in_context_defaults_to_not_current(self):
         context = Context({"has_general_faq_questions": True})
 
-        result = get_extra_menu_items(context)
+        with self.assertRaises(ValueError):
+            SideNavMenuData(context).get_extra_menu_items()
 
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0]["current"])
-
-    def test_faq_item_request_without_path(self):
-        """Test FAQ item when request doesn't have path attribute"""
-        request = Mock()
-        delattr(request, "path")
-        context = Context({"request": request, "has_general_faq_questions": True})
-
-        result = get_extra_menu_items(context)
-
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0]["current"])
-
-    @patch("open_inwoner.components.templatetags.side_navigation.reverse")
-    def test_faq_item_exception_handling(self, mock_reverse):
-        """Test that exceptions during FAQ item creation are handled gracefully"""
-        mock_reverse.side_effect = Exception("Unexpected error")
-        context = Context({"request": self.request, "has_general_faq_questions": True})
-
-        result = get_extra_menu_items(context)
-
-        self.assertEqual(result, [])  # Should return empty list when exception occurs
-
-
-class TestReactSidenavDataAdditionalCases(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.context = Context({"request": self.request})
-
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_mijn_profiel_node_skipped(self, mock_menu_pool):
-        """Test that 'Mijn Profiel' node is skipped"""
-        profiel_node = Mock()
-        profiel_node.visible = True
-        profiel_node.title = "Mijn Profiel"
-        profiel_node.get_menu_title.return_value = "Mijn Profiel"
-        profiel_node.get_absolute_url.return_value = "/profiel/"
-
-        other_node = Mock()
-        other_node.visible = True
-        other_node.title = "Other"
-        other_node.get_menu_title.return_value = "Other"
-        other_node.get_absolute_url.return_value = "/other/"
-        other_node.selected = False
-        delattr(other_node, "indicator")
-        # Remove common and menu_icon to get empty icon
-        delattr(other_node, "common")
-        delattr(other_node, "menu_icon")
-        delattr(other_node, "attr")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [profiel_node, other_node]
-        # Home node needs to be visible to be found, but not processed itself
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        result = react_sidenav_data(self.context)
-
-        # Should only include the other_node, not the profiel_node
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["label"], "Other")
-
-    @patch("open_inwoner.components.templatetags.side_navigation.resolve")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_special_route_contactmoment_list_current(
-        self, mock_menu_pool, mock_resolve
-    ):
-        """Test special route handling for contactmoment_list sets current=True"""
-        mock_resolved = Mock()
-        mock_resolved.url_name = "contactmoment_list"
-        mock_resolve.return_value = mock_resolved
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Contact"
-        child_node.get_menu_title.return_value = "Contact"
-        child_node.selected = False
-        child_node.attr = Mock()
-        child_node.attr.redirect_url = "/contactmomenten/lijst/"
-        # Make sure attr.get returns the redirect_url properly
-        child_node.attr.get = Mock(return_value="/contactmomenten/lijst/")
-        delattr(child_node, "indicator")
-        # Remove common and menu_icon to get empty icon
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        # Home node needs to be visible to be found, but not processed itself
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        request = self.factory.get("/contactmoment/list/")
-        context = Context({"request": request})
-
-        result = react_sidenav_data(context)
-
-        self.assertEqual(len(result), 1)
-        self.assertTrue(result[0]["current"])
-        mock_resolve.assert_called_once_with("/contactmoment/list/")
-
-    @patch("open_inwoner.components.templatetags.side_navigation.resolve")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_special_route_contactmoment_list_not_matching(
-        self, mock_menu_pool, mock_resolve
-    ):
-        """Test special route handling when redirect_url doesn't contain keyword"""
-        mock_resolved = Mock()
-        mock_resolved.url_name = "contactmoment_list"
-        mock_resolve.return_value = mock_resolved
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Contact"
-        child_node.get_menu_title.return_value = "Contact"
-        child_node.selected = True  # Initially selected
-        child_node.attr = Mock()
-        child_node.attr.redirect_url = (
-            "/other-url/"  # Doesn't contain "contactmomenten"
+    def test_url_reverse_failures_are_handled_gracefully(self):
+        context = Context(
+            {"request": self.factory.get("/"), "has_general_faq_questions": True}
         )
-        delattr(child_node, "indicator")
 
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
+        with patch(
+            "open_inwoner.components.templatetags.side_navigation.reverse"
+        ) as mock_reverse:
+            mock_reverse.side_effect = NoReverseMatch(
+                "general_faq URL pattern not found"
+            )
 
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        request = self.factory.get("/contactmoment/list/")
-        context = Context({"request": request})
-
-        result = react_sidenav_data(context)
-
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0]["current"])  # Should be reset to False
-
-    @patch("open_inwoner.components.templatetags.side_navigation.resolve")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_special_route_resolve_exception(self, mock_menu_pool, mock_resolve):
-        """Test that resolve exceptions are handled gracefully"""
-        mock_resolve.side_effect = Exception("Cannot resolve path")
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Contact"
-        child_node.get_menu_title.return_value = "Contact"
-        child_node.selected = True
-        child_node.get_absolute_url.return_value = "/contact/"
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        request = self.factory.get("/some-path/")
-        context = Context({"request": request})
-
-        result = react_sidenav_data(context)
-
-        self.assertEqual(len(result), 1)
-        self.assertTrue(result[0]["current"])  # Should keep original selected value
-
-    @patch("open_inwoner.components.templatetags.side_navigation.resolve")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_special_route_no_redirect_url(self, mock_menu_pool, mock_resolve):
-        """Test special route handling when node has no redirect_url"""
-        mock_resolved = Mock()
-        mock_resolved.url_name = "contactmoment_list"
-        mock_resolve.return_value = mock_resolved
-
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Contact"
-        child_node.get_menu_title.return_value = "Contact"
-        child_node.selected = True
-        child_node.attr = Mock()
-        # No redirect_url attribute
-        delattr(child_node.attr, "redirect_url")
-        child_node.get_absolute_url.return_value = "/contact/"
-        delattr(child_node, "indicator")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        request = self.factory.get("/contactmoment/list/")
-        context = Context({"request": request})
-
-        result = react_sidenav_data(context)
-
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0]["current"])  # Should be reset to False
-
-    @patch("open_inwoner.components.templatetags.side_navigation.get_extra_menu_items")
-    @patch("open_inwoner.components.templatetags.side_navigation.menu_pool")
-    def test_extra_items_integration(self, mock_menu_pool, mock_get_extra):
-        """Test that extra items are properly integrated with base menu"""
-        # Mock base menu
-        child_node = Mock()
-        child_node.visible = True
-        child_node.title = "Base Item"
-        child_node.get_menu_title.return_value = "Base Item"
-        child_node.get_absolute_url.return_value = "/base/"
-        child_node.selected = False
-        delattr(child_node, "indicator")
-        delattr(child_node, "attr")
-        delattr(child_node, "common")
-        delattr(child_node, "menu_icon")
-
-        home_node = Mock()
-        home_node.attr = Mock()
-        home_node.attr.reverse_id = "home"
-        home_node.attr.get = Mock(return_value="home")  # Make attr.get() work properly
-        home_node.children = [child_node]
-        # Home node needs to be visible to be found, but not processed itself
-        home_node.visible = True
-        home_node.title = "Home"
-
-        mock_renderer = Mock()
-        mock_renderer.get_nodes.return_value = [home_node]
-        mock_renderer.apply_modifiers.return_value = [home_node]
-        mock_menu_pool.get_renderer.return_value = mock_renderer
-
-        # Mock extra items
-        extra_items = [
-            {
-                "href": "/faq/",
-                "label": "FAQ",
-                "icon": "question_answer",
-                "current": False,
-                "counter": None,
-            }
-        ]
-        mock_get_extra.return_value = extra_items
-
-        result = react_sidenav_data(self.context)
-
-        self.assertEqual(len(result), 2)
-        # Base menu item
-        self.assertEqual(result[0]["label"], "Base Item")
-        self.assertEqual(result[0]["href"], "/base/")
-        # Extra item
-        self.assertEqual(result[1]["label"], "FAQ")
-        self.assertEqual(result[1]["href"], "/faq/")
-        mock_get_extra.assert_called_once_with(self.context)
+            extra_items = SideNavMenuData(context).get_extra_menu_items()
+            self.assertEqual(
+                extra_items,
+                [],
+                msg="Should return empty list on URL failure",
+            )

--- a/src/open_inwoner/components/tests/test_urls.py
+++ b/src/open_inwoner/components/tests/test_urls.py
@@ -1,0 +1,17 @@
+from django.urls import include, path
+from django.views.generic import TemplateView
+
+# Profile URLs (needed for exclude_urls_from_menu check)
+profile_patterns = [
+    path("detail/", TemplateView.as_view(), name="detail"),
+]
+
+# Minimal URL configuration for CMS tests
+urlpatterns = [
+    # Add profile namespace to prevent NoReverseMatch in exclude_urls_from_menu
+    path("profile/", include((profile_patterns, "profile"), namespace="profile")),
+    # Add FAQ URL for extra menu items
+    path("faq/", TemplateView.as_view(), name="general_faq"),
+    # CMS URLs (must be last to catch all remaining patterns)
+    path("", include("cms.urls")),
+]


### PR DESCRIPTION
## Summary

This ensures unpublished CMS pages do not appear in the sidenav menu. More generally, this PR involves a significant refactor of the earlier code with some additional tests covering a variety of edge cases. The logic was getting a bit hard to follow with all the applicable conditions, so I tried to break the logic up a bit into readable chunks.

## Issue References

- Taiga Issue: [#3479](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3479)

## Checklist

- [x] CHANGELOG.rst updated
