### PR TITLE
fix: ensure openklant2 question subject always has a value for zaak q…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ Bugfixes
 
 * [:taiga-is:`3494`: :pr:`1955`]: Verhelpen bug waardoor er sporadisch errors werden
   getoond tijdens het zoeken naar zaken via de algemene zoek-functie.
+* [:taiga-is:`3495`: :pr:`1956`]: Bij het aanmaken van contactmomenten onder een zaak
+  in OpenKlant2 werd de zaak omschrijving als onderwerp gebruikt. Dit veld is in
+  OpenKlant2 echter verplicht, en de omschrijving kan leeg zijn, hetgeen sporadisch tot
+  errors leidde. We gebruiken nu de zaak identificatie en een standaard tekst, die
+  altijd aanwezig is.
 * [:taiga-is:`3486`: :pr:`1946`]: Menu-items op pagina 'Mijn Zaken' worden niet langer
   dubbel getoond in de sidebar en het dropdownmenu.
 * [:taiga-is:`3480`, :pr:`1934`]: De paginering van de contactmomenten lijstweergave

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -1082,7 +1082,6 @@ class CaseContactFormView(CaseAccessMixin, LogMixin, FormView):
         question = service.create_question_for_zaak(
             partij_uuid=partij["uuid"],
             question=question,
-            subject=self.case.omschrijving,
             zaak=self.case,
         )
 

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1557,11 +1557,12 @@ class OpenKlant2Service(
         self,
         partij_uuid: str,
         question: str,
-        subject: str,
         zaak: Zaak,
     ) -> OpenKlant2Question:
         ok2_question = self.create_question_for_partij(
-            partij_uuid=partij_uuid, question=question, subject=subject
+            partij_uuid=partij_uuid,
+            question=question,
+            subject=f"Vraag voor zaak: {zaak.identificatie}",
         )
 
         self.log_system_action(

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_cannot_use_existing_user_email_when_updating_user_from_partij.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_cannot_use_existing_user_email_when_updating_user_from_partij.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"50bf373f-13e4-437c-a7fb-96e8f87e286f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/50bf373f-13e4-437c-a7fb-96e8f87e286f","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/50bf373f-13e4-437c-a7fb-96e8f87e286f
+      - http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "50bf373f-13e4-437c-a7fb-96e8f87e286f"},
+    body: '{"identificeerdePartij": {"uuid": "7dcafc65-51c3-4372-ac84-89e8962414b7"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"393d8c5d-d861-4f66-977b-0bb03ab55526","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/393d8c5d-d861-4f66-977b-0bb03ab55526","identificeerdePartij":{"uuid":"50bf373f-13e4-437c-a7fb-96e8f87e286f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/50bf373f-13e4-437c-a7fb-96e8f87e286f"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"577fe242-dce2-42b8-9991-513db288ee5e","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/577fe242-dce2-42b8-9991-513db288ee5e","identificeerdePartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/393d8c5d-d861-4f66-977b-0bb03ab55526
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/577fe242-dce2-42b8-9991-513db288ee5e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=50bf373f-13e4-437c-a7fb-96e8f87e286f
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7dcafc65-51c3-4372-ac84-89e8962414b7
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -136,7 +136,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "another-user@foo.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "50bf373f-13e4-437c-a7fb-96e8f87e286f"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7dcafc65-51c3-4372-ac84-89e8962414b7"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -149,7 +149,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"c6f9d0ae-0c76-49f5-b164-f81c8e665db1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c6f9d0ae-0c76-49f5-b164-f81c8e665db1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"50bf373f-13e4-437c-a7fb-96e8f87e286f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/50bf373f-13e4-437c-a7fb-96e8f87e286f"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -159,17 +159,17 @@ interactions:
       Content-Length:
       - '470'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c6f9d0ae-0c76-49f5-b164-f81c8e665db1
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -187,10 +187,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=50bf373f-13e4-437c-a7fb-96e8f87e286f
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7dcafc65-51c3-4372-ac84-89e8962414b7
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"c6f9d0ae-0c76-49f5-b164-f81c8e665db1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c6f9d0ae-0c76-49f5-b164-f81c8e665db1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"50bf373f-13e4-437c-a7fb-96e8f87e286f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/50bf373f-13e4-437c-a7fb-96e8f87e286f"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -200,11 +200,11 @@ interactions:
       Content-Length:
       - '535'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_partij_from_user_data.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_partij_from_user_data.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e
+      - http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "8a485728-0715-4c73-a071-fce4ea46209e"},
+    body: '{"identificeerdePartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"3db0ceea-b227-4ba7-b2e9-4147aaa6536c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3db0ceea-b227-4ba7-b2e9-4147aaa6536c","identificeerdePartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"493fc360-8998-46d9-b37b-fcbfbea012f2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/493fc360-8998-46d9-b37b-fcbfbea012f2","identificeerdePartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3db0ceea-b227-4ba7-b2e9-4147aaa6536c
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/493fc360-8998-46d9-b37b-fcbfbea012f2
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=8a485728-0715-4c73-a071-fce4ea46209e
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -140,7 +140,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=8a485728-0715-4c73-a071-fce4ea46209e
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -152,11 +152,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -174,7 +174,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0644938475", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "8a485728-0715-4c73-a071-fce4ea46209e"},
+      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -187,7 +187,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"7f402fde-af92-4f2e-b1ac-230a92d3d4bc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7f402fde-af92-4f2e-b1ac-230a92d3d4bc","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -197,17 +197,17 @@ interactions:
       Content-Length:
       - '468'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7f402fde-af92-4f2e-b1ac-230a92d3d4bc
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62
       Referrer-Policy:
       - same-origin
       Vary:
@@ -225,10 +225,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=8a485728-0715-4c73-a071-fce4ea46209e
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"7f402fde-af92-4f2e-b1ac-230a92d3d4bc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7f402fde-af92-4f2e-b1ac-230a92d3d4bc","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -238,11 +238,11 @@ interactions:
       Content-Length:
       - '533'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -260,7 +260,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "user@bar.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "8a485728-0715-4c73-a071-fce4ea46209e"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -273,7 +273,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"cb2fe564-57b2-4cb5-84bd-7584ae3973c2","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/cb2fe564-57b2-4cb5-84bd-7584ae3973c2","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -283,17 +283,17 @@ interactions:
       Content-Length:
       - '462'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/cb2fe564-57b2-4cb5-84bd-7584ae3973c2
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe
       Referrer-Policy:
       - same-origin
       Vary:
@@ -311,11 +311,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=8a485728-0715-4c73-a071-fce4ea46209e
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"cb2fe564-57b2-4cb5-84bd-7584ae3973c2","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/cb2fe564-57b2-4cb5-84bd-7584ae3973c2","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"7f402fde-af92-4f2e-b1ac-230a92d3d4bc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7f402fde-af92-4f2e-b1ac-230a92d3d4bc","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -325,11 +325,11 @@ interactions:
       Content-Length:
       - '1009'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -347,7 +347,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0687654321", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "8a485728-0715-4c73-a071-fce4ea46209e"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -360,7 +360,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"939a36b6-e628-4d74-9683-280030c5c728","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/939a36b6-e628-4d74-9683-280030c5c728","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"7995ec98-3c5f-466d-b852-9f27c53eef17","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -370,17 +370,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/939a36b6-e628-4d74-9683-280030c5c728
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17
       Referrer-Policy:
       - same-origin
       Vary:
@@ -398,12 +398,12 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=8a485728-0715-4c73-a071-fce4ea46209e
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
   response:
     body:
-      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"939a36b6-e628-4d74-9683-280030c5c728","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/939a36b6-e628-4d74-9683-280030c5c728","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"cb2fe564-57b2-4cb5-84bd-7584ae3973c2","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/cb2fe564-57b2-4cb5-84bd-7584ae3973c2","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"7f402fde-af92-4f2e-b1ac-230a92d3d4bc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7f402fde-af92-4f2e-b1ac-230a92d3d4bc","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"8a485728-0715-4c73-a071-fce4ea46209e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8a485728-0715-4c73-a071-fce4ea46209e"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"7995ec98-3c5f-466d-b852-9f27c53eef17","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -413,11 +413,11 @@ interactions:
       Content-Length:
       - '1492'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_user_from_partij.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_user_from_partij.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+      - http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},
+    body: '{"identificeerdePartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"b4e62aaa-c14a-48ec-b69d-4f192ef62813","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b4e62aaa-c14a-48ec-b69d-4f192ef62813","identificeerdePartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"00a28204-0f3e-45a1-900a-c213a259a2bb","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/00a28204-0f3e-45a1-900a-c213a259a2bb","identificeerdePartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b4e62aaa-c14a-48ec-b69d-4f192ef62813
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/00a28204-0f3e-45a1-900a-c213a259a2bb
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -136,7 +136,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0644938475", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},
+      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -149,7 +149,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -159,17 +159,17 @@ interactions:
       Content-Length:
       - '468'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -187,10 +187,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -200,11 +200,11 @@ interactions:
       Content-Length:
       - '533'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -222,7 +222,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0687654321", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -235,7 +235,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"c088bd73-dfd8-4fa0-8d1c-19265c89625a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -245,17 +245,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -273,11 +273,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"c088bd73-dfd8-4fa0-8d1c-19265c89625a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -287,11 +287,11 @@ interactions:
       Content-Length:
       - '1016'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -309,7 +309,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -322,7 +322,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"4f975a6a-d19f-4d0b-897c-a156346f4554","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/4f975a6a-d19f-4d0b-897c-a156346f4554","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -332,17 +332,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/4f975a6a-d19f-4d0b-897c-a156346f4554
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -360,12 +360,12 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
-      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"4f975a6a-d19f-4d0b-897c-a156346f4554","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/4f975a6a-d19f-4d0b-897c-a156346f4554","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"c088bd73-dfd8-4fa0-8d1c-19265c89625a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -375,11 +375,11 @@ interactions:
       Content-Length:
       - '1499'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -397,7 +397,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "bar@foo.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -410,7 +410,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"e2b8af42-6440-42ea-a226-12a59570ea86","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e2b8af42-6440-42ea-a226-12a59570ea86","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -420,17 +420,17 @@ interactions:
       Content-Length:
       - '461'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e2b8af42-6440-42ea-a226-12a59570ea86
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -448,13 +448,13 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
-      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"e2b8af42-6440-42ea-a226-12a59570ea86","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e2b8af42-6440-42ea-a226-12a59570ea86","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"4f975a6a-d19f-4d0b-897c-a156346f4554","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/4f975a6a-d19f-4d0b-897c-a156346f4554","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"c088bd73-dfd8-4fa0-8d1c-19265c89625a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -464,11 +464,11 @@ interactions:
       Content-Length:
       - '1974'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -490,13 +490,13 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a9a32ff3-f4b6-426c-bebd-14c8e31bc762
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
   response:
     body:
-      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"e2b8af42-6440-42ea-a226-12a59570ea86","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e2b8af42-6440-42ea-a226-12a59570ea86","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"4f975a6a-d19f-4d0b-897c-a156346f4554","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/4f975a6a-d19f-4d0b-897c-a156346f4554","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"c088bd73-dfd8-4fa0-8d1c-19265c89625a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/c088bd73-dfd8-4fa0-8d1c-19265c89625a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"9d1d1956-1b3a-4d1d-81da-6898692725fd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/9d1d1956-1b3a-4d1d-81da-6898692725fd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a9a32ff3-f4b6-426c-bebd-14c8e31bc762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a9a32ff3-f4b6-426c-bebd-14c8e31bc762"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -506,11 +506,11 @@ interactions:
       Content-Length:
       - '1974'
       Content-Security-Policy:
