### PR TITLE
chore(deps): bump djangorestframework to 3.16.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Onderhoud
 
 * [:pr:`1943`]: ``waitress`` bijgewerkt naar versie ``3.0.2``.
 * [:pr:`1943`]: ``Flask-CORS`` bijgewerkt naar versie ``6.0.1``.
+* [:pr:`1944`]: ``djangorestframework`` bijgewerkt naar versie ``3.16.1``.
 * [:taiga-us:`3461`, :taiga-ta:`3472`, :pr:`1834`]: Python versie bijgewerkt naar
   ``v3.12``.
 * [:taiga-us:`3450`, :pr:`1927`]: ``maykin-django-prosemirror`` dependency toegevoegd.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -312,7 +312,7 @@ djangocms-picture==4.1.1
     # via -r requirements/base.in
 djangocms-text-ckeditor==5.1.2
     # via -r requirements/base.in
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.in
     #   django-extra-fields
@@ -573,7 +573,6 @@ pytz==2021.3
     # via
     #   -r requirements/base.in
     #   django-yubin
-    #   djangorestframework
 pyyaml==6.0.2
     # via
     #   drf-spectacular

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -518,7 +518,7 @@ djangocms-text-ckeditor==5.1.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1035,7 +1035,6 @@ pytz==2021.3
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-yubin
-    #   djangorestframework
 pyyaml==6.0.2
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -555,7 +555,7 @@ djangocms-text-ckeditor==5.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1151,7 +1151,6 @@ pytz==2021.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-yubin
-    #   djangorestframework
 pyyaml==6.0.2
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
## Summary

Fix low priority Dependabot alert [#309](https://github.com/maykinmedia/open-inwoner/security/dependabot/309).

## Checklist

- [x] CHANGELOG.rst updated
