### PR TITLE
fix: use paginator object in contactmomenten list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Bugfixes
   niet was geconfigureerd.
 * [:taiga-is:`3479`: :pr:`1940`]: Ongepubliceerde CMS pagina's worden niet meer
   weergegeven in de zijnavigatie.
+* [:taiga-is:`3493`: :pr:`1954`]: Paginering op contactmomenten lijst wordt nu correct
+  weergegeven.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -161,9 +161,8 @@ class KlantContactMomentListView(
                     )
 
         questions.sort(key=lambda q: q["registered_date"], reverse=True)
-        ctx["questions"] = questions
 
-        paginator_dict = self.paginate_with_context(ctx["questions"])
+        paginator_dict = self.paginate_with_context(questions)
         ctx.update(paginator_dict)
 
         siteconfig = SiteConfiguration.get_solo()

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -105,7 +105,7 @@ class ContactMomentViewsTestCase(
         list_url = reverse("cases:contactmoment_list")
         response = self.app.get(list_url, user=data.user)
 
-        kcms = response.context["questions"]
+        kcms = response.context["page_obj"].object_list
         cm_data = data.contactmoment
 
         self.assertEqual(len(kcms), 2)
@@ -156,6 +156,32 @@ class ContactMomentViewsTestCase(
         self.assertIn(f"{_('Status')}\n{_('Afgehandeld')}", status_item.text())
         self.assertNotIn(_("Nieuw antwoord beschikbaar"), response.text)
 
+    def test_contactmoment_list_pagination(
+        self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
+    ):
+        data = MockAPIReadData().install_mocks(m)
+        list_url = reverse("cases:contactmoment_list")
+
+        with patch(
+            "open_inwoner.accounts.views.contactmoments.KlantContactMomentListView.paginate_by",
+            1,
+        ):
+            # Test first page (default)
+            response = self.app.get(list_url, user=data.user)
+            kcms = response.context["page_obj"].object_list
+
+            self.assertEqual(len(kcms), 1)
+            self.assertEqual(kcms[0]["identification"], "openklant2_identification")
+
+            # Test second page
+            response = self.app.get(list_url, {"page": "2"}, user=data.user)
+            kcms = response.context["page_obj"].object_list
+
+            self.assertEqual(len(kcms), 1)
+            self.assertEqual(
+                kcms[0]["identification"], data.contactmoment["identificatie"]
+            )
+
     @freeze_time("2022-01-01")
     def test_contactmoment_list_bsn_new_answer_available(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
@@ -192,7 +218,7 @@ class ContactMomentViewsTestCase(
         list_url = reverse("cases:contactmoment_list")
         response = self.app.get(list_url, user=data.user)
 
-        kcms = response.context["questions"]
+        kcms = response.context["page_obj"].object_list
         cm_data = data.contactmoment
 
         self.assertEqual(len(kcms), 2)
@@ -275,7 +301,7 @@ class ContactMomentViewsTestCase(
                 list_url = reverse("cases:contactmoment_list")
                 response = self.app.get(list_url, user=data.eherkenning_user)
 
-                kcms = response.context["questions"]
+                kcms = response.context["page_obj"].object_list
                 cm_data = data.contactmoment2
 
                 self.assertEqual(len(kcms), 2)
@@ -347,7 +373,7 @@ class ContactMomentViewsTestCase(
 
                 response = self.client.get(list_url)
 
-                kcms = response.context["questions"]
+                kcms = response.context["page_obj"].object_list
                 cm_data = data.contactmoment_vestiging
 
                 self.assertEqual(len(kcms), 2)
@@ -636,7 +662,7 @@ class ContactMomentViewsTestCase(
         list_url = reverse("cases:contactmoment_list")
         response = self.app.get(list_url, user=data.user)
 
-        kcms = response.context["questions"]
+        kcms = response.context["page_obj"].object_list
         cm_data = data.contactmoment
 
         self.assertEqual(len(kcms), 2)
@@ -700,7 +726,7 @@ class ContactMomentViewsTestCase(
         list_url = reverse("cases:contactmoment_list")
         response = self.app.get(list_url, user=data.user)
 
-        kcms = response.context["questions"]
+        kcms = response.context["page_obj"].object_list
         cm_data = data.contactmoment
 
         self.assertEqual(len(kcms), 2)

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content %}
-    <h1 class="utrecht-heading-1" id="contactmomenten">{{ page_title }} ({{ questions|length }})</h1>
+    <h1 class="utrecht-heading-1" id="contactmomenten">{{ page_title }} ({{ paginator.count }})</h1>
 
     {% if contactmoment_contact_form_enabled %}
     {# title + scroll down button #}
@@ -40,14 +40,14 @@
 
     {# grid with Question objects #}
     <div class="contactmomenten">
-        {% if questions %}
+        {% if paginator.count %}
             <h2 class="contactmomenten__title">{% trans "Eerder gestelde vragen" %}</h2>
         {% else %}
             <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></p>
         {% endif %}
 
         {% render_grid %}
-            {% for question in questions %}
+            {% for question in page_obj.object_list %}
                 {% render_column start=forloop.counter_0|multiply:4 span=4 %}
                 <div class="card card--compact card--stretch">
                     {% if question.new_answer_available %}
@@ -81,9 +81,7 @@
         {% endrender_grid %}
     </div>
 
-    {% if questions %}
-        {% pagination page_obj=page_obj paginator=paginator request=request %}
-    {% endif %}
+    {% pagination page_obj=page_obj paginator=paginator request=request %}
 
     {% if contactmoment_contact_form_enabled %}
     <section class="contactmomenten contactmomenten__contact-form" data-testid="contactmomenten__contact_form">


### PR DESCRIPTION
## Summary

The contactmomenten list template did not properly use the paginator object to control view, pagination and conditional logic. This commit fixes all references to the raw questions list to use the paginator object.  

## Issue References

- Taiga Issue: [#3493](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3493)

## Checklist

- [x] CHANGELOG.rst updated