-      - 'worker-src ''self'' blob:; img-src ''self'' data: cdn.redoc.ly; font-src
-        ''self'' fonts.gstatic.com; frame-ancestors ''none''; object-src ''none'';
-        script-src ''self'' ''unsafe-inline''; base-uri ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; default-src ''self'';
-        form-action ''self'''
+      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
+        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
+        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
+        frame-ancestors ''none'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -129,7 +129,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -138,17 +138,17 @@ interactions:
       Content-Length:
       - '901'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe
+      - http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef
       Referrer-Policy:
       - same-origin
       Vary:
@@ -178,11 +178,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -199,7 +199,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},
+    body: '{"identificeerdePartij": {"uuid": "2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},
       "partijIdentificator": {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
       "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
     headers:
@@ -213,7 +213,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      string: '{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -222,17 +222,17 @@ interactions:
       Content-Length:
       - '532'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3
       Referrer-Policy:
       - same-origin
       Vary:
@@ -262,11 +262,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -283,8 +283,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},
-      "subIdentificatorVan": {"uuid": "cfb357d0-5239-488e-97e1-68991c9ea655"}, "partijIdentificator":
+    body: '{"identificeerdePartij": {"uuid": "2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},
+      "subIdentificatorVan": {"uuid": "88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}, "partijIdentificator":
       {"codeObjecttype": "vestiging", "codeSoortObjectId": "vestigingsnummer", "objectId":
       "123456789123", "codeRegister": "hr"}}'
     headers:
@@ -298,7 +298,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}}'
+      string: '{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}'
     headers:
       API-version:
       - 0.1.2
@@ -307,17 +307,17 @@ interactions:
       Content-Length:
       - '685'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028
       Referrer-Policy:
       - same-origin
       Vary:
@@ -338,7 +338,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -347,11 +347,11 @@ interactions:
       Content-Length:
       - '2184'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -376,7 +376,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}},{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}},{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -385,11 +385,11 @@ interactions:
       Content-Length:
       - '1270'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -414,7 +414,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -423,11 +423,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -452,7 +452,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -461,11 +461,11 @@ interactions:
       Content-Length:
       - '737'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -487,10 +487,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef
   response:
     body:
-      string: '{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -499,11 +499,11 @@ interactions:
       Content-Length:
       - '2119'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -528,7 +528,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -537,11 +537,11 @@ interactions:
       Content-Length:
       - '2184'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -566,7 +566,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"a4990d8e-a33f-40a8-98ae-748ef6a57620","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/a4990d8e-a33f-40a8-98ae-748ef6a57620","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655"}},{"uuid":"cfb357d0-5239-488e-97e1-68991c9ea655","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cfb357d0-5239-488e-97e1-68991c9ea655","identificeerdePartij":{"uuid":"2f19cde0-c666-4e4d-ae50-b0368e5cd8fe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f19cde0-c666-4e4d-ae50-b0368e5cd8fe"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}},{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -575,11 +575,11 @@ interactions:
       Content-Length:
       - '1270'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -129,7 +129,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -138,17 +138,17 @@ interactions:
       Content-Length:
       - '901'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39
+      - http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09
       Referrer-Policy:
       - same-origin
       Vary:
@@ -178,11 +178,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -199,7 +199,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "55c16112-9092-4ffe-ae6b-ad62fdf59b39"},
+    body: '{"identificeerdePartij": {"uuid": "685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},
       "partijIdentificator": {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
       "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
     headers:
@@ -213,7 +213,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      string: '{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -222,17 +222,17 @@ interactions:
       Content-Length:
       - '532'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30
       Referrer-Policy:
       - same-origin
       Vary:
@@ -253,7 +253,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -262,11 +262,11 @@ interactions:
       Content-Length:
       - '1498'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -291,7 +291,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -300,11 +300,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -329,7 +329,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -338,11 +338,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -364,10 +364,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09
   response:
     body:
-      string: '{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -376,11 +376,11 @@ interactions:
       Content-Length:
       - '1433'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -405,7 +405,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -414,11 +414,11 @@ interactions:
       Content-Length:
       - '1498'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -443,7 +443,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"8e71eac1-a4d1-49d5-939a-b96c82abc8f9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/8e71eac1-a4d1-49d5-939a-b96c82abc8f9","identificeerdePartij":{"uuid":"55c16112-9092-4ffe-ae6b-ad62fdf59b39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55c16112-9092-4ffe-ae6b-ad62fdf59b39"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -452,11 +452,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -92,7 +92,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"f5969298-c396-445c-b7d6-a3d85849b478","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f5969298-c396-445c-b7d6-a3d85849b478","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"}}'
     headers:
       API-version:
@@ -102,17 +102,17 @@ interactions:
       Content-Length:
       - '1023'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/f5969298-c396-445c-b7d6-a3d85849b478
+      - http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -133,7 +133,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"f5969298-c396-445c-b7d6-a3d85849b478","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f5969298-c396-445c-b7d6-a3d85849b478","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"},"_expand":{}}]}'
     headers:
       API-version:
@@ -143,11 +143,11 @@ interactions:
       Content-Length:
       - '1088'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -181,11 +181,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -218,7 +218,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"7f300270-c0c8-423a-b968-3e96d2d5fe65","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7f300270-c0c8-423a-b968-3e96d2d5fe65","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"uuid":"e8ba8251-2451-4df1-9fa2-39e3605f45c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"}}'
     headers:
       API-version:
@@ -228,17 +228,17 @@ interactions:
       Content-Length:
       - '1023'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/7f300270-c0c8-423a-b968-3e96d2d5fe65
+      - http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5
       Referrer-Policy:
       - same-origin
       Vary:
@@ -259,8 +259,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"7f300270-c0c8-423a-b968-3e96d2d5fe65","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7f300270-c0c8-423a-b968-3e96d2d5fe65","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
-        Anonymous"},"_expand":{}},{"uuid":"f5969298-c396-445c-b7d6-a3d85849b478","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f5969298-c396-445c-b7d6-a3d85849b478","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"e8ba8251-2451-4df1-9fa2-39e3605f45c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+        Anonymous"},"_expand":{}},{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"},"_expand":{}}]}'
     headers:
       API-version:
@@ -270,11 +270,11 @@ interactions:
       Content-Length:
       - '2125'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -132,7 +132,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"}}'
     headers:
       API-version:
@@ -142,17 +142,17 @@ interactions:
       Content-Length:
       - '1533'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607
       Referrer-Policy:
       - same-origin
       Vary:
@@ -173,7 +173,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -183,11 +183,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -212,7 +212,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -221,11 +221,11 @@ interactions:
       Content-Length:
       - '574'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -250,7 +250,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -260,11 +260,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -286,10 +286,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
   response:
     body:
-      string: '{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{"betrokkenen":[]}}'
     headers:
       API-version:
@@ -299,11 +299,11 @@ interactions:
       Content-Length:
       - '1562'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -328,7 +328,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -338,11 +338,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -367,7 +367,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"93887b37-3e67-45cf-aee1-36dcedbcad8c","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/93887b37-3e67-45cf-aee1-36dcedbcad8c","identificeerdePartij":{"uuid":"e9588abf-b779-4fb5-946b-cdd539c6b237","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e9588abf-b779-4fb5-946b-cdd539c6b237"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -376,11 +376,11 @@ interactions:
       Content-Length:
       - '574'
       Content-Security-Policy:
-      - 'object-src ''none''; form-action ''self''; base-uri ''self''; img-src ''self''
-        data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com; script-src ''self''
-        ''unsafe-inline''; worker-src ''self'' blob:; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; frame-ancestors ''none''; frame-src ''self''; default-src
-        ''self'''
+      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
+        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"c168d9f7-c994-47b5-bcba-92988965e83e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c168d9f7-c994-47b5-bcba-92988965e83e","naam":"Afdeling
+      string: '{"uuid":"4df8c82c-c7a1-4c4a-85c7-069b6d58bf57","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4df8c82c-c7a1-4c4a-85c7-069b6d58bf57","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/c168d9f7-c994-47b5-bcba-92988965e83e
+      - http://localhost:8338/klantinteracties/api/v1/actoren/4df8c82c-c7a1-4c4a-85c7-069b6d58bf57
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,8 +48,8 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "goh", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Miss", "voornaam": "Alice", "voorvoegselAchternaam":
+      false, "voorkeurstaal": "chk", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
       "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
@@ -61,7 +62,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"050296d6-65ff-4de9-bf7a-5990826ebc73","url":"http://localhost:8338/klantinteracties/api/v1/partijen/050296d6-65ff-4de9-bf7a-5990826ebc73","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"goh","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Miss","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+      string: '{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"chk","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
         Mr. McAlice"}}'
     headers:
       API-version:
@@ -71,16 +72,17 @@ interactions:
       Content-Length:
       - '1031'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/050296d6-65ff-4de9-bf7a-5990826ebc73
+      - http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502
       Referrer-Policy:
       - same-origin
       Vary:
@@ -94,23 +96,23 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "chk", "soortPartij": "persoon", "partijIdentificatie":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      false, "voorkeurstaal": "ach", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mx.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Miss", "achternaam": "McBob"}}}'
+      "Dr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '362'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"0b229a52-1935-4311-a778-5ef0590b5391","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0b229a52-1935-4311-a778-5ef0590b5391","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"chk","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Bob","voorvoegselAchternaam":"Miss","achternaam":"McBob"},"volledigeNaam":"Bob
-        Miss McBob"}}'
+      string: '{"uuid":"dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"ach","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Dr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
@@ -119,16 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/0b229a52-1935-4311-a778-5ef0590b5391
+      - http://localhost:8338/klantinteracties/api/v1/partijen/dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","naam":"Afdeling
+      string: '{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca
+      - http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -200,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+      string: '{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
         questions","inhoud":"A question asked by Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -210,16 +214,17 @@ interactions:
       Content-Length:
       - '511'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea
       Referrer-Policy:
       - same-origin
       Vary:
