### PR TITLE
Add more opentelemetry metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Deployment aandachtspunten
 Nieuwe features
 ---------------
 
+* [:taiga-us:`3478`, :pr:`1953`]: Extra OpenTelemetry metrics toegevoegd voor
+  account- en profiel gerelateerde acties, zoals aanmeldingen, registraties,
+  uitnodigingen en profielwijzigingen.
 * [:taiga-us:`3461`, :taiga-ta:`3473`, :pr:`1932`]: Basisinfrastructuur voor
   OpenTelemetry toegevoegd, inclusief logging en metrics ondersteuning voor
   observability.

--- a/src/open_inwoner/accounts/metrics.py
+++ b/src/open_inwoner/accounts/metrics.py
@@ -4,6 +4,7 @@ from django.db.models import Count, Q
 
 from opentelemetry import metrics
 
+from .choices import LoginTypeChoices
 from .models import User
 
 meter = metrics.get_meter("open_inwoner.accounts")
@@ -14,6 +15,12 @@ def count_users(options: metrics.CallbackOptions) -> Collection[metrics.Observat
         total=Count("id"),
         staff=Count("id", filter=Q(is_staff=True)),
         superuser=Count("id", filter=Q(is_superuser=True)),
+        login_default=Count("id", filter=Q(login_type=LoginTypeChoices.default)),
+        login_digid=Count("id", filter=Q(login_type=LoginTypeChoices.digid)),
+        login_eherkenning=Count(
+            "id", filter=Q(login_type=LoginTypeChoices.eherkenning)
+        ),
+        login_oidc=Count("id", filter=Q(login_type=LoginTypeChoices.oidc)),
     )
     return (
         metrics.Observation(
@@ -27,6 +34,22 @@ def count_users(options: metrics.CallbackOptions) -> Collection[metrics.Observat
         metrics.Observation(
             counts["superuser"],
             {"scope": "global", "type": "superuser"},
+        ),
+        metrics.Observation(
+            counts["login_default"],
+            {"scope": "global", "type": "all", "login_type": "default"},
+        ),
+        metrics.Observation(
+            counts["login_digid"],
+            {"scope": "global", "type": "all", "login_type": "digid"},
+        ),
+        metrics.Observation(
+            counts["login_eherkenning"],
+            {"scope": "global", "type": "all", "login_type": "eherkenning"},
+        ),
+        metrics.Observation(
+            counts["login_oidc"],
+            {"scope": "global", "type": "all", "login_type": "oidc"},
         ),
     )
 

--- a/src/open_inwoner/accounts/metrics.py
+++ b/src/open_inwoner/accounts/metrics.py
@@ -84,3 +84,27 @@ user_lockouts = meter.create_counter(
     unit="1",  # unitless count
     description="The number of user lockouts because of failed logins.",
 )
+
+contactmoment_list_views = meter.create_counter(
+    "contactmoments.list_views",
+    unit="1",
+    description=(
+        "Number of times users view the contactmoments list. "
+        "Attributes: num_questions_viewed (int)"
+    ),
+)
+
+contactmoment_detail_views = meter.create_counter(
+    "contactmoments.detail_views",
+    unit="1",
+    description="Number of times users view contactmoment details",
+)
+
+contactmoment_registrations = meter.create_counter(
+    "contactmoments.registrations",
+    unit="1",
+    description=(
+        "Contactmoment/question registrations. "
+        "Attributes: channel ('email', 'esuite', or 'openklant'), success (bool)"
+    ),
+)

--- a/src/open_inwoner/accounts/metrics.py
+++ b/src/open_inwoner/accounts/metrics.py
@@ -108,3 +108,75 @@ contactmoment_registrations = meter.create_counter(
         "Attributes: channel ('email', 'esuite', or 'openklant'), success (bool)"
     ),
 )
+
+profile_updates = meter.create_counter(
+    "profile.updates",
+    unit="1",
+    description="Number of times users update their profile information",
+)
+
+profile_update_failures = meter.create_counter(
+    "profile.update_failures",
+    unit="1",
+    description=(
+        "Profile update failures due to API service issues. "
+        "Attributes: failed_services (str), changed_fields (str)"
+    ),
+)
+
+profile_categories_updates = meter.create_counter(
+    "profile.categories_updates",
+    unit="1",
+    description="Number of times users update their interest categories",
+)
+
+profile_newsletter_updates = meter.create_counter(
+    "profile.newsletter_updates",
+    unit="1",
+    description="Number of times users update newsletter subscriptions. Attributes: success (bool)",
+)
+
+profile_notifications_updates = meter.create_counter(
+    "profile.notifications_updates",
+    unit="1",
+    description="Number of times users update their notification preferences",
+)
+
+profile_deletions = meter.create_counter(
+    "profile.deletions",
+    unit="1",
+    description="Number of times users delete their account via the frontend",
+)
+
+brp_data_requests = meter.create_counter(
+    "profile.brp_data_requests",
+    unit="1",
+    description="Number of times users request their BRP (personal) data",
+)
+
+invites_accepted = meter.create_counter(
+    "registration.invites_accepted",
+    unit="1",
+    description="Number of invites accepted",
+)
+
+necessary_fields_completions = meter.create_counter(
+    "registration.necessary_fields_completions",
+    unit="1",
+    description=(
+        "Number of times users complete necessary registration fields. "
+        "Attributes: has_invite (bool), updated_esuite (bool), updated_openklant (bool)"
+    ),
+)
+
+email_verification_requests = meter.create_counter(
+    "registration.email_verification_requests",
+    unit="1",
+    description="Number of email verification requests by users",
+)
+
+email_verification_completions = meter.create_counter(
+    "registration.email_verification_completions",
+    unit="1",
+    description="Number of email verification completions. Attributes: success (bool)",
+)

--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -15,6 +15,7 @@ from requests import RequestException
 from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.accounts.models import User
+from open_inwoner.accounts.views.mixins import ContactmomentLogMixin
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import KlantContactMomentAnswer, KlantenSysteemConfig
@@ -172,10 +173,12 @@ class KlantContactMomentListView(
             and klanten_config.contact_registration_enabled
         )
 
+        self.log_contactmoment_list_accessed(questions=questions)
+
         return ctx
 
 
-class KlantContactMomentDetailView(KlantContactMomentBaseView):
+class KlantContactMomentDetailView(ContactmomentLogMixin, KlantContactMomentBaseView):
     template_name = "pages/contactmoment/detail.html"
 
     @cached_property
@@ -272,6 +275,10 @@ class KlantContactMomentDetailView(KlantContactMomentBaseView):
         if not local_kcm.is_seen:
             local_kcm.is_seen = True
             local_kcm.save()
+
+        self.log_contactmoment_detail_accessed(
+            identification=question["identification"]
+        )
 
         return ctx
 

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
@@ -28,48 +26,33 @@ class ContactmomentLogMixin(LogMixin):
     request: HttpRequest
 
     def log_contactmoment_registered_by_email(self, success: bool):
-        """
-        Log registering a contactmoment by email
-        """
-        log = partial(self.log_system_action, user=self.request.user)
-
         if success:
-            log("registered contactmoment by email")
+            msg = "registered contactmoment by email"
         else:
-            log("error while registering contactmoment by email")
+            msg = "error while registering contactmoment by email"
 
+        self.log_system_action(msg, user=self.request.user)
         contactmoment_registrations.add(1, {"channel": "email", "success": success})
 
     def log_question_registered_via_openklant(self, success: bool):
-        """
-        Log registering a question via OpenKlant2
-        """
         if success:
-            self.log_system_action(
-                "registered question via OpenKlant", user=self.request.user
-            )
+            msg = "registered question via OpenKlant"
         else:
-            self.log_system_action("failed to register question via OpenKlant")
+            msg = "failed to register question via OpenKlant"
 
+        self.log_system_action(msg, user=self.request.user)
         contactmoment_registrations.add(1, {"channel": "openklant", "success": success})
 
     def log_contactmoment_registered_via_esuite(self, success: bool):
-        """
-        Log registering a contactmoment via eSuite
-        """
-        log = partial(self.log_system_action, user=self.request.user)
-
         if success:
-            log("registered contactmoment via eSuite")
+            msg = "registered contactmoment via eSuite"
         else:
-            log("error while registering contactmoment by API")
+            msg = "error while registering contactmoment by API"
 
+        self.log_system_action(msg, user=self.request.user)
         contactmoment_registrations.add(1, {"channel": "esuite", "success": success})
 
     def log_klant_patched(self, patched_fields: list[str]):
-        """
-        Log patching a klant with missing fields
-        """
         self.log_system_action(
             "patched klant from user with missing fields: {patched}".format(
                 patched=", ".join(sorted(patched_fields))
@@ -78,20 +61,12 @@ class ContactmomentLogMixin(LogMixin):
         )
 
     def log_klant_contact_info_appended_to_message(self):
-        """
-        Log when contact info is appended to message because klant couldn't be created
-        """
         self.log_system_action(
             "could not retrieve or create klant for user, appended info to message",
             user=self.request.user,
         )
 
     def log_contactmoment_list_accessed(self, questions: list[dict]):
-        """
-        Log access to the contactmoment list view
-
-        Creates a single log for all questions
-        """
         question_ids = (question["identification"] for question in questions)
 
         self.log_user_action(
@@ -101,9 +76,6 @@ class ContactmomentLogMixin(LogMixin):
         contactmoment_list_views.add(1, {"num_questions_viewed": len(questions)})
 
     def log_contactmoment_detail_accessed(self, identification: str):
-        """
-        Log access to a specific contactmoment detail view
-        """
         self.log_user_action(
             self.request.user,
             f"Vraag bekeken: {identification}",
@@ -116,14 +88,11 @@ class ProfileLogMixin(LogMixin):
 
     def log_newsletter_subscription_modified(self, success: bool):
         if success:
-            self.log_user_action(
-                self.request.user, _("users newsletter subscriptions were modified")
-            )
+            msg = _("users newsletter subscriptions were modified")
         else:
-            self.log_user_action(
-                self.request.user, _("failed to modify user newsletter subscription")
-            )
+            msg = _("failed to modify user newsletter subscription")
 
+        self.log_user_action(self.request.user, msg)
         profile_newsletter_updates.add(1, {"success": success})
 
     def log_user_deleted(self, user: User):
@@ -175,8 +144,6 @@ class ProfileLogMixin(LogMixin):
 
 
 class RegistrationLogMixin(LogMixin):
-    """Mixin for logging and metrics related to user registration"""
-
     request: HttpRequest
 
     def log_invite_accepted(self):
@@ -189,7 +156,6 @@ class RegistrationLogMixin(LogMixin):
         updated_esuite: bool,
         updated_openklant: bool,
     ):
-        """Log when a user completes necessary registration fields"""
         self.log_user_action(user, _("user was updated with necessary fields"))
         necessary_fields_completions.add(
             1,
@@ -204,14 +170,14 @@ class RegistrationLogMixin(LogMixin):
         self.log_user_action(user, _("user was created"))
 
     def log_email_verification_requested(self, user: User):
-        """Log when a user requests email verification"""
         self.log_user_action(user, _("user requested e-mail address verification"))
         email_verification_requests.add(1)
 
     def log_email_verification_completed(self, user: User, success: bool):
-        """Log when a user completes email verification"""
         if success:
-            self.log_user_action(user, _("user verified e-mail address"))
+            msg = _("user verified e-mail address")
         else:
-            self.log_user_action(user, _("user failed to verify e-mail address"))
+            msg = _("user failed to verify e-mail address")
+
+        self.log_user_action(user, msg)
         email_verification_completions.add(1, {"success": success})

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -1,0 +1,62 @@
+from functools import partial
+
+from django.http import HttpRequest
+
+from open_inwoner.utils.views import LogMixin
+
+
+class ContactmomentLogMixin(LogMixin):
+    request: HttpRequest
+
+    def log_contactmoment_registered_by_email(self, success: bool):
+        """
+        Log registering a contactmoment by email
+        """
+        log = partial(self.log_system_action, user=self.request.user)
+
+        if success:
+            log("registered contactmoment by email")
+        else:
+            log("error while registering contactmoment by email")
+
+    def log_question_registered_via_openklant(self, success: bool):
+        """
+        Log registering a question via OpenKlant2
+        """
+        if success:
+            self.log_system_action(
+                "registered question via OpenKlant", user=self.request.user
+            )
+        else:
+            self.log_system_action("failed to register question via OpenKlant")
+
+    def log_contactmoment_registered_via_esuite(self, success: bool):
+        """
+        Log registering a contactmoment via eSuite
+        """
+        log = partial(self.log_system_action, user=self.request.user)
+
+        if success:
+            log("registered contactmoment via eSuite")
+        else:
+            log("error while registering contactmoment by API")
+
+    def log_klant_patched(self, patched_fields: list[str]):
+        """
+        Log patching a klant with missing fields
+        """
+        self.log_system_action(
+            "patched klant from user with missing fields: {patched}".format(
+                patched=", ".join(sorted(patched_fields))
+            ),
+            user=self.request.user,
+        )
+
+    def log_klant_contact_info_appended_to_message(self):
+        """
+        Log when contact info is appended to message because klant couldn't be created
+        """
+        self.log_system_action(
+            "could not retrieve or create klant for user, appended info to message",
+            user=self.request.user,
+        )

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -2,6 +2,11 @@ from functools import partial
 
 from django.http import HttpRequest
 
+from open_inwoner.accounts.metrics import (
+    contactmoment_detail_views,
+    contactmoment_list_views,
+    contactmoment_registrations,
+)
 from open_inwoner.utils.views import LogMixin
 
 
@@ -19,6 +24,8 @@ class ContactmomentLogMixin(LogMixin):
         else:
             log("error while registering contactmoment by email")
 
+        contactmoment_registrations.add(1, {"channel": "email", "success": success})
+
     def log_question_registered_via_openklant(self, success: bool):
         """
         Log registering a question via OpenKlant2
@@ -29,6 +36,8 @@ class ContactmomentLogMixin(LogMixin):
             )
         else:
             self.log_system_action("failed to register question via OpenKlant")
+
+        contactmoment_registrations.add(1, {"channel": "openklant", "success": success})
 
     def log_contactmoment_registered_via_esuite(self, success: bool):
         """
@@ -41,6 +50,7 @@ class ContactmomentLogMixin(LogMixin):
         else:
             log("error while registering contactmoment by API")
 
+        contactmoment_registrations.add(1, {"channel": "esuite", "success": success})
 
     def log_klant_patched(self, patched_fields: list[str]):
         """
@@ -74,6 +84,7 @@ class ContactmomentLogMixin(LogMixin):
             self.request.user,
             f"Vragen bekeken: {', '.join(question_ids)}",
         )
+        contactmoment_list_views.add(1, {"num_questions_viewed": len(questions)})
 
     def log_contactmoment_detail_accessed(self, identification: str):
         """
@@ -83,3 +94,4 @@ class ContactmomentLogMixin(LogMixin):
             self.request.user,
             f"Vraag bekeken: {identification}",
         )
+        contactmoment_detail_views.add(1)

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -41,6 +41,7 @@ class ContactmomentLogMixin(LogMixin):
         else:
             log("error while registering contactmoment by API")
 
+
     def log_klant_patched(self, patched_fields: list[str]):
         """
         Log patching a klant with missing fields
@@ -59,4 +60,26 @@ class ContactmomentLogMixin(LogMixin):
         self.log_system_action(
             "could not retrieve or create klant for user, appended info to message",
             user=self.request.user,
+        )
+
+    def log_contactmoment_list_accessed(self, questions: list[dict]):
+        """
+        Log access to the contactmoment list view
+
+        Creates a single log for all questions
+        """
+        question_ids = (question["identification"] for question in questions)
+
+        self.log_user_action(
+            self.request.user,
+            f"Vragen bekeken: {', '.join(question_ids)}",
+        )
+
+    def log_contactmoment_detail_accessed(self, identification: str):
+        """
+        Log access to a specific contactmoment detail view
+        """
+        self.log_user_action(
+            self.request.user,
+            f"Vraag bekeken: {identification}",
         )

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -1,12 +1,15 @@
 from functools import partial
 
 from django.http import HttpRequest
+from django.utils.translation import gettext_lazy as _
 
 from open_inwoner.accounts.metrics import (
     contactmoment_detail_views,
     contactmoment_list_views,
     contactmoment_registrations,
 )
+from open_inwoner.accounts.models import User
+from open_inwoner.utils.logentry import system_error
 from open_inwoner.utils.views import LogMixin
 
 
@@ -95,3 +98,52 @@ class ContactmomentLogMixin(LogMixin):
             f"Vraag bekeken: {identification}",
         )
         contactmoment_detail_views.add(1)
+
+
+class ProfileLogMixin(LogMixin):
+    request: HttpRequest
+
+    def log_newsletter_subscription_modified(self, success: bool):
+        if success:
+            self.log_user_action(
+                self.request.user, _("users newsletter subscriptions were modified")
+            )
+        else:
+            self.log_user_action(
+                self.request.user, _("failed to modify user newsletter subscription")
+            )
+
+    def log_user_deleted(self, user: User):
+        self.log_user_action(user, _("user was deleted via frontend"))
+
+    def log_profile_modified(self, user: User):
+        self.log_change(user, _("profile was modified"))
+
+    def log_profile_update_failed(
+        self, user: User, failed_services: list[str], changed_fields: list[str]
+    ):
+        log_msg = (
+            "API service failure when updating user profile. "
+            "Failed services: %(failed_services)s. "
+            "Changed fields: %(changed_fields)s"
+            % {
+                "failed_services": " and ".join(failed_services),
+                "changed_fields": ", ".join(changed_fields),
+            }
+        )
+        system_error(message=log_msg, user=user)
+
+    def log_digitaal_adres_deleted(self, user: User, digitaal_adres_uuid: str):
+        self.log_system_action(
+            f"deleted old digitaal adres {digitaal_adres_uuid}",
+            instance=user,
+        )
+
+    def log_categories_modified(self, user: User):
+        self.log_change(user, _("categories were modified"))
+
+    def log_brp_data_requested(self):
+        self.log_user_action(self.request.user, _("user requests for brp data"))
+
+    def log_notifications_modified(self, user: User):
+        self.log_change(user, _("users notifications were modified"))

--- a/src/open_inwoner/accounts/views/mixins.py
+++ b/src/open_inwoner/accounts/views/mixins.py
@@ -4,9 +4,20 @@ from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from open_inwoner.accounts.metrics import (
+    brp_data_requests,
     contactmoment_detail_views,
     contactmoment_list_views,
     contactmoment_registrations,
+    email_verification_completions,
+    email_verification_requests,
+    invites_accepted,
+    necessary_fields_completions,
+    profile_categories_updates,
+    profile_deletions,
+    profile_newsletter_updates,
+    profile_notifications_updates,
+    profile_update_failures,
+    profile_updates,
 )
 from open_inwoner.accounts.models import User
 from open_inwoner.utils.logentry import system_error
@@ -113,11 +124,15 @@ class ProfileLogMixin(LogMixin):
                 self.request.user, _("failed to modify user newsletter subscription")
             )
 
+        profile_newsletter_updates.add(1, {"success": success})
+
     def log_user_deleted(self, user: User):
         self.log_user_action(user, _("user was deleted via frontend"))
+        profile_deletions.add(1)
 
     def log_profile_modified(self, user: User):
         self.log_change(user, _("profile was modified"))
+        profile_updates.add(1)
 
     def log_profile_update_failed(
         self, user: User, failed_services: list[str], changed_fields: list[str]
@@ -132,6 +147,13 @@ class ProfileLogMixin(LogMixin):
             }
         )
         system_error(message=log_msg, user=user)
+        profile_update_failures.add(
+            1,
+            {
+                "failed_services": " and ".join(failed_services),
+                "changed_fields": ", ".join(changed_fields),
+            },
+        )
 
     def log_digitaal_adres_deleted(self, user: User, digitaal_adres_uuid: str):
         self.log_system_action(
@@ -141,9 +163,55 @@ class ProfileLogMixin(LogMixin):
 
     def log_categories_modified(self, user: User):
         self.log_change(user, _("categories were modified"))
+        profile_categories_updates.add(1)
 
     def log_brp_data_requested(self):
         self.log_user_action(self.request.user, _("user requests for brp data"))
+        brp_data_requests.add(1)
 
     def log_notifications_modified(self, user: User):
         self.log_change(user, _("users notifications were modified"))
+        profile_notifications_updates.add(1)
+
+
+class RegistrationLogMixin(LogMixin):
+    """Mixin for logging and metrics related to user registration"""
+
+    request: HttpRequest
+
+    def log_invite_accepted(self):
+        invites_accepted.add(1)
+
+    def log_necessary_fields_completed(
+        self,
+        user: User,
+        has_invite: bool,
+        updated_esuite: bool,
+        updated_openklant: bool,
+    ):
+        """Log when a user completes necessary registration fields"""
+        self.log_user_action(user, _("user was updated with necessary fields"))
+        necessary_fields_completions.add(
+            1,
+            {
+                "has_invite": has_invite,
+                "updated_esuite": updated_esuite,
+                "updated_openklant": updated_openklant,
+            },
+        )
+
+    def log_custom_user_registration(self, user):
+        self.log_user_action(user, _("user was created"))
+
+    def log_email_verification_requested(self, user: User):
+        """Log when a user requests email verification"""
+        self.log_user_action(user, _("user requested e-mail address verification"))
+        email_verification_requests.add(1)
+
+    def log_email_verification_completed(self, user: User, success: bool):
+        """Log when a user completes email verification"""
+        if success:
+            self.log_user_action(user, _("user verified e-mail address"))
+        else:
+            self.log_user_action(user, _("user failed to verify e-mail address"))
+        email_verification_completions.add(1, {"success": success})

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -42,14 +42,15 @@ from open_inwoner.openklant.types import PartijUpdateData
 from open_inwoner.plans.models import Plan
 from open_inwoner.qmatic.client import NoServiceConfigured, qmatic_client_factory
 from open_inwoner.questionnaire.models import QuestionnaireStep
-from open_inwoner.utils.logentry import system_action, system_error
-from open_inwoner.utils.views import CommonPageMixin, LogMixin
+from open_inwoner.utils.views import CommonPageMixin
+
+from .mixins import ProfileLogMixin
 
 logger = logging.getLogger(__name__)
 
 
 class MyProfileView(
-    LogMixin,
+    ProfileLogMixin,
     LoginRequiredMixin,
     CommonPageMixin,
     BaseBreadcrumbMixin,
@@ -72,15 +73,11 @@ class MyProfileView(
 
         # Display errors raised by Laposta API
         if form.errors:
-            self.log_user_action(
-                self.request.user, _("failed to modify user newsletter subscription")
-            )
+            self.log_newsletter_subscription_modified(success=False)
             return self.form_invalid(form)
 
         messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-        self.log_user_action(
-            self.request.user, _("users newsletter subscriptions were modified")
-        )
+        self.log_newsletter_subscription_modified(success=True)
         return HttpResponseRedirect(self.get_success_url())
 
     @cached_property
@@ -205,7 +202,7 @@ class MyProfileView(
                 return redirect("profile:detail")
 
             # continue with delete
-            self.log_user_action(instance, _("user was deleted via frontend"))
+            self.log_user_deleted(instance)
             instance.delete()
             request.session.flush()
 
@@ -216,7 +213,7 @@ class MyProfileView(
 
 
 class EditProfileView(
-    LogMixin,
+    ProfileLogMixin,
     LoginRequiredMixin,
     CommonPageMixin,
     BaseBreadcrumbMixin,
@@ -247,7 +244,7 @@ class EditProfileView(
         ):
             form.save()
             messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-            self.log_change(self.get_object(), _("profile was modified"))
+            self.log_profile_modified(user)
             return HttpResponseRedirect(self.get_success_url())
 
         # write changes to API's; abort saving if write fails
@@ -282,22 +279,13 @@ class EditProfileView(
                 ),
             )
 
-            log_msg = (
-                "API service failure when updating user profile. "
-                "Failed services: %(failed_services)s. "
-                "Changed fields: %(changed_fields)s"
-                % {
-                    "failed_services": " and ".join(failed_services),
-                    "changed_fields": ", ".join(form.changed_data),
-                }
-            )
-            system_error(message=log_msg, user=self.get_object())
+            self.log_profile_update_failed(user, failed_services, form.changed_data)
 
             return HttpResponseRedirect(self.get_success_url())
 
         form.save()
         messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-        self.log_change(self.get_object(), _("profile was modified"))
+        self.log_profile_modified(user)
         return HttpResponseRedirect(self.get_success_url())
 
     def update_klant_via_openklant(self, user_form_data: dict, user: User) -> bool:
@@ -342,10 +330,7 @@ class EditProfileView(
                     pass
                 else:
                     service.client.digitaal_adres.delete(digitaal_adres["uuid"])
-                    system_action(
-                        f"deleted old digitaal adres {digitaal_adres['uuid']}",
-                        content_object=user,
-                    )
+                    self.log_digitaal_adres_deleted(user, digitaal_adres["uuid"])
 
             return service.update_partij_from_user_data(
                 partij_uuid=partij["uuid"],
@@ -398,7 +383,11 @@ class EditProfileView(
 
 
 class MyCategoriesView(
-    LogMixin, LoginRequiredMixin, CommonPageMixin, BaseBreadcrumbMixin, UpdateView
+    ProfileLogMixin,
+    LoginRequiredMixin,
+    CommonPageMixin,
+    BaseBreadcrumbMixin,
+    UpdateView,
 ):
     template_name = "pages/profile/categories.html"
     model = User
@@ -418,12 +407,16 @@ class MyCategoriesView(
     def form_valid(self, form):
         form.save()
         messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-        self.log_change(self.object, _("categories were modified"))
+        self.log_categories_modified(self.get_object())
         return HttpResponseRedirect(self.get_success_url())
 
 
 class MyDataView(
-    LogMixin, LoginRequiredMixin, CommonPageMixin, BaseBreadcrumbMixin, TemplateView
+    ProfileLogMixin,
+    LoginRequiredMixin,
+    CommonPageMixin,
+    BaseBreadcrumbMixin,
+    TemplateView,
 ):
     template_name = "pages/profile/mydata.html"
 
@@ -440,13 +433,13 @@ class MyDataView(
         return context
 
     def get_brp_data(self):
-        self.log_user_action(self.request.user, _("user requests for brp data"))
+        self.log_brp_data_requested()
         data = fetch_brp(self.request.user.bsn)
         return data
 
 
 class MyNotificationsView(
-    LogMixin,
+    ProfileLogMixin,
     LoginRequiredMixin,
     CommonPageMixin,
     BaseBreadcrumbMixin,
@@ -493,7 +486,7 @@ class MyNotificationsView(
             self.update_klant_via_esuite(user)
 
         messages.success(self.request, _("Uw wijzigingen zijn opgeslagen"))
-        self.log_change(self.object, _("users notifications were modified"))
+        self.log_change(user, _("users notifications were modified"))
         return HttpResponseRedirect(self.get_success_url())
 
     def update_klant_via_esuite(self, user: User):
@@ -516,7 +509,7 @@ class MyNotificationsView(
 
 
 class UserAppointmentsView(
-    LogMixin,
+    ProfileLogMixin,
     LoginRequiredMixin,
     CommonPageMixin,
     BaseBreadcrumbMixin,

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -28,7 +28,9 @@ from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenServ
 from open_inwoner.openklant.types import PartijUpdateData
 from open_inwoner.utils.text import html_tag_wrap_format
 from open_inwoner.utils.url import get_next_url_from
-from open_inwoner.utils.views import CommonPageMixin, LogMixin
+from open_inwoner.utils.views import CommonPageMixin
+
+from .mixins import RegistrationLogMixin
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +74,7 @@ class InviteMixin(CommonPageMixin):
             invite.inviter.user_contacts.add(invitee)
 
 
-class CustomRegistrationView(LogMixin, InviteMixin, RegistrationView):
+class CustomRegistrationView(RegistrationLogMixin, InviteMixin, RegistrationView):
     form_class = CustomRegistrationForm
 
     def page_title(self):
@@ -88,6 +90,7 @@ class CustomRegistrationView(LogMixin, InviteMixin, RegistrationView):
         invite = form.cleaned_data["invite"]
         if invite:
             self.add_invitee(invite, user)
+            self.log_invite_accepted()
 
         # Remove invite url from user's session
         session = self.request.session
@@ -95,7 +98,8 @@ class CustomRegistrationView(LogMixin, InviteMixin, RegistrationView):
             del session["invite_url"]
 
         self.request.user = user
-        self.log_user_action(user, _("user was created"))
+        self.log_custom_user_registration(user)
+
         return HttpResponseRedirect(self.get_success_url())
 
     def get_context_data(self, **kwargs):
@@ -144,7 +148,7 @@ class CustomRegistrationView(LogMixin, InviteMixin, RegistrationView):
 
 
 class NecessaryFieldsUserView(
-    LogMixin,
+    RegistrationLogMixin,
     LoginRequiredMixin,
     InviteMixin,
     UpdateView,
@@ -174,16 +178,26 @@ class NecessaryFieldsUserView(
         user = form.save()
 
         klanten_config = KlantenSysteemConfig.get_solo()
+        updated_esuite = False
+        updated_openklant = False
+
         if klanten_config.has_api_service_configured(KlantenServiceType.ESUITE):
             self.update_klant_via_esuite(form)
+            updated_esuite = True
         if klanten_config.has_api_service_configured(KlantenServiceType.OPENKLANT2):
             self.update_klant_via_openklant(form)
+            updated_openklant = True
 
         invite = form.cleaned_data["invite"]
         if invite:
             self.add_invitee(invite, user)
 
-        self.log_user_action(user, _("user was updated with necessary fields"))
+        self.log_necessary_fields_completed(
+            user,
+            has_invite=bool(invite),
+            updated_esuite=updated_esuite,
+            updated_openklant=updated_openklant,
+        )
         return HttpResponseRedirect(self.get_success_url())
 
     def get_initial(self):
@@ -258,7 +272,7 @@ class NecessaryFieldsUserView(
         service.update_klant_from_user(klant, user, update_fields=update_fields)
 
 
-class EmailVerificationUserView(LogMixin, LoginRequiredMixin, TemplateView):
+class EmailVerificationUserView(RegistrationLogMixin, LoginRequiredMixin, TemplateView):
     model = User
     template_name = "accounts/email_verification.html"
 
@@ -300,7 +314,7 @@ class EmailVerificationUserView(LogMixin, LoginRequiredMixin, TemplateView):
         )
 
         messages.add_message(self.request, messages.SUCCESS, _("E-mail is verzonden"))
-        self.log_user_action(user, _("user requested e-mail address verification"))
+        self.log_email_verification_requested(user)
 
         return redirect(self.get_success_url())
 

--- a/src/open_inwoner/cms/cases/metrics.py
+++ b/src/open_inwoner/cms/cases/metrics.py
@@ -1,0 +1,40 @@
+from opentelemetry import metrics
+
+meter = metrics.get_meter("open_inwoner.cases")
+
+
+case_list_views = meter.create_counter(
+    "cases.list_views",
+    unit="1",
+    description=(
+        "Number of times users view the cases list. "
+        "Attributes: list_size (int), page (int)"
+    ),
+)
+
+case_detail_views = meter.create_counter(
+    "cases.detail_views",
+    unit="1",
+    description="Number of times users view case details",
+)
+
+case_document_downloads = meter.create_counter(
+    "cases.document_downloads",
+    unit="1",
+    description="Number of times users download case documents",
+)
+
+case_document_uploads = meter.create_counter(
+    "cases.document_uploads",
+    unit="1",
+    description="Number of times users upload documents to cases",
+)
+
+case_contact_form_registrations = meter.create_counter(
+    "cases.contact_form.registrations",
+    unit="1",
+    description=(
+        "Contact form submissions. "
+        "Attributes: channel ('email' or 'api'), success (bool)"
+    ),
+)

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -117,10 +117,10 @@ class InnerCaseListView(
         context["cases"] = case_dicts
         context.update(paginator_dict)
 
-        self.log_access_cases(case_dicts)
-
         # other data
         context["hxget"] = reverse("cases:cases_content")
         context["title_text"] = config.title_text
+
+        self.log_case_list_accessed(case_dicts)
 
         return context

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -6,6 +6,13 @@ from django.http import Http404, HttpRequest
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext_lazy as _
 
+from open_inwoner.cms.cases.metrics import (
+    case_contact_form_registrations,
+    case_detail_views,
+    case_document_downloads,
+    case_document_uploads,
+    case_list_views,
+)
 from open_inwoner.openzaak.models import OpenZaakConfig, ZGWApiGroupConfig
 from open_inwoner.openzaak.types import UniformCase
 from open_inwoner.openzaak.utils import is_zaak_visible
@@ -23,18 +30,20 @@ class CaseLogMixin(LogMixin):
 
         Creates a single log for all cases
         """
-        case_ids = (case["identification"] for case in cases)
+        case_ids = [case["identification"] for case in cases]
 
         self.log_user_action(
             self.request.user,
             _("Zaken bekeken: {cases}").format(cases=", ".join(case_ids)),
         )
+        case_list_views.add(1, {"num_cases_viewed": len(case_ids)})
 
     def log_case_detail_accessed(self, case: UniformCase):
         self.log_user_action(
             self.request.user,
             _("Zaak bekeken: {case}").format(case=case.identification),
         )
+        case_detail_views.add(1)
 
     def log_case_document_downloaded(self, case: UniformCase, filename: str):
         """
@@ -47,6 +56,7 @@ class CaseLogMixin(LogMixin):
                 filename=filename,
             ),
         )
+        case_document_downloads.add(1)
 
     def log_case_document_uploaded(self, case: UniformCase, filename: str):
         """
@@ -59,20 +69,25 @@ class CaseLogMixin(LogMixin):
                 filename=filename,
             ),
         )
+        case_document_uploads.add(1)
 
     def log_contactmoment_for_zaak_registered_by_email(self, success: bool):
         """
         Log registering a contactmoment by email
         """
+        success = True
         if success:
             self.log_system_action(
                 "registered contactmoment by email", user=self.request.user
             )
         else:
+            success = False
             self.log_system_action(
                 "error while registering contactmoment by email",
                 user=self.request.user,
             )
+
+        case_contact_form_registrations.add(1, {"channel": "email", "success": success})
 
     def log_contactmoment_for_zaak_registered_by_api(
         self,
@@ -84,16 +99,21 @@ class CaseLogMixin(LogMixin):
         """
         log = partial(self.log_system_action, user=self.request.user)
 
+        success = True
         if contactmoment_success:
             log("registered contactmoment by API")
         else:
+            sucess = False
             log("error while registering contactmoment by API")
 
         if objectcontactmoment_success is not None:
             if objectcontactmoment_success:
                 log("registered objectcontactmoment by API")
             else:
+                sucess = False
                 log("error linking objectcontactmoment to contactmoment by API")
+
+        case_contact_form_registrations.add(1, {"channel": "api", "success": success})
 
 
 class CaseAccessMixin(AccessMixin):

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -1,7 +1,8 @@
 import logging
+from functools import partial
 
 from django.contrib.auth.mixins import AccessMixin, LoginRequiredMixin
-from django.http import Http404
+from django.http import Http404, HttpRequest
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext_lazy as _
 
@@ -14,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 class CaseLogMixin(LogMixin):
-    def log_access_cases(self, cases: list[dict]):
+    request: HttpRequest
+
+    def log_case_list_accessed(self, cases: list[dict]):
         """
         Log access to cases on the list view
 
@@ -27,11 +30,70 @@ class CaseLogMixin(LogMixin):
             _("Zaken bekeken: {cases}").format(cases=", ".join(case_ids)),
         )
 
-    def log_access_case_detail(self, case: UniformCase):
+    def log_case_detail_accessed(self, case: UniformCase):
         self.log_user_action(
             self.request.user,
             _("Zaak bekeken: {case}").format(case=case.identification),
         )
+
+    def log_case_document_downloaded(self, case: UniformCase, filename: str):
+        """
+        Log downloading a document from a case
+        """
+        self.log_user_action(
+            self.request.user,
+            _("Document van zaak gedownload {case}: {filename}").format(
+                case=case.identification,
+                filename=filename,
+            ),
+        )
+
+    def log_case_document_uploaded(self, case: UniformCase, filename: str):
+        """
+        Log uploading a document to a case
+        """
+        self.log_user_action(
+            self.request.user,
+            _("Document was uploaded for {case}: {filename}").format(
+                case=case.identification,
+                filename=filename,
+            ),
+        )
+
+    def log_contactmoment_for_zaak_registered_by_email(self, success: bool):
+        """
+        Log registering a contactmoment by email
+        """
+        if success:
+            self.log_system_action(
+                "registered contactmoment by email", user=self.request.user
+            )
+        else:
+            self.log_system_action(
+                "error while registering contactmoment by email",
+                user=self.request.user,
+            )
+
+    def log_contactmoment_for_zaak_registered_by_api(
+        self,
+        contactmoment_success: bool,
+        objectcontactmoment_success: bool | None = None,
+    ):
+        """
+        Log registering a contactmoment and optionally objectcontactmoment by API
+        """
+        log = partial(self.log_system_action, user=self.request.user)
+
+        if contactmoment_success:
+            log("registered contactmoment by API")
+        else:
+            log("error while registering contactmoment by API")
+
+        if objectcontactmoment_success is not None:
+            if objectcontactmoment_success:
+                log("registered objectcontactmoment by API")
+            else:
+                log("error linking objectcontactmoment to contactmoment by API")
 
 
 class CaseAccessMixin(AccessMixin):

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -1,5 +1,4 @@
 import logging
-from functools import partial
 
 from django.contrib.auth.mixins import AccessMixin, LoginRequiredMixin
 from django.http import Http404, HttpRequest
@@ -25,11 +24,6 @@ class CaseLogMixin(LogMixin):
     request: HttpRequest
 
     def log_case_list_accessed(self, cases: list[dict]):
-        """
-        Log access to cases on the list view
-
-        Creates a single log for all cases
-        """
         case_ids = [case["identification"] for case in cases]
 
         self.log_user_action(
@@ -46,9 +40,6 @@ class CaseLogMixin(LogMixin):
         case_detail_views.add(1)
 
     def log_case_document_downloaded(self, case: UniformCase, filename: str):
-        """
-        Log downloading a document from a case
-        """
         self.log_user_action(
             self.request.user,
             _("Document van zaak gedownload {case}: {filename}").format(
@@ -59,9 +50,6 @@ class CaseLogMixin(LogMixin):
         case_document_downloads.add(1)
 
     def log_case_document_uploaded(self, case: UniformCase, filename: str):
-        """
-        Log uploading a document to a case
-        """
         self.log_user_action(
             self.request.user,
             _("Document was uploaded for {case}: {filename}").format(
@@ -72,21 +60,12 @@ class CaseLogMixin(LogMixin):
         case_document_uploads.add(1)
 
     def log_contactmoment_for_zaak_registered_by_email(self, success: bool):
-        """
-        Log registering a contactmoment by email
-        """
-        success = True
         if success:
-            self.log_system_action(
-                "registered contactmoment by email", user=self.request.user
-            )
+            msg = "registered contactmoment by email"
         else:
-            success = False
-            self.log_system_action(
-                "error while registering contactmoment by email",
-                user=self.request.user,
-            )
+            msg = "error while registering contactmoment by email"
 
+        self.log_system_action(msg, user=self.request.user)
         case_contact_form_registrations.add(1, {"channel": "email", "success": success})
 
     def log_contactmoment_for_zaak_registered_by_api(
@@ -94,24 +73,24 @@ class CaseLogMixin(LogMixin):
         contactmoment_success: bool,
         objectcontactmoment_success: bool | None = None,
     ):
-        """
-        Log registering a contactmoment and optionally objectcontactmoment by API
-        """
-        log = partial(self.log_system_action, user=self.request.user)
+        success = contactmoment_success and (
+            objectcontactmoment_success is None or objectcontactmoment_success
+        )
 
-        success = True
         if contactmoment_success:
-            log("registered contactmoment by API")
+            msg = "registered contactmoment by API"
         else:
-            sucess = False
-            log("error while registering contactmoment by API")
+            msg = "error while registering contactmoment by API"
+
+        self.log_system_action(msg, user=self.request.user)
 
         if objectcontactmoment_success is not None:
             if objectcontactmoment_success:
-                log("registered objectcontactmoment by API")
+                msg = "registered objectcontactmoment by API"
             else:
-                sucess = False
-                log("error linking objectcontactmoment to contactmoment by API")
+                msg = "error linking objectcontactmoment to contactmoment by API"
+
+            self.log_system_action(msg, user=self.request.user)
 
         case_contact_form_registrations.add(1, {"channel": "api", "success": success})
 

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -63,7 +63,7 @@ from open_inwoner.openzaak.utils import get_role_name_display, is_info_object_vi
 from open_inwoner.userfeed import hooks
 from open_inwoner.utils.glom import glom_multiple
 from open_inwoner.utils.time import has_new_elements
-from open_inwoner.utils.views import CommonPageMixin, LogMixin
+from open_inwoner.utils.views import CommonPageMixin
 
 from .mixins import CaseAccessMixin, CaseLogMixin, OuterCaseAccessMixin
 
@@ -208,7 +208,7 @@ class InnerCaseDetailView(
 
         # case is retrieved via CaseAccessMixin
         if self.case:
-            self.log_access_case_detail(self.case)
+            self.log_case_detail_accessed(self.case)
 
             openzaak_config = OpenZaakConfig.get_solo()
 
@@ -771,7 +771,7 @@ class InnerCaseDetailView(
         return anchors
 
 
-class CaseDocumentDownloadView(LogMixin, CaseAccessMixin, View):
+class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
     def get(self, request, *args, **kwargs):
         if not self.case:
             raise Http404
@@ -809,13 +809,7 @@ class CaseDocumentDownloadView(LogMixin, CaseAccessMixin, View):
         if not content_stream:
             raise Http404
 
-        self.log_user_action(
-            self.request.user,
-            _("Document van zaak gedownload {case}: {filename}").format(
-                case=self.case.identificatie,
-                filename=info_object.bestandsnaam,
-            ),
-        )
+        self.log_case_document_downloaded(self.case, info_object.bestandsnaam)
 
         headers = {
             "Content-Disposition": f'attachment; filename="{info_object.bestandsnaam}"',
@@ -830,7 +824,7 @@ class CaseDocumentDownloadView(LogMixin, CaseAccessMixin, View):
         raise PermissionDenied()
 
 
-class CaseDocumentUploadFormView(CaseAccessMixin, LogMixin, FormView):
+class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
     template_name = "pages/cases/document_form.html"
     form_class = CaseUploadForm
 
@@ -894,13 +888,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, LogMixin, FormView):
             if not created_relationship:
                 return self.handle_document_error(request, file)
 
-            self.log_user_action(
-                request.user,
-                _("Document was uploaded for {case}: {filename}").format(
-                    case=self.case.identificatie,
-                    filename=file.name,
-                ),
-            )
+            self.log_case_document_uploaded(self.case, file.name)
             created_documents.append(created_document)
 
         success_message = (
@@ -952,7 +940,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, LogMixin, FormView):
         return context
 
 
-class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
+class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
     template_name = "pages/cases/contact_form.html"
     form_class = CaseContactForm
 
@@ -1037,17 +1025,8 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
 
         success = template.send_email([recipient_email], context)
 
-        if success:
-            self.log_system_action(
-                "registered contactmoment by email", user=self.request.user
-            )
-            return True
-        else:
-            self.log_system_action(
-                "error while registering contactmoment by email",
-                user=self.request.user,
-            )
-            return False
+        self.log_contactmoment_for_zaak_registered_by_email(success)
+        return bool(success)
 
     def register_by_api(self, form, api_group: ZGWApiGroupConfig):
         if not api_group.klant_backend:
@@ -1107,20 +1086,6 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
             klant, created = service.get_or_create_klant(
                 fetch_params=fetch_params, user=user
             )
-            if not klant:
-                self.log_system_action(
-                    "could not create klant for user", user=self.request.user
-                )
-            else:
-                if created:
-                    self.log_system_action(
-                        (
-                            "created klant for basic authenticated user"
-                            if created
-                            else "retrieved klant for user"
-                        ),
-                        user=self.request.user,
-                    )
 
         # create contact moment
         question = form.cleaned_data["question"]
@@ -1141,11 +1106,9 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
             logger.error("Failed to build eSuiteVragenService")
             return
 
-        contactmoment = service.create_contactmoment(data, klant=klant)
-
-        if not contactmoment:
-            self.log_system_action(
-                "error while registering contactmoment by API", user=self.request.user
+        if not (contactmoment := service.create_contactmoment(data, klant=klant)):
+            self.log_contactmoment_for_zaak_registered_by_api(
+                contactmoment_success=False
             )
             messages.error(
                 request=self.request,
@@ -1153,21 +1116,13 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
             )
             return False
 
-        self.log_system_action(
-            "registered contactmoment by API", user=self.request.user
-        )
         objectcontactmoment = service.create_objectcontactmoment(
             contactmoment, self.case
         )
-        if objectcontactmoment:
-            self.log_system_action(
-                "registered objectcontactmoment by API", user=self.request.user
-            )
-        else:
-            self.log_system_action(
-                "error while registering objectcontactmoment by API",
-                user=self.request.user,
-            )
+        self.log_contactmoment_for_zaak_registered_by_api(
+            contactmoment_success=True,
+            objectcontactmoment_success=bool(objectcontactmoment),
+        )
 
         # We'll mark this call as successful if the cotactmoment is created, independent of
         # whether we've successfully associated the contactmoment with the case, because we

--- a/src/open_inwoner/mail/views.py
+++ b/src/open_inwoner/mail/views.py
@@ -6,13 +6,13 @@ from django.shortcuts import redirect, reverse
 from django.utils.translation import gettext as _
 from django.views import View
 
+from open_inwoner.accounts.views.mixins import RegistrationLogMixin
 from open_inwoner.utils.url import get_next_url_from
-from open_inwoner.utils.views import LogMixin
 
 from .verification import VERIFY_GET_PARAM, validate_email_verification_token
 
 
-class EmailVerificationTokenView(LoginRequiredMixin, LogMixin, View):
+class EmailVerificationTokenView(LoginRequiredMixin, RegistrationLogMixin, View):
     def get(self, request):
         if not request.user.is_authenticated:
             raise PermissionDenied("not authenticated")
@@ -25,7 +25,7 @@ class EmailVerificationTokenView(LoginRequiredMixin, LogMixin, View):
             messages.add_message(
                 self.request, messages.SUCCESS, _("Uw e-mailadres is bevestigd")
             )
-            self.log_user_action(request.user, _("user verified e-mail address"))
+            self.log_email_verification_completed(request.user, success=True)
 
             return HttpResponseRedirect(
                 get_next_url_from(self.request, default=reverse("pages-root"))
@@ -38,6 +38,7 @@ class EmailVerificationTokenView(LoginRequiredMixin, LogMixin, View):
                     "Er is iets misgegaan met het valideren van de link. Probeer het opnieuw"
                 ),
             )
+            self.log_email_verification_completed(request.user, success=False)
 
             from django.urls.exceptions import NoReverseMatch
 

--- a/src/open_inwoner/openklant/tests/test_contactform.py
+++ b/src/open_inwoner/openklant/tests/test_contactform.py
@@ -510,7 +510,6 @@ class ContactFormIntegrationTest(
             },
         )
 
-        self.assertTimelineLog("retrieved klant for BSN or KVK user")
         self.assertTimelineLog("registered contactmoment via eSuite")
         mock_send_confirm.assert_called_once_with("foo@example.com", subject.subject)
 
@@ -687,8 +686,6 @@ class ContactFormIntegrationTest(
                             "rol": KlantContactRol.BELANGHEBBENDE,
                         },
                     )
-
-                    self.assertTimelineLog("retrieved klant for BSN or KVK user")
                     self.assertTimelineLog("registered contactmoment via eSuite")
 
                     mock_send_confirm.assert_called_once_with(
@@ -777,7 +774,6 @@ class ContactFormIntegrationTest(
             },
         )
 
-        self.assertTimelineLog("retrieved klant for BSN or KVK user")
         self.assertTimelineLog(
             "patched klant from user with missing fields: emailadres, telefoonnummer"
         )
@@ -903,7 +899,6 @@ class ContactFormIntegrationTest(
                         },
                     )
 
-                    self.assertTimelineLog("retrieved klant for BSN or KVK user")
                     self.assertTimelineLog(
                         "patched klant from user with missing fields: emailadres, telefoonnummer"
                     )

--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -14,6 +14,7 @@ from django.views.generic import FormView
 from mail_editor.helpers import find_template
 from view_breadcrumbs import BaseBreadcrumbMixin
 
+from open_inwoner.accounts.views.mixins import ContactmomentLogMixin
 from open_inwoner.mail.service import send_contact_confirmation_mail
 from open_inwoner.openklant.api_models import (
     ContactMomentCreateData,
@@ -26,12 +27,14 @@ from open_inwoner.openklant.forms import ContactForm
 from open_inwoner.openklant.models import ESuiteKlantConfig, KlantenSysteemConfig
 from open_inwoner.openklant.services import OpenKlant2Service, eSuiteVragenService
 from open_inwoner.openklant.views.utils import generate_question_answer_pair
-from open_inwoner.utils.views import CommonPageMixin, LogMixin
+from open_inwoner.utils.views import CommonPageMixin
 
 logger = logging.getLogger(__name__)
 
 
-class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
+class ContactFormView(
+    CommonPageMixin, ContactmomentLogMixin, BaseBreadcrumbMixin, FormView
+):
     """
     View for handling the sumission of contact forms
 
@@ -183,17 +186,9 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
 
         success = template.send_email([recipient_email], context)
 
-        if success:
-            self.log_system_action(
-                "registered contactmoment by email", user=self.request.user
-            )
-            return True
-        else:
-            self.log_system_action(
-                "error while registering contactmoment by email",
-                user=self.request.user,
-            )
-            return False
+        self.log_contactmoment_registered_by_email(success)
+
+        return success
 
     def register_by_api(self, form, config: KlantenSysteemConfig):
         if config.primary_backend == KlantenServiceType.ESUITE.value:
@@ -230,12 +225,10 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
                     phonenumber=phonenumber,
                 )
         except Exception:
-            self.log_system_action("failed to register question via OpenKlant")
+            self.log_question_registered_via_openklant(success=False)
             return False, ""
 
-        self.log_system_action(
-            "registered question via OpenKlant", user=self.request.user
-        )
+        self.log_question_registered_via_openklant(success=True)
 
         return True, email
 
@@ -255,15 +248,10 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
             form.cleaned_data, esuite_config, klant
         )
 
-        if not contactmoment:
-            self.log_system_action(
-                "error while registering contactmoment by API", user=self.request.user
-            )
-            return False, getattr(klant, "emailadres", None)
-        self.log_system_action(
-            "registered contactmoment via eSuite", user=self.request.user
-        )
-        return True, getattr(klant, "emailadres", None)
+        success = bool(contactmoment)
+        self.log_contactmoment_registered_via_esuite(success)
+
+        return success, getattr(klant, "emailadres", None)
 
     def _fetch_klant(self) -> Klant | None:
         user = self.request.user
@@ -281,13 +269,9 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
             **self.vragen_service.get_fetch_parameters(self.request.user)
         )
 
-        self.log_system_action("retrieved klant for BSN or KVK user", user=user)
-
         return klant
 
     def _update_klant_with_form_data(self, klant: Klant, form_data: dict):
-        user = self.request.user
-
         update_data = {}
         user_email = form_data.get("email")
         phonenumber = form_data.get("phonenumber")
@@ -298,12 +282,7 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
             update_data["telefoonnummer"] = phonenumber
         if update_data:
             self.klanten_client.partial_update_klant(klant, update_data)
-            self.log_system_action(
-                "patched klant from user with missing fields: {patched}".format(
-                    patched=", ".join(sorted(update_data.keys()))
-                ),
-                user=user,
-            )
+            self.log_klant_patched(list(update_data.keys()))
 
     def _create_contactmoment(
         self,
@@ -324,10 +303,7 @@ class ContactFormView(CommonPageMixin, LogMixin, BaseBreadcrumbMixin, FormView):
                 text=text, full_name=full_name
             )
 
-            self.log_system_action(
-                "could not retrieve or create klant for user, appended info to message",
-                user=self.request.user,
-            )
+            self.log_klant_contact_info_appended_to_message()
 
         data = ContactMomentCreateData(
             bronorganisatie=klanten_config.register_bronorganisatie_rsin,

--- a/src/open_inwoner/openzaak/api/views.py
+++ b/src/open_inwoner/openzaak/api/views.py
@@ -11,13 +11,13 @@ from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.api_models import Notification
 from open_inwoner.openzaak.auth import get_valid_subscription_from_request
 from open_inwoner.openzaak.exceptions import InvalidAuth
+from open_inwoner.openzaak.mixins import WebhookLogMixin
 from open_inwoner.openzaak.tasks import process_zaken_notification
-from open_inwoner.utils.logentry import system_action as log_system_action
 
 logger = logging.getLogger(__name__)
 
 
-class NotificationsWebhookBaseView(APIView):
+class NotificationsWebhookBaseView(WebhookLogMixin, APIView):
     """
     Generic ZGW notification webhook handler
     """
@@ -37,7 +37,7 @@ class NotificationsWebhookBaseView(APIView):
         try:
             subscription = get_valid_subscription_from_request(request)
         except InvalidAuth as e:
-            log_system_action(str(e), log_level=logging.ERROR)
+            self.log_webhook_auth_error(str(e))
             return Response(
                 {"detail": "cannot authenticate subscription"},
                 status=status.HTTP_401_UNAUTHORIZED,
@@ -46,44 +46,47 @@ class NotificationsWebhookBaseView(APIView):
         # deserialize
         serializer = NotificatieSerializer(data=request.data)
         if not serializer.is_valid():
-            log_system_action(
-                "cannot deserialize notification", log_level=logging.ERROR
-            )
+            self.log_webhook_deserialization_error()
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         notification = factory(Notification, serializer.validated_data)
 
         # verify channel
         if notification.kanaal == "test":
-            log_system_action(
-                "received notification on 'test' channel", log_level=logging.INFO
-            )
+            self.log_webhook_test_channel(notification)
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         if notification.kanaal not in subscription.channels:
-            msg = f"notification channel '{notification.kanaal}' not subscribed to"
-            log_system_action(msg, log_level=logging.ERROR)
-            return Response({"detail": msg}, status=status.HTTP_400_BAD_REQUEST)
+            self.log_webhook_channel_not_subscribed(notification)
+            return Response(
+                {
+                    "detail": f"notification channel '{notification.kanaal}' not subscribed to"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if self.accept_channels and notification.kanaal not in self.accept_channels:
-            msg = f"notification channel '{notification.kanaal}' not acceptable by webhook"
-            log_system_action(msg, log_level=logging.ERROR)
-            return Response({"detail": msg}, status=status.HTTP_400_BAD_REQUEST)
+            self.log_webhook_channel_not_acceptable(notification)
+            return Response(
+                {
+                    "detail": f"notification channel '{notification.kanaal}' not acceptable by webhook"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # call actual handler
         try:
             self.handle_notification(notification)
         except Exception as e:
             # handler had an error
-            log_system_action(
-                f"error handling notification: {e}", log_level=logging.ERROR, exc_info=e
-            )
+            self.log_webhook_handler_error(notification, e)
             return Response(
                 {"detail": "internal error handling notification"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         else:
             # looks like we're good
+            self.log_webhook_notification_received(notification, "accepted")
             return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/src/open_inwoner/openzaak/metrics.py
+++ b/src/open_inwoner/openzaak/metrics.py
@@ -1,0 +1,30 @@
+from opentelemetry import metrics
+
+meter = metrics.get_meter("open_inwoner.openzaak")
+
+webhook_notifications_received = meter.create_counter(
+    "webhooks.notifications_received",
+    unit="1",
+    description=(
+        "Number of webhook notifications received. "
+        "Attributes: channel (str), result (str)"
+    ),
+)
+
+webhook_notifications_processed = meter.create_counter(
+    "webhooks.notifications_processed",
+    unit="1",
+    description=(
+        "Number of webhook notifications successfully processed. "
+        "Attributes: channel (str), resource (str)"
+    ),
+)
+
+webhook_notification_emails_sent = meter.create_counter(
+    "webhooks.notification_emails_sent",
+    unit="1",
+    description=(
+        "Number of notification emails sent to users. "
+        "Attributes: notification_type (str), template_name (str)"
+    ),
+)

--- a/src/open_inwoner/openzaak/mixins.py
+++ b/src/open_inwoner/openzaak/mixins.py
@@ -1,0 +1,125 @@
+import logging
+from typing import TYPE_CHECKING
+
+from django.http import HttpRequest
+
+from open_inwoner.openzaak.metrics import (
+    webhook_notification_emails_sent,
+    webhook_notifications_processed,
+    webhook_notifications_received,
+)
+from open_inwoner.utils.logentry import system_action as log_system_action
+from open_inwoner.utils.views import LogMixin
+
+if TYPE_CHECKING:
+    from open_inwoner.openzaak.api_models import Notification
+
+
+class WebhookLogMixin(LogMixin):
+    """Mixin for logging and metrics related to webhook notifications"""
+
+    request: HttpRequest
+
+    def log_webhook_notification_received(
+        self, notification: "Notification", result: str
+    ):
+        webhook_notifications_received.add(
+            1, {"channel": notification.kanaal, "result": result}
+        )
+
+    def log_webhook_auth_error(self, error_message: str):
+        log_system_action(error_message, log_level=logging.ERROR)
+
+    def log_webhook_deserialization_error(self):
+        log_system_action("cannot deserialize notification", log_level=logging.ERROR)
+
+    def log_webhook_test_channel(self, notification: "Notification"):
+        log_system_action(
+            "received notification on 'test' channel", log_level=logging.INFO
+        )
+        self.log_webhook_notification_received(notification, result="accepted")
+
+    def log_webhook_channel_not_subscribed(self, notification: "Notification"):
+        msg = f"notification channel '{notification.kanaal}' not subscribed to"
+        log_system_action(msg, log_level=logging.ERROR)
+        self.log_webhook_notification_received(notification, result="not_subscribed")
+
+    def log_webhook_channel_not_acceptable(self, notification: "Notification"):
+        msg = f"notification channel '{notification.kanaal}' not acceptable by webhook"
+        log_system_action(msg, log_level=logging.ERROR)
+        self.log_webhook_notification_received(notification, result="not_acceptable")
+
+    def log_webhook_handler_error(self, notification: "Notification", error: Exception):
+        log_system_action(
+            f"error handling notification: {error}",
+            log_level=logging.ERROR,
+            exc_info=error,
+        )
+        self.log_webhook_notification_received(notification, result="handler_error")
+
+    def log_notification_ignored(
+        self,
+        notification: "Notification",
+        reason: str,
+        case_url: str,
+        log_level: int = logging.INFO,
+    ):
+        log_system_action(
+            f"ignored {notification.resource} notification: {reason} for case {case_url}",
+            log_level=log_level,
+        )
+
+    def log_notification_accepted(
+        self, notification: "Notification", users: list, case_url: str
+    ):
+        from open_inwoner.openzaak.notifications import _wrap_join
+
+        log_system_action(
+            f"accepted {notification.resource} notification: attempt informing users {_wrap_join(users)} for case {case_url}",
+            log_level=logging.INFO,
+        )
+        webhook_notifications_processed.add(
+            1, {"channel": notification.kanaal, "resource": notification.resource}
+        )
+
+    def log_notification_email_blocked_by_user(
+        self, notification: "Notification", user, resource_url: str, case_url: str
+    ):
+        log_system_action(
+            f"ignored user-disabled notification delivery for user '{user}' {resource_url} case {case_url}",
+            log_level=logging.INFO,
+        )
+
+    def log_notification_email_duplicate(
+        self, notification: "Notification", user, resource_url: str, case_url: str
+    ):
+        log_system_action(
+            f"ignored duplicate {notification.resource} notification delivery for user '{user}' {resource_url} case {case_url}",
+            log_level=logging.INFO,
+        )
+
+    def log_notification_email_rate_limited(
+        self, notification: "Notification", user, resource_url: str, case_url: str
+    ):
+        log_system_action(
+            f"blocked over-frequent {notification.resource} notification email for user '{user}' {resource_url} case {case_url}",
+            log_level=logging.INFO,
+        )
+
+    def log_notification_email_sent(
+        self,
+        notification: "Notification",
+        user,
+        resource_url: str,
+        case_url: str,
+    ):
+        log_system_action(
+            f"sent {notification.resource} notification email for user '{user}' {resource_url} case {case_url}",
+            log_level=logging.INFO,
+        )
+        webhook_notification_emails_sent.add(
+            1,
+            {
+                "notification_type": notification.resource,
+            },
+        )

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -13,12 +13,13 @@ from open_inwoner.openzaak.api_models import (
     Notification,
     Rol,
     Status,
+    StatusType,
     Zaak,
     ZaakInformatieObject,
-    ZaakType,
 )
 from open_inwoner.openzaak.clients import CatalogiClient, ZakenClient
 from open_inwoner.openzaak.documents import fetch_single_information_object_from_url
+from open_inwoner.openzaak.mixins import WebhookLogMixin
 from open_inwoner.openzaak.models import (
     OpenZaakConfig,
     UserCaseInfoObjectNotification,
@@ -38,6 +39,9 @@ from open_inwoner.utils.logentry import system_action as log_system_action
 from open_inwoner.utils.url import build_absolute_url
 
 logger = logging.getLogger(__name__)
+
+# Create a helper instance for logging
+_log_helper = WebhookLogMixin()
 
 
 # TODO: check siteconfig for notification enabled
@@ -251,15 +255,13 @@ def _handle_zaakinformatieobject_notification(
         return
 
     # reaching here means we're going to inform users
-    log_system_action(
-        f"accepted {r} notification: attempt informing users {_wrap_join(inform_users)} for case {case.url}",
-        log_level=logging.INFO,
-    )
+    _log_helper.log_notification_accepted(notification, inform_users, case.url)
     for user in inform_users:
-        _handle_zaakinformatieobject_update(user, case, ziobj, api_group)
+        _handle_zaakinformatieobject_update(notification, user, case, ziobj, api_group)
 
 
 def _handle_zaakinformatieobject_update(
+    notification: Notification,
     user: User,
     case: Zaak,
     zaak_info_object: ZaakInformatieObject,
@@ -271,10 +273,8 @@ def _handle_zaakinformatieobject_update(
     hooks.case_document_added_notification_received(user, case, zaak_info_object)
 
     if not user.cases_notifications or not user.get_contact_email():
-        log_system_action(
-            f"ignored user-disabled notification delivery for user "
-            f"'{user}' zaakinformatieobject {zaak_info_object.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_blocked_by_user(
+            notification, user, zaak_info_object.url, case.url
         )
         return
 
@@ -285,30 +285,24 @@ def _handle_zaakinformatieobject_update(
         template_name,
     )
     if not note:
-        log_system_action(
-            f"ignored duplicate zaakinformatieobject notification delivery "
-            f"for user '{user}' zaakinformatieobject {zaak_info_object.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_duplicate(
+            notification, user, zaak_info_object.url, case.url
         )
         return
 
     # let's not spam the users
     period = timedelta(seconds=settings.ZGW_LIMIT_NOTIFICATIONS_FREQUENCY)
     if note.has_received_similar_notes_within(period, template_name):
-        log_system_action(
-            f"blocked over-frequent zaakinformatieobject notification email "
-            f"for user '{user}' zaakinformatieobject {zaak_info_object.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_rate_limited(
+            notification, user, zaak_info_object.url, case.url
         )
         return
 
     send_case_update_email(user, case, template_name, api_group=api_group)
     note.mark_sent()
 
-    log_system_action(
-        f"send zaakinformatieobject notification email for user '{user}' "
-        f"zaakinformatieobject {zaak_info_object.url} case {case.url}",
-        log_level=logging.INFO,
+    _log_helper.log_notification_email_sent(
+        notification, user, zaak_info_object.url, case.url
     )
 
 
@@ -378,7 +372,7 @@ def _check_status_type(
     status: Status,
     oz_config: OpenZaakConfig,
     catalogi_client: CatalogiClient,
-) -> ZaakType | None:
+) -> StatusType | None:
     """
     Check if a status_type exists for `status` and if notifications are enabled
     """
@@ -475,6 +469,7 @@ def _check_statustype_config(
 
 
 def _check_user_status_notitifactions(
+    notification: Notification,
     user: User,
     case: Zaak,
     status: Status,
@@ -489,10 +484,8 @@ def _check_user_status_notitifactions(
         return True
 
     if not user.cases_notifications or not user.get_contact_email():
-        log_system_action(
-            f"ignored user-disabled notification delivery for user '{user}' status "
-            f"{status.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_blocked_by_user(
+            notification, user, status.url, case.url
         )
         return False
 
@@ -532,6 +525,7 @@ def _handle_status_notification(
     if not status:
         # TODO: check if should we return or continue if the case has no status
         logger.error("Unable to fetch status for %s", case.status)
+        return
 
     case.status = status
     if not (status_type_config := _check_statustype_config(notification, case, ztc)):
@@ -541,21 +535,20 @@ def _handle_status_notification(
 
     for user in inform_users:
         if not _check_user_status_notitifactions(
-            user, case, status, status_type_config
+            notification, user, case, status, status_type_config
         ):
             return
 
         # all checks have passed
-        log_system_action(
-            f"accepted {notification.resource} notification: attempt informing users "
-            f"{_wrap_join(inform_users)} for case {case.url}",
-            log_level=logging.INFO,
-        )
+        _log_helper.log_notification_accepted(notification, inform_users, case.url)
         # TODO: replace with notify_about_status_update(...args, method: Callable)
-        _handle_status_update(user, case, status, status_type_config, api_group)
+        _handle_status_update(
+            notification, user, case, status, status_type_config, api_group
+        )
 
 
 def _handle_status_update(
+    notification: Notification,
     user: User,
     case: Zaak,
     status: Status,
@@ -579,20 +572,16 @@ def _handle_status_update(
         template_name,
     )
     if not note:
-        log_system_action(
-            f"ignored duplicate status notification delivery for user '{user}' status "
-            f"{status.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_duplicate(
+            notification, user, status.url, case.url
         )
         return
 
     # let's not spam the users
     period = timedelta(seconds=settings.ZGW_LIMIT_NOTIFICATIONS_FREQUENCY)
     if note.has_received_similar_notes_within(period, template_name):
-        log_system_action(
-            f"blocked over-frequent status notification email for user '{user}' status "
-            f"{status.url} case {case.url}",
-            log_level=logging.INFO,
+        _log_helper.log_notification_email_rate_limited(
+            notification, user, status.url, case.url
         )
         return
 
@@ -601,10 +590,7 @@ def _handle_status_update(
     )
     note.mark_sent()
 
-    log_system_action(
-        f"send status notification email for user '{user}' status {status.url} case {case.url}",
-        log_level=logging.INFO,
-    )
+    _log_helper.log_notification_email_sent(notification, user, status.url, case.url)
 
 
 # - - - - -

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
@@ -88,9 +88,9 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
                 # check call arguments
                 args = mock_handle.call_args.args
-                self.assertEqual(args[0], user_initiator)
-                self.assertEqual(args[1].url, zaak["url"])
-                self.assertEqual(args[2].url, zaak_info_obj["url"])
+                self.assertEqual(args[1], user_initiator)
+                self.assertEqual(args[2].url, zaak["url"])
+                self.assertEqual(args[3].url, zaak_info_obj["url"])
 
         log_dump = self.getTimelineLogDump()
         self.assertIn("total 2 timelinelogs", log_dump)
@@ -128,9 +128,9 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
                 # check call arguments
                 args = mock_handle.call_args.args
-                self.assertEqual(args[0], data.eherkenning_user_initiator)
-                self.assertEqual(args[1].url, data.zaak2["url"])
-                self.assertEqual(args[2].url, data.zaak_informatie_object2["url"])
+                self.assertEqual(args[1], data.eherkenning_user_initiator)
+                self.assertEqual(args[2].url, data.zaak2["url"])
+                self.assertEqual(args[3].url, data.zaak_informatie_object2["url"])
 
                 self.assertTimelineLog(
                     "accepted zaakinformatieobject notification: attempt informing users ",
@@ -390,7 +390,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
-        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
+        _handle_zaakinformatieobject_update(
+            data.zio_notification, user, case, zio, api_group=data.api_group
+        )
 
         # not called because disabled notifications
         mock_send.assert_not_called()
@@ -423,7 +425,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
-        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
+        _handle_zaakinformatieobject_update(
+            data.zio_notification, user, case, zio, api_group=data.api_group
+        )
 
         # not called because bad email
         mock_send.assert_not_called()
@@ -455,7 +459,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
         # first call
-        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
+        _handle_zaakinformatieobject_update(
+            data.zio_notification, user, case, zio, api_group=data.api_group
+        )
 
         mock_send.assert_called_once()
         mock_send.assert_called_with(
@@ -478,7 +484,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
 
         # check side effects
         self.assertTimelineLog(
-            "send zaakinformatieobject notification email for user",
+            "sent zaakinformatieobject notification email for user",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -487,7 +493,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         )
 
         # second call with same case/status
-        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
+        _handle_zaakinformatieobject_update(
+            data.zio_notification, user, case, zio, api_group=data.api_group
+        )
 
         # no duplicate mail for this user/case/status
         mock_send.assert_not_called()
@@ -501,7 +509,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         # other user is fine
         other_user = UserFactory.create()
         _handle_zaakinformatieobject_update(
-            other_user, case, zio, api_group=data.api_group
+            data.zio_notification, other_user, case, zio, api_group=data.api_group
         )
 
         mock_send.assert_called_once()
@@ -521,7 +529,9 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             InformatieObject, copy_with_new_uuid(data.informatie_object)
         )
 
-        _handle_zaakinformatieobject_update(user, case, zio, api_group=data.api_group)
+        _handle_zaakinformatieobject_update(
+            data.zio_notification, user, case, zio, api_group=data.api_group
+        )
 
         # not sent because we already send to this user within the frequency
         mock_send.assert_not_called()
@@ -541,7 +551,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
                 InformatieObject, copy_with_new_uuid(data.informatie_object)
             )
             _handle_zaakinformatieobject_update(
-                user, case, zio, api_group=data.api_group
+                data.zio_notification, user, case, zio, api_group=data.api_group
             )
 
             # this one succeeds

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
@@ -89,32 +89,35 @@ class StatusNotificationHandlerTestCase(
         config.notifications_cases_enabled = True
         config.save()
 
-        for api_group, notification, zaak, status, user_initiator in [
-            (
-                data.api_group,
-                data.status_notification,
-                data.zaak,
-                data.status_final,
-                data.user_initiator,
-            ),
-            (
-                data_alt.api_group_alt,
-                data_alt.status_notification_alt,
-                data_alt.zaak_alt,
-                data_alt.status_final_alt,
-                data_alt.user_initiator_alt,
-            ),
-        ]:
-            with self.subTest(f"api_group {api_group.id}"):
+        for idx, (api_group, notification, zaak, status, user_initiator) in enumerate(
+            [
+                (
+                    data.api_group,
+                    data.status_notification,
+                    data.zaak,
+                    data.status_final,
+                    data.user_initiator,
+                ),
+                (
+                    data_alt.api_group_alt,
+                    data_alt.status_notification_alt,
+                    data_alt.zaak_alt,
+                    data_alt.status_final_alt,
+                    data_alt.user_initiator_alt,
+                ),
+            ]
+        ):
+            with self.subTest(f"api_group_{idx}"):
                 webhook_view.handle_notification(notification)
 
                 mock_handle.assert_called()
 
                 # check call arguments
                 args = mock_handle.call_args.args
-                self.assertEqual(args[0], user_initiator)
-                self.assertEqual(args[1].url, zaak["url"])
-                self.assertEqual(args[2].url, status["url"])
+                self.assertEqual(args[0], notification)
+                self.assertEqual(args[1], user_initiator)
+                self.assertEqual(args[2].url, zaak["url"])
+                self.assertEqual(args[3].url, status["url"])
 
         log_dump = self.getTimelineLogDump()
         self.assertIn("total 2 timelinelogs", log_dump)
@@ -416,9 +419,10 @@ class StatusNotificationHandlerTestCase(
 
         # check call arguments
         args = mock_handle.call_args.args
-        self.assertEqual(args[0], data.user_initiator)
-        self.assertEqual(args[1].url, data.zaak["url"])
-        self.assertEqual(args[2].url, data.status_final["url"])
+        self.assertEqual(args[0], data.status_notification)
+        self.assertEqual(args[1], data.user_initiator)
+        self.assertEqual(args[2].url, data.zaak["url"])
+        self.assertEqual(args[3].url, data.status_final["url"])
 
         self.assertTimelineLog(
             "accepted status notification: attempt informing users ",
@@ -646,7 +650,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
 
         # first call
         _handle_status_update(
-            user, case, status_initial, status_type_config_initial, data.api_group
+            data.status_notification,
+            user,
+            case,
+            status_initial,
+            status_type_config_initial,
+            data.api_group,
         )
 
         mock_send.assert_called_once()
@@ -673,7 +682,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         mock_send.reset_mock()
 
         self.assertTimelineLog(
-            "send status notification email for user",
+            "sent status notification email for user",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -683,7 +692,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
 
         # second call with same case/status
         _handle_status_update(
-            user, case, status_initial, status_type_config_initial, data.api_group
+            data.status_notification,
+            user,
+            case,
+            status_initial,
+            status_type_config_initial,
+            data.api_group,
         )
 
         # no duplicate mail for this user/case/status
@@ -692,7 +706,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         with self.subTest("mails are throttled based on template_name"):
             # call with different status and different configuration with action_required=True
             _handle_status_update(
-                user, case, status_final, status_type_config_final, data.api_group
+                data.status_notification,
+                user,
+                case,
+                status_final,
+                status_type_config_final,
+                data.api_group,
             )
 
             mock_send.assert_called_once()
@@ -716,7 +735,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         # other user is fine
         other_user = UserFactory.create()
         _handle_status_update(
-            other_user, case, status_initial, status_type_config_initial, data.api_group
+            data.status_notification,
+            other_user,
+            case,
+            status_initial,
+            status_type_config_initial,
+            data.api_group,
         )
 
         mock_send.assert_called_once()
@@ -734,7 +758,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             StatusType, copy_with_new_uuid(data.status_type_final)
         )
         _handle_status_update(
-            user, case, status, status_type_config_initial, data.api_group
+            data.status_notification,
+            user,
+            case,
+            status,
+            status_type_config_initial,
+            data.api_group,
         )
 
         # not sent because we already send to this user within the frequency
@@ -753,7 +782,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
                 StatusType, copy_with_new_uuid(data.status_type_final)
             )
             _handle_status_update(
-                user, case, status, status_type_config_initial, data.api_group
+                data.status_notification,
+                user,
+                case,
+                status,
+                status_type_config_initial,
+                data.api_group,
             )
 
             # this one succeeds
@@ -786,7 +820,14 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             action_required=True,
         )
 
-        _handle_status_update(user, case, status, status_type_config, data.api_group)
+        _handle_status_update(
+            data.status_notification,
+            user,
+            case,
+            status,
+            status_type_config,
+            data.api_group,
+        )
 
         mock_send.assert_called_once()
         # check call arguments


### PR DESCRIPTION
## Summary

In addition to adding the metrics, this PR involves moving all logging calls into semantically named logging mixins, so we have a clear central hook for logs and metrics (they're a similar concern), and so that the business methods don't have to worry about implementation details.

## Issue References

- Taiga User Story: [#3468](https://taiga.maykinmedia.nl/project/open-inwoner/us/3468)

## Checklist

- [x] CHANGELOG.rst updated
