### PR TITLE
Apply ruff tidy import

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -31,3 +31,6 @@ f851eac2759d7dd65687dce1869037296511140c
 
 # chore: apply pre-commit QA checks
 50e637f07d232890bb5b4039822ed63eb630693a
+
+# refactor: apply ruff TID252 prohibit relative import from parents
+d2e40fbe2f6d8887ae16ffd5be45d84fb7e0c368

--- a/ruff.toml
+++ b/ruff.toml
@@ -72,6 +72,8 @@ select = [
     "S",
     # https://docs.astral.sh/ruff/rules/#flake8-print-t20
     "T20",
+    # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
+    "TID",
 ]
 ignore = [
     # Whitespace before ':' (conflicts with Black)
@@ -146,6 +148,9 @@ section-order = [
     "local-folder",
 ]
 
+[lint.flake8-tidy-imports]
+# Disallow relative imports from parents, but allow from siblings
+ban-relative-imports = "parents"
 
 [format]
 line-ending = "lf"

--- a/src/notifications/api/serializers.py
+++ b/src/notifications/api/serializers.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
-from ..validators import UntilNowValidator
+from notifications.validators import UntilNowValidator
 
 
 class NotificatieSerializer(serializers.Serializer):

--- a/src/notifications/tests/test_webhook.py
+++ b/src/notifications/tests/test_webhook.py
@@ -8,8 +8,9 @@ from requests.exceptions import RequestException
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models.services import Service
 
-from ..admin import deregister_webhook, register_webhook
-from ..models import NotificationsAPIConfig, Subscription
+from notifications.admin import deregister_webhook, register_webhook
+from notifications.models import NotificationsAPIConfig, Subscription
+
 from .utils import make_request_with_middleware
 
 

--- a/src/open_inwoner/accounts/management/commands/delete_invitations.py
+++ b/src/open_inwoner/accounts/management/commands/delete_invitations.py
@@ -5,9 +5,8 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
+from open_inwoner.accounts.models import Invite
 from open_inwoner.utils.logentry import system_action
-
-from ...models import Invite
 
 
 class Command(BaseCommand):

--- a/src/open_inwoner/accounts/migrations/0043_change_digid_email.py
+++ b/src/open_inwoner/accounts/migrations/0043_change_digid_email.py
@@ -1,8 +1,7 @@
 from django.db import migrations
 
+from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.utils.hash import generate_email_from_string
-
-from ..choices import LoginTypeChoices
 
 
 def change_bsn_email_to_hash(apps, _):

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -25,6 +25,7 @@ from privates.storages import PrivateMediaFileSystemStorage
 from timeline_logger.models import TimelineLog
 
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.plans.models import PlanContact
 from open_inwoner.utils.hash import create_sha256_hash
 from open_inwoner.utils.validators import (
     CharFieldValidator,
@@ -33,7 +34,6 @@ from open_inwoner.utils.validators import (
     validate_vestiging,
 )
 
-from ..plans.models import PlanContact
 from .choices import (
     ContactTypeChoices,
     LoginTypeChoices,
@@ -607,12 +607,12 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.login_type == LoginTypeChoices.eherkenning
 
     def has_group_managed_categories(self) -> bool:
-        from ..pdc.models import Category
+        from open_inwoner.pdc.models import Category
 
         return Category.objects.filter(access_groups__user=self).exists()
 
     def get_group_managed_categories(self):
-        from ..pdc.models import Category
+        from open_inwoner.pdc.models import Category
 
         return Category.objects.filter(access_groups__user=self)
 

--- a/src/open_inwoner/accounts/tests/test_action_views.py
+++ b/src/open_inwoner/accounts/tests/test_action_views.py
@@ -11,13 +11,15 @@ from django_webtest import WebTest
 from playwright.sync_api import expect
 from privates.test import temp_private_root
 
+from open_inwoner.accounts.choices import StatusChoices
+from open_inwoner.accounts.models import Action
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.utils.tests.playwright import get_driver_name
+from open_inwoner.utils.tests.playwright import (
+    PlaywrightSyncLiveServerTestCase,
+    get_driver_name,
+)
 
-from ...utils.tests.playwright import PlaywrightSyncLiveServerTestCase
-from ..choices import StatusChoices
-from ..models import Action
 from .factories import ActionFactory, DigidUserFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_admin.py
+++ b/src/open_inwoner/accounts/tests/test_admin.py
@@ -5,10 +5,10 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 from webtest import Upload
 
+from open_inwoner.accounts.choices import ContactTypeChoices
+from open_inwoner.accounts.models import User
 from open_inwoner.utils.tests.helpers import create_image_bytes
 
-from ..choices import ContactTypeChoices
-from ..models import User
 from .factories import UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -14,9 +14,17 @@ from django_webtest import WebTest
 from furl import furl
 from pyquery import PyQuery
 
-from open_inwoner.accounts.choices import NotificationChannelChoice
+from open_inwoner.accounts.choices import LoginTypeChoices, NotificationChannelChoice
 from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.models import (
+    OpenIDDigiDConfig,
+    OpenIDEHerkenningConfig,
+    User,
+)
 from open_inwoner.accounts.signals import KvKClient, update_user_on_login
+from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.tests.mixins import HaalCentraalMixin
 from open_inwoner.kvk.tests.factories import CertificateFactory
@@ -27,15 +35,12 @@ from open_inwoner.openklant.tests.factories import (
     ESuiteConfigFactory,
     OpenKlant2ConfigFactory,
 )
-from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
+from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.tests.helpers import (
+    AssertRedirectsMixin,
+    AssertTimelineLogMixin,
+)
 
-from ...cms.collaborate.cms_apps import CollaborateApphook
-from ...cms.profile.cms_apps import ProfileApphook
-from ...cms.tests import cms_tools
-from ...utils.test import ClearCachesMixin
-from ...utils.tests.helpers import AssertRedirectsMixin
-from ..choices import LoginTypeChoices
-from ..models import OpenIDDigiDConfig, OpenIDEHerkenningConfig, User
 from .factories import (
     DigidUserFactory,
     InviteFactory,

--- a/src/open_inwoner/accounts/tests/test_auth_2fa_sms.py
+++ b/src/open_inwoner/accounts/tests/test_auth_2fa_sms.py
@@ -15,10 +15,10 @@ from freezegun import freeze_time
 from furl import furl
 from timeline_logger.models import TimelineLog
 
+from open_inwoner.accounts.gateways import GatewayError
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.logentry import LOG_ACTIONS
 
-from ..gateways import GatewayError
 from .factories import UserFactory
 
 signer = TimestampSigner()

--- a/src/open_inwoner/accounts/tests/test_commands.py
+++ b/src/open_inwoner/accounts/tests/test_commands.py
@@ -3,9 +3,9 @@ from django.test import TestCase
 
 from freezegun import freeze_time
 
+from open_inwoner.accounts.models import Invite
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
 
-from ..models import Invite
 from .factories import InviteFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -9,12 +9,12 @@ from django.utils.translation import gettext_lazy as _
 
 from django_webtest import WebTest
 
+from open_inwoner.accounts.choices import ContactTypeChoices
 from open_inwoner.accounts.models import User
+from open_inwoner.cms.inbox.cms_apps import InboxApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.utils.tests.helpers import create_image_bytes
 
-from ...cms.inbox.cms_apps import InboxApphook
-from ...cms.tests import cms_tools
-from ..choices import ContactTypeChoices
 from .factories import DigidUserFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_createinitialsuperuser.py
+++ b/src/open_inwoner/accounts/tests/test_createinitialsuperuser.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import exceptions, reverse
 
-from ..models import User
+from open_inwoner.accounts.models import User
 
 
 class CreateInitialSuperuserTests(TestCase):

--- a/src/open_inwoner/accounts/tests/test_forms.py
+++ b/src/open_inwoner/accounts/tests/test_forms.py
@@ -1,9 +1,8 @@
 from django.test import TestCase
 
+from open_inwoner.accounts.forms import CustomRegistrationForm, UserForm
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
-
-from ..forms import CustomRegistrationForm, UserForm
 
 
 class RegistrationFormTest(TestCase):

--- a/src/open_inwoner/accounts/tests/test_gateways.py
+++ b/src/open_inwoner/accounts/tests/test_gateways.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-from ..gateways import MessageBird
+from open_inwoner.accounts.gateways import MessageBird
 
 
 class MessageBirdSMSTestCase(TestCase):

--- a/src/open_inwoner/accounts/tests/test_inbox_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_page.py
@@ -9,11 +9,11 @@ from playwright.sync_api import expect
 from privates.test import temp_private_root
 from webtest import Upload
 
+from open_inwoner.accounts.models import Message
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.tests.helpers import create_image_bytes
 from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
-from ..models import Message
 from .factories import DigidUserFactory, MessageFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_inbox_start_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_start_page.py
@@ -7,10 +7,10 @@ from furl import furl
 from privates.test import temp_private_root
 from webtest import Upload
 
+from open_inwoner.accounts.models import Message
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.tests.helpers import create_image_bytes
 
-from ..models import Message
 from .factories import DocumentFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -15,14 +15,13 @@ from maykin_2fa.test import disable_admin_mfa
 from privates.test import temp_private_root
 from timeline_logger.models import TimelineLog
 
-from open_inwoner.accounts.models import Invite
+from open_inwoner.accounts.choices import LoginTypeChoices, StatusChoices
+from open_inwoner.accounts.forms import ActionForm
+from open_inwoner.accounts.models import Action, Invite, Message, User
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.pdc.tests.factories import CategoryFactory
 from open_inwoner.utils.logentry import LOG_ACTIONS
 
-from ..choices import LoginTypeChoices, StatusChoices
-from ..forms import ActionForm
-from ..models import Action, Message, User
 from .factories import (
     ActionFactory,
     DocumentFactory,

--- a/src/open_inwoner/accounts/tests/test_message_query.py
+++ b/src/open_inwoner/accounts/tests/test_message_query.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from ..models import Message
+from open_inwoner.accounts.models import Message
+
 from .factories import MessageFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
+++ b/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
@@ -5,10 +5,9 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from open_inwoner.accounts.choices import StatusChoices
+from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.accounts.tests.factories import ActionFactory, UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
-
-from ..tasks import schedule_user_notifications
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/accounts/tests/test_notify_expiring_plans.py
+++ b/src/open_inwoner/accounts/tests/test_notify_expiring_plans.py
@@ -5,12 +5,11 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.plans.models import Plan
 from open_inwoner.plans.tests.factories import PlanFactory
-
-from ..tasks import schedule_user_notifications
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/accounts/tests/test_notify_messages.py
+++ b/src/open_inwoner/accounts/tests/test_notify_messages.py
@@ -2,9 +2,9 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.configurations.models import SiteConfiguration
 
-from ..tasks import schedule_user_notifications
 from .factories import MessageFactory, UserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -18,18 +18,18 @@ from furl import furl
 from mozilla_django_oidc_db.models import OpenIDConnectConfig
 from pyquery import PyQuery
 
+from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
+from open_inwoner.accounts.models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
 from open_inwoner.accounts.views.auth_oidc import (
     GENERIC_DIGID_ERROR_MSG,
     GENERIC_EHERKENNING_ERROR_MSG,
 )
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.choices import OpenIDDisplayChoices
 from open_inwoner.configurations.models import SiteConfiguration
 
-from ...cms.profile.cms_apps import ProfileApphook
-from ...cms.tests import cms_tools
-from ..choices import LoginTypeChoices
-from ..models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
 from .factories import (
     DigidUserFactory,
     UserFactory,

--- a/src/open_inwoner/accounts/tests/test_previous_login.py
+++ b/src/open_inwoner/accounts/tests/test_previous_login.py
@@ -4,7 +4,7 @@ from django.test import Client, TestCase
 
 import pytz
 
-from ..models import User
+from open_inwoner.accounts.models import User
 
 
 class TestPrevLogin(TestCase):

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -15,33 +15,37 @@ from freezegun import freeze_time
 from pyquery import PyQuery
 from webtest import Upload
 
-from open_inwoner.accounts.choices import NotificationChannelChoice, StatusChoices
+from open_inwoner.accounts.choices import (
+    ContactTypeChoices,
+    LoginTypeChoices,
+    NotificationChannelChoice,
+    StatusChoices,
+)
+from open_inwoner.accounts.forms import BrpUserForm, UserForm
+from open_inwoner.accounts.models import User
+from open_inwoner.cms.cases.cms_apps import CasesApphook
+from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
+from open_inwoner.cms.inbox.cms_apps import InboxApphook
 from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.haalcentraal.api_models import BRPData
 from open_inwoner.haalcentraal.tests.mixins import HaalCentraalMixin
 from open_inwoner.laposta.models import LapostaConfig
 from open_inwoner.laposta.tests.factories import LapostaListFactory, MemberFactory
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import ESuiteKlantConfig
+from open_inwoner.openklant.tests.data import MockAPIReadPatchData
 from open_inwoner.pdc.tests.factories import CategoryFactory
 from open_inwoner.plans.tests.factories import PlanFactory
 from open_inwoner.qmatic.tests.data import QmaticMockData
+from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
 from open_inwoner.utils.forms import ErrorMessageMixin
 from open_inwoner.utils.logentry import LOG_ACTIONS
 from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, create_image_bytes
 
-from ...cms.cases.cms_apps import CasesApphook
-from ...cms.collaborate.cms_apps import CollaborateApphook
-from ...cms.inbox.cms_apps import InboxApphook
-from ...cms.profile.cms_apps import ProfileApphook
-from ...cms.tests import cms_tools
-from ...haalcentraal.api_models import BRPData
-from ...openklant.tests.data import MockAPIReadPatchData
-from ...questionnaire.tests.factories import QuestionnaireStepFactory
-from ..choices import ContactTypeChoices, LoginTypeChoices
-from ..forms import BrpUserForm, UserForm
-from ..models import User
 from .factories import (
     ActionFactory,
     DigidUserFactory,

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -3,10 +3,10 @@ from django.db import IntegrityError
 from django.test import TestCase
 
 from open_inwoner.accounts.choices import LoginTypeChoices
+from open_inwoner.accounts.models import User
+from open_inwoner.plans.tests.factories import PlanFactory
 from open_inwoner.utils.hash import generate_email_from_string
 
-from ...plans.tests.factories import PlanFactory
-from ..models import User
 from .factories import UserFactory, eHerkenningVestigingUserFactory
 
 

--- a/src/open_inwoner/accounts/tests/test_user_manager.py
+++ b/src/open_inwoner/accounts/tests/test_user_manager.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 
 from open_inwoner.accounts.choices import LoginTypeChoices
+from open_inwoner.accounts.models import User
 
-from ..models import User
 from .factories import UserFactory, eHerkenningUserFactory
 
 

--- a/src/open_inwoner/accounts/views/actions.py
+++ b/src/open_inwoner/accounts/views/actions.py
@@ -18,15 +18,14 @@ from cms.models import Page
 from privates.views import PrivateMediaView
 from view_breadcrumbs import BaseBreadcrumbMixin
 
+from open_inwoner.accounts.forms import ActionForm, ActionListForm
+from open_inwoner.accounts.models import Action
 from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
 from open_inwoner.components.utils import RenderableTag
 from open_inwoner.htmx.views import HtmxTemplateTagModelFormView
 from open_inwoner.utils.logentry import get_verbose_change_message
 from open_inwoner.utils.mixins import ExportMixin
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ..forms import ActionForm, ActionListForm
-from ..models import Action
 
 
 class ActionsEnabledMixin(AppConfigMixin):

--- a/src/open_inwoner/accounts/views/auth.py
+++ b/src/open_inwoner/accounts/views/auth.py
@@ -24,13 +24,12 @@ from eherkenning.mock import eherkenning_conf
 from eherkenning.mock.views.eherkenning import (
     eHerkenningAssertionConsumerServiceMockView,
 )
+from open_inwoner.accounts.choices import LoginTypeChoices
+from open_inwoner.accounts.forms import CustomPasswordResetForm
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.kvk.client import KvKClient
 from open_inwoner.kvk.exceptions import KVKAPIException
 from open_inwoner.utils.views import LogMixin
-
-from ..choices import LoginTypeChoices
-from ..forms import CustomPasswordResetForm
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/accounts/views/auth_oidc.py
+++ b/src/open_inwoner/accounts/views/auth_oidc.py
@@ -15,7 +15,8 @@ from digid_eherkenning.oidc.models import BaseConfig
 from digid_eherkenning.oidc.views import OIDCAuthenticationCallbackView
 from mozilla_django_oidc_db.views import _OIDC_ERROR_SESSION_KEY, OIDCInit
 
-from ..models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
+from open_inwoner.accounts.models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
+
 from .auth import BlockEenmanszaakLoginMixin
 
 logger = logging.getLogger(__name__)

--- a/src/open_inwoner/accounts/views/contacts.py
+++ b/src/open_inwoner/accounts/views/contacts.py
@@ -13,11 +13,10 @@ from django.views.generic.edit import FormView
 from mail_editor.helpers import find_template
 from view_breadcrumbs import BaseBreadcrumbMixin
 
+from open_inwoner.accounts.forms import ContactCreateForm, ContactFilterForm
+from open_inwoner.accounts.models import Invite, User
 from open_inwoner.cms.utils.page_display import inbox_page_is_published
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ..forms import ContactCreateForm, ContactFilterForm
-from ..models import Invite, User
 
 
 class ContactListView(

--- a/src/open_inwoner/accounts/views/documents.py
+++ b/src/open_inwoner/accounts/views/documents.py
@@ -3,9 +3,8 @@ from django.urls.base import reverse_lazy
 from django.utils.translation import gettext as _
 from django.views.generic import DeleteView
 
+from open_inwoner.accounts.models import Document
 from open_inwoner.utils.views import LogMixin
-
-from ..models import Document
 
 
 class DocumentDeleteView(LogMixin, LoginRequiredMixin, DeleteView):

--- a/src/open_inwoner/accounts/views/inbox.py
+++ b/src/open_inwoner/accounts/views/inbox.py
@@ -12,13 +12,12 @@ from django.views.generic import FormView
 
 from privates.views import PrivateMediaView
 
+from open_inwoner.accounts.forms import InboxForm
+from open_inwoner.accounts.models import Document, Message, User
+from open_inwoner.accounts.query import MessageQuerySet
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.mixins import PaginationMixin
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ..forms import InboxForm
-from ..models import Document, Message, User
-from ..query import MessageQuerySet
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/accounts/views/invite.py
+++ b/src/open_inwoner/accounts/views/invite.py
@@ -6,10 +6,9 @@ from django.views.generic import UpdateView
 
 from furl import furl
 
+from open_inwoner.accounts.forms import InviteForm
+from open_inwoner.accounts.models import Invite
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ..forms import InviteForm
-from ..models import Invite
 
 
 class InviteAcceptView(LogMixin, CommonPageMixin, UpdateView):

--- a/src/open_inwoner/accounts/views/login.py
+++ b/src/open_inwoner/accounts/views/login.py
@@ -17,13 +17,12 @@ from formtools.wizard.views import SessionWizardView
 from furl import furl
 from oath import totp
 
+from open_inwoner.accounts.forms import PhoneNumberForm, VerifyTokenForm
+from open_inwoner.accounts.gateways import GatewayError, gateway
+from open_inwoner.accounts.models import User
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.mixins import ThrottleMixin
 from open_inwoner.utils.views import LogMixin
-
-from ..forms import PhoneNumberForm, VerifyTokenForm
-from ..gateways import GatewayError, gateway
-from ..models import User
 
 signer = TimestampSigner()
 

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -20,6 +20,13 @@ from open_inwoner.accounts.choices import (
     LoginTypeChoices,
     StatusChoices,
 )
+from open_inwoner.accounts.forms import (
+    BrpUserForm,
+    CategoriesForm,
+    UserForm,
+    UserNotificationsForm,
+)
+from open_inwoner.accounts.models import Action, User
 from open_inwoner.cms.utils.page_display import (
     benefits_page_is_published,
     inbox_page_is_published,
@@ -37,9 +44,6 @@ from open_inwoner.qmatic.client import NoServiceConfigured, qmatic_client_factor
 from open_inwoner.questionnaire.models import QuestionnaireStep
 from open_inwoner.utils.logentry import system_action, system_error
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ..forms import BrpUserForm, CategoriesForm, UserForm, UserNotificationsForm
-from ..models import Action, User
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -13,18 +13,22 @@ from django.views.generic import TemplateView, UpdateView
 from django_registration.backends.one_step.views import RegistrationView
 from furl import furl
 
+from open_inwoner.accounts.forms import CustomRegistrationForm, NecessaryUserForm
+from open_inwoner.accounts.models import (
+    Invite,
+    OpenIDDigiDConfig,
+    OpenIDEHerkenningConfig,
+    User,
+)
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.mail.verification import send_user_email_verification_mail
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
 from open_inwoner.openklant.types import PartijUpdateData
 from open_inwoner.utils.text import html_tag_wrap_format
+from open_inwoner.utils.url import get_next_url_from
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
-
-from ...mail.verification import send_user_email_verification_mail
-from ...utils.url import get_next_url_from
-from ..forms import CustomRegistrationForm, NecessaryUserForm
-from ..models import Invite, OpenIDDigiDConfig, OpenIDEHerkenningConfig, User
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/cms/banner/tests/test_plugin_banner.py
+++ b/src/open_inwoner/cms/banner/tests/test_plugin_banner.py
@@ -2,11 +2,10 @@ import os
 
 from django.test import TestCase
 
+from open_inwoner.cms.banner.cms_plugins import BannerImagePlugin, BannerTextPlugin
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.utils.test import temp_media_root
 from open_inwoner.utils.tests.factories import FilerImageFactory
-
-from ..cms_plugins import BannerImagePlugin, BannerTextPlugin
 
 
 @temp_media_root()

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -31,6 +31,7 @@ from view_breadcrumbs import BaseBreadcrumbMixin
 from zgw_consumers.api_models.constants import RolOmschrijving
 
 from open_inwoner.accounts.models import User
+from open_inwoner.cms.cases.forms import CaseContactForm, CaseUploadForm
 from open_inwoner.mail.service import send_contact_confirmation_mail
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import (
@@ -64,7 +65,6 @@ from open_inwoner.utils.glom import glom_multiple
 from open_inwoner.utils.time import has_new_elements
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
 
-from ..forms import CaseContactForm, CaseUploadForm
 from .mixins import CaseAccessMixin, CaseLogMixin, OuterCaseAccessMixin
 
 logger = logging.getLogger(__name__)

--- a/src/open_inwoner/cms/collaborate/cms_plugins.py
+++ b/src/open_inwoner/cms/collaborate/cms_plugins.py
@@ -3,9 +3,8 @@ from django.utils.translation import gettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from open_inwoner.cms.utils.plugin_mixins import CMSActiveAppMixin
 from open_inwoner.plans.models import Plan
-
-from ..utils.plugin_mixins import CMSActiveAppMixin
 
 
 @plugin_pool.register_plugin

--- a/src/open_inwoner/cms/footer/migrations/0002_migrate_flatpages_content_to_cms.py
+++ b/src/open_inwoner/cms/footer/migrations/0002_migrate_flatpages_content_to_cms.py
@@ -5,7 +5,7 @@ from django.utils.text import slugify
 
 from cms.api import add_plugin, create_page
 
-from ..cms_plugins import CMSFlatPagePlugin
+from open_inwoner.cms.footer.cms_plugins import CMSFlatPagePlugin
 
 
 def create_cms_pages(apps, schema_editor):

--- a/src/open_inwoner/cms/plugins/cms_plugins/tasks.py
+++ b/src/open_inwoner/cms/plugins/cms_plugins/tasks.py
@@ -10,8 +10,13 @@ from cms.plugin_pool import plugin_pool
 from objectsapiclient.models import Configuration
 from pydantic import ValidationError
 
-from ..api_models import ExternFormulierTaak, KoppelingProduct, KoppelingZaak, UrlTaak
-from ..models import TasksConfig
+from open_inwoner.cms.plugins.api_models import (
+    ExternFormulierTaak,
+    KoppelingProduct,
+    KoppelingZaak,
+    UrlTaak,
+)
+from open_inwoner.cms.plugins.models import TasksConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/cms/plugins/tests/test_appointments.py
+++ b/src/open_inwoner/cms/plugins/tests/test_appointments.py
@@ -5,10 +5,9 @@ import requests_mock
 from freezegun import freeze_time
 from pyquery import PyQuery
 
+from open_inwoner.cms.plugins.cms_plugins import UserAppointmentsPlugin
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.qmatic.tests.data import QmaticMockData
-
-from ..cms_plugins import UserAppointmentsPlugin
 
 
 @requests_mock.Mocker()

--- a/src/open_inwoner/cms/plugins/tests/test_tasks.py
+++ b/src/open_inwoner/cms/plugins/tests/test_tasks.py
@@ -3,9 +3,9 @@ from django.test import TestCase, override_settings
 import requests_mock
 
 from open_inwoner.accounts.tests.factories import DigidUserFactory
+from open_inwoner.cms.plugins.cms_plugins import TasksPlugin
 from open_inwoner.cms.tests import cms_tools
 
-from ..cms_plugins import TasksPlugin
 from .mocks import (
     UUID_OBJECT_TYPE_DIENSVERLENING,
     UUID_OBJECT_TYPE_DIMPACT_1,

--- a/src/open_inwoner/cms/plugins/tests/test_userfeed.py
+++ b/src/open_inwoner/cms/plugins/tests/test_userfeed.py
@@ -5,10 +5,9 @@ from django.utils.translation import ngettext
 from pyquery import PyQuery
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.plugins.cms_plugins import UserFeedPlugin
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.userfeed.hooks.common import simple_message
-
-from ..cms_plugins import UserFeedPlugin
 
 
 class TestUserFeedPlugin(TestCase):

--- a/src/open_inwoner/cms/plugins/tests/test_videoplayer.py
+++ b/src/open_inwoner/cms/plugins/tests/test_videoplayer.py
@@ -1,9 +1,8 @@
 from django.test import TestCase
 
+from open_inwoner.cms.plugins.cms_plugins import VideoPlayerPlugin
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.media.tests.factories import VideoFactory
-
-from ..cms_plugins import VideoPlayerPlugin
 
 
 class TestVideoPlayerPlugin(TestCase):

--- a/src/open_inwoner/cms/products/cms_plugins.py
+++ b/src/open_inwoner/cms/products/cms_plugins.py
@@ -5,13 +5,12 @@ from cms.apphook_pool import apphook_pool
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from open_inwoner.cms.utils.plugin_mixins import CMSActiveAppMixin
 from open_inwoner.components.templatetags.side_navigation import react_sidenav_data
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.pdc.forms import ProductFinderForm
 from open_inwoner.pdc.models import Category, ProductCondition, ProductLocation
 from open_inwoner.questionnaire.models import QuestionnaireStep
-
-from ..utils.plugin_mixins import CMSActiveAppMixin
 
 
 def selected_categories_enabled() -> bool:

--- a/src/open_inwoner/cms/products/tests/test_plugin_categories.py
+++ b/src/open_inwoner/cms/products/tests/test_plugin_categories.py
@@ -18,7 +18,9 @@ from open_inwoner.accounts.tests.factories import (
     eHerkenningVestigingUserFactory,
 )
 from open_inwoner.cms.products.cms_apps import ProductsApphook
+from open_inwoner.cms.products.cms_plugins import CategoriesPlugin
 from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import (
@@ -33,9 +35,6 @@ from open_inwoner.openzaak.tests.shared import (
 )
 from open_inwoner.pdc.tests.factories import CategoryFactory
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
-
-from ...tests import cms_tools
-from ..cms_plugins import CategoriesPlugin
 
 TODAY = date.today()
 

--- a/src/open_inwoner/cms/products/tests/test_plugin_product_location.py
+++ b/src/open_inwoner/cms/products/tests/test_plugin_product_location.py
@@ -3,11 +3,10 @@ from django.urls import reverse
 
 from django_webtest import WebTest
 
+from open_inwoner.cms.products.cms_apps import ProductsApphook
+from open_inwoner.cms.products.cms_plugins import ProductLocationPlugin
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.pdc.tests.factories import ProductFactory, ProductLocationFactory
-
-from ...tests import cms_tools
-from ..cms_apps import ProductsApphook
-from ..cms_plugins import ProductLocationPlugin
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/components/tests/test_messages.py
+++ b/src/open_inwoner/components/tests/test_messages.py
@@ -4,9 +4,10 @@ from django.utils import timezone
 
 from freezegun import freeze_time
 
-from ...accounts.forms import InboxForm
-from ...accounts.models import Message
-from ...accounts.tests.factories import MessageFactory, UserFactory
+from open_inwoner.accounts.forms import InboxForm
+from open_inwoner.accounts.models import Message
+from open_inwoner.accounts.tests.factories import MessageFactory, UserFactory
+
 from .abstract import InclusionTagWebTest
 
 

--- a/src/open_inwoner/conf/app/csp.py
+++ b/src/open_inwoner/conf/app/csp.py
@@ -1,6 +1,6 @@
 from django.urls import reverse_lazy
 
-from ..utils import config
+from open_inwoner.conf.utils import config
 
 # The Open Forms SDK files might differ from the API domain.
 OPEN_FORMS_API_DOMAIN = config("OPEN_FORMS_DOMAIN", "")

--- a/src/open_inwoner/conf/app/setup_configuration.py
+++ b/src/open_inwoner/conf/app/setup_configuration.py
@@ -1,4 +1,4 @@
-from ..utils import config
+from open_inwoner.conf.utils import config
 
 SETUP_CONFIGURATION_STEPS = [
     "mozilla_django_oidc_db.setup_configuration.steps.AdminOIDCConfigurationStep",

--- a/src/open_inwoner/configurations/admin.py
+++ b/src/open_inwoner/configurations/admin.py
@@ -19,12 +19,12 @@ from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInli
 from solo.admin import SingletonModelAdmin
 
 from open_inwoner.ckeditor5.widgets import CKEditorWidget
+from open_inwoner.utils.colors import ACCESSIBLE_CONTRAST_RATIO, get_contrast_ratio
+from open_inwoner.utils.css import ALLOWED_PROPERTIES
+from open_inwoner.utils.fields import CSSEditorWidget
+from open_inwoner.utils.iteration import split
 from open_inwoner.utils.logentry import user_action
 
-from ..utils.colors import ACCESSIBLE_CONTRAST_RATIO, get_contrast_ratio
-from ..utils.css import ALLOWED_PROPERTIES
-from ..utils.fields import CSSEditorWidget
-from ..utils.iteration import split
 from .models import CustomFontSet, SiteConfiguration, SiteConfigurationPage
 
 logger = logging.getLogger(__name__)

--- a/src/open_inwoner/configurations/models.py
+++ b/src/open_inwoner/configurations/models.py
@@ -15,11 +15,15 @@ from filer.fields.image import FilerImageField
 from ordered_model.models import OrderedModel, OrderedModelManager
 from solo.models import SingletonModel
 
-from ..utils.colors import hex_to_hsl
-from ..utils.css import clean_stylesheet
-from ..utils.fields import CSSField
-from ..utils.files import OverwriteStorage
-from ..utils.validators import DutchPhoneNumberValidator, FilerExactImageSizeValidator
+from open_inwoner.utils.colors import hex_to_hsl
+from open_inwoner.utils.css import clean_stylesheet
+from open_inwoner.utils.fields import CSSField
+from open_inwoner.utils.files import OverwriteStorage
+from open_inwoner.utils.validators import (
+    DutchPhoneNumberValidator,
+    FilerExactImageSizeValidator,
+)
+
 from .choices import ColorTypeChoices, CustomFontName, OpenIDDisplayChoices
 from .validators import validate_javascript_file, validate_oidc_config
 

--- a/src/open_inwoner/configurations/tests/bootstrap/_test_setup_auth_config.py
+++ b/src/open_inwoner/configurations/tests/bootstrap/_test_setup_auth_config.py
@@ -24,15 +24,14 @@ from privates.test import temp_private_root
 from simple_certmanager.constants import CertificateTypes
 
 from open_inwoner.accounts.models import OpenIDDigiDConfig, OpenIDEHerkenningConfig
-from open_inwoner.utils.test import ClearCachesMixin
-
-from ...bootstrap.auth import (
+from open_inwoner.configurations.bootstrap.auth import (
     AdminOIDCConfigurationStep,
     DigiDOIDCConfigurationStep,
     DigiDSAMLConfigurationStep,
     eHerkenningOIDCConfigurationStep,
     eHerkenningSAMLConfigurationStep,
 )
+from open_inwoner.utils.test import ClearCachesMixin
 
 IDENTITY_PROVIDER = "https://keycloak.local/realms/digid/"
 CONTACTMOMENTEN_API_ROOT = "https://openklant.local/contactmomenten/api/v1/"

--- a/src/open_inwoner/configurations/tests/bootstrap/_test_setup_cms.py
+++ b/src/open_inwoner/configurations/tests/bootstrap/_test_setup_cms.py
@@ -11,8 +11,7 @@ from open_inwoner.cms.utils.page_display import (
     products_page_is_published,
     profile_page_is_published,
 )
-
-from ...bootstrap.cms import (
+from open_inwoner.configurations.bootstrap.cms import (
     CMSBenefitsConfigurationStep,
     CMSCasesConfigurationStep,
     CMSCollaborateConfigurationStep,

--- a/src/open_inwoner/configurations/tests/bootstrap/_test_setup_site_config.py
+++ b/src/open_inwoner/configurations/tests/bootstrap/_test_setup_site_config.py
@@ -2,10 +2,9 @@ from django.test import TestCase, override_settings
 
 from django_setup_configuration.exceptions import ConfigurationRunFailed
 
+from open_inwoner.configurations.bootstrap.siteconfig import SiteConfigurationStep
 from open_inwoner.configurations.choices import ColorTypeChoices, OpenIDDisplayChoices
 from open_inwoner.configurations.models import SiteConfiguration
-
-from ...bootstrap.siteconfig import SiteConfigurationStep
 
 
 @override_settings(

--- a/src/open_inwoner/configurations/tests/bootstrap/test_setup_openklant_config.py
+++ b/src/open_inwoner/configurations/tests/bootstrap/test_setup_openklant_config.py
@@ -7,6 +7,11 @@ from django_setup_configuration.exceptions import ConfigurationRunFailed
 from django_setup_configuration.test_utils import execute_single_step
 from zgw_consumers.constants import APITypes
 
+from open_inwoner.configurations.bootstrap.openklant import (
+    ESuiteKlantConfigurationStep,
+    KlantenSysteemConfigurationStep,
+    OpenKlant2ConfigurationStep,
+)
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import (
     ESuiteKlantConfig,
@@ -14,12 +19,6 @@ from open_inwoner.openklant.models import (
     OpenKlant2Config,
 )
 from open_inwoner.openzaak.tests.factories import ServiceFactory
-
-from ...bootstrap.openklant import (
-    ESuiteKlantConfigurationStep,
-    KlantenSysteemConfigurationStep,
-    OpenKlant2ConfigurationStep,
-)
 
 KLANTEN_SERVICE_API_ROOT = "https://openklant.local/klanten/api/v1/"
 CONTACTMOMENTEN_SERVICE_API_ROOT = "https://openklant.local/contactmomenten/api/v1/"

--- a/src/open_inwoner/configurations/tests/factories.py
+++ b/src/open_inwoner/configurations/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from ..models import SiteConfiguration
+from open_inwoner.configurations.models import SiteConfiguration
 
 
 class SiteConfigurationFactory(factory.django.DjangoModelFactory):

--- a/src/open_inwoner/configurations/tests/test_admin.py
+++ b/src/open_inwoner/configurations/tests/test_admin.py
@@ -16,13 +16,12 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from open_inwoner.accounts.tests.factories import UserFactory
-
-from ..admin import (
+from open_inwoner.configurations.admin import (
     SiteConfigurationAdmin,
     SiteConfigurationAdminForm,
 )
-from ..models import SiteConfiguration
-from ..validators import validate_javascript_file
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.configurations.validators import validate_javascript_file
 
 
 @disable_admin_mfa()

--- a/src/open_inwoner/configurations/tests/test_analytics.py
+++ b/src/open_inwoner/configurations/tests/test_analytics.py
@@ -4,11 +4,10 @@ from django.utils.translation import gettext as _
 
 from playwright.sync_api import expect
 
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.test import ClearCachesMixin
-
-from ...cms.tests import cms_tools
-from ...utils.tests.playwright import PlaywrightSyncLiveServerTestCase
-from ..models import SiteConfiguration
+from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
 
 class TestRenderedAnalytics(TestCase):

--- a/src/open_inwoner/configurations/tests/test_emails.py
+++ b/src/open_inwoner/configurations/tests/test_emails.py
@@ -7,10 +7,9 @@ from django.test import TestCase, override_settings
 from django_yubin.models import Message
 from freezegun import freeze_time
 
+from open_inwoner.configurations.emails import inform_admins_about_failing_emails
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.configurations.tasks import send_failed_mail_digest
-
-from ..emails import inform_admins_about_failing_emails
-from ..models import SiteConfiguration
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/src/open_inwoner/configurations/tests/test_extra_css.py
+++ b/src/open_inwoner/configurations/tests/test_extra_css.py
@@ -5,9 +5,9 @@ from django.utils.html import escape
 
 from django_webtest import WebTest
 
-from ...cms.tests import cms_tools
-from ...utils.test import ClearCachesMixin, temp_media_root
-from ..models import SiteConfiguration
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.utils.test import ClearCachesMixin, temp_media_root
 
 
 @temp_media_root()

--- a/src/open_inwoner/configurations/tests/test_help_modal.py
+++ b/src/open_inwoner/configurations/tests/test_help_modal.py
@@ -5,10 +5,10 @@ from django.utils.translation import gettext_lazy as _
 from django_webtest import WebTest
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.pdc.tests.factories import ProductFactory
 
-from ...cms.tests import cms_tools
-from ..models import SiteConfiguration
 from .factories import SiteConfigurationFactory
 
 

--- a/src/open_inwoner/configurations/tests/test_oidc.py
+++ b/src/open_inwoner/configurations/tests/test_oidc.py
@@ -6,10 +6,9 @@ from maykin_2fa.test import disable_admin_mfa
 from mozilla_django_oidc_db.models import OpenIDConnectConfig
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.configurations.choices import OpenIDDisplayChoices
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.utils.test import ClearCachesMixin
-
-from ..choices import OpenIDDisplayChoices
 
 
 @disable_admin_mfa()

--- a/src/open_inwoner/configurations/tests/test_redirect_to.py
+++ b/src/open_inwoner/configurations/tests/test_redirect_to.py
@@ -3,8 +3,7 @@ from django.urls import reverse
 from django_webtest import WebTest
 
 from open_inwoner.accounts.tests.factories import UserFactory
-
-from ..models import SiteConfiguration
+from open_inwoner.configurations.models import SiteConfiguration
 
 
 class TestRedirectTo(WebTest):

--- a/src/open_inwoner/configurations/tests/test_social.py
+++ b/src/open_inwoner/configurations/tests/test_social.py
@@ -3,8 +3,8 @@ from django.urls import reverse
 
 from pyquery import PyQuery
 
-from ...pdc.tests.factories import ProductFactory
-from ..models import SiteConfiguration
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.pdc.tests.factories import ProductFactory
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/configurations/tests/test_upload.py
+++ b/src/open_inwoner/configurations/tests/test_upload.py
@@ -5,9 +5,8 @@ from maykin_2fa.test import disable_admin_mfa
 from webtest import Upload
 
 from open_inwoner.accounts.tests.factories import UserFactory
-
-from ...utils.test import ClearCachesMixin
-from ..models import CustomFontSet, SiteConfiguration
+from open_inwoner.configurations.models import CustomFontSet, SiteConfiguration
+from open_inwoner.utils.test import ClearCachesMixin
 
 
 @disable_admin_mfa()

--- a/src/open_inwoner/core/tests/test_views.py
+++ b/src/open_inwoner/core/tests/test_views.py
@@ -6,9 +6,8 @@ from open_inwoner.accounts.tests.factories import (
     DigidUserFactory,
     eHerkenningUserFactory,
 )
+from open_inwoner.core.views import _get_category_data_for_user
 from open_inwoner.pdc.tests.factories import CategoryFactory, ProductFactory
-
-from ..views import _get_category_data_for_user
 
 
 class SitemapCategoryDataTest(TestCase):

--- a/src/open_inwoner/haalcentraal/tests/mixins.py
+++ b/src/open_inwoner/haalcentraal/tests/mixins.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from ..models import HaalCentraalConfig
+from open_inwoner.haalcentraal.models import HaalCentraalConfig
+
 from .factories import ServiceFactory
 
 

--- a/src/open_inwoner/haalcentraal/tests/test_client.py
+++ b/src/open_inwoner/haalcentraal/tests/test_client.py
@@ -4,8 +4,9 @@ from django.test import TestCase
 
 import requests_mock
 
-from ..api import BRP_2_1
-from ..models import HaalCentraalConfig
+from open_inwoner.haalcentraal.api import BRP_2_1
+from open_inwoner.haalcentraal.models import HaalCentraalConfig
+
 from .mixins import HaalCentraalMixin
 
 

--- a/src/open_inwoner/haalcentraal/tests/test_signal.py
+++ b/src/open_inwoner/haalcentraal/tests/test_signal.py
@@ -9,10 +9,10 @@ from timeline_logger.models import TimelineLog
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.haalcentraal.models import HaalCentraalConfig
+from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
 
-from ...utils.test import ClearCachesMixin
-from ..models import HaalCentraalConfig
 from .factories import ServiceFactory
 from .mixins import HaalCentraalMixin
 

--- a/src/open_inwoner/kvk/tests/test_api.py
+++ b/src/open_inwoner/kvk/tests/test_api.py
@@ -6,9 +6,10 @@ import requests
 import requests_mock
 from requests.exceptions import InvalidJSONError, SSLError
 
-from ..client import KvKClient
-from ..exceptions import KVKAPIException
-from ..models import KvKConfig
+from open_inwoner.kvk.client import KvKClient
+from open_inwoner.kvk.exceptions import KVKAPIException
+from open_inwoner.kvk.models import KvKConfig
+
 from . import mocks
 from .factories import CLIENT_CERT, CLIENT_CERT_PAIR, SERVER_CERT
 

--- a/src/open_inwoner/kvk/tests/test_validators.py
+++ b/src/open_inwoner/kvk/tests/test_validators.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
-from ..validators import validate_api_root
+from open_inwoner.kvk.validators import validate_api_root
 
 
 class KvKAPIRootValidationTest(TestCase):

--- a/src/open_inwoner/kvk/views.py
+++ b/src/open_inwoner/kvk/views.py
@@ -11,9 +11,9 @@ from furl import furl
 
 from open_inwoner.accounts.eherkenning_session import EHerkenningSessionContext
 from open_inwoner.accounts.models import User
+from open_inwoner.utils.url import get_next_url_from
 from open_inwoner.utils.views import LogMixin
 
-from ..utils.url import get_next_url_from
 from .client import KvKClient
 from .exceptions import KVKAPIException
 from .forms import CompanyBranchChoiceForm

--- a/src/open_inwoner/laposta/client.py
+++ b/src/open_inwoner/laposta/client.py
@@ -8,8 +8,8 @@ from ape_pie.client import APIClient
 from requests.exceptions import RequestException
 
 from open_inwoner.utils.api import ClientError, get_json_response
+from open_inwoner.utils.decorators import cache as cache_result
 
-from ..utils.decorators import cache as cache_result
 from .api_models import LapostaList, Member, UserData
 from .models import LapostaConfig
 

--- a/src/open_inwoner/laposta/forms.py
+++ b/src/open_inwoner/laposta/forms.py
@@ -8,11 +8,11 @@ from django.utils.translation import gettext_lazy as _
 from ipware import get_client_ip
 from requests.exceptions import RequestException
 
+from open_inwoner.accounts.models import User
 from open_inwoner.laposta.api_models import UserData
 from open_inwoner.laposta.models import LapostaConfig
 from open_inwoner.utils.api import ClientError
 
-from ..accounts.models import User
 from .choices import get_list_choices, get_list_remarks_mapping
 from .client import create_laposta_client
 

--- a/src/open_inwoner/laposta/tests/factories.py
+++ b/src/open_inwoner/laposta/tests/factories.py
@@ -1,6 +1,6 @@
 from polyfactory.factories.pydantic_factory import ModelFactory
 
-from ..api_models import LapostaList, Member
+from open_inwoner.laposta.api_models import LapostaList, Member
 
 
 class LapostaListFactory(ModelFactory[LapostaList]):

--- a/src/open_inwoner/laposta/tests/test_forms.py
+++ b/src/open_inwoner/laposta/tests/test_forms.py
@@ -8,10 +8,10 @@ import requests_mock
 
 from open_inwoner.accounts.tests.factories import DigidUserFactory
 from open_inwoner.cms.tests.cms_tools import get_request
+from open_inwoner.laposta.forms import NewsletterSubscriptionForm
+from open_inwoner.laposta.models import LapostaConfig
 from open_inwoner.utils.test import ClearCachesMixin
 
-from ..forms import NewsletterSubscriptionForm
-from ..models import LapostaConfig
 from .factories import LapostaListFactory, MemberFactory
 
 LAPOSTA_API_ROOT = "https://laposta.local/api/v2/"

--- a/src/open_inwoner/mail/admin.py
+++ b/src/open_inwoner/mail/admin.py
@@ -6,7 +6,7 @@ from django_yubin.admin import (
 )
 from django_yubin.models import Log as YubinLog, Message as YubinMessage
 
-from ..utils.admin import ReadOnlyAdminMixin
+from open_inwoner.utils.admin import ReadOnlyAdminMixin
 
 
 class LogReadOnlyAdmin(ReadOnlyAdminMixin, YubinLogAdmin):

--- a/src/open_inwoner/mail/views.py
+++ b/src/open_inwoner/mail/views.py
@@ -6,8 +6,9 @@ from django.shortcuts import redirect, reverse
 from django.utils.translation import gettext as _
 from django.views import View
 
-from ..utils.url import get_next_url_from
-from ..utils.views import LogMixin
+from open_inwoner.utils.url import get_next_url_from
+from open_inwoner.utils.views import LogMixin
+
 from .verification import VERIFY_GET_PARAM, validate_email_verification_token
 
 

--- a/src/open_inwoner/openklant/tests/mocks.py
+++ b/src/open_inwoner/openklant/tests/mocks.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
 
-from ..constants import KlantenServiceType
-from ..services import OpenKlant2Question
+from open_inwoner.openklant.constants import KlantenServiceType
+from open_inwoner.openklant.services import OpenKlant2Question
 
 
 class MockOpenKlant2Service:

--- a/src/open_inwoner/openklant/tests/test_contactform.py
+++ b/src/open_inwoner/openklant/tests/test_contactform.py
@@ -11,6 +11,7 @@ from django_webtest import WebTest
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.cms.tests.cms_tools import create_apphook_page
 from open_inwoner.openklant.api_models import KlantContactRol
+from open_inwoner.openklant.cms_apps import OpenklantApphook
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import (
     ESuiteKlantConfig,
@@ -24,8 +25,6 @@ from open_inwoner.openklant.tests.factories import (
 from open_inwoner.openklant.views.contactform import ContactFormView
 from open_inwoner.utils.test import ClearCachesMixin, DisableRequestLogMixin
 from open_inwoner.utils.tests.helpers import AssertFormMixin, AssertTimelineLogMixin
-
-from ..cms_apps import OpenklantApphook
 
 
 @requests_mock.Mocker()

--- a/src/open_inwoner/openklant/tests/test_fetch.py
+++ b/src/open_inwoner/openklant/tests/test_fetch.py
@@ -8,6 +8,7 @@ from open_inwoner.accounts.tests.factories import (
     eHerkenningVestigingUserFactory,
 )
 from open_inwoner.openklant.api_models import KlantContactMoment
+from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
 from open_inwoner.openklant.tests.data import MockAPIReadData
 from open_inwoner.openklant.wrap import (
     fetch_klantcontactmoment,
@@ -15,7 +16,6 @@ from open_inwoner.openklant.wrap import (
 )
 from open_inwoner.utils.test import ClearCachesMixin, DisableRequestLogMixin
 
-from ..services import OpenKlant2Service, eSuiteKlantenService
 from .factories import ESuiteConfigFactory, OpenKlant2ConfigFactory
 
 

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -24,8 +24,8 @@ from zgw_consumers.service import pagination_helper
 from open_inwoner.openzaak.api_models import InformatieObject
 from open_inwoner.openzaak.exceptions import MultiZgwClientProxyError
 from open_inwoner.utils.api import ClientError, get_json_response
+from open_inwoner.utils.decorators import cache as cache_result
 
-from ..utils.decorators import cache as cache_result
 from .api_models import (
     InformatieObjectType,
     OpenSubmission,

--- a/src/open_inwoner/openzaak/documents.py
+++ b/src/open_inwoner/openzaak/documents.py
@@ -4,8 +4,7 @@ from django.conf import settings
 
 from open_inwoner.openzaak.api_models import InformatieObject
 from open_inwoner.openzaak.clients import DocumentenClient
-
-from ..utils.decorators import cache as cache_result
+from open_inwoner.utils.decorators import cache as cache_result
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/openzaak/tests/test_admin.py
+++ b/src/open_inwoner/openzaak/tests/test_admin.py
@@ -16,8 +16,8 @@ from pyquery import PyQuery
 from webtest import Upload
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.openzaak.api_models import ResultaatType
 
-from ..api_models import ResultaatType
 from .factories import (
     CatalogusConfigFactory,
     ServiceFactory,

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -44,7 +44,9 @@ from open_inwoner.openklant.models import (
 from open_inwoner.openklant.services import eSuiteVragenService
 from open_inwoner.openklant.tests.factories import make_question_from_contactmoment
 from open_inwoner.openklant.tests.mocks import MockOpenKlant2Service
+from open_inwoner.openzaak.api_models import Status, StatusType
 from open_inwoner.openzaak.constants import StatusIndicators
+from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import (
     ZaakTypeConfigFactory,
     ZaakTypeInformatieObjectTypeConfigFactory,
@@ -52,13 +54,11 @@ from open_inwoner.openzaak.tests.factories import (
     ZaakTypeStatusTypeConfigFactory,
 )
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response, uuid_from_url
+from open_inwoner.utils.tests.helpers import AssertRedirectsMixin
 from openklant2.types.resources.klant_contact import KlantContactValidator
 from openklant2.types.resources.onderwerp_object import OnderwerpObjectValidator
 from openklant2.types.resources.partij import PartijValidator
 
-from ...utils.tests.helpers import AssertRedirectsMixin
-from ..api_models import Status, StatusType
-from ..models import OpenZaakConfig
 from .factories import CatalogusConfigFactory, ServiceFactory, ZGWApiGroupConfigFactory
 from .helpers import generate_oas_component_cached
 from .shared import (

--- a/src/open_inwoner/openzaak/tests/test_case_request.py
+++ b/src/open_inwoner/openzaak/tests/test_case_request.py
@@ -3,9 +3,9 @@ from django.test import TestCase
 import requests_mock
 
 from open_inwoner.openzaak.clients import build_zaken_clients
+from open_inwoner.openzaak.models import OpenZaakConfig
+from open_inwoner.utils.test import ClearCachesMixin
 
-from ...utils.test import ClearCachesMixin
-from ..models import OpenZaakConfig
 from .factories import ZGWApiGroupConfigFactory
 from .helpers import generate_oas_component_cached
 from .shared import ZAKEN_ROOT

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -26,13 +26,16 @@ from open_inwoner.accounts.tests.factories import (
     eHerkenningVestigingUserFactory,
 )
 from open_inwoner.cms.cases.views.cases import CaseFilterFormOption, InnerCaseListView
+from open_inwoner.openzaak.api_models import Zaak
+from open_inwoner.openzaak.constants import StatusIndicators, ZaakBetrokkeneRol
+from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
-from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
+from open_inwoner.utils.tests.helpers import (
+    AssertRedirectsMixin,
+    AssertTimelineLogMixin,
+    Lookups,
+)
 
-from ...utils.tests.helpers import AssertRedirectsMixin
-from ..api_models import Zaak
-from ..constants import StatusIndicators, ZaakBetrokkeneRol
-from ..models import OpenZaakConfig
 from .factories import (
     CatalogusConfigFactory,
     ZaakTypeConfigFactory,

--- a/src/open_inwoner/openzaak/tests/test_cases_cache.py
+++ b/src/open_inwoner/openzaak/tests/test_cases_cache.py
@@ -12,9 +12,9 @@ from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
-from ..models import OpenZaakConfig
 from .factories import ZGWApiGroupConfigFactory
 from .helpers import generate_oas_component_cached
 from .shared import CATALOGI_ROOT, ZAKEN_ROOT

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -22,9 +22,9 @@ from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.cms.cases.views.status import SimpleFile
 from open_inwoner.openzaak.clients import build_documenten_clients, build_zaken_clients
+from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
-from ..models import OpenZaakConfig
 from .factories import (
     CertificateFactory,
     ZaakTypeConfigFactory,

--- a/src/open_inwoner/openzaak/tests/test_import_export.py
+++ b/src/open_inwoner/openzaak/tests/test_import_export.py
@@ -5,7 +5,11 @@ import uuid
 from django.core.files.storage.memory import InMemoryStorage
 from django.test import TestCase
 
-from open_inwoner.openzaak.import_export import ZGWConfigExport, ZGWConfigImport
+from open_inwoner.openzaak.import_export import (
+    ZGWConfigExport,
+    ZGWConfigImport,
+    ZGWImportError,
+)
 from open_inwoner.openzaak.models import (
     CatalogusConfig,
     ZaakTypeConfig,
@@ -14,7 +18,6 @@ from open_inwoner.openzaak.models import (
     ZaakTypeStatusTypeConfig,
 )
 
-from ..import_export import ZGWImportError
 from .factories import (
     CatalogusConfigFactory,
     ServiceFactory,

--- a/src/open_inwoner/openzaak/tests/test_notification_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_utils.py
@@ -10,6 +10,7 @@ from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
 
 from open_inwoner.accounts.tests.factories import DigidUserFactory, UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.openzaak.api_models import Status, StatusType, Zaak, ZaakType
 from open_inwoner.openzaak.notifications import (
     _get_initiator_users_from_roles,
     _get_np_initiator_bsns_from_roles,
@@ -18,7 +19,6 @@ from open_inwoner.openzaak.notifications import (
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory, generate_rol
 from open_inwoner.openzaak.tests.shared import ZAKEN_ROOT
 
-from ..api_models import Status, StatusType, Zaak, ZaakType
 from .test_notification_data import MockAPIData
 
 

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
@@ -9,6 +9,13 @@ from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.openzaak.api_models import (
+    InformatieObject,
+    Zaak,
+    ZaakInformatieObject,
+    ZaakType,
+)
+from open_inwoner.openzaak.models import OpenZaakConfig, UserCaseInfoObjectNotification
 from open_inwoner.openzaak.notifications import (
     _handle_zaakinformatieobject_update,
     handle_zaken_notification,
@@ -20,8 +27,6 @@ from open_inwoner.openzaak.tests.factories import (
 from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
 
-from ..api_models import InformatieObject, Zaak, ZaakInformatieObject, ZaakType
-from ..models import OpenZaakConfig, UserCaseInfoObjectNotification
 from .helpers import copy_with_new_uuid
 from .test_notification_data import MockAPIData, MockAPIDataAlt
 

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
@@ -11,6 +11,8 @@ from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.api.views import ZakenNotificationsWebhookView
+from open_inwoner.openzaak.api_models import Status, StatusType, Zaak, ZaakType
+from open_inwoner.openzaak.models import OpenZaakConfig, UserCaseStatusNotification
 from open_inwoner.openzaak.notifications import (
     _handle_status_update,
     handle_zaken_notification,
@@ -18,8 +20,6 @@ from open_inwoner.openzaak.notifications import (
 from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
 
-from ..api_models import Status, StatusType, Zaak, ZaakType
-from ..models import OpenZaakConfig, UserCaseStatusNotification
 from .factories import (
     NotificationFactory,
     ZaakTypeConfigFactory,

--- a/src/open_inwoner/openzaak/tests/test_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_utils.py
@@ -12,8 +12,8 @@ from open_inwoner.openzaak.utils import (
     is_info_object_visible,
     is_zaak_visible,
 )
+from open_inwoner.utils.test import ClearCachesMixin
 
-from ...utils.test import ClearCachesMixin
 from .helpers import copy_with_new_uuid
 from .shared import CATALOGI_ROOT, ZAKEN_ROOT
 

--- a/src/open_inwoner/pdc/admin/category.py
+++ b/src/open_inwoner/pdc/admin/category.py
@@ -14,10 +14,10 @@ from treebeard.forms import movenodeform_factory
 
 from open_inwoner.ckeditor5.widgets import CKEditorWidget
 from open_inwoner.openzaak.models import OpenZaakConfig, ZaakTypeConfig
+from open_inwoner.pdc.models import Category, CategoryProduct
+from open_inwoner.pdc.resources import CategoryExportResource, CategoryImportResource
 from open_inwoner.utils.logentry import system_action
 
-from ..models import Category, CategoryProduct
-from ..resources import CategoryExportResource, CategoryImportResource
 from .faq import QuestionInline
 
 

--- a/src/open_inwoner/pdc/admin/faq.py
+++ b/src/open_inwoner/pdc/admin/faq.py
@@ -4,8 +4,7 @@ from django.contrib import admin
 from ordered_model.admin import OrderedModelAdmin
 
 from open_inwoner.ckeditor5.widgets import CKEditorWidget
-
-from ..models import Question
+from open_inwoner.pdc.models import Question
 
 
 class QuestionAdminForm(forms.ModelForm):

--- a/src/open_inwoner/pdc/admin/mixins.py
+++ b/src/open_inwoner/pdc/admin/mixins.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from ..widgets import MapWidget
+from open_inwoner.pdc.widgets import MapWidget
 
 
 class GeoAdminForm(forms.ModelForm):

--- a/src/open_inwoner/pdc/admin/neighbourhood.py
+++ b/src/open_inwoner/pdc/admin/neighbourhood.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from ..models import Neighbourhood
+from open_inwoner.pdc.models import Neighbourhood
 
 
 @admin.register(Neighbourhood)

--- a/src/open_inwoner/pdc/admin/organization.py
+++ b/src/open_inwoner/pdc/admin/organization.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
-from ..models import Organization, OrganizationType
+from open_inwoner.pdc.models import Organization, OrganizationType
+
 from .mixins import GeoAdminMixin
 
 

--- a/src/open_inwoner/pdc/admin/product.py
+++ b/src/open_inwoner/pdc/admin/product.py
@@ -8,10 +8,7 @@ from import_export.formats import base_formats
 from ordered_model.admin import OrderedModelAdmin
 
 from open_inwoner.ckeditor5.widgets import CKEditorWidget
-from open_inwoner.utils.logentry import system_action
-from open_inwoner.utils.mixins import UUIDAdminFirstInOrder
-
-from ..models import (
+from open_inwoner.pdc.models import (
     Category,
     Product,
     ProductCondition,
@@ -20,7 +17,10 @@ from ..models import (
     ProductLink,
     ProductLocation,
 )
-from ..resources import ProductExportResource, ProductImportResource
+from open_inwoner.pdc.resources import ProductExportResource, ProductImportResource
+from open_inwoner.utils.logentry import system_action
+from open_inwoner.utils.mixins import UUIDAdminFirstInOrder
+
 from . import QuestionInline
 from .mixins import GeoAdminMixin
 

--- a/src/open_inwoner/pdc/admin/tag.py
+++ b/src/open_inwoner/pdc/admin/tag.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from ..models import Tag, TagType
+from open_inwoner.pdc.models import Tag, TagType
 
 
 @admin.register(Tag)

--- a/src/open_inwoner/pdc/models/category.py
+++ b/src/open_inwoner/pdc/models/category.py
@@ -7,7 +7,7 @@ from filer.fields.image import FilerImageField
 from treebeard.exceptions import InvalidMoveToDescendant
 from treebeard.mp_tree import MP_MoveHandler, MP_Node
 
-from ..managers import CategoryPublishedQueryset
+from open_inwoner.pdc.managers import CategoryPublishedQueryset
 
 
 class PublishedMoveHandler(MP_MoveHandler):

--- a/src/open_inwoner/pdc/models/product.py
+++ b/src/open_inwoner/pdc/models/product.py
@@ -11,9 +11,9 @@ from filer.fields.image import FilerImageField
 from openformsclient.models import OpenFormsSlugField
 from ordered_model.models import OrderedModel
 
+from open_inwoner.pdc.managers import ProductQueryset
 from open_inwoner.utils.validators import DutchPhoneNumberValidator
 
-from ..managers import ProductQueryset
 from .mixins import GeoModel
 
 

--- a/src/open_inwoner/pdc/resources/export_resource.py
+++ b/src/open_inwoner/pdc/resources/export_resource.py
@@ -1,7 +1,7 @@
 from import_export import fields, resources
 from import_export.widgets import CharWidget, ManyToManyWidget
 
-from ..models import Category, Organization, Product, Tag
+from open_inwoner.pdc.models import Category, Organization, Product, Tag
 
 
 class CategoryExportResource(resources.ModelResource):

--- a/src/open_inwoner/pdc/resources/import_resource.py
+++ b/src/open_inwoner/pdc/resources/import_resource.py
@@ -6,7 +6,8 @@ from import_export.exceptions import ImportExportError
 from import_export.instance_loaders import CachedInstanceLoader
 from import_export.widgets import CharWidget
 
-from ..models import Category, Organization, Product, Tag
+from open_inwoner.pdc.models import Category, Organization, Product, Tag
+
 from .widgets import ValidatedManyToManyWidget
 
 

--- a/src/open_inwoner/pdc/tests/factories.py
+++ b/src/open_inwoner/pdc/tests/factories.py
@@ -3,7 +3,7 @@ from django.utils.text import slugify
 
 import factory.fuzzy
 
-from ..models import (
+from open_inwoner.pdc.models import (
     Category,
     Organization,
     OrganizationType,

--- a/src/open_inwoner/pdc/tests/test_category.py
+++ b/src/open_inwoner/pdc/tests/test_category.py
@@ -9,9 +9,9 @@ from open_inwoner.accounts.tests.factories import (
     UserFactory,
     eHerkenningUserFactory,
 )
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
 
-from ...cms.tests import cms_tools
 from .factories import CategoryFactory
 
 PATCHED_MIDDLEWARE = [

--- a/src/open_inwoner/pdc/tests/test_category_admin.py
+++ b/src/open_inwoner/pdc/tests/test_category_admin.py
@@ -10,8 +10,8 @@ from maykin_2fa.test import disable_admin_mfa
 
 from open_inwoner.accounts.tests.factories import GroupFactory, UserFactory
 from open_inwoner.openzaak.tests.factories import ZaakTypeConfigFactory
+from open_inwoner.pdc.models.category import Category
 
-from ..models.category import Category
 from .factories import CategoryFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_category_resources.py
+++ b/src/open_inwoner/pdc/tests/test_category_resources.py
@@ -5,8 +5,9 @@ from django.test import TestCase
 import tablib
 from import_export.exceptions import ImportExportError
 
-from ..models import Category
-from ..resources import CategoryExportResource, CategoryImportResource
+from open_inwoner.pdc.models import Category
+from open_inwoner.pdc.resources import CategoryExportResource, CategoryImportResource
+
 from .factories import CategoryFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_faq.py
+++ b/src/open_inwoner/pdc/tests/test_faq.py
@@ -5,7 +5,8 @@ from django.urls import reverse
 
 from django_webtest import WebTest
 
-from ..models import Question
+from open_inwoner.pdc.models import Question
+
 from .factories import CategoryFactory, ProductFactory, QuestionFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_logging.py
+++ b/src/open_inwoner/pdc/tests/test_logging.py
@@ -11,10 +11,10 @@ from timeline_logger.models import TimelineLog
 from webtest import Upload
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.pdc.models.category import Category
+from open_inwoner.pdc.models.product import Product
 from open_inwoner.utils.logentry import LOG_ACTIONS
 
-from ..models.category import Category
-from ..models.product import Product
 from .factories import CategoryFactory, ProductFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_product.py
+++ b/src/open_inwoner/pdc/tests/test_product.py
@@ -8,12 +8,12 @@ from django_webtest import WebTest
 from playwright.sync_api import expect
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.media.tests.factories import VideoFactory
+from open_inwoner.pdc.models import CategoryProduct
 from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
 from open_inwoner.utils.test import ClearCachesMixin
 from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
-from ...media.tests.factories import VideoFactory
-from ..models import CategoryProduct
 from .factories import (
     CategoryFactory,
     ProductConditionFactory,

--- a/src/open_inwoner/pdc/tests/test_product_finder.py
+++ b/src/open_inwoner/pdc/tests/test_product_finder.py
@@ -3,7 +3,8 @@ from django.urls import reverse
 
 from django_webtest import WebTest
 
-from ..models import ProductCondition
+from open_inwoner.pdc.models import ProductCondition
+
 from .factories import ProductConditionFactory, ProductFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_product_location.py
+++ b/src/open_inwoner/pdc/tests/test_product_location.py
@@ -10,8 +10,8 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.pdc.models import ProductLocation
 
-from ..models import ProductLocation
 from .factories import ProductFactory, ProductLocationFactory
 
 

--- a/src/open_inwoner/pdc/tests/test_product_resources.py
+++ b/src/open_inwoner/pdc/tests/test_product_resources.py
@@ -8,8 +8,9 @@ import tablib
 from freezegun import freeze_time
 from import_export.exceptions import ImportExportError
 
-from ..models import Product
-from ..resources import ProductExportResource, ProductImportResource
+from open_inwoner.pdc.models import Product
+from open_inwoner.pdc.resources import ProductExportResource, ProductImportResource
+
 from .factories import CategoryFactory, ProductFactory
 
 

--- a/src/open_inwoner/pdc/views.py
+++ b/src/open_inwoner/pdc/views.py
@@ -11,10 +11,9 @@ from view_breadcrumbs import BaseBreadcrumbMixin, ListBreadcrumbMixin
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.pdc.models.product import ProductCondition
 from open_inwoner.questionnaire.models import QuestionnaireStep
-from open_inwoner.utils.views import LoginMaybeRequiredMixin
+from open_inwoner.utils.ckeditor import get_rendered_content
+from open_inwoner.utils.views import CommonPageMixin, LoginMaybeRequiredMixin
 
-from ..utils.ckeditor import get_rendered_content
-from ..utils.views import CommonPageMixin
 from .choices import YesNo
 from .forms import ProductFinderForm
 from .models import Category, Product, ProductLocation, Question

--- a/src/open_inwoner/plans/tests/test_logging.py
+++ b/src/open_inwoner/plans/tests/test_logging.py
@@ -15,9 +15,9 @@ from open_inwoner.accounts.tests.factories import (
     DocumentFactory,
     UserFactory,
 )
+from open_inwoner.plans.models import Plan
 from open_inwoner.utils.logentry import LOG_ACTIONS
 
-from ..models import Plan
 from .factories import PlanFactory
 
 

--- a/src/open_inwoner/plans/tests/test_views.py
+++ b/src/open_inwoner/plans/tests/test_views.py
@@ -23,12 +23,12 @@ from open_inwoner.accounts.tests.factories import (
     UserFactory,
 )
 from open_inwoner.accounts.tests.test_action_views import ActionsPlaywrightTests
+from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
+from open_inwoner.cms.extensions.constants import Icons, IndicatorChoices
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.pdc.tests.factories import CategoryFactory
+from open_inwoner.plans.models import Plan, PlanContact
 
-from ...cms.collaborate.cms_apps import CollaborateApphook
-from ...cms.extensions.constants import Icons, IndicatorChoices
-from ...cms.tests import cms_tools
-from ..models import Plan, PlanContact
 from .factories import ActionTemplateFactory, PlanFactory, PlanTemplateFactory
 
 

--- a/src/open_inwoner/qmatic/tests/factories.py
+++ b/src/open_inwoner/qmatic/tests/factories.py
@@ -1,6 +1,6 @@
 from polyfactory.factories.pydantic_factory import ModelFactory
 
-from ..client import Appointment, BranchDetail, QmaticService
+from open_inwoner.qmatic.client import Appointment, BranchDetail, QmaticService
 
 
 class BranchDetailFactory(ModelFactory[BranchDetail]):

--- a/src/open_inwoner/questionnaire/admin.py
+++ b/src/open_inwoner/questionnaire/admin.py
@@ -6,9 +6,9 @@ from django.utils.translation import gettext as _
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
 
+from open_inwoner.ckeditor5.widgets import CKEditorWidget
 from open_inwoner.pdc.models.product import Product
 
-from ..ckeditor5.widgets import CKEditorWidget
 from .models import QuestionnaireStep, QuestionnaireStepFile
 
 

--- a/src/open_inwoner/questionnaire/tests/factories.py
+++ b/src/open_inwoner/questionnaire/tests/factories.py
@@ -2,7 +2,7 @@ from django.utils.text import slugify
 
 import factory
 
-from ..models import QuestionnaireStep, QuestionnaireStepFile
+from open_inwoner.questionnaire.models import QuestionnaireStep, QuestionnaireStepFile
 
 
 class QuestionnaireStepFactory(factory.django.DjangoModelFactory):

--- a/src/open_inwoner/questionnaire/tests/test_admin.py
+++ b/src/open_inwoner/questionnaire/tests/test_admin.py
@@ -6,9 +6,8 @@ from maykin_2fa.test import disable_admin_mfa
 
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.pdc.tests.factories import ProductFactory
+from open_inwoner.questionnaire.models import QuestionnaireStep
 from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
-
-from ..models import QuestionnaireStep
 
 
 @disable_admin_mfa()

--- a/src/open_inwoner/questionnaire/tests/test_export.py
+++ b/src/open_inwoner/questionnaire/tests/test_export.py
@@ -8,8 +8,8 @@ from privates.test import temp_private_root
 from open_inwoner.accounts.models import Document
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.pdc.tests.factories import ProductFactory
+from open_inwoner.questionnaire.views import QUESTIONNAIRE_SESSION_KEY
 
-from ..views import QUESTIONNAIRE_SESSION_KEY
 from .factories import QuestionnaireStepFactory
 
 

--- a/src/open_inwoner/questionnaire/tests/test_forms.py
+++ b/src/open_inwoner/questionnaire/tests/test_forms.py
@@ -1,6 +1,10 @@
 from django.test import TestCase
 
-from ..forms import QuestionnaireStepChoiceField, QuestionnaireStepForm
+from open_inwoner.questionnaire.forms import (
+    QuestionnaireStepChoiceField,
+    QuestionnaireStepForm,
+)
+
 from .factories import QuestionnaireStepFactory
 
 

--- a/src/open_inwoner/questionnaire/tests/test_models.py
+++ b/src/open_inwoner/questionnaire/tests/test_models.py
@@ -2,7 +2,8 @@ from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.utils.translation import gettext as _
 
-from ..models import QuestionnaireStep
+from open_inwoner.questionnaire.models import QuestionnaireStep
+
 from .factories import QuestionnaireStepFactory, QuestionnaireStepFileFactory
 
 

--- a/src/open_inwoner/questionnaire/tests/test_views.py
+++ b/src/open_inwoner/questionnaire/tests/test_views.py
@@ -7,17 +7,20 @@ from django.views.generic import FormView
 
 from django_webtest import WebTest
 
+from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.pdc.models import Product
+from open_inwoner.pdc.tests.factories import ProductFactory
+from open_inwoner.questionnaire.forms import QuestionnaireStepForm
+from open_inwoner.questionnaire.models import QuestionnaireStep
+from open_inwoner.questionnaire.views import (
+    QUESTIONNAIRE_SESSION_KEY,
+    QuestionnaireStepView,
+)
 from open_inwoner.utils.test import SessionMiddleware
 
-from ...accounts.tests.factories import UserFactory
-from ...cms.profile.cms_appconfig import ProfileConfig
-from ...cms.profile.cms_apps import ProfileApphook
-from ...cms.tests import cms_tools
-from ...pdc.models import Product
-from ...pdc.tests.factories import ProductFactory
-from ..forms import QuestionnaireStepForm
-from ..models import QuestionnaireStep
-from ..views import QUESTIONNAIRE_SESSION_KEY, QuestionnaireStepView
 from .factories import QuestionnaireStepFactory, QuestionnaireStepFileFactory
 
 

--- a/src/open_inwoner/search/resources/resources.py
+++ b/src/open_inwoner/search/resources/resources.py
@@ -1,7 +1,7 @@
 from import_export import fields, resources
 from import_export.widgets import SimpleArrayWidget
 
-from ..models import Synonym
+from open_inwoner.search.models import Synonym
 
 
 class SynonymResource(resources.ModelResource):

--- a/src/open_inwoner/search/tests/factories.py
+++ b/src/open_inwoner/search/tests/factories.py
@@ -1,8 +1,7 @@
 import factory
 
 from open_inwoner.accounts.tests.factories import UserFactory
-
-from ..models import Feedback, Synonym
+from open_inwoner.search.models import Feedback, Synonym
 
 
 class SynonymFactory(factory.django.DjangoModelFactory):

--- a/src/open_inwoner/search/tests/test_feedback.py
+++ b/src/open_inwoner/search/tests/test_feedback.py
@@ -10,8 +10,8 @@ from furl import furl
 
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.pdc.tests.factories import CategoryFactory, ProductFactory, TagFactory
+from open_inwoner.search.models import Feedback
 
-from ..models import Feedback
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -5,19 +5,19 @@ from django.urls import reverse_lazy
 from django_webtest import WebTest
 from playwright.sync_api import expect
 
+from open_inwoner.cms.products.cms_apps import ProductsApphook
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.pdc.tests.factories import (
     CategoryFactory,
     OrganizationFactory,
     ProductFactory,
     TagFactory,
 )
+from open_inwoner.search.constants import FacetChoices
+from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
-from ...cms.products.cms_apps import ProductsApphook
-from ...cms.tests import cms_tools
-from ...configurations.models import SiteConfiguration
-from ...utils.test import ClearCachesMixin
-from ...utils.tests.playwright import PlaywrightSyncLiveServerTestCase
-from ..constants import FacetChoices
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/search/tests/test_search_autocomplete.py
+++ b/src/open_inwoner/search/tests/test_search_autocomplete.py
@@ -1,8 +1,8 @@
 from django.test import TestCase, tag
 
 from open_inwoner.pdc.tests.factories import ProductFactory
+from open_inwoner.search.searches import search_autocomplete
 
-from ..searches import search_autocomplete
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/search/tests/test_search_products.py
+++ b/src/open_inwoner/search/tests/test_search_products.py
@@ -7,9 +7,9 @@ from open_inwoner.pdc.tests.factories import (
     TagFactory,
 )
 from open_inwoner.search.constants import FacetChoices
+from open_inwoner.search.results import FacetBucket
 from open_inwoner.search.views import multi_search
 
-from ..results import FacetBucket
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/search/tests/test_search_products_boost.py
+++ b/src/open_inwoner/search/tests/test_search_products_boost.py
@@ -1,9 +1,9 @@
 from django.test import TestCase, tag
 
 from open_inwoner.pdc.tests.factories import ProductFactory
+from open_inwoner.search.models import FieldBoost
+from open_inwoner.search.searches import multi_search
 
-from ..models import FieldBoost
-from ..searches import multi_search
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/search/tests/test_synonym_resources.py
+++ b/src/open_inwoner/search/tests/test_synonym_resources.py
@@ -5,8 +5,9 @@ from django.test import TestCase
 
 import tablib
 
-from ..models import Synonym
-from ..resources import SynonymResource
+from open_inwoner.search.models import Synonym
+from open_inwoner.search.resources import SynonymResource
+
 from .factories import SynonymFactory
 
 

--- a/src/open_inwoner/search/tests/test_tasks.py
+++ b/src/open_inwoner/search/tests/test_tasks.py
@@ -3,8 +3,7 @@ from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from open_inwoner.celery import app as celery_app
-
-from ..tasks import rebuild_search_index
+from open_inwoner.search.tasks import rebuild_search_index
 
 
 class SearchTaskTest(TestCase):

--- a/src/open_inwoner/search/tests/test_views.py
+++ b/src/open_inwoner/search/tests/test_views.py
@@ -15,6 +15,7 @@ from open_inwoner.accounts.tests.factories import DigidUserFactory
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import (
     ANOTHER_CATALOGI_ROOT,
     ANOTHER_ZAKEN_ROOT,
@@ -23,7 +24,6 @@ from open_inwoner.openzaak.tests.shared import (
 )
 from open_inwoner.utils.test import paginated_response
 
-from ...openzaak.tests.helpers import generate_oas_component_cached
 from .utils import ESMixin
 
 

--- a/src/open_inwoner/soap/tests/factories.py
+++ b/src/open_inwoner/soap/tests/factories.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import factory
 
-from ..models import SoapService
+from open_inwoner.soap.models import SoapService
 
 DATA_DIR = Path(__file__).parent.resolve() / "data"
 

--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -11,7 +11,8 @@ from django.utils import timezone
 import requests
 from requests import Response
 
-from ..utils.export import render_pdf
+from open_inwoner.utils.export import render_pdf
+
 from .exceptions import SSDClientException
 from .models import SSDConfig
 from .xml import get_jaaropgaven, get_uitkeringen

--- a/src/open_inwoner/ssd/models.py
+++ b/src/open_inwoner/ssd/models.py
@@ -3,8 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from solo.models import SingletonModel
 
-from ..configurations.models import SiteConfiguration
-from ..utils.validators import CharFieldValidator, validate_digits
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.utils.validators import CharFieldValidator, validate_digits
 
 
 class SSDConfigManager(models.Manager):

--- a/src/open_inwoner/ssd/templatetags/ssd_tags.py
+++ b/src/open_inwoner/ssd/templatetags/ssd_tags.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django import template
 from django.template.defaultfilters import date as django_date
 
-from ..service.jaaropgave.fwi_include_resolved import CdPositiefNegatief
+from open_inwoner.ssd.service.jaaropgave.fwi_include_resolved import CdPositiefNegatief
 
 register = template.Library()
 

--- a/src/open_inwoner/ssd/tests/factories.py
+++ b/src/open_inwoner/ssd/tests/factories.py
@@ -1,9 +1,8 @@
 import factory
 
 from open_inwoner.soap.tests.factories import SoapServiceFactory
-
-from ..client import SSDBaseClient
-from ..models import SSDConfig
+from open_inwoner.ssd.client import SSDBaseClient
+from open_inwoner.ssd.models import SSDConfig
 
 
 class SSDConfigFactory(factory.django.DjangoModelFactory):

--- a/src/open_inwoner/ssd/tests/test_client.py
+++ b/src/open_inwoner/ssd/tests/test_client.py
@@ -8,8 +8,9 @@ import requests_mock
 from lxml import etree
 from requests.exceptions import ConnectionError
 
-from ..client import JaaropgaveClient, UitkeringClient
-from ..exceptions import SSDClientException
+from open_inwoner.ssd.client import JaaropgaveClient, UitkeringClient
+from open_inwoner.ssd.exceptions import SSDClientException
+
 from .factories import ConcreteSSDClient, SSDConfigFactory
 
 FILES_DIR = Path(__file__).parent.resolve() / "files"

--- a/src/open_inwoner/ssd/tests/test_forms.py
+++ b/src/open_inwoner/ssd/tests/test_forms.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from ..forms import get_monthly_report_dates, get_yearly_report_dates
+from open_inwoner.ssd.forms import get_monthly_report_dates, get_yearly_report_dates
+
 from .factories import SSDConfigFactory
 
 

--- a/src/open_inwoner/ssd/tests/test_templates.py
+++ b/src/open_inwoner/ssd/tests/test_templates.py
@@ -4,12 +4,13 @@ from unittest.mock import patch
 
 from pyquery import PyQuery
 
-from ..client import UitkeringClient
-from ..models import SSDConfig
-from ..service.uitkering import (
+from open_inwoner.ssd.client import UitkeringClient
+from open_inwoner.ssd.models import SSDConfig
+from open_inwoner.ssd.service.uitkering import (
     UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
 )
-from ..xml import get_uitkeringen
+from open_inwoner.ssd.xml import get_uitkeringen
+
 from .utils import get_total_component_value, mock_get_report_info, render_html
 
 UITKERING_INFO_RESPONSE_NODE = (

--- a/src/open_inwoner/ssd/tests/test_views.py
+++ b/src/open_inwoner/ssd/tests/test_views.py
@@ -19,13 +19,12 @@ from freezegun import freeze_time
 from pyquery import PyQuery
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.ssd.client import UitkeringClient
 from open_inwoner.ssd.tests.factories import SSDConfigFactory
 from open_inwoner.ssd.tests.mocks import (
     mock_jaaropgave_response,
     mock_uitkering_response_basic,
 )
-
-from ..client import UitkeringClient
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/ssd/tests/test_xml.py
+++ b/src/open_inwoner/ssd/tests/test_xml.py
@@ -2,11 +2,11 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-from ..service.jaaropgave import JaarOpgaveInfoResponse
-from ..service.uitkering import (
+from open_inwoner.ssd.service.jaaropgave import JaarOpgaveInfoResponse
+from open_inwoner.ssd.service.uitkering import (
     UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
 )
-from ..templatetags.ssd_tags import (
+from open_inwoner.ssd.templatetags.ssd_tags import (
     format_currency,
     format_date_month_name,
     format_period,
@@ -14,7 +14,8 @@ from ..templatetags.ssd_tags import (
     format_string,
     get_detail_value_for_column,
 )
-from ..xml import get_jaaropgaven, get_uitkeringen
+from open_inwoner.ssd.xml import get_jaaropgaven, get_uitkeringen
+
 from .utils import get_component_value, mock_get_report_info
 
 JAAROPGAVE_INFO_RESPONSE_NODE = (

--- a/src/open_inwoner/userfeed/hooks/external_task.py
+++ b/src/open_inwoner/userfeed/hooks/external_task.py
@@ -9,11 +9,10 @@ from open_inwoner.accounts.models import User
 from open_inwoner.openzaak.api_models import OpenTask
 from open_inwoner.openzaak.clients import build_forms_clients
 from open_inwoner.userfeed.adapter import FeedItem
+from open_inwoner.userfeed.adapters import register_item_adapter
 from open_inwoner.userfeed.choices import FeedItemType
 from open_inwoner.userfeed.models import FeedItemData
 from open_inwoner.utils.api import ClientError
-
-from ..adapters import register_item_adapter
 
 logger = logging.getLogger(__name__)
 

--- a/src/open_inwoner/utils/apps.py
+++ b/src/open_inwoner/utils/apps.py
@@ -8,7 +8,8 @@ class UtilsConfig(AppConfig):
         from django.apps import registry
 
         # force the task autodiscovery
-        from ..celery import app
+        from open_inwoner.celery import app
+
         from . import checks  # noqa
         from .signals import copy_log_entry_to_timeline_logger  # noqa
 

--- a/src/open_inwoner/utils/tests/test_api_utils.py
+++ b/src/open_inwoner/utils/tests/test_api_utils.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from pydantic import BaseModel, HttpUrl
 
-from ..api import JSONEncoderMixin
+from open_inwoner.utils.api import JSONEncoderMixin
 
 
 class TestDummy(JSONEncoderMixin, BaseModel):

--- a/src/open_inwoner/utils/tests/test_timeline_logger.py
+++ b/src/open_inwoner/utils/tests/test_timeline_logger.py
@@ -11,9 +11,8 @@ from timeline_logger.models import TimelineLog
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.plans.models import Plan
 from open_inwoner.plans.tests.factories import PlanFactory
-
-from ..admin import CustomTimelineLogAdmin
-from ..logentry import LOG_ACTIONS
+from open_inwoner.utils.admin import CustomTimelineLogAdmin
+from open_inwoner.utils.logentry import LOG_ACTIONS
 
 
 @disable_admin_mfa()

--- a/src/open_inwoner/utils/tests/test_uuid_mixin.py
+++ b/src/open_inwoner/utils/tests/test_uuid_mixin.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from ..mixins import UUIDAdminFirstInOrder
+from open_inwoner.utils.mixins import UUIDAdminFirstInOrder
 
 
 class MockRequest:

--- a/src/open_inwoner/utils/tests/test_validators.py
+++ b/src/open_inwoner/utils/tests/test_validators.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
-from ..validators import (
+from open_inwoner.utils.validators import (
     DutchPhoneNumberValidator,
     format_phone_number,
     validate_array_contents_non_empty,


### PR DESCRIPTION
The rationale for this rule, apart from readability and explicitness, is that it will make doing refactors a bit more easy (e.g. more reliable rewriting by LSPs).