### PR TITLE
chore: bump sqlparse to 0.5.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Onderhoud
   ``v3.12``.
 * [:taiga-us:`3450`, :pr:`1927`]: ``maykin-django-prosemirror`` dependency toegevoegd.
 * [:taiga-ta:`3473`, :pr:`1931`]: ``maykin-common`` dependency toegevoegd.
+* [:pr:`1942`] ``sqlparse`` bijgewerkt naar versie ``0.5.3``.
 
 1.35.0 (2025-09-18)
 ===================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -625,7 +625,7 @@ six==1.16.0
     #   qrcode
 soupsieve==2.5
     # via beautifulsoup4
-sqlparse==0.4.4
+sqlparse==0.5.3
     # via django
 svglib==1.5.1
     # via easy-thumbnails

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1152,7 +1152,7 @@ sphinxcontrib-qthelp==1.0.7
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sqlparse==0.4.4
+sqlparse==0.5.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1312,7 +1312,7 @@ sphinxcontrib-serializinghtml==1.1.10
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
-sqlparse==0.4.4
+sqlparse==0.5.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

Fix a few non-critical dependabot issues: [#288](https://github.com/maykinmedia/open-inwoner/security/dependabot/288),  [#289](https://github.com/maykinmedia/open-inwoner/security/dependabot/289), [#290](https://github.com/maykinmedia/open-inwoner/security/dependabot/290)

## Checklist

- [x] CHANGELOG.rst updated

