### PR TITLE
fix: use correct result attribute in case ID search

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:taiga-is:`3494`: :pr:`1955`]: Verhelpen bug waardoor er sporadisch errors werden
+  getoond tijdens het zoeken naar zaken via de algemene zoek-functie.
 * [:taiga-is:`3486`: :pr:`1946`]: Menu-items op pagina 'Mijn Zaken' worden niet langer
   dubbel getoond in de sidebar en het dropdownmenu.
 * [:taiga-is:`3480`, :pr:`1934`]: De paginering van de contactmomenten lijstweergave

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -101,21 +101,21 @@ class SearchView(
                         api_group = ZGWApiGroupConfig.objects.resolve_group_from_hints(
                             client=case_result.client
                         )
-                        zaak = proxy_result.responses[0].result[0]
-                        zaaktype = api_group.catalogi_client.fetch_single_case_type(
-                            zaak.zaaktype
-                        )
-                        zaak.zaaktype = zaaktype
-                        if is_zaak_visible(zaak):
-                            return HttpResponseRedirect(
-                                reverse(
-                                    "cases:case_detail",
-                                    kwargs={
-                                        "object_id": str(zaak.uuid),
-                                        "api_group_id": api_group.id,
-                                    },
-                                )
+                        for zaak in case_result.result:
+                            zaaktype = api_group.catalogi_client.fetch_single_case_type(
+                                zaak.zaaktype
                             )
+                            zaak.zaaktype = zaaktype
+                            if is_zaak_visible(zaak):
+                                return HttpResponseRedirect(
+                                    reverse(
+                                        "cases:case_detail",
+                                        kwargs={
+                                            "object_id": str(zaak.uuid),
+                                            "api_group_id": api_group.id,
+                                        },
+                                    )
+                                )
 
         # perform search
         try:


### PR DESCRIPTION
## Summary

Previously we were using the wrong attribute (`proxy_result.responses[0].result[0]` rather than `case_result.result[0]`). This PR fixes this, and also ensures we redirect to the first case we find.

## Issue References

- Taiga Issue: [#3494](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3494)

## Checklist

- [x] CHANGELOG.rst updated