@@ -232,21 +237,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "007dedad-3b74-4ca9-9036-2a4b11b74e69"},
-      "wasPartij": {"uuid": "050296d6-65ff-4de9-bf7a-5990826ebc73"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "bd73ab73-3080-441a-a903-0e4f10bf5502"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"fe536c2d-475f-4161-bc31-33e07f32d961","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/fe536c2d-475f-4161-bc31-33e07f32d961","wasPartij":{"uuid":"050296d6-65ff-4de9-bf7a-5990826ebc73","url":"http://localhost:8338/klantinteracties/api/v1/partijen/050296d6-65ff-4de9-bf7a-5990826ebc73"},"hadKlantcontact":{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c","wasPartij":{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502"},"hadKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -256,16 +262,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/fe536c2d-475f-4161-bc31-33e07f32d961
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -278,10 +285,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "007dedad-3b74-4ca9-9036-2a4b11b74e69"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "b5b28ff9-7bac-4a43-a2c2-2362e494a3ca"}}'
+      {"uuid": "a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -293,9 +300,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"589f5027-7af5-4c9d-bb94-2d8f50e73e34","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/589f5027-7af5-4c9d-bb94-2d8f50e73e34","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69"},"toegewezenAanActor":{"uuid":"b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca"},"toegewezenAanActoren":[{"uuid":"b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:08:38.838957Z","afgehandeldOp":null}'
+      string: '{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"toegewezenAanActor":{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"},"toegewezenAanActoren":[{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:09.912368Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -304,16 +311,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/589f5027-7af5-4c9d-bb94-2d8f50e73e34
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5
       Referrer-Policy:
       - same-origin
       Vary:
@@ -334,7 +342,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"fe536c2d-475f-4161-bc31-33e07f32d961","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/fe536c2d-475f-4161-bc31-33e07f32d961"}],"leiddeTotInterneTaken":[{"uuid":"589f5027-7af5-4c9d-bb94-2d8f50e73e34","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/589f5027-7af5-4c9d-bb94-2d8f50e73e34"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c"}],"leiddeTotInterneTaken":[{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
         questions","inhoud":"A question asked by Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
     headers:
       API-version:
@@ -344,10 +352,11 @@ interactions:
       Content-Length:
       - '877'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -372,7 +381,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fe536c2d-475f-4161-bc31-33e07f32d961","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/fe536c2d-475f-4161-bc31-33e07f32d961","wasPartij":{"uuid":"050296d6-65ff-4de9-bf7a-5990826ebc73","url":"http://localhost:8338/klantinteracties/api/v1/partijen/050296d6-65ff-4de9-bf7a-5990826ebc73"},"hadKlantcontact":{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c","wasPartij":{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502"},"hadKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -382,10 +391,11 @@ interactions:
       Content-Length:
       - '1130'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -410,9 +420,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"589f5027-7af5-4c9d-bb94-2d8f50e73e34","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/589f5027-7af5-4c9d-bb94-2d8f50e73e34","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"007dedad-3b74-4ca9-9036-2a4b11b74e69","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/007dedad-3b74-4ca9-9036-2a4b11b74e69"},"toegewezenAanActor":{"uuid":"b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca"},"toegewezenAanActoren":[{"uuid":"b5b28ff9-7bac-4a43-a2c2-2362e494a3ca","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b5b28ff9-7bac-4a43-a2c2-2362e494a3ca"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:08:38.838957Z","afgehandeldOp":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"toegewezenAanActor":{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"},"toegewezenAanActoren":[{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:09.912368Z","afgehandeldOp":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -421,10 +431,11 @@ interactions:
       Content-Length:
       - '952'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"41807b85-18d5-4ca9-8003-1af15522c5ea","url":"http://localhost:8338/klantinteracties/api/v1/actoren/41807b85-18d5-4ca9-8003-1af15522c5ea","naam":"Afdeling
+      string: '{"uuid":"4d2aede8-e77d-4a42-b7d1-a6c94821caad","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4d2aede8-e77d-4a42-b7d1-a6c94821caad","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/41807b85-18d5-4ca9-8003-1af15522c5ea
+      - http://localhost:8338/klantinteracties/api/v1/actoren/4d2aede8-e77d-4a42-b7d1-a6c94821caad
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,40 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "swa", "soortPartij": "persoon", "partijIdentificatie":
+      false, "voorkeurstaal": "bin", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McAlice"}}}'
+      "Mrs.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '367'
+      - '368'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"6d01332a-c4a2-4e59-9372-2d78d93e301c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6d01332a-c4a2-4e59-9372-2d78d93e301c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"swa","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Dr. McAlice"}}'
+      string: '{"uuid":"68729d66-1f70-44cc-91e0-d5a8f7296fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"bin","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1032'
+      - '1034'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/6d01332a-c4a2-4e59-9372-2d78d93e301c
+      - http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -95,22 +97,22 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "dar", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McBob"}}}'
+      true, "voorkeurstaal": "lat", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Miss", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '364'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"e75904f4-280e-4ad0-b0e6-2c9333fa9b91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e75904f4-280e-4ad0-b0e6-2c9333fa9b91","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"dar","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Dr. McBob"}}'
+      string: '{"uuid":"216294ea-b3a6-4e52-a60d-a6f8e9a08062","url":"http://localhost:8338/klantinteracties/api/v1/partijen/216294ea-b3a6-4e52-a60d-a6f8e9a08062","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"lat","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Miss","achternaam":"McBob"},"volledigeNaam":"Bob
+        Miss McBob"}}'
     headers:
       API-version:
       - 0.1.2
@@ -119,16 +121,17 @@ interactions:
       Content-Length:
       - '1025'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/e75904f4-280e-4ad0-b0e6-2c9333fa9b91
+      - http://localhost:8338/klantinteracties/api/v1/partijen/216294ea-b3a6-4e52-a60d-a6f8e9a08062
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"4450dba5-42a9-4b84-820a-cd7ab8965d76","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4450dba5-42a9-4b84-820a-cd7ab8965d76","naam":"Afdeling
+      string: '{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/4450dba5-42a9-4b84-820a-cd7ab8965d76
+      - http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -186,40 +190,41 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Important question",
-      "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
-      "2024-10-02T14:00:25.587564+00:00"}'
+    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+      Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+      "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '199'
+      - '209'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"c529b296-52b6-424c-83a1-2533374cc7c9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      string: '{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '511'
+      - '521'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -232,21 +237,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "c529b296-52b6-424c-83a1-2533374cc7c9"},
-      "wasPartij": {"uuid": "6d01332a-c4a2-4e59-9372-2d78d93e301c"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "68729d66-1f70-44cc-91e0-d5a8f7296fa8"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"4c97f5d7-0268-439f-acfa-4451b9938662","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4c97f5d7-0268-439f-acfa-4451b9938662","wasPartij":{"uuid":"6d01332a-c4a2-4e59-9372-2d78d93e301c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6d01332a-c4a2-4e59-9372-2d78d93e301c"},"hadKlantcontact":{"uuid":"c529b296-52b6-424c-83a1-2533374cc7c9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"bd17caec-992a-4c4f-91cc-e7ae23b26869","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/bd17caec-992a-4c4f-91cc-e7ae23b26869","wasPartij":{"uuid":"68729d66-1f70-44cc-91e0-d5a8f7296fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8"},"hadKlantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -256,16 +262,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/4c97f5d7-0268-439f-acfa-4451b9938662
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/bd17caec-992a-4c4f-91cc-e7ae23b26869
       Referrer-Policy:
       - same-origin
       Vary:
@@ -278,10 +285,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "c529b296-52b6-424c-83a1-2533374cc7c9"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "4450dba5-42a9-4b84-820a-cd7ab8965d76"}}'
+      {"uuid": "cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -293,9 +300,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"c8e1dff6-2af3-4b70-b9af-706928d01c98","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c8e1dff6-2af3-4b70-b9af-706928d01c98","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"c529b296-52b6-424c-83a1-2533374cc7c9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9"},"toegewezenAanActor":{"uuid":"4450dba5-42a9-4b84-820a-cd7ab8965d76","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4450dba5-42a9-4b84-820a-cd7ab8965d76"},"toegewezenAanActoren":[{"uuid":"4450dba5-42a9-4b84-820a-cd7ab8965d76","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4450dba5-42a9-4b84-820a-cd7ab8965d76"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:08:48.314969Z","afgehandeldOp":null}'
+      string: '{"uuid":"c087c227-46df-4b10-84fe-582c4b00d30e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c087c227-46df-4b10-84fe-582c4b00d30e","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"toegewezenAanActor":{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"},"toegewezenAanActoren":[{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:16.169507Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -304,16 +311,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/c8e1dff6-2af3-4b70-b9af-706928d01c98
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/c087c227-46df-4b10-84fe-582c4b00d30e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -326,7 +334,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "c529b296-52b6-424c-83a1-2533374cc7c9"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -340,7 +348,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"85c52ee7-af8c-464b-b582-67a8c2b3bfb6","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/85c52ee7-af8c-464b-b582-67a8c2b3bfb6","klantcontact":{"uuid":"c529b296-52b6-424c-83a1-2533374cc7c9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"0b8d8dfd-113f-40c4-9484-41ad59d10ed4","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4","klantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
@@ -350,16 +358,17 @@ interactions:
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/85c52ee7-af8c-464b-b582-67a8c2b3bfb6
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4
       Referrer-Policy:
       - same-origin
       Vary:
@@ -380,7 +389,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"85c52ee7-af8c-464b-b582-67a8c2b3bfb6","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/85c52ee7-af8c-464b-b582-67a8c2b3bfb6","klantcontact":{"uuid":"c529b296-52b6-424c-83a1-2533374cc7c9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c529b296-52b6-424c-83a1-2533374cc7c9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0b8d8dfd-113f-40c4-9484-41ad59d10ed4","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4","klantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}]}'
     headers:
       API-version:
@@ -390,10 +399,11 @@ interactions:
       Content-Length:
       - '544'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"8666cd44-093c-41a3-bbe0-4fb538e09a87","url":"http://localhost:8338/klantinteracties/api/v1/actoren/8666cd44-093c-41a3-bbe0-4fb538e09a87","naam":"Afdeling
+      string: '{"uuid":"fddfaeca-4151-4946-b802-b9b8e4990d1b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/fddfaeca-4151-4946-b802-b9b8e4990d1b","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/8666cd44-093c-41a3-bbe0-4fb538e09a87
+      - http://localhost:8338/klantinteracties/api/v1/actoren/fddfaeca-4151-4946-b802-b9b8e4990d1b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -46,41 +47,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "iku", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      false, "voorkeurstaal": "hun", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Miss", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Misc.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '366'
+      - '369'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"c9fbdcd6-6370-430e-9324-74125501e40e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c9fbdcd6-6370-430e-9324-74125501e40e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"iku","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
+      string: '{"uuid":"0dbd81d7-52f9-45e1-a3e1-3741126d514e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0dbd81d7-52f9-45e1-a3e1-3741126d514e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"hun","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Miss","voornaam":"Alice","voorvoegselAchternaam":"Misc.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Misc. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1031'
+      - '1036'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/c9fbdcd6-6370-430e-9324-74125501e40e
+      - http://localhost:8338/klantinteracties/api/v1/partijen/0dbd81d7-52f9-45e1-a3e1-3741126d514e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -95,9 +97,9 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "mno", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McBob"}}}'
+      true, "voorkeurstaal": "tup", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -109,8 +111,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"c782cc5e-2562-4a1b-82c9-dcf011e997a9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c782cc5e-2562-4a1b-82c9-dcf011e997a9","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"mno","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Dr. McBob"}}'
+      string: '{"uuid":"a1c7e0df-7f10-4b98-ac16-8342dd2542ee","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1c7e0df-7f10-4b98-ac16-8342dd2542ee","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tup","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
@@ -119,16 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/c782cc5e-2562-4a1b-82c9-dcf011e997a9
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a1c7e0df-7f10-4b98-ac16-8342dd2542ee
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"10296d34-faec-4f87-86e1-dbc72c0ca9c8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/10296d34-faec-4f87-86e1-dbc72c0ca9c8","naam":"Afdeling
+      string: '{"uuid":"31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/10296d34-faec-4f87-86e1-dbc72c0ca9c8
+      - http://localhost:8338/klantinteracties/api/v1/actoren/31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"7884d0f5-9468-4298-96d1-41a36f658688","url":"http://localhost:8338/klantinteracties/api/v1/actoren/7884d0f5-9468-4298-96d1-41a36f658688","naam":"Afdeling
+      string: '{"uuid":"0bc962cc-670d-4e6b-9082-a7f28a976cc7","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0bc962cc-670d-4e6b-9082-a7f28a976cc7","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,66 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/7884d0f5-9468-4298-96d1-41a36f658688
+      - http://localhost:8338/klantinteracties/api/v1/actoren/0bc962cc-670d-4e6b-9082-a7f28a976cc7
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "sga", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Dr.", "achternaam": "McAlice"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '366'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"f832a476-7230-4e15-a7d8-c597083a53d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f832a476-7230-4e15-a7d8-c597083a53d3","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"sga","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Dr. McAlice"}}'
+    headers:
+      API-version:
+      - 0.1.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1031'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/f832a476-7230-4e15-a7d8-c597083a53d3
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,88 +97,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "crh", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Misc.", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "lua", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '369'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"d0103cc3-521d-47a8-ba32-4e227165e167","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d0103cc3-521d-47a8-ba32-4e227165e167","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"crh","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Misc.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Misc. McAlice"}}'
+      string: '{"uuid":"5e0e7c8d-b307-47fd-be45-c4b99a32fe8e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5e0e7c8d-b307-47fd-be45-c4b99a32fe8e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"lua","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1036'
+      - '1024'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/d0103cc3-521d-47a8-ba32-4e227165e167
-      Referrer-Policy:
-      - same-origin
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "pol", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McBob"}}}'
-    headers:
-      Authorization:
-      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
-      Content-Length:
-      - '361'
-      Content-Type:
-      - application/json
-    method: POST
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen
-  response:
-    body:
-      string: '{"uuid":"cabec903-bba7-4df1-aa77-8089146c3b93","url":"http://localhost:8338/klantinteracties/api/v1/partijen/cabec903-bba7-4df1-aa77-8089146c3b93","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"pol","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}'
-    headers:
-      API-version:
-      - 0.1.2
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      Content-Length:
-      - '1022'
-      Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/cabec903-bba7-4df1-aa77-8089146c3b93
+      - http://localhost:8338/klantinteracties/api/v1/partijen/5e0e7c8d-b307-47fd-be45-c4b99a32fe8e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"569281b4-9326-4497-870c-2e628fec8dd4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4","naam":"Afdeling
+      string: '{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4
+      - http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -200,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+      string: '{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
         inquiry","inhoud":"A question from an anonymous user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -210,16 +214,17 @@ interactions:
       Content-Length:
       - '517'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -232,9 +237,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},
