### PR TITLE
:bug: [#3486] fix duplicate shown menu items both in sidebar and top-…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Bugfixes
 * [:taiga-is:`3477`: :pr:`1935`]: Wanneer er geen CMS-pagina's zijn en het menu leeg is,
   dan wordt de zijnavigatie nu onzichtbaar, zodat de rest van de inhoud niet meer te smal
   wordt weergegeven.
+* [:taiga-is:`3486`: :pr:`1946`]: Menu-items op pagina 'Mijn Zaken' worden niet langer
+  dubbel getoond in de sidebar en het dropdownmenu.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/templates/cms/menu/primary.html
+++ b/src/open_inwoner/templates/cms/menu/primary.html
@@ -1,7 +1,7 @@
 {% load menu_tags link_tags %}
 {% for child in children %}
     {% with url=child.attr.redirect_url|default:child.get_absolute_url %}
-        <li class="primary-navigation__list-item {% if request.resolver_match.url_name not in "pages-root,contactmoment_list,plan_list,uitkeringen,general_faq,category_list" %}primary-navigation__list-item--always-visible{% endif %}">
+        <li class="primary-navigation__list-item {% if request.resolver_match.url_name not in "pages-root,contactmoment_list,plan_list,uitkeringen,general_faq,category_list" and request.resolver_match.namespaces.0 != "cases" and request.resolver_match.url_name != "index" %}primary-navigation__list-item--always-visible{% endif %}">
             {% link text=child.get_menu_title href=url icon=child.common.menu_icon icon_outlined=True icon_position="before" %}
             {% if child.indicator %}
                 <span class="indicator"><a class="link secondary indicator__link" href="{{ url }}">{{ child.indicator }}</a></span>


### PR DESCRIPTION
## Summary

:bug: [#3486] fix duplicate shown menu items both in sidebar and top-right dropdown for mijn zaken.

## Issue References

https://taiga.maykinmedia.nl/project/open-inwoner/issue/3486

- Taiga Issue: #3486

## Checklist

- [x] CHANGELOG.rst updated @swrichards not sure where to put it since there was something said in which version this will be patched.