-      "wasPartij": null, "initiator": true, "organisatienaam": "Open Inwoner Platform",
-      "contactnaam": {"voornaam": "Hieronymous", "achternaam": "Anonymous"}}'
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      {"voornaam": "Hieronymous", "achternaam": "Anonymous"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -246,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82","wasPartij":null,"hadKlantcontact":{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+      string: '{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","wasPartij":null,"hadKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
         Anonymous","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -256,16 +261,17 @@ interactions:
       Content-Length:
       - '963'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -283,7 +289,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=5ac1e659-d3f3-41eb-b84e-32e0123bfe82
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -295,10 +301,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -317,7 +324,7 @@ interactions:
 - request:
     body: '{"adres": "hieronymous.anonymous@example.com", "soortDigitaalAdres": "email",
       "isStandaardAdres": false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene":
-      {"uuid": "5ac1e659-d3f3-41eb-b84e-32e0123bfe82"}, "verstrektDoorPartij": null}'
+      {"uuid": "e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"}, "verstrektDoorPartij": null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -329,7 +336,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"dc73be68-0c98-46da-aa20-636a236fc644","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/dc73be68-0c98-46da-aa20-636a236fc644","verstrektDoorBetrokkene":{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -339,16 +346,17 @@ interactions:
       Content-Length:
       - '486'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/dc73be68-0c98-46da-aa20-636a236fc644
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -366,10 +374,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=5ac1e659-d3f3-41eb-b84e-32e0123bfe82
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"dc73be68-0c98-46da-aa20-636a236fc644","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/dc73be68-0c98-46da-aa20-636a236fc644","verstrektDoorBetrokkene":{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -379,10 +387,11 @@ interactions:
       Content-Length:
       - '551'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -400,7 +409,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},
       "verstrektDoorPartij": null}'
     headers:
       Authorization:
@@ -413,7 +422,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"8eb63fb0-425a-47a1-83b7-821213b91f2a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/8eb63fb0-425a-47a1-83b7-821213b91f2a","verstrektDoorBetrokkene":{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -423,16 +432,17 @@ interactions:
       Content-Length:
       - '472'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/8eb63fb0-425a-47a1-83b7-821213b91f2a
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da
       Referrer-Policy:
       - same-origin
       Vary:
@@ -445,10 +455,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "569281b4-9326-4497-870c-2e628fec8dd4"}}'
+      {"uuid": "b2528cf4-e394-4b2a-8855-2038c8b9b82a"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -460,9 +470,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"307cfcd5-5b89-495a-a885-cb613110401a","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/307cfcd5-5b89-495a-a885-cb613110401a","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},"toegewezenAanActor":{"uuid":"569281b4-9326-4497-870c-2e628fec8dd4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4"},"toegewezenAanActoren":[{"uuid":"569281b4-9326-4497-870c-2e628fec8dd4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:07.101199Z","afgehandeldOp":null}'
+      string: '{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"toegewezenAanActor":{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"},"toegewezenAanActoren":[{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:28.048764Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -471,16 +481,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/307cfcd5-5b89-495a-a885-cb613110401a
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -501,7 +512,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"}],"leiddeTotInterneTaken":[{"uuid":"307cfcd5-5b89-495a-a885-cb613110401a","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/307cfcd5-5b89-495a-a885-cb613110401a"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"}],"leiddeTotInterneTaken":[{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
         inquiry","inhoud":"A question from an anonymous user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
     headers:
       API-version:
@@ -511,10 +522,11 @@ interactions:
       Content-Length:
       - '883'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -539,7 +551,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82","wasPartij":null,"hadKlantcontact":{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},"digitaleAdressen":[{"uuid":"dc73be68-0c98-46da-aa20-636a236fc644","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/dc73be68-0c98-46da-aa20-636a236fc644"},{"uuid":"8eb63fb0-425a-47a1-83b7-821213b91f2a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/8eb63fb0-425a-47a1-83b7-821213b91f2a"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","wasPartij":null,"hadKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"digitaleAdressen":[{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c"},{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
         Anonymous","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -549,10 +561,11 @@ interactions:
       Content-Length:
       - '1339'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -577,9 +590,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"307cfcd5-5b89-495a-a885-cb613110401a","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/307cfcd5-5b89-495a-a885-cb613110401a","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"9bd11ca1-21bc-4b7f-8107-096ffcaa26e1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/9bd11ca1-21bc-4b7f-8107-096ffcaa26e1"},"toegewezenAanActor":{"uuid":"569281b4-9326-4497-870c-2e628fec8dd4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4"},"toegewezenAanActoren":[{"uuid":"569281b4-9326-4497-870c-2e628fec8dd4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/569281b4-9326-4497-870c-2e628fec8dd4"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:07.101199Z","afgehandeldOp":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"toegewezenAanActor":{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"},"toegewezenAanActoren":[{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:28.048764Z","afgehandeldOp":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -588,10 +601,11 @@ interactions:
       Content-Length:
       - '952'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -613,11 +627,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=5ac1e659-d3f3-41eb-b84e-32e0123bfe82
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"8eb63fb0-425a-47a1-83b7-821213b91f2a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/8eb63fb0-425a-47a1-83b7-821213b91f2a","verstrektDoorBetrokkene":{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"dc73be68-0c98-46da-aa20-636a236fc644","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/dc73be68-0c98-46da-aa20-636a236fc644","verstrektDoorBetrokkene":{"uuid":"5ac1e659-d3f3-41eb-b84e-32e0123bfe82","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5ac1e659-d3f3-41eb-b84e-32e0123bfe82"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -627,10 +641,11 @@ interactions:
       Content-Length:
       - '1037'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"27a68f7c-8c81-48b4-abfd-ea8d94c27e91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/27a68f7c-8c81-48b4-abfd-ea8d94c27e91","naam":"Afdeling
+      string: '{"uuid":"3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/27a68f7c-8c81-48b4-abfd-ea8d94c27e91
+      - http://localhost:8338/klantinteracties/api/v1/actoren/3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,9 +48,9 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "que", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mrs.", "achternaam": "McAlice"}}}'
+      false, "voorkeurstaal": "lug", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -61,26 +62,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"a0aa093e-0344-4e8c-8d33-dceba55ad5fd","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a0aa093e-0344-4e8c-8d33-dceba55ad5fd","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"que","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mrs. McAlice"}}'
+      string: '{"uuid":"b1be5d36-7b49-4f41-8bfa-74ae91826eaa","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b1be5d36-7b49-4f41-8bfa-74ae91826eaa","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"lug","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1032'
+      - '1031'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/a0aa093e-0344-4e8c-8d33-dceba55ad5fd
+      - http://localhost:8338/klantinteracties/api/v1/partijen/b1be5d36-7b49-4f41-8bfa-74ae91826eaa
       Referrer-Policy:
       - same-origin
       Vary:
@@ -94,41 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "cha", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mx.", "achternaam": "McBob"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "kir", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '365'
+      - '361'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"03c379e5-f617-4502-95c6-87307a8ded21","url":"http://localhost:8338/klantinteracties/api/v1/partijen/03c379e5-f617-4502-95c6-87307a8ded21","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"cha","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mx. McBob"}}'
+      string: '{"uuid":"51ada906-d610-41e9-8c3d-3a5cab322213","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51ada906-d610-41e9-8c3d-3a5cab322213","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"kir","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1026'
+      - '1022'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/03c379e5-f617-4502-95c6-87307a8ded21
+      - http://localhost:8338/klantinteracties/api/v1/partijen/51ada906-d610-41e9-8c3d-3a5cab322213
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"f12a7204-e6e0-4a98-8141-fe83edfb3925","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f12a7204-e6e0-4a98-8141-fe83edfb3925","naam":"Afdeling
+      string: '{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/f12a7204-e6e0-4a98-8141-fe83edfb3925
+      - http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91
       Referrer-Policy:
       - same-origin
       Vary:
@@ -200,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"4ecafe51-8fde-4f69-9fc8-132cd2f95da8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4ecafe51-8fde-4f69-9fc8-132cd2f95da8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
+      string: '{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
         only inquiry","inhoud":"A question with only email","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -210,16 +214,17 @@ interactions:
       Content-Length:
       - '511'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/4ecafe51-8fde-4f69-9fc8-132cd2f95da8
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696
       Referrer-Policy:
       - same-origin
       Vary:
@@ -232,9 +237,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "4ecafe51-8fde-4f69-9fc8-132cd2f95da8"},
-      "wasPartij": null, "initiator": true, "organisatienaam": "Open Inwoner Platform",
-      "contactnaam": {"voornaam": "Bob", "achternaam": "EmailOnly"}}'
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "599137d8-a6f5-4ae8-b105-71cfde799696"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      {"voornaam": "Bob", "achternaam": "EmailOnly"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -246,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"cdfe292b-74a2-4102-acac-17bdb8828bbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/cdfe292b-74a2-4102-acac-17bdb8828bbe","wasPartij":null,"hadKlantcontact":{"uuid":"4ecafe51-8fde-4f69-9fc8-132cd2f95da8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4ecafe51-8fde-4f69-9fc8-132cd2f95da8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+      string: '{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13","wasPartij":null,"hadKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
         EmailOnly","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -256,16 +261,17 @@ interactions:
       Content-Length:
       - '947'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/cdfe292b-74a2-4102-acac-17bdb8828bbe
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13
       Referrer-Policy:
       - same-origin
       Vary:
@@ -283,7 +289,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=cdfe292b-74a2-4102-acac-17bdb8828bbe
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=a5ea6fe0-6254-4bb0-9054-2e7f76187e13
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -295,10 +301,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -316,7 +323,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "bob.email@example.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "cdfe292b-74a2-4102-acac-17bdb8828bbe"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},
       "verstrektDoorPartij": null}'
     headers:
       Authorization:
@@ -329,7 +336,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"24e4e0a5-c95b-4a34-8874-712148e91112","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/24e4e0a5-c95b-4a34-8874-712148e91112","verstrektDoorBetrokkene":{"uuid":"cdfe292b-74a2-4102-acac-17bdb8828bbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/cdfe292b-74a2-4102-acac-17bdb8828bbe"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c","verstrektDoorBetrokkene":{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -339,16 +346,17 @@ interactions:
       Content-Length:
       - '474'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/24e4e0a5-c95b-4a34-8874-712148e91112
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -361,10 +369,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "4ecafe51-8fde-4f69-9fc8-132cd2f95da8"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "599137d8-a6f5-4ae8-b105-71cfde799696"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "f12a7204-e6e0-4a98-8141-fe83edfb3925"}}'
+      {"uuid": "a45af51d-dbde-4fd8-8fd3-11117b554b91"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -376,9 +384,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"b0f971a2-b340-46fb-9f26-8aca78ae9e73","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b0f971a2-b340-46fb-9f26-8aca78ae9e73","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"4ecafe51-8fde-4f69-9fc8-132cd2f95da8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4ecafe51-8fde-4f69-9fc8-132cd2f95da8"},"toegewezenAanActor":{"uuid":"f12a7204-e6e0-4a98-8141-fe83edfb3925","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f12a7204-e6e0-4a98-8141-fe83edfb3925"},"toegewezenAanActoren":[{"uuid":"f12a7204-e6e0-4a98-8141-fe83edfb3925","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f12a7204-e6e0-4a98-8141-fe83edfb3925"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:16.428059Z","afgehandeldOp":null}'
+      string: '{"uuid":"dbfb4c70-e8ce-4bd9-893d-1049b5281cf0","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/dbfb4c70-e8ce-4bd9-893d-1049b5281cf0","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"toegewezenAanActor":{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91"},"toegewezenAanActoren":[{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:33.976173Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -387,16 +395,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/b0f971a2-b340-46fb-9f26-8aca78ae9e73
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/dbfb4c70-e8ce-4bd9-893d-1049b5281cf0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -417,7 +426,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"cdfe292b-74a2-4102-acac-17bdb8828bbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/cdfe292b-74a2-4102-acac-17bdb8828bbe","wasPartij":null,"hadKlantcontact":{"uuid":"4ecafe51-8fde-4f69-9fc8-132cd2f95da8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4ecafe51-8fde-4f69-9fc8-132cd2f95da8"},"digitaleAdressen":[{"uuid":"24e4e0a5-c95b-4a34-8874-712148e91112","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/24e4e0a5-c95b-4a34-8874-712148e91112"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13","wasPartij":null,"hadKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"digitaleAdressen":[{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
         EmailOnly","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -427,10 +436,11 @@ interactions:
       Content-Length:
       - '1167'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -452,10 +462,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=cdfe292b-74a2-4102-acac-17bdb8828bbe
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=a5ea6fe0-6254-4bb0-9054-2e7f76187e13
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"24e4e0a5-c95b-4a34-8874-712148e91112","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/24e4e0a5-c95b-4a34-8874-712148e91112","verstrektDoorBetrokkene":{"uuid":"cdfe292b-74a2-4102-acac-17bdb8828bbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/cdfe292b-74a2-4102-acac-17bdb8828bbe"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c","verstrektDoorBetrokkene":{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -465,10 +475,11 @@ interactions:
       Content-Length:
       - '539'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"41c4d9fe-d73f-4dce-a6d9-f4424d0e8798","url":"http://localhost:8338/klantinteracties/api/v1/actoren/41c4d9fe-d73f-4dce-a6d9-f4424d0e8798","naam":"Afdeling
+      string: '{"uuid":"34ea0915-b527-4860-9638-45e5446e07af","url":"http://localhost:8338/klantinteracties/api/v1/actoren/34ea0915-b527-4860-9638-45e5446e07af","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/41c4d9fe-d73f-4dce-a6d9-f4424d0e8798
+      - http://localhost:8338/klantinteracties/api/v1/actoren/34ea0915-b527-4860-9638-45e5446e07af
       Referrer-Policy:
       - same-origin
       Vary:
@@ -46,41 +47,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "chi", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Ms.", "achternaam": "McAlice"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "wak", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '365'
+      - '368'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"f0ac0d1d-2765-45f5-9249-ac163c122cc7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f0ac0d1d-2765-45f5-9249-ac163c122cc7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"chi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Ms.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Ms. McAlice"}}'
+      string: '{"uuid":"0f34f272-4a63-4e79-bc09-00241fa179c2","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0f34f272-4a63-4e79-bc09-00241fa179c2","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"wak","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1030'
+      - '1033'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/f0ac0d1d-2765-45f5-9249-ac163c122cc7
+      - http://localhost:8338/klantinteracties/api/v1/partijen/0f34f272-4a63-4e79-bc09-00241fa179c2
       Referrer-Policy:
       - same-origin
       Vary:
@@ -94,41 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "ice", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Ms.", "achternaam": "McBob"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "tmh", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Miss", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '361'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"29b046bc-d970-4f3c-acd6-98258ba2619f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/29b046bc-d970-4f3c-acd6-98258ba2619f","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"ice","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Ms.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Ms. McBob"}}'
+      string: '{"uuid":"a2f114d5-3339-4175-9b4c-5c47adf57762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a2f114d5-3339-4175-9b4c-5c47adf57762","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tmh","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Miss","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1022'
+      - '1024'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/29b046bc-d970-4f3c-acd6-98258ba2619f
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a2f114d5-3339-4175-9b4c-5c47adf57762
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"319835c9-54f7-43bb-8ea9-763933d45dfb","url":"http://localhost:8338/klantinteracties/api/v1/actoren/319835c9-54f7-43bb-8ea9-763933d45dfb","naam":"Afdeling
+      string: '{"uuid":"5e4d4379-086d-4c6e-9946-685efad57ddc","url":"http://localhost:8338/klantinteracties/api/v1/actoren/5e4d4379-086d-4c6e-9946-685efad57ddc","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/319835c9-54f7-43bb-8ea9-763933d45dfb
+      - http://localhost:8338/klantinteracties/api/v1/actoren/5e4d4379-086d-4c6e-9946-685efad57ddc
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"63a2f4c3-59ea-4da3-b1a0-d6a590c71852","url":"http://localhost:8338/klantinteracties/api/v1/actoren/63a2f4c3-59ea-4da3-b1a0-d6a590c71852","naam":"Afdeling
+      string: '{"uuid":"e4dfae60-bfaa-4c75-ab59-12cb416a49b2","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e4dfae60-bfaa-4c75-ab59-12cb416a49b2","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,64 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/63a2f4c3-59ea-4da3-b1a0-d6a590c71852
-      Referrer-Policy:
-      - same-origin
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "ain", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
-    headers:
-      Authorization:
-      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
-      Content-Length:
-      - '365'
-      Content-Type:
-      - application/json
-    method: POST
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen
-  response:
-    body:
-      string: '{"uuid":"348fe543-2e33-4a79-a0ea-639ec9ad3c74","url":"http://localhost:8338/klantinteracties/api/v1/partijen/348fe543-2e33-4a79-a0ea-639ec9ad3c74","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"ain","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
-    headers:
-      API-version:
-      - 0.1.2
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      Content-Length:
-      - '1030'
-      Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/348fe543-2e33-4a79-a0ea-639ec9ad3c74
+      - http://localhost:8338/klantinteracties/api/v1/actoren/e4dfae60-bfaa-4c75-ab59-12cb416a49b2
       Referrer-Policy:
       - same-origin
       Vary:
@@ -95,40 +48,90 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "nyo", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Miss", "achternaam": "McBob"}}}'
+      false, "voorkeurstaal": "sme", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '363'
+      - '367'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"b19ec0eb-c6bd-47fb-a0fc-c4277c3f52c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b19ec0eb-c6bd-47fb-a0fc-c4277c3f52c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nyo","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Miss","achternaam":"McBob"},"volledigeNaam":"Bob
-        Miss McBob"}}'
+      string: '{"uuid":"54b20078-cde9-4bde-b01f-dd6e581864b0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/54b20078-cde9-4bde-b01f-dd6e581864b0","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"sme","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1025'
+      - '1032'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/b19ec0eb-c6bd-47fb-a0fc-c4277c3f52c5
+      - http://localhost:8338/klantinteracties/api/v1/partijen/54b20078-cde9-4bde-b01f-dd6e581864b0
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "tur", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"398ad0f5-2969-448d-9e1a-70f3a5462e3d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/398ad0f5-2969-448d-9e1a-70f3a5462e3d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"tur","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
+    headers:
+      API-version:
+      - 0.1.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1022'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/398ad0f5-2969-448d-9e1a-70f3a5462e3d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"1d54b902-74b3-4948-8f8d-2f710c7b1b9c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1d54b902-74b3-4948-8f8d-2f710c7b1b9c","naam":"Afdeling
+      string: '{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/1d54b902-74b3-4948-8f8d-2f710c7b1b9c
+      - http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -200,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
+      string: '{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
         inquiry","inhoud":"A question without contact details","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -210,16 +214,17 @@ interactions:
       Content-Length:
       - '516'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10
       Referrer-Policy:
       - same-origin
       Vary:
@@ -232,9 +237,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d"},
-      "wasPartij": null, "initiator": true, "organisatienaam": "Open Inwoner Platform",
-      "contactnaam": {"voornaam": "Jane", "achternaam": "Minimal"}}'
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "fe5cb401-38d8-42f7-8dda-27775e089d10"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      {"voornaam": "Jane", "achternaam": "Minimal"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -246,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"91c4f275-83aa-4442-91aa-d768f15cedc5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/91c4f275-83aa-4442-91aa-d768f15cedc5","wasPartij":null,"hadKlantcontact":{"uuid":"1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+      string: '{"uuid":"896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","wasPartij":null,"hadKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
         Minimal","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -256,16 +261,17 @@ interactions:
       Content-Length:
       - '945'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/91c4f275-83aa-4442-91aa-d768f15cedc5
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70
       Referrer-Policy:
       - same-origin
       Vary:
@@ -278,10 +284,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "fe5cb401-38d8-42f7-8dda-27775e089d10"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "1d54b902-74b3-4948-8f8d-2f710c7b1b9c"}}'
+      {"uuid": "0d21972d-bbac-45f9-8f18-95db41e371b9"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -293,9 +299,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"09f0a978-76e5-49d1-91d7-787686593fb4","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/09f0a978-76e5-49d1-91d7-787686593fb4","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d"},"toegewezenAanActor":{"uuid":"1d54b902-74b3-4948-8f8d-2f710c7b1b9c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1d54b902-74b3-4948-8f8d-2f710c7b1b9c"},"toegewezenAanActoren":[{"uuid":"1d54b902-74b3-4948-8f8d-2f710c7b1b9c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1d54b902-74b3-4948-8f8d-2f710c7b1b9c"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:34.967857Z","afgehandeldOp":null}'
+      string: '{"uuid":"71c8ab9c-db75-4882-985f-d71e03cc5bed","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/71c8ab9c-db75-4882-985f-d71e03cc5bed","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"toegewezenAanActor":{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9"},"toegewezenAanActoren":[{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:46.479728Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -304,16 +310,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/09f0a978-76e5-49d1-91d7-787686593fb4
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/71c8ab9c-db75-4882-985f-d71e03cc5bed
       Referrer-Policy:
       - same-origin
       Vary:
@@ -334,7 +341,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"91c4f275-83aa-4442-91aa-d768f15cedc5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/91c4f275-83aa-4442-91aa-d768f15cedc5","wasPartij":null,"hadKlantcontact":{"uuid":"1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b1c7b1e-ef83-4cac-aa5b-44246a0feb2d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","wasPartij":null,"hadKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
         Minimal","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -344,10 +351,11 @@ interactions:
       Content-Length:
       - '1010'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -369,7 +377,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=91c4f275-83aa-4442-91aa-d768f15cedc5
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=896b1bf7-51cd-4a08-917d-a7e4e5ccbc70
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -381,10 +389,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"b09c8cd0-140b-49df-b7f8-3862a20e30c9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b09c8cd0-140b-49df-b7f8-3862a20e30c9","naam":"Afdeling
+      string: '{"uuid":"2d6c9451-315a-4d9c-aae6-00c5296a58c3","url":"http://localhost:8338/klantinteracties/api/v1/actoren/2d6c9451-315a-4d9c-aae6-00c5296a58c3","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,64 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/b09c8cd0-140b-49df-b7f8-3862a20e30c9
-      Referrer-Policy:
-      - same-origin
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "btk", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mx.", "achternaam": "McAlice"}}}'
-    headers:
-      Authorization:
-      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
-      Content-Length:
-      - '368'
-      Content-Type:
-      - application/json
-    method: POST
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen
-  response:
-    body:
-      string: '{"uuid":"fbc68ce9-0345-4787-9065-8bcfc21efc43","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fbc68ce9-0345-4787-9065-8bcfc21efc43","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"btk","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mx. McAlice"}}'
-    headers:
-      API-version:
-      - 0.1.2
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      Content-Length:
-      - '1033'
-      Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/fbc68ce9-0345-4787-9065-8bcfc21efc43
+      - http://localhost:8338/klantinteracties/api/v1/actoren/2d6c9451-315a-4d9c-aae6-00c5296a58c3
       Referrer-Policy:
       - same-origin
       Vary:
@@ -95,40 +48,90 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "geo", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McBob"}}}'
+      true, "voorkeurstaal": "mni", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Ms.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '362'
+      - '365'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"1c62aac8-db88-421e-98f1-64c742fed651","url":"http://localhost:8338/klantinteracties/api/v1/partijen/1c62aac8-db88-421e-98f1-64c742fed651","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"geo","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Dr. McBob"}}'
+      string: '{"uuid":"6de13359-bae3-4fd7-98f3-ee6216f07fa1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6de13359-bae3-4fd7-98f3-ee6216f07fa1","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"mni","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Ms.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Ms. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1023'
+      - '1030'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/1c62aac8-db88-421e-98f1-64c742fed651
+      - http://localhost:8338/klantinteracties/api/v1/partijen/6de13359-bae3-4fd7-98f3-ee6216f07fa1
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      false, "voorkeurstaal": "luo", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Ind.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"4d403d9e-541b-4f2e-8ca2-36e9370d7c39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d403d9e-541b-4f2e-8ca2-36e9370d7c39","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"luo","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ind.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
+    headers:
+      API-version:
+      - 0.1.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1024'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/4d403d9e-541b-4f2e-8ca2-36e9370d7c39
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"a6c7cb30-688f-4df5-80f8-3a314fa216e7","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a6c7cb30-688f-4df5-80f8-3a314fa216e7","naam":"Afdeling
+      string: '{"uuid":"1d14ed0a-42d1-4363-a73e-b354436b94b2","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1d14ed0a-42d1-4363-a73e-b354436b94b2","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/a6c7cb30-688f-4df5-80f8-3a314fa216e7
+      - http://localhost:8338/klantinteracties/api/v1/actoren/1d14ed0a-42d1-4363-a73e-b354436b94b2
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"c4bd86a7-4b95-4b78-aa8e-c0ccd2490ed1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c4bd86a7-4b95-4b78-aa8e-c0ccd2490ed1","naam":"Afdeling
+      string: '{"uuid":"3741d4fc-8dbb-4489-a50e-3b2525d8657b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3741d4fc-8dbb-4489-a50e-3b2525d8657b","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,16 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/c4bd86a7-4b95-4b78-aa8e-c0ccd2490ed1
+      - http://localhost:8338/klantinteracties/api/v1/actoren/3741d4fc-8dbb-4489-a50e-3b2525d8657b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,9 +48,9 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "oci", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Ms.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "phi", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -61,8 +62,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"oci","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ms.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Dr. McAlice"}}'
+      string: '{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"phi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
@@ -71,16 +72,17 @@ interactions:
       Content-Length:
       - '1031'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba
+      - http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005
       Referrer-Policy:
       - same-origin
       Vary:
@@ -94,8 +96,8 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "kar", "soortPartij": "persoon", "partijIdentificatie":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      false, "voorkeurstaal": "nog", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
       "Mr.", "achternaam": "McBob"}}}'
     headers:
@@ -109,7 +111,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"kar","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+      string: '{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"nog","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
         Mr. McBob"}}'
     headers:
       API-version:
@@ -119,16 +121,17 @@ interactions:
       Content-Length:
       - '1023'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de
+      - http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -154,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df","naam":"Afdeling
+      string: '{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -164,16 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df
+      - http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63
       Referrer-Policy:
       - same-origin
       Vary:
@@ -186,7 +190,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba, part
+    body: '{"inhoud": "A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005, part
       0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -200,8 +204,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba,
+      string: '{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -211,16 +215,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102
       Referrer-Policy:
       - same-origin
       Vary:
@@ -233,21 +238,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "a3f4b4b8-739e-407c-b919-9863bb45c100"},
-      "wasPartij": {"uuid": "8e4c5ef5-ab3e-44c5-a842-1462868955ba"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"29b4dc72-00e1-45fc-ac16-99c8cb900317","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -257,16 +263,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da
       Referrer-Policy:
       - same-origin
       Vary:
@@ -279,10 +286,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "a3f4b4b8-739e-407c-b919-9863bb45c100"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "69d20084-46d3-4457-80d6-7915161136df"}}'
+      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -294,9 +301,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"124b6cb4-dcd1-493b-aed5-e9c00db15b00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/124b6cb4-dcd1-493b-aed5-e9c00db15b00","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.368779Z","afgehandeldOp":null}'
+      string: '{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.029933Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -305,16 +312,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/124b6cb4-dcd1-493b-aed5-e9c00db15b00
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -327,7 +335,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba, part
+    body: '{"inhoud": "A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005, part
       1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -341,8 +349,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba,
+      string: '{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
         part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -352,16 +360,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -374,21 +383,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "813446d8-f707-4e8e-a37b-ab73a0f99c1c"},
-      "wasPartij": {"uuid": "8e4c5ef5-ab3e-44c5-a842-1462868955ba"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "5141001e-3354-435c-8f36-7d1d7a49fa7c"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"1dc059aa-55e1-4e25-88d0-438eddb1b3d1","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1dc059aa-55e1-4e25-88d0-438eddb1b3d1","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -398,16 +408,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/1dc059aa-55e1-4e25-88d0-438eddb1b3d1
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153
       Referrer-Policy:
       - same-origin
       Vary:
@@ -420,10 +431,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "813446d8-f707-4e8e-a37b-ab73a0f99c1c"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "5141001e-3354-435c-8f36-7d1d7a49fa7c"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "69d20084-46d3-4457-80d6-7915161136df"}}'
+      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -435,9 +446,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"71cd5fda-65f3-4f95-8816-13a02d7d828e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/71cd5fda-65f3-4f95-8816-13a02d7d828e","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.403350Z","afgehandeldOp":null}'
+      string: '{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.085171Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -446,16 +457,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/71cd5fda-65f3-4f95-8816-13a02d7d828e
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025
       Referrer-Policy:
       - same-origin
       Vary:
@@ -473,11 +485,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102
   response:
     body:
-      string: '{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"29b4dc72-00e1-45fc-ac16-99c8cb900317","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317"}],"leiddeTotInterneTaken":[{"uuid":"124b6cb4-dcd1-493b-aed5-e9c00db15b00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/124b6cb4-dcd1-493b-aed5-e9c00db15b00"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba,
+      string: '{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -487,10 +499,11 @@ interactions:
       Content-Length:
       - '846'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -520,7 +533,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+      string: '{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
         and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -530,16 +543,17 @@ interactions:
       Content-Length:
       - '497'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203
       Referrer-Policy:
       - same-origin
       Vary:
@@ -552,8 +566,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "43661ac9-6075-489b-aa10-2fe5ded4e257"},
-      "initiator": true, "wasPartij": {"uuid": "8e4c5ef5-ab3e-44c5-a842-1462868955ba"},
+    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "fd8a022b-b5f5-44df-9f96-33ed6ab22203"},
+      "initiator": true, "wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},
       "organisatienaam": "Open Inwoner Platform"}'
     headers:
       Authorization:
@@ -566,7 +580,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"9fb2d3a3-b41c-4608-b83d-0414383cc3e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9fb2d3a3-b41c-4608-b83d-0414383cc3e2","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -576,16 +590,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/9fb2d3a3-b41c-4608-b83d-0414383cc3e2
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96
       Referrer-Policy:
       - same-origin
       Vary:
@@ -598,8 +613,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "43661ac9-6075-489b-aa10-2fe5ded4e257"}, "wasKlantcontact":
-      {"uuid": "a3f4b4b8-739e-407c-b919-9863bb45c100"}}'
+    body: '{"klantcontact": {"uuid": "fd8a022b-b5f5-44df-9f96-33ed6ab22203"}, "wasKlantcontact":
+      {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -611,7 +626,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"9c85e999-f697-4608-a1b4-ec0eb95cfd79","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79","klantcontact":{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257"},"wasKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -620,16 +635,17 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410
       Referrer-Policy:
       - same-origin
       Vary:
@@ -642,7 +658,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de, part
+    body: '{"inhoud": "A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d, part
       0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -656,8 +672,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de,
+      string: '{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -667,16 +683,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -689,21 +706,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "b30ec77e-2594-49f8-8d56-e3bd821ed48c"},
-      "wasPartij": {"uuid": "3baa2da0-bf30-409b-89de-0b19cfbb04de"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -713,16 +731,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae
       Referrer-Policy:
       - same-origin
       Vary:
@@ -735,10 +754,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "b30ec77e-2594-49f8-8d56-e3bd821ed48c"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "69d20084-46d3-4457-80d6-7915161136df"}}'
+      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -750,9 +769,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","nummer":"0000000003","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.481930Z","afgehandeldOp":null}'
+      string: '{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68","nummer":"0000000003","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.201602Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -761,16 +780,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/6eb3ad84-6050-4e62-a2fb-f1eba8bb235e
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68
       Referrer-Policy:
       - same-origin
       Vary:
@@ -783,7 +803,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de, part
+    body: '{"inhoud": "A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d, part
       1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -797,8 +817,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de,
+      string: '{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
         part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -808,16 +828,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10
       Referrer-Policy:
       - same-origin
       Vary:
@@ -830,21 +851,22 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "1fcce50f-a431-4f0f-811f-ef41e1f7e271"},
-      "wasPartij": {"uuid": "3baa2da0-bf30-409b-89de-0b19cfbb04de"}, "initiator":
-      true, "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "199a9ed9-2aff-448c-a7af-21ec8966ef10"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"438c1964-b9be-42b3-9b53-6328ea7745b5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/438c1964-b9be-42b3-9b53-6328ea7745b5","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -854,16 +876,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/438c1964-b9be-42b3-9b53-6328ea7745b5
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -876,10 +899,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "1fcce50f-a431-4f0f-811f-ef41e1f7e271"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "199a9ed9-2aff-448c-a7af-21ec8966ef10"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "69d20084-46d3-4457-80d6-7915161136df"}}'
+      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -891,9 +914,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"4a1e7573-9ca0-42f2-9f43-2090c8d0c086","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/4a1e7573-9ca0-42f2-9f43-2090c8d0c086","nummer":"0000000004","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.524855Z","afgehandeldOp":null}'
+      string: '{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de","nummer":"0000000004","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.265009Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -902,16 +925,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/4a1e7573-9ca0-42f2-9f43-2090c8d0c086
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de
       Referrer-Policy:
       - same-origin
       Vary:
@@ -929,11 +953,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8
   response:
     body:
-      string: '{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe"}],"leiddeTotInterneTaken":[{"uuid":"6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6eb3ad84-6050-4e62-a2fb-f1eba8bb235e"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de,
+      string: '{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -943,10 +967,11 @@ interactions:
       Content-Length:
       - '846'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -976,7 +1001,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+      string: '{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
         and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -986,16 +1011,17 @@ interactions:
       Content-Length:
       - '497'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1008,8 +1034,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "e05e6284-9fd9-429e-a581-f16a336e91e2"},
-      "initiator": true, "wasPartij": {"uuid": "3baa2da0-bf30-409b-89de-0b19cfbb04de"},
+    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "89a7baba-368b-470a-8513-d821b1b4063a"},
+      "initiator": true, "wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},
       "organisatienaam": "Open Inwoner Platform"}'
     headers:
       Authorization:
@@ -1022,7 +1048,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -1032,16 +1058,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1054,8 +1081,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "e05e6284-9fd9-429e-a581-f16a336e91e2"}, "wasKlantcontact":
-      {"uuid": "b30ec77e-2594-49f8-8d56-e3bd821ed48c"}}'
+    body: '{"klantcontact": {"uuid": "89a7baba-368b-470a-8513-d821b1b4063a"}, "wasKlantcontact":
+      {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -1067,7 +1094,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"23598a83-77c5-4efc-b9d7-7a4c0b780fa9","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/23598a83-77c5-4efc-b9d7-7a4c0b780fa9","klantcontact":{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2"},"wasKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff","klantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"wasKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -1076,16 +1103,17 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/23598a83-77c5-4efc-b9d7-7a4c0b780fa9
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1106,33 +1134,33 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
   response:
     body:
-      string: '{"count":6,"next":null,"previous":null,"results":[{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2","gingOverOnderwerpobjecten":[{"uuid":"23598a83-77c5-4efc-b9d7-7a4c0b780fa9","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/23598a83-77c5-4efc-b9d7-7a4c0b780fa9"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"23598a83-77c5-4efc-b9d7-7a4c0b780fa9","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/23598a83-77c5-4efc-b9d7-7a4c0b780fa9","klantcontact":{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2"},"wasKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"e05e6284-9fd9-429e-a581-f16a336e91e2","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e05e6284-9fd9-429e-a581-f16a336e91e2"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe"},{"uuid":"438c1964-b9be-42b3-9b53-6328ea7745b5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/438c1964-b9be-42b3-9b53-6328ea7745b5"},{"uuid":"3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3f2b8fd0-1a7f-49a9-b6fc-d9859c5bb9de"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"kar","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"438c1964-b9be-42b3-9b53-6328ea7745b5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/438c1964-b9be-42b3-9b53-6328ea7745b5"}],"leiddeTotInterneTaken":[{"uuid":"4a1e7573-9ca0-42f2-9f43-2090c8d0c086","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/4a1e7573-9ca0-42f2-9f43-2090c8d0c086"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de,
-        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"438c1964-b9be-42b3-9b53-6328ea7745b5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/438c1964-b9be-42b3-9b53-6328ea7745b5","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"4a1e7573-9ca0-42f2-9f43-2090c8d0c086","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/4a1e7573-9ca0-42f2-9f43-2090c8d0c086","nummer":"0000000004","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"1fcce50f-a431-4f0f-811f-ef41e1f7e271","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1fcce50f-a431-4f0f-811f-ef41e1f7e271"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.524855Z","afgehandeldOp":null}]}},{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe"}],"leiddeTotInterneTaken":[{"uuid":"6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6eb3ad84-6050-4e62-a2fb-f1eba8bb235e"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 3baa2da0-bf30-409b-89de-0b19cfbb04de,
-        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8bcde4b9-8b11-4eaa-a28e-3f9b94ed97fe","wasPartij":{"uuid":"3baa2da0-bf30-409b-89de-0b19cfbb04de","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3baa2da0-bf30-409b-89de-0b19cfbb04de"},"hadKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6eb3ad84-6050-4e62-a2fb-f1eba8bb235e","nummer":"0000000003","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b30ec77e-2594-49f8-8d56-e3bd821ed48c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b30ec77e-2594-49f8-8d56-e3bd821ed48c"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.481930Z","afgehandeldOp":null}]}},{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257","gingOverOnderwerpobjecten":[{"uuid":"9c85e999-f697-4608-a1b4-ec0eb95cfd79","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"9fb2d3a3-b41c-4608-b83d-0414383cc3e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9fb2d3a3-b41c-4608-b83d-0414383cc3e2"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"9c85e999-f697-4608-a1b4-ec0eb95cfd79","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79","klantcontact":{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257"},"wasKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"9fb2d3a3-b41c-4608-b83d-0414383cc3e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9fb2d3a3-b41c-4608-b83d-0414383cc3e2","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"29b4dc72-00e1-45fc-ac16-99c8cb900317","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317"},{"uuid":"1dc059aa-55e1-4e25-88d0-438eddb1b3d1","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1dc059aa-55e1-4e25-88d0-438eddb1b3d1"},{"uuid":"9fb2d3a3-b41c-4608-b83d-0414383cc3e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9fb2d3a3-b41c-4608-b83d-0414383cc3e2"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"oci","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ms.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Dr. McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1dc059aa-55e1-4e25-88d0-438eddb1b3d1","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1dc059aa-55e1-4e25-88d0-438eddb1b3d1"}],"leiddeTotInterneTaken":[{"uuid":"71cd5fda-65f3-4f95-8816-13a02d7d828e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/71cd5fda-65f3-4f95-8816-13a02d7d828e"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba,
-        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"1dc059aa-55e1-4e25-88d0-438eddb1b3d1","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1dc059aa-55e1-4e25-88d0-438eddb1b3d1","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"71cd5fda-65f3-4f95-8816-13a02d7d828e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/71cd5fda-65f3-4f95-8816-13a02d7d828e","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"813446d8-f707-4e8e-a37b-ab73a0f99c1c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/813446d8-f707-4e8e-a37b-ab73a0f99c1c"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.403350Z","afgehandeldOp":null}]}},{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"29b4dc72-00e1-45fc-ac16-99c8cb900317","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317"}],"leiddeTotInterneTaken":[{"uuid":"124b6cb4-dcd1-493b-aed5-e9c00db15b00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/124b6cb4-dcd1-493b-aed5-e9c00db15b00"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 8e4c5ef5-ab3e-44c5-a842-1462868955ba,
-        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"29b4dc72-00e1-45fc-ac16-99c8cb900317","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/29b4dc72-00e1-45fc-ac16-99c8cb900317","wasPartij":{"uuid":"8e4c5ef5-ab3e-44c5-a842-1462868955ba","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8e4c5ef5-ab3e-44c5-a842-1462868955ba"},"hadKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"124b6cb4-dcd1-493b-aed5-e9c00db15b00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/124b6cb4-dcd1-493b-aed5-e9c00db15b00","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"toegewezenAanActor":{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"},"toegewezenAanActoren":[{"uuid":"69d20084-46d3-4457-80d6-7915161136df","url":"http://localhost:8338/klantinteracties/api/v1/actoren/69d20084-46d3-4457-80d6-7915161136df"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-06T16:09:52.368779Z","afgehandeldOp":null}]}}]}'
+      string: '{"count":6,"next":null,"previous":null,"results":[{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a","gingOverOnderwerpobjecten":[{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff","klantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"wasKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"},{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e"},{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"nog","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e"}],"leiddeTotInterneTaken":[{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
+        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de","nummer":"0000000004","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.265009Z","afgehandeldOp":null}]}},{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
+        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68","nummer":"0000000003","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.201602Z","afgehandeldOp":null}]}},{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203","gingOverOnderwerpobjecten":[{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"},{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153"},{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"phi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153"}],"leiddeTotInterneTaken":[{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
+        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.085171Z","afgehandeldOp":null}]}},{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
+        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.029933Z","afgehandeldOp":null}]}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -1141,10 +1169,11 @@ interactions:
       Content-Length:
       - '19911'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -1166,10 +1195,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79
+    uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410
   response:
     body:
-      string: '{"uuid":"9c85e999-f697-4608-a1b4-ec0eb95cfd79","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/9c85e999-f697-4608-a1b4-ec0eb95cfd79","klantcontact":{"uuid":"43661ac9-6075-489b-aa10-2fe5ded4e257","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/43661ac9-6075-489b-aa10-2fe5ded4e257"},"wasKlantcontact":{"uuid":"a3f4b4b8-739e-407c-b919-9863bb45c100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a3f4b4b8-739e-407c-b919-9863bb45c100"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -1178,10 +1207,11 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'object-src ''none''; frame-src ''self''; default-src ''self''; font-src ''self''
-        fonts.gstatic.com; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; script-src ''self'' ''unsafe-inline''; form-action
-        ''self''; frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
@@ -13,27 +13,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"1fde1751-a62b-42d0-9c5b-e8726f7cb938","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1fde1751-a62b-42d0-9c5b-e8726f7cb938","naam":"Afdeling
+      string: '{"uuid":"ffe144c7-8827-43db-8582-a1a49200e2e8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/ffe144c7-8827-43db-8582-a1a49200e2e8","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/1fde1751-a62b-42d0-9c5b-e8726f7cb938
+      - http://localhost:8338/klantinteracties/api/v1/actoren/ffe144c7-8827-43db-8582-a1a49200e2e8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "tel", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Miss", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "frm", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '366'
+      - '367'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"48bfb579-a80a-453c-bd71-19a51c8008a5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/48bfb579-a80a-453c-bd71-19a51c8008a5","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"tel","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Miss","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Miss McAlice"}}'
+      string: '{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"frm","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '1032'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/48bfb579-a80a-453c-bd71-19a51c8008a5
+      - http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,42 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "ast", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McBob"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "lad", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '361'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"8de68dbd-0754-497b-bea2-c4606568fb32","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8de68dbd-0754-497b-bea2-c4606568fb32","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"ast","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}'
+      string: '{"uuid":"314c26b8-f7a0-4dcd-bd53-3dce301d2efe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/314c26b8-f7a0-4dcd-bd53-3dce301d2efe","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"lad","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1022'
+      - '1024'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/8de68dbd-0754-497b-bea2-c4606568fb32
+      - http://localhost:8338/klantinteracties/api/v1/partijen/314c26b8-f7a0-4dcd-bd53-3dce301d2efe
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,27 +157,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"24c9e75c-2ba7-4884-a599-ea90a0c06612","url":"http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612","naam":"Afdeling
+      string: '{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612
+      - http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -201,17 +201,17 @@ interactions:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -231,7 +231,7 @@ interactions:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
       true, "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voornaam": "Jeffrey", "achternaam": "Mason", "voorletters":
+      {"contactnaam": {"voornaam": "Michael", "achternaam": "Smith", "voorletters":
       "", "voorvoegselAchternaam": ""}}, "partijIdentificatoren": [{"partijIdentificator":
       {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId": "bsn", "objectId":
       "123456782", "codeRegister": "brp"}}]}'
@@ -246,27 +246,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"497a41ce-071f-409e-990b-2e57f55f27fc","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/497a41ce-071f-409e-990b-2e57f55f27fc","identificeerdePartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jeffrey","voorvoegselAchternaam":"","achternaam":"Mason"},"volledigeNaam":"Jeffrey
-        Mason"}}'
+      string: '{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
+        Smith"}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '1543'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91
+      - http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62
       Referrer-Policy:
       - same-origin
       Vary:
@@ -279,41 +279,41 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Important question",
-      "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
-      "2024-10-02T14:00:25.587564+00:00"}'
+    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+      Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+      "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '199'
+      - '209'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      string: '{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '511'
+      - '521'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da
       Referrer-Policy:
       - same-origin
       Vary:
@@ -326,41 +326,42 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "88f245d9-03ea-4b53-ab00-401fbab2fb4c"},
-      "initiator": true, "wasPartij": {"uuid": "96405bc1-8bda-4432-842a-a09968d4ae91"},
-      "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38","wasPartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"hadKlantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -373,10 +374,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "88f245d9-03ea-4b53-ab00-401fbab2fb4c"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "24c9e75c-2ba7-4884-a599-ea90a0c06612"}}'
+      {"uuid": "06906acb-2aae-45d2-8241-e8d8611c6cbf"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -388,28 +389,28 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"bc7cd4ee-6193-4785-ac87-dfab6d126a00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bc7cd4ee-6193-4785-ac87-dfab6d126a00","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c"},"toegewezenAanActor":{"uuid":"24c9e75c-2ba7-4884-a599-ea90a0c06612","url":"http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612"},"toegewezenAanActoren":[{"uuid":"24c9e75c-2ba7-4884-a599-ea90a0c06612","url":"http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-07T13:44:21.521887Z","afgehandeldOp":null}'
+      string: '{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"toegewezenAanActor":{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"},"toegewezenAanActoren":[{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:56:06.166151Z","afgehandeldOp":null}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/bc7cd4ee-6193-4785-ac87-dfab6d126a00
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee
       Referrer-Policy:
       - same-origin
       Vary:
@@ -422,7 +423,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "88f245d9-03ea-4b53-ab00-401fbab2fb4c"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -436,27 +437,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618","klantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf","klantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -469,41 +470,41 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Important question",
-      "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
-      "2024-10-02T14:00:25.587564+00:00"}'
+    body: '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+      Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+      "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '199'
+      - '209'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      string: '{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '511'
+      - '521'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff
       Referrer-Policy:
       - same-origin
       Vary:
@@ -516,41 +517,42 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "3eea61d5-c36f-4df8-9c54-8933d425e560"},
-      "initiator": true, "wasPartij": {"uuid": "48bfb579-a80a-453c-bd71-19a51c8008a5"},
-      "organisatienaam": "Open Inwoner Platform"}'
+    body: '{"wasPartij": {"uuid": "ff19cc79-d7ed-4693-a6df-ae4ed319c450"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '211'
+      - '232'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"a00a70a8-9eb4-4cee-9b80-1aeabd24b431","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a00a70a8-9eb4-4cee-9b80-1aeabd24b431","wasPartij":{"uuid":"48bfb579-a80a-453c-bd71-19a51c8008a5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/48bfb579-a80a-453c-bd71-19a51c8008a5"},"hadKlantcontact":{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415","wasPartij":{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450"},"hadKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a00a70a8-9eb4-4cee-9b80-1aeabd24b431
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415
       Referrer-Policy:
       - same-origin
       Vary:
@@ -563,10 +565,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "3eea61d5-c36f-4df8-9c54-8933d425e560"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "24c9e75c-2ba7-4884-a599-ea90a0c06612"}}'
+      {"uuid": "06906acb-2aae-45d2-8241-e8d8611c6cbf"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -578,28 +580,28 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"32213428-7805-41d0-8ce8-93efd2f3a60d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/32213428-7805-41d0-8ce8-93efd2f3a60d","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560"},"toegewezenAanActor":{"uuid":"24c9e75c-2ba7-4884-a599-ea90a0c06612","url":"http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612"},"toegewezenAanActoren":[{"uuid":"24c9e75c-2ba7-4884-a599-ea90a0c06612","url":"http://localhost:8338/klantinteracties/api/v1/actoren/24c9e75c-2ba7-4884-a599-ea90a0c06612"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-08-07T13:44:21.622141Z","afgehandeldOp":null}'
+      string: '{"uuid":"be8bc615-c574-4b2f-89a3-d008518543a1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"toegewezenAanActor":{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"},"toegewezenAanActoren":[{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:56:06.235792Z","afgehandeldOp":null}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/32213428-7805-41d0-8ce8-93efd2f3a60d
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -612,7 +614,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "3eea61d5-c36f-4df8-9c54-8933d425e560"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -626,27 +628,27 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"fdee9e5f-c1c0-46f7-8263-48baff11bdaa","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fdee9e5f-c1c0-46f7-8263-48baff11bdaa","klantcontact":{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"ad1d1e51-b536-4045-9ec9-02025e94a4ed","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed","klantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fdee9e5f-c1c0-46f7-8263-48baff11bdaa
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed
       Referrer-Policy:
       - same-origin
       Vary:
@@ -667,24 +669,24 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=Coffee+zaak&expand=hadBetrokkenen
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560","gingOverOnderwerpobjecten":[{"uuid":"fdee9e5f-c1c0-46f7-8263-48baff11bdaa","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fdee9e5f-c1c0-46f7-8263-48baff11bdaa"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a00a70a8-9eb4-4cee-9b80-1aeabd24b431","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a00a70a8-9eb4-4cee-9b80-1aeabd24b431"}],"leiddeTotInterneTaken":[{"uuid":"32213428-7805-41d0-8ce8-93efd2f3a60d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/32213428-7805-41d0-8ce8-93efd2f3a60d"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"a00a70a8-9eb4-4cee-9b80-1aeabd24b431","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a00a70a8-9eb4-4cee-9b80-1aeabd24b431","wasPartij":{"uuid":"48bfb579-a80a-453c-bd71-19a51c8008a5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/48bfb579-a80a-453c-bd71-19a51c8008a5"},"hadKlantcontact":{"uuid":"3eea61d5-c36f-4df8-9c54-8933d425e560","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eea61d5-c36f-4df8-9c54-8933d425e560"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true}]}},{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c","gingOverOnderwerpobjecten":[{"uuid":"e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38"}],"leiddeTotInterneTaken":[{"uuid":"bc7cd4ee-6193-4785-ac87-dfab6d126a00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bc7cd4ee-6193-4785-ac87-dfab6d126a00"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38","wasPartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"hadKlantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff","gingOverOnderwerpobjecten":[{"uuid":"ad1d1e51-b536-4045-9ec9-02025e94a4ed","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415"}],"leiddeTotInterneTaken":[{"uuid":"be8bc615-c574-4b2f-89a3-d008518543a1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415","wasPartij":{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450"},"hadKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true}]}},{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"leiddeTotInterneTaken":[{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}]}}]}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '4183'
+      - '4203'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -709,21 +711,21 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"497a41ce-071f-409e-990b-2e57f55f27fc","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/497a41ce-071f-409e-990b-2e57f55f27fc","identificeerdePartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jeffrey","voorvoegselAchternaam":"","achternaam":"Mason"},"volledigeNaam":"Jeffrey
-        Mason"},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
+        Smith"},"_expand":{}}]}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
       - '1758'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -745,26 +747,26 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
   response:
     body:
-      string: '{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"497a41ce-071f-409e-990b-2e57f55f27fc","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/497a41ce-071f-409e-990b-2e57f55f27fc","identificeerdePartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jeffrey","voorvoegselAchternaam":"","achternaam":"Mason"},"volledigeNaam":"Jeffrey
-        Mason"},"_expand":{"betrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38","wasPartij":{"uuid":"96405bc1-8bda-4432-842a-a09968d4ae91","url":"http://localhost:8338/klantinteracties/api/v1/partijen/96405bc1-8bda-4432-842a-a09968d4ae91"},"hadKlantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"88f245d9-03ea-4b53-ab00-401fbab2fb4c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/88f245d9-03ea-4b53-ab00-401fbab2fb4c","gingOverOnderwerpobjecten":[{"uuid":"e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/e0f8b3e5-eda5-4c5b-9c7f-2fcf8e268618"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"146080ed-f33b-438e-b611-26bf5a6e2f38","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/146080ed-f33b-438e-b611-26bf5a6e2f38"}],"leiddeTotInterneTaken":[{"uuid":"bc7cd4ee-6193-4785-ac87-dfab6d126a00","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bc7cd4ee-6193-4785-ac87-dfab6d126a00"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
-        question","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}}}],"digitaleAdressen":[]}}'
+      string: '{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
+        Smith"},"_expand":{"betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"leiddeTotInterneTaken":[{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}}}],"digitaleAdressen":[]}}'
     headers:
       API-version:
-      - 0.3.0
+      - 0.1.2
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       Content-Length:
-      - '3808'
+      - '3818'
       Content-Security-Policy:
-      - 'font-src ''self'' fonts.gstatic.com; worker-src ''self'' blob:; default-src
-        ''self''; frame-ancestors ''none''; object-src ''none''; base-uri ''self'';
-        form-action ''self''; img-src ''self'' data: cdn.redoc.ly; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; frame-src ''self''; script-src ''self''
-        ''unsafe-inline'''
+      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
+        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
+        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
+        base-uri ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/mocks.py
+++ b/src/open_inwoner/openklant/tests/mocks.py
@@ -45,7 +45,6 @@ class MockOpenKlant2Service:
         self,
         partij_uuid: str,
         question: str,
-        subject: str,
         zaak: str,
     ) -> OpenKlant2Question:
         return OpenKlant2Question(

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -533,7 +533,6 @@ class QuestionAnswerTestCase(Openklant2ServiceTestCase):
         question = self.service.create_question_for_zaak(
             self.een_persoon["uuid"],
             question="A question asked by Morice",
-            subject="Important question",
             zaak=zaak,
         )
 
@@ -569,13 +568,11 @@ class QuestionAnswerTestCase(Openklant2ServiceTestCase):
         question_initiated_by_user = self.service.create_question_for_zaak(
             persoon["uuid"],
             question="A question asked by Morice",
-            subject="Important question",
             zaak=zaak,
         )
         question_initiated_by_another_partij = self.service.create_question_for_zaak(
             self.een_persoon["uuid"],
             question="A question asked by Morice",
-            subject="Important question",
             zaak=zaak,
         )
 


### PR DESCRIPTION
We defaulted to using zaak.omschrijving for the question subject in our openklant2 question-for-zaken method, but that can be an empty string, which triggers a Bad Request error.

## Summary

## Issue References

- Taiga Issue: [#3495](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3495)

## Checklist

- [x] CHANGELOG.rst updated

