### PR TITLE
fix: handle anonymous questions when fetching a Partij's openklant qu…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,8 @@ Bugfixes
   weergegeven in de zijnavigatie.
 * [:taiga-is:`3493`: :pr:`1954`]: Paginering op contactmomenten lijst wordt nu correct
   weergegeven.
+* [:taiga-is:`3497`: :pr:`1958`]: Het ophalen van vragen in Openklant geeft geen
+  foutmeldingen meer als er ook anonieme vragen voorkomen in de backend.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1660,7 +1660,10 @@ class OpenKlant2Service(
             lambda row: partij_uuid
             in glom.glom(
                 row,
-                ("_expand.hadBetrokkenen", ["wasPartij.uuid"]),
+                (
+                    "_expand.hadBetrokkenen",
+                    [(glom.Coalesce("wasPartij.uuid", default=glom.SKIP),)],
+                ),
             ),
             klantcontacten,
         )
@@ -1901,9 +1904,10 @@ class OpenKlant2Service(
             if _expand := klantcontact.get("_expand"):
                 if had_betrokkenen := _expand.get("hadBetrokkenen"):
                     for betrokkene in had_betrokkenen:
-                        partij_was_betrokkene = (
-                            betrokkene["wasPartij"]["uuid"] == partij["uuid"]
-                        )
+                        was_partij = betrokkene.get("wasPartij")
+                        if was_partij is None:
+                            continue
+                        partij_was_betrokkene = was_partij["uuid"] == partij["uuid"]
                         partij_was_initiator = betrokkene["initiator"]
 
                         if partij_was_betrokkene and partij_was_initiator:

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_cannot_use_existing_user_email_when_updating_user_from_partij.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_cannot_use_existing_user_email_when_updating_user_from_partij.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"a1a76f07-2d0e-40da-99f7-6e21a0a80ce0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1a76f07-2d0e-40da-99f7-6e21a0a80ce0","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a1a76f07-2d0e-40da-99f7-6e21a0a80ce0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "7dcafc65-51c3-4372-ac84-89e8962414b7"},
+    body: '{"identificeerdePartij": {"uuid": "a1a76f07-2d0e-40da-99f7-6e21a0a80ce0"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"577fe242-dce2-42b8-9991-513db288ee5e","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/577fe242-dce2-42b8-9991-513db288ee5e","identificeerdePartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"7d7aeb1c-6345-4559-a8f5-3f0b1c6410d6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/7d7aeb1c-6345-4559-a8f5-3f0b1c6410d6","identificeerdePartij":{"uuid":"a1a76f07-2d0e-40da-99f7-6e21a0a80ce0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1a76f07-2d0e-40da-99f7-6e21a0a80ce0"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/577fe242-dce2-42b8-9991-513db288ee5e
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/7d7aeb1c-6345-4559-a8f5-3f0b1c6410d6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7dcafc65-51c3-4372-ac84-89e8962414b7
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a1a76f07-2d0e-40da-99f7-6e21a0a80ce0
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -136,7 +136,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "another-user@foo.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7dcafc65-51c3-4372-ac84-89e8962414b7"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "a1a76f07-2d0e-40da-99f7-6e21a0a80ce0"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -149,7 +149,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"63385548-b1ea-4cdc-a207-23f185aa86d9","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/63385548-b1ea-4cdc-a207-23f185aa86d9","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a1a76f07-2d0e-40da-99f7-6e21a0a80ce0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1a76f07-2d0e-40da-99f7-6e21a0a80ce0"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -159,17 +159,17 @@ interactions:
       Content-Length:
       - '470'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/63385548-b1ea-4cdc-a207-23f185aa86d9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -187,10 +187,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7dcafc65-51c3-4372-ac84-89e8962414b7
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=a1a76f07-2d0e-40da-99f7-6e21a0a80ce0
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/58ebb1b6-1fe7-4033-87b7-93e93ea0a48a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7dcafc65-51c3-4372-ac84-89e8962414b7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7dcafc65-51c3-4372-ac84-89e8962414b7"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"63385548-b1ea-4cdc-a207-23f185aa86d9","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/63385548-b1ea-4cdc-a207-23f185aa86d9","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"a1a76f07-2d0e-40da-99f7-6e21a0a80ce0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1a76f07-2d0e-40da-99f7-6e21a0a80ce0"},"adres":"another-user@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -200,11 +200,11 @@ interactions:
       Content-Length:
       - '535'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_partij_from_user_data.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_partij_from_user_data.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731
+      - http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
+    body: '{"identificeerdePartij": {"uuid": "2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"493fc360-8998-46d9-b37b-fcbfbea012f2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/493fc360-8998-46d9-b37b-fcbfbea012f2","identificeerdePartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"441eafe2-b001-450b-8904-f8d22e79431b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/441eafe2-b001-450b-8904-f8d22e79431b","identificeerdePartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/493fc360-8998-46d9-b37b-fcbfbea012f2
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/441eafe2-b001-450b-8904-f8d22e79431b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -140,7 +140,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -152,11 +152,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -174,7 +174,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0644938475", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
+      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -187,7 +187,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"uuid":"725634f1-fd1e-4845-819d-e719f34646dd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/725634f1-fd1e-4845-819d-e719f34646dd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -197,17 +197,17 @@ interactions:
       Content-Length:
       - '468'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/725634f1-fd1e-4845-819d-e719f34646dd
       Referrer-Policy:
       - same-origin
       Vary:
@@ -225,10 +225,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"725634f1-fd1e-4845-819d-e719f34646dd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/725634f1-fd1e-4845-819d-e719f34646dd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -238,11 +238,11 @@ interactions:
       Content-Length:
       - '533'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -260,7 +260,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "user@bar.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -273,7 +273,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"aeb6b07a-2a56-486c-9412-dd2cf5de7d84","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/aeb6b07a-2a56-486c-9412-dd2cf5de7d84","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -283,17 +283,17 @@ interactions:
       Content-Length:
       - '462'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/aeb6b07a-2a56-486c-9412-dd2cf5de7d84
       Referrer-Policy:
       - same-origin
       Vary:
@@ -311,11 +311,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"aeb6b07a-2a56-486c-9412-dd2cf5de7d84","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/aeb6b07a-2a56-486c-9412-dd2cf5de7d84","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"725634f1-fd1e-4845-819d-e719f34646dd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/725634f1-fd1e-4845-819d-e719f34646dd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -325,11 +325,11 @@ interactions:
       Content-Length:
       - '1009'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -347,7 +347,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0687654321", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "c88c84e3-1c05-47b1-82cd-828a5c4a1731"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -360,7 +360,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"7995ec98-3c5f-466d-b852-9f27c53eef17","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"de4d18b2-6f7b-434d-8ee6-1859fd7a323e","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/de4d18b2-6f7b-434d-8ee6-1859fd7a323e","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -370,17 +370,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/de4d18b2-6f7b-434d-8ee6-1859fd7a323e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -398,12 +398,12 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=c88c84e3-1c05-47b1-82cd-828a5c4a1731
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=2a86fdaf-ad71-4d98-b53f-d35db3f53ee0
   response:
     body:
-      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"7995ec98-3c5f-466d-b852-9f27c53eef17","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7995ec98-3c5f-466d-b852-9f27c53eef17","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"e95a6752-8c45-46b2-bb53-4dde2208cfbe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e95a6752-8c45-46b2-bb53-4dde2208cfbe","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"ba13c769-a49b-4923-a137-a0ebad3ffe62","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ba13c769-a49b-4923-a137-a0ebad3ffe62","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"c88c84e3-1c05-47b1-82cd-828a5c4a1731","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c88c84e3-1c05-47b1-82cd-828a5c4a1731"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"de4d18b2-6f7b-434d-8ee6-1859fd7a323e","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/de4d18b2-6f7b-434d-8ee6-1859fd7a323e","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"aeb6b07a-2a56-486c-9412-dd2cf5de7d84","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/aeb6b07a-2a56-486c-9412-dd2cf5de7d84","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"user@bar.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"725634f1-fd1e-4845-819d-e719f34646dd","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/725634f1-fd1e-4845-819d-e719f34646dd","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"2a86fdaf-ad71-4d98-b53f-d35db3f53ee0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a86fdaf-ad71-4d98-b53f-d35db3f53ee0"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -413,11 +413,11 @@ interactions:
       Content-Length:
       - '1492'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_user_from_partij.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/Openklant2ServiceTest.test_update_user_from_partij.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
+      string: '{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"crp","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Test
         Persoon","voorvoegselAchternaam":"Mrs.","achternaam":"Gamble"},"volledigeNaam":"Test
         Persoon Mrs. Gamble"}}'
     headers:
@@ -27,17 +27,17 @@ interactions:
       Content-Length:
       - '1045'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1
+      - http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -50,7 +50,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"identificeerdePartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
+    body: '{"identificeerdePartij": {"uuid": "7e7218a0-cfc6-4953-9aae-270976c5fea6"},
       "partijIdentificator": {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId":
       "bsn", "objectId": "521311408", "codeRegister": "brp"}, "anderePartijIdentificator":
       "optional_identifier_123"}'
@@ -65,7 +65,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"00a28204-0f3e-45a1-900a-c213a259a2bb","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/00a28204-0f3e-45a1-900a-c213a259a2bb","identificeerdePartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
+      string: '{"uuid":"d9fb3b76-ce15-409c-8e99-3929245215fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d9fb3b76-ce15-409c-8e99-3929245215fd","identificeerdePartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"anderePartijIdentificator":"optional_identifier_123","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -74,17 +74,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/00a28204-0f3e-45a1-900a-c213a259a2bb
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d9fb3b76-ce15-409c-8e99-3929245215fd
       Referrer-Policy:
       - same-origin
       Vary:
@@ -102,7 +102,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -114,11 +114,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -136,7 +136,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0644938475", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
+      true, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7e7218a0-cfc6-4953-9aae-270976c5fea6"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -149,7 +149,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -159,17 +159,17 @@ interactions:
       Content-Length:
       - '468'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -187,10 +187,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -200,11 +200,11 @@ interactions:
       Content-Length:
       - '533'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -222,7 +222,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0687654321", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7e7218a0-cfc6-4953-9aae-270976c5fea6"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -235,7 +235,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"89482910-02bc-4d53-8ae1-e9b702f84f13","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -245,17 +245,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13
       Referrer-Policy:
       - same-origin
       Vary:
@@ -273,11 +273,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"89482910-02bc-4d53-8ae1-e9b702f84f13","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -287,11 +287,11 @@ interactions:
       Content-Length:
       - '1016'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -309,7 +309,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7e7218a0-cfc6-4953-9aae-270976c5fea6"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -322,7 +322,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"2e94f42e-b53b-457f-aec7-f688ea146c7f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/2e94f42e-b53b-457f-aec7-f688ea146c7f","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -332,17 +332,17 @@ interactions:
       Content-Length:
       - '469'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/2e94f42e-b53b-457f-aec7-f688ea146c7f
       Referrer-Policy:
       - same-origin
       Vary:
@@ -360,12 +360,12 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
-      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":3,"next":null,"previous":null,"results":[{"uuid":"2e94f42e-b53b-457f-aec7-f688ea146c7f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/2e94f42e-b53b-457f-aec7-f688ea146c7f","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"89482910-02bc-4d53-8ae1-e9b702f84f13","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -375,11 +375,11 @@ interactions:
       Content-Length:
       - '1499'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -397,7 +397,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "bar@foo.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "e6ef9734-242c-4644-85cf-c67dd81c3ac1"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorPartij": {"uuid": "7e7218a0-cfc6-4953-9aae-270976c5fea6"},
       "verstrektDoorBetrokkene": null}'
     headers:
       Authorization:
@@ -410,7 +410,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"fb4168be-60cf-4329-acac-783e0d9c64b6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/fb4168be-60cf-4329-acac-783e0d9c64b6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -420,17 +420,17 @@ interactions:
       Content-Length:
       - '461'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/fb4168be-60cf-4329-acac-783e0d9c64b6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -448,13 +448,13 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
-      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"fb4168be-60cf-4329-acac-783e0d9c64b6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/fb4168be-60cf-4329-acac-783e0d9c64b6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"2e94f42e-b53b-457f-aec7-f688ea146c7f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/2e94f42e-b53b-457f-aec7-f688ea146c7f","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"89482910-02bc-4d53-8ae1-e9b702f84f13","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -464,11 +464,11 @@ interactions:
       Content-Length:
       - '1974'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -490,13 +490,13 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=e6ef9734-242c-4644-85cf-c67dd81c3ac1
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid=7e7218a0-cfc6-4953-9aae-270976c5fea6
   response:
     body:
-      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"92e4b666-1d2f-4f63-99b0-1b36b47e13a8","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/92e4b666-1d2f-4f63-99b0-1b36b47e13a8","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"7c08db4f-2d67-4c1e-b64b-4981d9577cc1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/7c08db4f-2d67-4c1e-b64b-4981d9577cc1","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"64750216-6cf5-4f55-9d44-851cf8d0f9f6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/64750216-6cf5-4f55-9d44-851cf8d0f9f6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"3c03b020-c803-401f-b0d5-cc3e8600015d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/3c03b020-c803-401f-b0d5-cc3e8600015d","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"e6ef9734-242c-4644-85cf-c67dd81c3ac1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e6ef9734-242c-4644-85cf-c67dd81c3ac1"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
+      string: '{"count":4,"next":null,"previous":null,"results":[{"uuid":"fb4168be-60cf-4329-acac-783e0d9c64b6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/fb4168be-60cf-4329-acac-783e0d9c64b6","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"bar@foo.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"2e94f42e-b53b-457f-aec7-f688ea146c7f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/2e94f42e-b53b-457f-aec7-f688ea146c7f","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"89482910-02bc-4d53-8ae1-e9b702f84f13","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/89482910-02bc-4d53-8ae1-e9b702f84f13","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0687654321","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"26daed35-ccad-4bc5-8279-894864597e8a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/26daed35-ccad-4bc5-8279-894864597e8a","verstrektDoorBetrokkene":null,"verstrektDoorPartij":{"uuid":"7e7218a0-cfc6-4953-9aae-270976c5fea6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7e7218a0-cfc6-4953-9aae-270976c5fea6"},"adres":"0644938475","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":true,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -506,11 +506,11 @@ interactions:
       Content-Length:
       - '1974'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; font-src ''self'' fonts.gstatic.com;
-        base-uri ''self''; form-action ''self''; style-src ''self'' ''unsafe-inline''
-        fonts.googleapis.com; default-src ''self''; object-src ''none''; worker-src
-        ''self'' blob:; script-src ''self'' ''unsafe-inline''; frame-src ''self'';
-        frame-ancestors ''none'''
+      - 'frame-src ''self''; script-src ''self'' ''unsafe-inline''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; object-src
+        ''none''; font-src ''self'' fonts.gstatic.com; img-src ''self'' data: cdn.redoc.ly;
+        form-action ''self''; base-uri ''self''; worker-src ''self'' blob:; default-src
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -129,7 +129,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -138,17 +138,17 @@ interactions:
       Content-Length:
       - '901'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef
+      - http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc
       Referrer-Policy:
       - same-origin
       Vary:
@@ -178,11 +178,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -199,7 +199,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},
+    body: '{"identificeerdePartij": {"uuid": "791e9f93-fe30-4650-b31b-c609f54290cc"},
       "partijIdentificator": {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
       "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
     headers:
@@ -213,7 +213,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      string: '{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -222,17 +222,17 @@ interactions:
       Content-Length:
       - '532'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -262,11 +262,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -283,8 +283,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},
-      "subIdentificatorVan": {"uuid": "88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}, "partijIdentificator":
+    body: '{"identificeerdePartij": {"uuid": "791e9f93-fe30-4650-b31b-c609f54290cc"},
+      "subIdentificatorVan": {"uuid": "863a2be1-223e-412b-875b-19c1f98bfda8"}, "partijIdentificator":
       {"codeObjecttype": "vestiging", "codeSoortObjectId": "vestigingsnummer", "objectId":
       "123456789123", "codeRegister": "hr"}}'
     headers:
@@ -298,7 +298,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}'
+      string: '{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}}'
     headers:
       API-version:
       - 0.1.2
@@ -307,17 +307,17 @@ interactions:
       Content-Length:
       - '685'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -338,7 +338,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -347,11 +347,11 @@ interactions:
       Content-Length:
       - '2184'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -376,7 +376,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}},{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}},{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -385,11 +385,11 @@ interactions:
       Content-Length:
       - '1270'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -414,7 +414,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -423,11 +423,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -452,7 +452,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -461,11 +461,11 @@ interactions:
       Content-Length:
       - '737'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -487,10 +487,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc
   response:
     body:
-      string: '{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -499,11 +499,11 @@ interactions:
       Content-Length:
       - '2119'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -528,7 +528,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -537,11 +537,11 @@ interactions:
       Content-Length:
       - '2184'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -566,7 +566,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"67c1714e-1885-41b7-b50b-9ddd31789028","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/67c1714e-1885-41b7-b50b-9ddd31789028","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3"}},{"uuid":"88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/88dfc5dc-ae5e-4679-aec5-fae2f46ce9b3","identificeerdePartij":{"uuid":"2a7249e9-7e67-42a3-91fd-d44c97cc15ef","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2a7249e9-7e67-42a3-91fd-d44c97cc15ef"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"04ddaf3b-5f60-43bc-9d10-f97283f933f6","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/04ddaf3b-5f60-43bc-9d10-f97283f933f6","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8"}},{"uuid":"863a2be1-223e-412b-875b-19c1f98bfda8","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/863a2be1-223e-412b-875b-19c1f98bfda8","identificeerdePartij":{"uuid":"791e9f93-fe30-4650-b31b-c609f54290cc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/791e9f93-fe30-4650-b31b-c609f54290cc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -575,11 +575,11 @@ interactions:
       Content-Length:
       - '1270'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -129,7 +129,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -138,17 +138,17 @@ interactions:
       Content-Length:
       - '901'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602
       Referrer-Policy:
       - same-origin
       Vary:
@@ -178,11 +178,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -199,7 +199,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identificeerdePartij": {"uuid": "685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},
+    body: '{"identificeerdePartij": {"uuid": "a7e8a143-2e10-4168-9bf0-ff86d5032602"},
       "partijIdentificator": {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
       "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
     headers:
@@ -213,7 +213,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      string: '{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
     headers:
       API-version:
       - 0.1.2
@@ -222,17 +222,17 @@ interactions:
       Content-Length:
       - '532'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30
+      - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26
       Referrer-Policy:
       - same-origin
       Vary:
@@ -253,7 +253,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -262,11 +262,11 @@ interactions:
       Content-Length:
       - '1498'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -291,7 +291,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -300,11 +300,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -329,7 +329,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -338,11 +338,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -364,10 +364,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602
   response:
     body:
-      string: '{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      string: '{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -376,11 +376,11 @@ interactions:
       Content-Length:
       - '1433'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -405,7 +405,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
@@ -414,11 +414,11 @@ interactions:
       Content-Length:
       - '1498'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -443,7 +443,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11eb39b2-cfc6-4b22-bf96-67c8263e6e30","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/11eb39b2-cfc6-4b22-bf96-67c8263e6e30","identificeerdePartij":{"uuid":"685d6dfb-4a49-46f7-87ab-6613ec0a1c09","url":"http://localhost:8338/klantinteracties/api/v1/partijen/685d6dfb-4a49-46f7-87ab-6613ec0a1c09"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"cde4dae6-3b74-44c4-b813-0fd4eb910b26","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/cde4dae6-3b74-44c4-b813-0fd4eb910b26","identificeerdePartij":{"uuid":"a7e8a143-2e10-4168-9bf0-ff86d5032602","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a7e8a143-2e10-4168-9bf0-ff86d5032602"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -452,11 +452,11 @@ interactions:
       Content-Length:
       - '584'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -92,7 +92,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"uuid":"eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"}}'
     headers:
       API-version:
@@ -102,17 +102,17 @@ interactions:
       Content-Length:
       - '1023'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a
+      - http://localhost:8338/klantinteracties/api/v1/partijen/eed66f4c-d4db-4ac9-ac4a-6d04d1de694a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -133,7 +133,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"},"_expand":{}}]}'
     headers:
       API-version:
@@ -143,11 +143,11 @@ interactions:
       Content-Length:
       - '1088'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -181,11 +181,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -218,7 +218,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"e8ba8251-2451-4df1-9fa2-39e3605f45c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"uuid":"e4a69729-60fe-4e25-a519-1b34a005681e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e4a69729-60fe-4e25-a519-1b34a005681e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"}}'
     headers:
       API-version:
@@ -228,17 +228,17 @@ interactions:
       Content-Length:
       - '1023'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5
+      - http://localhost:8338/klantinteracties/api/v1/partijen/e4a69729-60fe-4e25-a519-1b34a005681e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -259,8 +259,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"e8ba8251-2451-4df1-9fa2-39e3605f45c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e8ba8251-2451-4df1-9fa2-39e3605f45c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
-        Anonymous"},"_expand":{}},{"uuid":"2729b90d-ea56-402a-a524-2b44f9a3457a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2729b90d-ea56-402a-a524-2b44f9a3457a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"e4a69729-60fe-4e25-a519-1b34a005681e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e4a69729-60fe-4e25-a519-1b34a005681e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+        Anonymous"},"_expand":{}},{"uuid":"eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eed66f4c-d4db-4ac9-ac4a-6d04d1de694a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
         Anonymous"},"_expand":{}}]}'
     headers:
       API-version:
@@ -270,11 +270,11 @@ interactions:
       Content-Length:
       - '2125'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
@@ -17,11 +17,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -55,11 +55,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -93,11 +93,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -132,7 +132,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"}}'
     headers:
       API-version:
@@ -142,17 +142,17 @@ interactions:
       Content-Length:
       - '1533'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607
+      - http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26
       Referrer-Policy:
       - same-origin
       Vary:
@@ -173,7 +173,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -183,11 +183,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -212,7 +212,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -221,11 +221,11 @@ interactions:
       Content-Length:
       - '574'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -250,7 +250,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -260,11 +260,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -286,10 +286,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
   response:
     body:
-      string: '{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{"betrokkenen":[]}}'
     headers:
       API-version:
@@ -299,11 +299,11 @@ interactions:
       Content-Length:
       - '1562'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -328,7 +328,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
         Doe"},"_expand":{}}]}'
     headers:
       API-version:
@@ -338,11 +338,11 @@ interactions:
       Content-Length:
       - '1598'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -367,7 +367,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fea28677-0410-41fa-91aa-d2bbe7f6f1e2","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/fea28677-0410-41fa-91aa-d2bbe7f6f1e2","identificeerdePartij":{"uuid":"a8df0c53-fe4c-4ca5-b643-5675b3297607","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8df0c53-fe4c-4ca5-b643-5675b3297607"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b67872bd-2761-4d2f-a71f-7ba9dd959c9b","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/b67872bd-2761-4d2f-a71f-7ba9dd959c9b","identificeerdePartij":{"uuid":"aeb05e06-f449-4221-92f9-0d880bcf3c26","url":"http://localhost:8338/klantinteracties/api/v1/partijen/aeb05e06-f449-4221-92f9-0d880bcf3c26"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -376,11 +376,11 @@ interactions:
       Content-Length:
       - '574'
       Content-Security-Policy:
-      - 'script-src ''self'' ''unsafe-inline''; img-src ''self'' data: cdn.redoc.ly;
-        worker-src ''self'' blob:; form-action ''self''; default-src ''self''; object-src
-        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
-        ''self'' fonts.gstatic.com; frame-src ''self''; frame-ancestors ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; font-src ''self'' fonts.gstatic.com; script-src ''self''
+        ''unsafe-inline''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        frame-ancestors ''none''; object-src ''none''; default-src ''self''; img-src
+        ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; base-uri ''self'';
+        frame-src ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"4df8c82c-c7a1-4c4a-85c7-069b6d58bf57","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4df8c82c-c7a1-4c4a-85c7-069b6d58bf57","naam":"Afdeling
+      string: '{"uuid":"fba0ce49-2331-4835-a029-e494e5fae945","url":"http://localhost:8338/klantinteracties/api/v1/actoren/fba0ce49-2331-4835-a029-e494e5fae945","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,66 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/4df8c82c-c7a1-4c4a-85c7-069b6d58bf57
-      Referrer-Policy:
-      - same-origin
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "chk", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
-    headers:
-      Authorization:
-      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
-      Content-Length:
-      - '366'
-      Content-Type:
-      - application/json
-    method: POST
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen
-  response:
-    body:
-      string: '{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"chk","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
-    headers:
-      API-version:
-      - 0.1.2
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      Content-Length:
-      - '1031'
-      Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502
+      - http://localhost:8338/klantinteracties/api/v1/actoren/fba0ce49-2331-4835-a029-e494e5fae945
       Referrer-Policy:
       - same-origin
       Vary:
@@ -97,9 +48,58 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "ach", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McBob"}}}'
+      true, "voorkeurstaal": "tir", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mrs.", "achternaam": "McAlice"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '368'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"a277c744-56ee-4b65-80f1-e03e260e6bd7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a277c744-56ee-4b65-80f1-e03e260e6bd7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tir","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}'
+    headers:
+      API-version:
+      - 0.1.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1034'
+      Content-Security-Policy:
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a277c744-56ee-4b65-80f1-e03e260e6bd7
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      false, "voorkeurstaal": "lug", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -111,8 +111,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"ach","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Dr. McBob"}}'
+      string: '{"uuid":"02dc8751-908a-49ee-b02b-3d1e52cafe82","url":"http://localhost:8338/klantinteracties/api/v1/partijen/02dc8751-908a-49ee-b02b-3d1e52cafe82","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"lug","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
     headers:
       API-version:
       - 0.1.2
@@ -121,17 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/dad5dc4b-a8b9-4155-a3b6-937da8fa5fa8
+      - http://localhost:8338/klantinteracties/api/v1/partijen/02dc8751-908a-49ee-b02b-3d1e52cafe82
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","naam":"Afdeling
+      string: '{"uuid":"23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a
+      - http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+      string: '{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
         questions","inhoud":"A question asked by Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -214,17 +214,17 @@ interactions:
       Content-Length:
       - '511'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07
       Referrer-Policy:
       - same-origin
       Vary:
@@ -237,8 +237,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "bd73ab73-3080-441a-a903-0e4f10bf5502"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},
+    body: '{"wasPartij": {"uuid": "a277c744-56ee-4b65-80f1-e03e260e6bd7"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -252,7 +252,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c","wasPartij":{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502"},"hadKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"a2b994c3-a7e4-4c58-acc3-77c315078845","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a2b994c3-a7e4-4c58-acc3-77c315078845","wasPartij":{"uuid":"a277c744-56ee-4b65-80f1-e03e260e6bd7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a277c744-56ee-4b65-80f1-e03e260e6bd7"},"hadKlantcontact":{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -262,17 +262,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a2b994c3-a7e4-4c58-acc3-77c315078845
       Referrer-Policy:
       - same-origin
       Vary:
@@ -285,10 +285,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}}'
+      {"uuid": "23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -300,9 +300,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"toegewezenAanActor":{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"},"toegewezenAanActoren":[{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:09.912368Z","afgehandeldOp":null}'
+      string: '{"uuid":"b0f1e084-4db1-4d81-93d6-517b133880fa","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b0f1e084-4db1-4d81-93d6-517b133880fa","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},"toegewezenAanActor":{"uuid":"23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8"},"toegewezenAanActoren":[{"uuid":"23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:11:46.699047Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -311,17 +311,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/b0f1e084-4db1-4d81-93d6-517b133880fa
       Referrer-Policy:
       - same-origin
       Vary:
@@ -342,7 +342,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c"}],"leiddeTotInterneTaken":[{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a2b994c3-a7e4-4c58-acc3-77c315078845","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a2b994c3-a7e4-4c58-acc3-77c315078845"}],"leiddeTotInterneTaken":[{"uuid":"b0f1e084-4db1-4d81-93d6-517b133880fa","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b0f1e084-4db1-4d81-93d6-517b133880fa"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
         questions","inhoud":"A question asked by Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
     headers:
       API-version:
@@ -352,11 +352,11 @@ interactions:
       Content-Length:
       - '877'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -381,7 +381,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"68ec7414-0a9a-4c5d-b938-004da5f2ce7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/68ec7414-0a9a-4c5d-b938-004da5f2ce7c","wasPartij":{"uuid":"bd73ab73-3080-441a-a903-0e4f10bf5502","url":"http://localhost:8338/klantinteracties/api/v1/partijen/bd73ab73-3080-441a-a903-0e4f10bf5502"},"hadKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a2b994c3-a7e4-4c58-acc3-77c315078845","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a2b994c3-a7e4-4c58-acc3-77c315078845","wasPartij":{"uuid":"a277c744-56ee-4b65-80f1-e03e260e6bd7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a277c744-56ee-4b65-80f1-e03e260e6bd7"},"hadKlantcontact":{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -391,11 +391,11 @@ interactions:
       Content-Length:
       - '1130'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -420,9 +420,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"23980d35-3fa9-42f7-8c4c-b02fb0df56f5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23980d35-3fa9-42f7-8c4c-b02fb0df56f5","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"afcc65f7-49eb-4986-b9cf-4c5ba44251ea","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/afcc65f7-49eb-4986-b9cf-4c5ba44251ea"},"toegewezenAanActor":{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"},"toegewezenAanActoren":[{"uuid":"a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a951a2fa-b43d-4dd3-8ea1-a448c1b6b33a"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:09.912368Z","afgehandeldOp":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b0f1e084-4db1-4d81-93d6-517b133880fa","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b0f1e084-4db1-4d81-93d6-517b133880fa","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ed8dd70a-e81f-46b2-a597-aa2a7c8e5f07"},"toegewezenAanActor":{"uuid":"23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8"},"toegewezenAanActoren":[{"uuid":"23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/23002e8e-fcb9-4cc3-bb2b-ea5da2f201d8"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:11:46.699047Z","afgehandeldOp":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -431,11 +431,11 @@ interactions:
       Content-Length:
       - '952'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"4d2aede8-e77d-4a42-b7d1-a6c94821caad","url":"http://localhost:8338/klantinteracties/api/v1/actoren/4d2aede8-e77d-4a42-b7d1-a6c94821caad","naam":"Afdeling
+      string: '{"uuid":"13bdc731-f07e-4d9c-9041-fb8afae79400","url":"http://localhost:8338/klantinteracties/api/v1/actoren/13bdc731-f07e-4d9c-9041-fb8afae79400","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/4d2aede8-e77d-4a42-b7d1-a6c94821caad
+      - http://localhost:8338/klantinteracties/api/v1/actoren/13bdc731-f07e-4d9c-9041-fb8afae79400
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "bin", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mrs.", "achternaam": "McAlice"}}}'
+      false, "voorkeurstaal": "art", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '368'
+      - '367'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"68729d66-1f70-44cc-91e0-d5a8f7296fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"bin","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mrs. McAlice"}}'
+      string: '{"uuid":"fc9aa043-9674-46c8-b2c5-07bdb0dfef4c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fc9aa043-9674-46c8-b2c5-07bdb0dfef4c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"art","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1034'
+      - '1032'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8
+      - http://localhost:8338/klantinteracties/api/v1/partijen/fc9aa043-9674-46c8-b2c5-07bdb0dfef4c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,42 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "lat", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Miss", "achternaam": "McBob"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      false, "voorkeurstaal": "crh", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '363'
+      - '362'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"216294ea-b3a6-4e52-a60d-a6f8e9a08062","url":"http://localhost:8338/klantinteracties/api/v1/partijen/216294ea-b3a6-4e52-a60d-a6f8e9a08062","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"lat","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Miss","achternaam":"McBob"},"volledigeNaam":"Bob
-        Miss McBob"}}'
+      string: '{"uuid":"42f55e71-e62b-4e51-9fd2-1ce01c1759a2","url":"http://localhost:8338/klantinteracties/api/v1/partijen/42f55e71-e62b-4e51-9fd2-1ce01c1759a2","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"crh","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1025'
+      - '1023'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/216294ea-b3a6-4e52-a60d-a6f8e9a08062
+      - http://localhost:8338/klantinteracties/api/v1/partijen/42f55e71-e62b-4e51-9fd2-1ce01c1759a2
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","naam":"Afdeling
+      string: '{"uuid":"cd1fa89e-7a4b-46bb-89ad-3c85248c984e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cd1fa89e-7a4b-46bb-89ad-3c85248c984e","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c
+      - http://localhost:8338/klantinteracties/api/v1/actoren/cd1fa89e-7a4b-46bb-89ad-3c85248c984e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+      string: '{"uuid":"ad5d65f8-9f27-4ee9-99eb-c54697df94c6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
         voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -214,17 +214,17 @@ interactions:
       Content-Length:
       - '521'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -237,8 +237,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "68729d66-1f70-44cc-91e0-d5a8f7296fa8"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},
+    body: '{"wasPartij": {"uuid": "fc9aa043-9674-46c8-b2c5-07bdb0dfef4c"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -252,7 +252,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"bd17caec-992a-4c4f-91cc-e7ae23b26869","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/bd17caec-992a-4c4f-91cc-e7ae23b26869","wasPartij":{"uuid":"68729d66-1f70-44cc-91e0-d5a8f7296fa8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/68729d66-1f70-44cc-91e0-d5a8f7296fa8"},"hadKlantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"e841a35d-ebe3-4e7f-8311-197d82d0e1fc","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e841a35d-ebe3-4e7f-8311-197d82d0e1fc","wasPartij":{"uuid":"fc9aa043-9674-46c8-b2c5-07bdb0dfef4c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fc9aa043-9674-46c8-b2c5-07bdb0dfef4c"},"hadKlantcontact":{"uuid":"ad5d65f8-9f27-4ee9-99eb-c54697df94c6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -262,17 +262,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/bd17caec-992a-4c4f-91cc-e7ae23b26869
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/e841a35d-ebe3-4e7f-8311-197d82d0e1fc
       Referrer-Policy:
       - same-origin
       Vary:
@@ -285,10 +285,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"}}'
+      {"uuid": "cd1fa89e-7a4b-46bb-89ad-3c85248c984e"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -300,9 +300,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"c087c227-46df-4b10-84fe-582c4b00d30e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c087c227-46df-4b10-84fe-582c4b00d30e","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"toegewezenAanActor":{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"},"toegewezenAanActoren":[{"uuid":"cb9fde26-d0f6-4ce6-a1fa-e8594d86577c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cb9fde26-d0f6-4ce6-a1fa-e8594d86577c"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:16.169507Z","afgehandeldOp":null}'
+      string: '{"uuid":"51c1f59b-d7db-45a9-8ad6-cb34d68479de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/51c1f59b-d7db-45a9-8ad6-cb34d68479de","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"ad5d65f8-9f27-4ee9-99eb-c54697df94c6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},"toegewezenAanActor":{"uuid":"cd1fa89e-7a4b-46bb-89ad-3c85248c984e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cd1fa89e-7a4b-46bb-89ad-3c85248c984e"},"toegewezenAanActoren":[{"uuid":"cd1fa89e-7a4b-46bb-89ad-3c85248c984e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/cd1fa89e-7a4b-46bb-89ad-3c85248c984e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:11:53.445224Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -311,17 +311,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/c087c227-46df-4b10-84fe-582c4b00d30e
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/51c1f59b-d7db-45a9-8ad6-cb34d68479de
       Referrer-Policy:
       - same-origin
       Vary:
@@ -334,7 +334,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "ea195ffd-7ec5-49d1-a8d9-556768ada5e9"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "ad5d65f8-9f27-4ee9-99eb-c54697df94c6"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -348,7 +348,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"0b8d8dfd-113f-40c4-9484-41ad59d10ed4","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4","klantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"0448ae0f-1037-46a7-9bd7-d2b9a84b5e67","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0448ae0f-1037-46a7-9bd7-d2b9a84b5e67","klantcontact":{"uuid":"ad5d65f8-9f27-4ee9-99eb-c54697df94c6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
@@ -358,17 +358,17 @@ interactions:
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0448ae0f-1037-46a7-9bd7-d2b9a84b5e67
       Referrer-Policy:
       - same-origin
       Vary:
@@ -389,7 +389,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0b8d8dfd-113f-40c4-9484-41ad59d10ed4","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0b8d8dfd-113f-40c4-9484-41ad59d10ed4","klantcontact":{"uuid":"ea195ffd-7ec5-49d1-a8d9-556768ada5e9","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ea195ffd-7ec5-49d1-a8d9-556768ada5e9"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0448ae0f-1037-46a7-9bd7-d2b9a84b5e67","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0448ae0f-1037-46a7-9bd7-d2b9a84b5e67","klantcontact":{"uuid":"ad5d65f8-9f27-4ee9-99eb-c54697df94c6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad5d65f8-9f27-4ee9-99eb-c54697df94c6"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}]}'
     headers:
       API-version:
@@ -399,11 +399,11 @@ interactions:
       Content-Length:
       - '544'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"fddfaeca-4151-4946-b802-b9b8e4990d1b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/fddfaeca-4151-4946-b802-b9b8e4990d1b","naam":"Afdeling
+      string: '{"uuid":"9272f289-b547-444c-aff1-2be2c4257a2c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9272f289-b547-444c-aff1-2be2c4257a2c","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/fddfaeca-4151-4946-b802-b9b8e4990d1b
+      - http://localhost:8338/klantinteracties/api/v1/actoren/9272f289-b547-444c-aff1-2be2c4257a2c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "hun", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Miss", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Misc.", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "nzi", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '369'
+      - '366'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"0dbd81d7-52f9-45e1-a3e1-3741126d514e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0dbd81d7-52f9-45e1-a3e1-3741126d514e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"hun","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Miss","voornaam":"Alice","voorvoegselAchternaam":"Misc.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Misc. McAlice"}}'
+      string: '{"uuid":"35d2bc70-445c-4818-b24a-09250855c029","url":"http://localhost:8338/klantinteracties/api/v1/partijen/35d2bc70-445c-4818-b24a-09250855c029","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"nzi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1036'
+      - '1031'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/0dbd81d7-52f9-45e1-a3e1-3741126d514e
+      - http://localhost:8338/klantinteracties/api/v1/partijen/35d2bc70-445c-4818-b24a-09250855c029
       Referrer-Policy:
       - same-origin
       Vary:
@@ -97,7 +97,7 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "tup", "soortPartij": "persoon", "partijIdentificatie":
+      true, "voorkeurstaal": "fiu", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
       "Mr.", "achternaam": "McBob"}}}'
     headers:
@@ -111,7 +111,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"a1c7e0df-7f10-4b98-ac16-8342dd2542ee","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a1c7e0df-7f10-4b98-ac16-8342dd2542ee","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tup","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+      string: '{"uuid":"b6ceb9f1-05c9-4361-a865-a59b4ff73cbf","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b6ceb9f1-05c9-4361-a865-a59b4ff73cbf","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"fiu","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
         Mr. McBob"}}'
     headers:
       API-version:
@@ -121,17 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/a1c7e0df-7f10-4b98-ac16-8342dd2542ee
+      - http://localhost:8338/klantinteracties/api/v1/partijen/b6ceb9f1-05c9-4361-a865-a59b4ff73cbf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e","naam":"Afdeling
+      string: '{"uuid":"9a72c889-5351-42d9-9d6b-e40906b83bd9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a72c889-5351-42d9-9d6b-e40906b83bd9","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/31d486c3-b1f7-4bd0-8b72-6db8f9b4bd4e
+      - http://localhost:8338/klantinteracties/api/v1/actoren/9a72c889-5351-42d9-9d6b-e40906b83bd9
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"0bc962cc-670d-4e6b-9082-a7f28a976cc7","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0bc962cc-670d-4e6b-9082-a7f28a976cc7","naam":"Afdeling
+      string: '{"uuid":"f16f2555-f2a4-4176-9f68-81a9ee42c1ee","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f16f2555-f2a4-4176-9f68-81a9ee42c1ee","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,66 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/0bc962cc-670d-4e6b-9082-a7f28a976cc7
-      Referrer-Policy:
-      - same-origin
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "sga", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Dr.", "achternaam": "McAlice"}}}'
-    headers:
-      Authorization:
-      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
-      Content-Length:
-      - '366'
-      Content-Type:
-      - application/json
-    method: POST
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen
-  response:
-    body:
-      string: '{"uuid":"f832a476-7230-4e15-a7d8-c597083a53d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f832a476-7230-4e15-a7d8-c597083a53d3","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"sga","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Dr. McAlice"}}'
-    headers:
-      API-version:
-      - 0.1.2
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      Content-Length:
-      - '1031'
-      Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/f832a476-7230-4e15-a7d8-c597083a53d3
+      - http://localhost:8338/klantinteracties/api/v1/actoren/f16f2555-f2a4-4176-9f68-81a9ee42c1ee
       Referrer-Policy:
       - same-origin
       Vary:
@@ -97,22 +48,71 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "lua", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mx.", "achternaam": "McBob"}}}'
+      true, "voorkeurstaal": "enm", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Dr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '363'
+      - '365'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"5e0e7c8d-b307-47fd-be45-c4b99a32fe8e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5e0e7c8d-b307-47fd-be45-c4b99a32fe8e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"lua","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mx. McBob"}}'
+      string: '{"uuid":"b7a05785-83d9-4aaf-b514-fe3785f0d8d5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b7a05785-83d9-4aaf-b514-fe3785f0d8d5","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"enm","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Dr. McAlice"}}'
+    headers:
+      API-version:
+      - 0.1.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1030'
+      Content-Security-Policy:
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/b7a05785-83d9-4aaf-b514-fe3785f0d8d5
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "gba", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mrs.", "achternaam": "McBob"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"abc5341e-394d-4ebf-94aa-b90cf4459dd1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/abc5341e-394d-4ebf-94aa-b90cf4459dd1","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"gba","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Bob","voorvoegselAchternaam":"Mrs.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mrs. McBob"}}'
     headers:
       API-version:
       - 0.1.2
@@ -121,17 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/5e0e7c8d-b307-47fd-be45-c4b99a32fe8e
+      - http://localhost:8338/klantinteracties/api/v1/partijen/abc5341e-394d-4ebf-94aa-b90cf4459dd1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a","naam":"Afdeling
+      string: '{"uuid":"d5b89b8f-64f9-40d6-935c-214f8cab8d9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a
+      - http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+      string: '{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
         inquiry","inhoud":"A question from an anonymous user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -214,17 +214,17 @@ interactions:
       Content-Length:
       - '517'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15
       Referrer-Policy:
       - same-origin
       Vary:
@@ -237,7 +237,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "4f590192-3630-4276-bfc4-a51c99943d15"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       {"voornaam": "Hieronymous", "achternaam": "Anonymous"}}'
     headers:
@@ -251,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","wasPartij":null,"hadKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+      string: '{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929","wasPartij":null,"hadKlantcontact":{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
         Anonymous","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -261,17 +261,17 @@ interactions:
       Content-Length:
       - '963'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929
       Referrer-Policy:
       - same-origin
       Vary:
@@ -289,7 +289,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=53715474-6fa5-49da-b38c-4fe6eb428929
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -301,11 +301,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -324,7 +324,7 @@ interactions:
 - request:
     body: '{"adres": "hieronymous.anonymous@example.com", "soortDigitaalAdres": "email",
       "isStandaardAdres": false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene":
-      {"uuid": "e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"}, "verstrektDoorPartij": null}'
+      {"uuid": "53715474-6fa5-49da-b38c-4fe6eb428929"}, "verstrektDoorPartij": null}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -336,7 +336,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"bf52ec3a-e68e-464d-8c54-01e978121a0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/bf52ec3a-e68e-464d-8c54-01e978121a0d","verstrektDoorBetrokkene":{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -346,17 +346,17 @@ interactions:
       Content-Length:
       - '486'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/bf52ec3a-e68e-464d-8c54-01e978121a0d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -374,10 +374,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=53715474-6fa5-49da-b38c-4fe6eb428929
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"bf52ec3a-e68e-464d-8c54-01e978121a0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/bf52ec3a-e68e-464d-8c54-01e978121a0d","verstrektDoorBetrokkene":{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -387,11 +387,11 @@ interactions:
       Content-Length:
       - '551'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -409,7 +409,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "53715474-6fa5-49da-b38c-4fe6eb428929"},
       "verstrektDoorPartij": null}'
     headers:
       Authorization:
@@ -422,7 +422,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"70b7b167-7c85-49c3-869c-b388660f0869","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/70b7b167-7c85-49c3-869c-b388660f0869","verstrektDoorBetrokkene":{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -432,17 +432,17 @@ interactions:
       Content-Length:
       - '472'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/70b7b167-7c85-49c3-869c-b388660f0869
       Referrer-Policy:
       - same-origin
       Vary:
@@ -455,10 +455,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "4f590192-3630-4276-bfc4-a51c99943d15"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "b2528cf4-e394-4b2a-8855-2038c8b9b82a"}}'
+      {"uuid": "d5b89b8f-64f9-40d6-935c-214f8cab8d9e"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -470,9 +470,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"toegewezenAanActor":{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"},"toegewezenAanActoren":[{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:28.048764Z","afgehandeldOp":null}'
+      string: '{"uuid":"6b96e387-1023-4211-a14c-7f6a1ad93b12","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6b96e387-1023-4211-a14c-7f6a1ad93b12","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15"},"toegewezenAanActor":{"uuid":"d5b89b8f-64f9-40d6-935c-214f8cab8d9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e"},"toegewezenAanActoren":[{"uuid":"d5b89b8f-64f9-40d6-935c-214f8cab8d9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:06.371763Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -481,17 +481,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/6b96e387-1023-4211-a14c-7f6a1ad93b12
       Referrer-Policy:
       - same-origin
       Vary:
@@ -512,7 +512,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"}],"leiddeTotInterneTaken":[{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"}],"leiddeTotInterneTaken":[{"uuid":"6b96e387-1023-4211-a14c-7f6a1ad93b12","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6b96e387-1023-4211-a14c-7f6a1ad93b12"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
         inquiry","inhoud":"A question from an anonymous user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
     headers:
       API-version:
@@ -522,11 +522,11 @@ interactions:
       Content-Length:
       - '883'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -551,7 +551,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","wasPartij":null,"hadKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"digitaleAdressen":[{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c"},{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929","wasPartij":null,"hadKlantcontact":{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15"},"digitaleAdressen":[{"uuid":"bf52ec3a-e68e-464d-8c54-01e978121a0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/bf52ec3a-e68e-464d-8c54-01e978121a0d"},{"uuid":"70b7b167-7c85-49c3-869c-b388660f0869","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/70b7b167-7c85-49c3-869c-b388660f0869"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
         Anonymous","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -561,11 +561,11 @@ interactions:
       Content-Length:
       - '1339'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -590,9 +590,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f439c32-4e64-4964-b386-bc31d002dbe6","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2f439c32-4e64-4964-b386-bc31d002dbe6","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/872e5e5a-dcdc-41a5-b0e6-8ec8ca51b7b6"},"toegewezenAanActor":{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"},"toegewezenAanActoren":[{"uuid":"b2528cf4-e394-4b2a-8855-2038c8b9b82a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b2528cf4-e394-4b2a-8855-2038c8b9b82a"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:28.048764Z","afgehandeldOp":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"6b96e387-1023-4211-a14c-7f6a1ad93b12","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/6b96e387-1023-4211-a14c-7f6a1ad93b12","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"4f590192-3630-4276-bfc4-a51c99943d15","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4f590192-3630-4276-bfc4-a51c99943d15"},"toegewezenAanActor":{"uuid":"d5b89b8f-64f9-40d6-935c-214f8cab8d9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e"},"toegewezenAanActoren":[{"uuid":"d5b89b8f-64f9-40d6-935c-214f8cab8d9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5b89b8f-64f9-40d6-935c-214f8cab8d9e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:06.371763Z","afgehandeldOp":null}]}'
     headers:
       API-version:
       - 0.1.2
@@ -601,11 +601,11 @@ interactions:
       Content-Length:
       - '952'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -627,11 +627,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=e9225a6c-dd0d-48ad-adcb-2876a6eaacf0
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=53715474-6fa5-49da-b38c-4fe6eb428929
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"eaab793c-863d-47cc-83a6-e1238c0240da","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/eaab793c-863d-47cc-83a6-e1238c0240da","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
-        profiel","_expand":{}},{"uuid":"f85038d1-adc3-4bce-b41f-a916ed52d43c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/f85038d1-adc3-4bce-b41f-a916ed52d43c","verstrektDoorBetrokkene":{"uuid":"e9225a6c-dd0d-48ad-adcb-2876a6eaacf0","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/e9225a6c-dd0d-48ad-adcb-2876a6eaacf0"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"70b7b167-7c85-49c3-869c-b388660f0869","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/70b7b167-7c85-49c3-869c-b388660f0869","verstrektDoorBetrokkene":{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","_expand":{}},{"uuid":"bf52ec3a-e68e-464d-8c54-01e978121a0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/bf52ec3a-e68e-464d-8c54-01e978121a0d","verstrektDoorBetrokkene":{"uuid":"53715474-6fa5-49da-b38c-4fe6eb428929","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/53715474-6fa5-49da-b38c-4fe6eb428929"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -641,11 +641,11 @@ interactions:
       Content-Length:
       - '1037'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1","naam":"Afdeling
+      string: '{"uuid":"6c534498-eae7-4320-95a0-41035b367933","url":"http://localhost:8338/klantinteracties/api/v1/actoren/6c534498-eae7-4320-95a0-41035b367933","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/3b85bcd7-a67f-4cbf-8d8f-81d0ee558ab1
+      - http://localhost:8338/klantinteracties/api/v1/actoren/6c534498-eae7-4320-95a0-41035b367933
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "lug", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "smj", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mrs.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '366'
+      - '367'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"b1be5d36-7b49-4f41-8bfa-74ae91826eaa","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b1be5d36-7b49-4f41-8bfa-74ae91826eaa","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"lug","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
+      string: '{"uuid":"060c0294-a9bb-4801-bea2-5fd5a2a3589b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/060c0294-a9bb-4801-bea2-5fd5a2a3589b","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"smj","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1031'
+      - '1033'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/b1be5d36-7b49-4f41-8bfa-74ae91826eaa
+      - http://localhost:8338/klantinteracties/api/v1/partijen/060c0294-a9bb-4801-bea2-5fd5a2a3589b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,42 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "kir", "soortPartij": "persoon", "partijIdentificatie":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "ota", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McBob"}}}'
+      "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '361'
+      - '362'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"51ada906-d610-41e9-8c3d-3a5cab322213","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51ada906-d610-41e9-8c3d-3a5cab322213","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"kir","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}'
+      string: '{"uuid":"f994ade6-2831-4e36-b94b-099fcf757daf","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f994ade6-2831-4e36-b94b-099fcf757daf","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"ota","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1022'
+      - '1023'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/51ada906-d610-41e9-8c3d-3a5cab322213
+      - http://localhost:8338/klantinteracties/api/v1/partijen/f994ade6-2831-4e36-b94b-099fcf757daf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91","naam":"Afdeling
+      string: '{"uuid":"541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91
+      - http://localhost:8338/klantinteracties/api/v1/actoren/541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
+      string: '{"uuid":"53b451e7-1568-49cd-ac34-318bf08f8b9f","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/53b451e7-1568-49cd-ac34-318bf08f8b9f","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
         only inquiry","inhoud":"A question with only email","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -214,17 +214,17 @@ interactions:
       Content-Length:
       - '511'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/53b451e7-1568-49cd-ac34-318bf08f8b9f
       Referrer-Policy:
       - same-origin
       Vary:
@@ -237,7 +237,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "599137d8-a6f5-4ae8-b105-71cfde799696"},
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "53b451e7-1568-49cd-ac34-318bf08f8b9f"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       {"voornaam": "Bob", "achternaam": "EmailOnly"}}'
     headers:
@@ -251,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13","wasPartij":null,"hadKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+      string: '{"uuid":"7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","wasPartij":null,"hadKlantcontact":{"uuid":"53b451e7-1568-49cd-ac34-318bf08f8b9f","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/53b451e7-1568-49cd-ac34-318bf08f8b9f"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
         EmailOnly","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -261,17 +261,17 @@ interactions:
       Content-Length:
       - '947'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba
       Referrer-Policy:
       - same-origin
       Vary:
@@ -289,7 +289,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=a5ea6fe0-6254-4bb0-9054-2e7f76187e13
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -301,11 +301,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -323,7 +323,7 @@ interactions:
       message: OK
 - request:
     body: '{"adres": "bob.email@example.com", "soortDigitaalAdres": "email", "isStandaardAdres":
-      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba"},
       "verstrektDoorPartij": null}'
     headers:
       Authorization:
@@ -336,7 +336,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
   response:
     body:
-      string: '{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c","verstrektDoorBetrokkene":{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"uuid":"e9dbfed7-358c-4a1d-85f8-5909a3973ccc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e9dbfed7-358c-4a1d-85f8-5909a3973ccc","verstrektDoorBetrokkene":{"uuid":"7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel"}'
     headers:
       API-version:
@@ -346,17 +346,17 @@ interactions:
       Content-Length:
       - '474'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e9dbfed7-358c-4a1d-85f8-5909a3973ccc
       Referrer-Policy:
       - same-origin
       Vary:
@@ -369,10 +369,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "599137d8-a6f5-4ae8-b105-71cfde799696"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "53b451e7-1568-49cd-ac34-318bf08f8b9f"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "a45af51d-dbde-4fd8-8fd3-11117b554b91"}}'
+      {"uuid": "541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -384,9 +384,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"dbfb4c70-e8ce-4bd9-893d-1049b5281cf0","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/dbfb4c70-e8ce-4bd9-893d-1049b5281cf0","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"toegewezenAanActor":{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91"},"toegewezenAanActoren":[{"uuid":"a45af51d-dbde-4fd8-8fd3-11117b554b91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a45af51d-dbde-4fd8-8fd3-11117b554b91"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:33.976173Z","afgehandeldOp":null}'
+      string: '{"uuid":"c414a200-acc2-4b3d-8d08-26fe99dbb76f","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c414a200-acc2-4b3d-8d08-26fe99dbb76f","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"53b451e7-1568-49cd-ac34-318bf08f8b9f","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/53b451e7-1568-49cd-ac34-318bf08f8b9f"},"toegewezenAanActor":{"uuid":"541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8"},"toegewezenAanActoren":[{"uuid":"541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/541cc6dd-4d6f-4a34-b1cf-3b7b613f8bd8"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:13.551335Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -395,17 +395,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/dbfb4c70-e8ce-4bd9-893d-1049b5281cf0
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/c414a200-acc2-4b3d-8d08-26fe99dbb76f
       Referrer-Policy:
       - same-origin
       Vary:
@@ -426,7 +426,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13","wasPartij":null,"hadKlantcontact":{"uuid":"599137d8-a6f5-4ae8-b105-71cfde799696","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/599137d8-a6f5-4ae8-b105-71cfde799696"},"digitaleAdressen":[{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","wasPartij":null,"hadKlantcontact":{"uuid":"53b451e7-1568-49cd-ac34-318bf08f8b9f","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/53b451e7-1568-49cd-ac34-318bf08f8b9f"},"digitaleAdressen":[{"uuid":"e9dbfed7-358c-4a1d-85f8-5909a3973ccc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e9dbfed7-358c-4a1d-85f8-5909a3973ccc"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
         EmailOnly","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -436,11 +436,11 @@ interactions:
       Content-Length:
       - '1167'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -462,10 +462,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=a5ea6fe0-6254-4bb0-9054-2e7f76187e13
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"93545898-0e81-4047-9661-db32b3883f6c","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/93545898-0e81-4047-9661-db32b3883f6c","verstrektDoorBetrokkene":{"uuid":"a5ea6fe0-6254-4bb0-9054-2e7f76187e13","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a5ea6fe0-6254-4bb0-9054-2e7f76187e13"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e9dbfed7-358c-4a1d-85f8-5909a3973ccc","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/e9dbfed7-358c-4a1d-85f8-5909a3973ccc","verstrektDoorBetrokkene":{"uuid":"7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7fc8eb95-fe9f-48a8-92ab-a46f53e3b9ba"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
         profiel","_expand":{}}]}'
     headers:
       API-version:
@@ -475,11 +475,11 @@ interactions:
       Content-Length:
       - '539'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"34ea0915-b527-4860-9638-45e5446e07af","url":"http://localhost:8338/klantinteracties/api/v1/actoren/34ea0915-b527-4860-9638-45e5446e07af","naam":"Afdeling
+      string: '{"uuid":"00d6d1f7-a3cd-4393-87c5-f20183d4faad","url":"http://localhost:8338/klantinteracties/api/v1/actoren/00d6d1f7-a3cd-4393-87c5-f20183d4faad","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/34ea0915-b527-4860-9638-45e5446e07af
+      - http://localhost:8338/klantinteracties/api/v1/actoren/00d6d1f7-a3cd-4393-87c5-f20183d4faad
       Referrer-Policy:
       - same-origin
       Vary:
@@ -47,42 +47,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "wak", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "hup", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Ms.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Dr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '368'
+      - '365'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"0f34f272-4a63-4e79-bc09-00241fa179c2","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0f34f272-4a63-4e79-bc09-00241fa179c2","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"wak","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
+      string: '{"uuid":"d29bbdd0-24ec-4323-bacb-a48a037e2d7a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d29bbdd0-24ec-4323-bacb-a48a037e2d7a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"hup","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ms.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Dr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1033'
+      - '1030'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/0f34f272-4a63-4e79-bc09-00241fa179c2
+      - http://localhost:8338/klantinteracties/api/v1/partijen/d29bbdd0-24ec-4323-bacb-a48a037e2d7a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -97,21 +97,21 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "tmh", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Miss", "voornaam": "Bob", "voorvoegselAchternaam":
+      false, "voorkeurstaal": "gla", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
       "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '363'
+      - '364'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"a2f114d5-3339-4175-9b4c-5c47adf57762","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a2f114d5-3339-4175-9b4c-5c47adf57762","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tmh","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Miss","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+      string: '{"uuid":"f3b52a32-207d-4d33-b849-79896d13bc4a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f3b52a32-207d-4d33-b849-79896d13bc4a","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"gla","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
         Mr. McBob"}}'
     headers:
       API-version:
@@ -119,19 +119,19 @@ interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1024'
+      - '1025'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/a2f114d5-3339-4175-9b4c-5c47adf57762
+      - http://localhost:8338/klantinteracties/api/v1/partijen/f3b52a32-207d-4d33-b849-79896d13bc4a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"5e4d4379-086d-4c6e-9946-685efad57ddc","url":"http://localhost:8338/klantinteracties/api/v1/actoren/5e4d4379-086d-4c6e-9946-685efad57ddc","naam":"Afdeling
+      string: '{"uuid":"2180fc50-c007-4b7d-b99f-ef73d66211b4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/2180fc50-c007-4b7d-b99f-ef73d66211b4","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/5e4d4379-086d-4c6e-9946-685efad57ddc
+      - http://localhost:8338/klantinteracties/api/v1/actoren/2180fc50-c007-4b7d-b99f-ef73d66211b4
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"e4dfae60-bfaa-4c75-ab59-12cb416a49b2","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e4dfae60-bfaa-4c75-ab59-12cb416a49b2","naam":"Afdeling
+      string: '{"uuid":"c28af2e5-6bda-47b7-a5ba-8e9037feff91","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c28af2e5-6bda-47b7-a5ba-8e9037feff91","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/e4dfae60-bfaa-4c75-ab59-12cb416a49b2
+      - http://localhost:8338/klantinteracties/api/v1/actoren/c28af2e5-6bda-47b7-a5ba-8e9037feff91
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      false, "voorkeurstaal": "sme", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mx.", "achternaam": "McAlice"}}}'
+      false, "voorkeurstaal": "mnc", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mrs.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '367'
+      - '368'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"54b20078-cde9-4bde-b01f-dd6e581864b0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/54b20078-cde9-4bde-b01f-dd6e581864b0","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"sme","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mx. McAlice"}}'
+      string: '{"uuid":"42cf7b56-813b-47bb-a640-960a6eaa31a1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/42cf7b56-813b-47bb-a640-960a6eaa31a1","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"mnc","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1032'
+      - '1034'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/54b20078-cde9-4bde-b01f-dd6e581864b0
+      - http://localhost:8338/klantinteracties/api/v1/partijen/42cf7b56-813b-47bb-a640-960a6eaa31a1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,42 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "tur", "soortPartij": "persoon", "partijIdentificatie":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      false, "voorkeurstaal": "yap", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McBob"}}}'
+      "Dr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '361'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"398ad0f5-2969-448d-9e1a-70f3a5462e3d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/398ad0f5-2969-448d-9e1a-70f3a5462e3d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"tur","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}'
+      string: '{"uuid":"b20db450-f70f-4846-989e-5e33d74b8393","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b20db450-f70f-4846-989e-5e33d74b8393","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"yap","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Dr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Dr. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1022'
+      - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/398ad0f5-2969-448d-9e1a-70f3a5462e3d
+      - http://localhost:8338/klantinteracties/api/v1/partijen/b20db450-f70f-4846-989e-5e33d74b8393
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9","naam":"Afdeling
+      string: '{"uuid":"a4fd8b87-8676-45b6-8b79-afc06fb1f1c0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a4fd8b87-8676-45b6-8b79-afc06fb1f1c0","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9
+      - http://localhost:8338/klantinteracties/api/v1/actoren/a4fd8b87-8676-45b6-8b79-afc06fb1f1c0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
+      string: '{"uuid":"b1ec19a0-ded8-4e74-ae32-b59a80d55b23","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b1ec19a0-ded8-4e74-ae32-b59a80d55b23","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
         inquiry","inhoud":"A question without contact details","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -214,17 +214,17 @@ interactions:
       Content-Length:
       - '516'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/b1ec19a0-ded8-4e74-ae32-b59a80d55b23
       Referrer-Policy:
       - same-origin
       Vary:
@@ -237,7 +237,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "fe5cb401-38d8-42f7-8dda-27775e089d10"},
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "b1ec19a0-ded8-4e74-ae32-b59a80d55b23"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       {"voornaam": "Jane", "achternaam": "Minimal"}}'
     headers:
@@ -251,7 +251,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","wasPartij":null,"hadKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+      string: '{"uuid":"71962b5b-6fb0-45e7-8572-02d90682aa01","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/71962b5b-6fb0-45e7-8572-02d90682aa01","wasPartij":null,"hadKlantcontact":{"uuid":"b1ec19a0-ded8-4e74-ae32-b59a80d55b23","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b1ec19a0-ded8-4e74-ae32-b59a80d55b23"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
         Minimal","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -261,17 +261,17 @@ interactions:
       Content-Length:
       - '945'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/71962b5b-6fb0-45e7-8572-02d90682aa01
       Referrer-Policy:
       - same-origin
       Vary:
@@ -284,10 +284,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "fe5cb401-38d8-42f7-8dda-27775e089d10"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "b1ec19a0-ded8-4e74-ae32-b59a80d55b23"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "0d21972d-bbac-45f9-8f18-95db41e371b9"}}'
+      {"uuid": "a4fd8b87-8676-45b6-8b79-afc06fb1f1c0"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -299,9 +299,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"71c8ab9c-db75-4882-985f-d71e03cc5bed","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/71c8ab9c-db75-4882-985f-d71e03cc5bed","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"toegewezenAanActor":{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9"},"toegewezenAanActoren":[{"uuid":"0d21972d-bbac-45f9-8f18-95db41e371b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0d21972d-bbac-45f9-8f18-95db41e371b9"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:46.479728Z","afgehandeldOp":null}'
+      string: '{"uuid":"4746ed9b-1378-405c-9ddc-065ab8dc8c4e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/4746ed9b-1378-405c-9ddc-065ab8dc8c4e","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b1ec19a0-ded8-4e74-ae32-b59a80d55b23","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b1ec19a0-ded8-4e74-ae32-b59a80d55b23"},"toegewezenAanActor":{"uuid":"a4fd8b87-8676-45b6-8b79-afc06fb1f1c0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a4fd8b87-8676-45b6-8b79-afc06fb1f1c0"},"toegewezenAanActoren":[{"uuid":"a4fd8b87-8676-45b6-8b79-afc06fb1f1c0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a4fd8b87-8676-45b6-8b79-afc06fb1f1c0"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:26.678723Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -310,17 +310,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/71c8ab9c-db75-4882-985f-d71e03cc5bed
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/4746ed9b-1378-405c-9ddc-065ab8dc8c4e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -341,7 +341,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/896b1bf7-51cd-4a08-917d-a7e4e5ccbc70","wasPartij":null,"hadKlantcontact":{"uuid":"fe5cb401-38d8-42f7-8dda-27775e089d10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fe5cb401-38d8-42f7-8dda-27775e089d10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"71962b5b-6fb0-45e7-8572-02d90682aa01","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/71962b5b-6fb0-45e7-8572-02d90682aa01","wasPartij":null,"hadKlantcontact":{"uuid":"b1ec19a0-ded8-4e74-ae32-b59a80d55b23","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b1ec19a0-ded8-4e74-ae32-b59a80d55b23"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
         Minimal","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{}}]}'
     headers:
       API-version:
@@ -351,11 +351,11 @@ interactions:
       Content-Length:
       - '1010'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -377,7 +377,7 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=896b1bf7-51cd-4a08-917d-a7e4e5ccbc70
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=71962b5b-6fb0-45e7-8572-02d90682aa01
   response:
     body:
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
@@ -389,11 +389,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"2d6c9451-315a-4d9c-aae6-00c5296a58c3","url":"http://localhost:8338/klantinteracties/api/v1/actoren/2d6c9451-315a-4d9c-aae6-00c5296a58c3","naam":"Afdeling
+      string: '{"uuid":"a9b47963-1026-40ca-9a69-75b106f03408","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a9b47963-1026-40ca-9a69-75b106f03408","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/2d6c9451-315a-4d9c-aae6-00c5296a58c3
+      - http://localhost:8338/klantinteracties/api/v1/actoren/a9b47963-1026-40ca-9a69-75b106f03408
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,7 +48,7 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "mni", "soortPartij": "persoon", "partijIdentificatie":
+      true, "voorkeurstaal": "jpn", "soortPartij": "persoon", "partijIdentificatie":
       {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
       "Ms.", "achternaam": "McAlice"}}}'
     headers:
@@ -62,7 +62,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"6de13359-bae3-4fd7-98f3-ee6216f07fa1","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6de13359-bae3-4fd7-98f3-ee6216f07fa1","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"mni","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Ms.","achternaam":"McAlice"},"volledigeNaam":"Alice
+      string: '{"uuid":"06615c65-65d3-4466-a813-e5aa9fff93c6","url":"http://localhost:8338/klantinteracties/api/v1/partijen/06615c65-65d3-4466-a813-e5aa9fff93c6","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"jpn","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Ms.","achternaam":"McAlice"},"volledigeNaam":"Alice
         Ms. McAlice"}}'
     headers:
       API-version:
@@ -72,17 +72,17 @@ interactions:
       Content-Length:
       - '1030'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/6de13359-bae3-4fd7-98f3-ee6216f07fa1
+      - http://localhost:8338/klantinteracties/api/v1/partijen/06615c65-65d3-4466-a813-e5aa9fff93c6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,22 +96,22 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "luo", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Ind.", "voornaam": "Bob", "voorvoegselAchternaam":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      true, "voorkeurstaal": "iba", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Bob", "voorvoegselAchternaam":
       "Mr.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '363'
+      - '362'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"4d403d9e-541b-4f2e-8ca2-36e9370d7c39","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d403d9e-541b-4f2e-8ca2-36e9370d7c39","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"luo","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ind.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+      string: '{"uuid":"5e35edd8-263e-4049-8387-52443eb16669","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5e35edd8-263e-4049-8387-52443eb16669","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"iba","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
         Mr. McBob"}}'
     headers:
       API-version:
@@ -119,19 +119,19 @@ interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1024'
+      - '1023'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/4d403d9e-541b-4f2e-8ca2-36e9370d7c39
+      - http://localhost:8338/klantinteracties/api/v1/partijen/5e35edd8-263e-4049-8387-52443eb16669
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"1d14ed0a-42d1-4363-a73e-b354436b94b2","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1d14ed0a-42d1-4363-a73e-b354436b94b2","naam":"Afdeling
+      string: '{"uuid":"0a8358f0-8ba1-42bb-955f-2440a1d74727","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0a8358f0-8ba1-42bb-955f-2440a1d74727","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/1d14ed0a-42d1-4363-a73e-b354436b94b2
+      - http://localhost:8338/klantinteracties/api/v1/actoren/0a8358f0-8ba1-42bb-955f-2440a1d74727
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"3741d4fc-8dbb-4489-a50e-3b2525d8657b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3741d4fc-8dbb-4489-a50e-3b2525d8657b","naam":"Afdeling
+      string: '{"uuid":"be8ac888-40b9-4271-8a0e-f75941505884","url":"http://localhost:8338/klantinteracties/api/v1/actoren/be8ac888-40b9-4271-8a0e-f75941505884","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/3741d4fc-8dbb-4489-a50e-3b2525d8657b
+      - http://localhost:8338/klantinteracties/api/v1/actoren/be8ac888-40b9-4271-8a0e-f75941505884
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,9 +48,9 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "phi", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
+      false, "voorkeurstaal": "fan", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Dr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -62,8 +62,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"phi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
+      string: '{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"fan","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
@@ -72,17 +72,17 @@ interactions:
       Content-Length:
       - '1031'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005
+      - http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -96,42 +96,42 @@ interactions:
       message: Created
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
-      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      false, "voorkeurstaal": "nog", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McBob"}}}'
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      false, "voorkeurstaal": "tum", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Ms.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '362'
+      - '363'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"nog","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}'
+      string: '{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tum","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ms.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1023'
+      - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d
+      - http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63","naam":"Afdeling
+      string: '{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63
+      - http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253
       Referrer-Policy:
       - same-origin
       Vary:
@@ -190,7 +190,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005, part
+    body: '{"inhoud": "A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e, part
       0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -204,8 +204,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
+      string: '{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -215,17 +215,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7
       Referrer-Policy:
       - same-origin
       Vary:
@@ -238,8 +238,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"},
+    body: '{"wasPartij": {"uuid": "fd2481bc-645f-4810-a92a-a4506192ae6e"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "22e92b61-8593-4d73-8b17-d00571a72ad7"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -253,7 +253,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"1d91847e-18d1-4390-aab4-e9ba3e44d05a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -263,17 +263,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -286,10 +286,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "22e92b61-8593-4d73-8b17-d00571a72ad7"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
+      {"uuid": "f67a249b-9fb7-486d-bb28-d2cc12351253"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -301,9 +301,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.029933Z","afgehandeldOp":null}'
+      string: '{"uuid":"363bb140-f090-41bf-8c4f-4fd2400fdd38","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/363bb140-f090-41bf-8c4f-4fd2400fdd38","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.453393Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -312,17 +312,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/363bb140-f090-41bf-8c4f-4fd2400fdd38
       Referrer-Policy:
       - same-origin
       Vary:
@@ -335,7 +335,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005, part
+    body: '{"inhoud": "A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e, part
       1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -349,8 +349,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
+      string: '{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e,
         part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -360,17 +360,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264
       Referrer-Policy:
       - same-origin
       Vary:
@@ -383,8 +383,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "5141001e-3354-435c-8f36-7d1d7a49fa7c"},
+    body: '{"wasPartij": {"uuid": "fd2481bc-645f-4810-a92a-a4506192ae6e"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -398,7 +398,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -408,17 +408,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/38451be4-d7bc-4cb6-b9d8-79ebdc2fd933
       Referrer-Policy:
       - same-origin
       Vary:
@@ -431,10 +431,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "5141001e-3354-435c-8f36-7d1d7a49fa7c"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
+      {"uuid": "f67a249b-9fb7-486d-bb28-d2cc12351253"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -446,9 +446,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.085171Z","afgehandeldOp":null}'
+      string: '{"uuid":"ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.510080Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -457,17 +457,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d
       Referrer-Policy:
       - same-origin
       Vary:
@@ -485,11 +485,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7
   response:
     body:
-      string: '{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
+      string: '{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d91847e-18d1-4390-aab4-e9ba3e44d05a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a"}],"leiddeTotInterneTaken":[{"uuid":"363bb140-f090-41bf-8c4f-4fd2400fdd38","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/363bb140-f090-41bf-8c4f-4fd2400fdd38"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -499,11 +499,11 @@ interactions:
       Content-Length:
       - '846'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -533,7 +533,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+      string: '{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
         and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -543,17 +543,17 @@ interactions:
       Content-Length:
       - '497'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377
       Referrer-Policy:
       - same-origin
       Vary:
@@ -566,8 +566,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "fd8a022b-b5f5-44df-9f96-33ed6ab22203"},
-      "initiator": true, "wasPartij": {"uuid": "5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},
+    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "ad99c577-91b2-47b6-8c19-13c8fa67a377"},
+      "initiator": true, "wasPartij": {"uuid": "fd2481bc-645f-4810-a92a-a4506192ae6e"},
       "organisatienaam": "Open Inwoner Platform"}'
     headers:
       Authorization:
@@ -580,7 +580,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -590,17 +590,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a6464637-fce4-40a2-9f7d-9c2f2d51a5a8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -613,8 +613,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "fd8a022b-b5f5-44df-9f96-33ed6ab22203"}, "wasKlantcontact":
-      {"uuid": "b93e5d1d-5088-4fed-961a-1bf8332cd102"}}'
+    body: '{"klantcontact": {"uuid": "ad99c577-91b2-47b6-8c19-13c8fa67a377"}, "wasKlantcontact":
+      {"uuid": "22e92b61-8593-4d73-8b17-d00571a72ad7"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -626,7 +626,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"293440ef-789d-425b-8036-da2750c6d460","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460","klantcontact":{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377"},"wasKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -635,17 +635,17 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460
       Referrer-Policy:
       - same-origin
       Vary:
@@ -658,7 +658,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d, part
+    body: '{"inhoud": "A question asked by 76e01806-9467-41ac-bba8-df532c1d4296, part
       0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -672,8 +672,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
+      string: '{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 76e01806-9467-41ac-bba8-df532c1d4296,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -683,17 +683,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -706,8 +706,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},
+    body: '{"wasPartij": {"uuid": "76e01806-9467-41ac-bba8-df532c1d4296"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -721,7 +721,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"2bf20b6c-afea-4b79-9635-94eb4110cad6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -731,17 +731,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -754,10 +754,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
+      {"uuid": "f67a249b-9fb7-486d-bb28-d2cc12351253"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -769,9 +769,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68","nummer":"0000000003","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.201602Z","afgehandeldOp":null}'
+      string: '{"uuid":"af7cd33a-3c3d-4195-979a-70723a0b8abf","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/af7cd33a-3c3d-4195-979a-70723a0b8abf","nummer":"0000000003","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.630689Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -780,17 +780,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/af7cd33a-3c3d-4195-979a-70723a0b8abf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -803,7 +803,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"inhoud": "A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d, part
+    body: '{"inhoud": "A question asked by 76e01806-9467-41ac-bba8-df532c1d4296, part
       1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal": "oip_mijn_vragen",
       "vertrouwelijk": false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
     headers:
@@ -817,8 +817,8 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
+      string: '{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 76e01806-9467-41ac-bba8-df532c1d4296,
         part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -828,17 +828,17 @@ interactions:
       Content-Length:
       - '545'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5
       Referrer-Policy:
       - same-origin
       Vary:
@@ -851,8 +851,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "199a9ed9-2aff-448c-a7af-21ec8966ef10"},
+    body: '{"wasPartij": {"uuid": "76e01806-9467-41ac-bba8-df532c1d4296"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "669155be-2d98-4c81-b8f7-5526c4c93ae5"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -866,7 +866,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"6dba3966-9e68-41a9-afa9-029f774c4323","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6dba3966-9e68-41a9-afa9-029f774c4323","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -876,17 +876,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/6dba3966-9e68-41a9-afa9-029f774c4323
       Referrer-Policy:
       - same-origin
       Vary:
@@ -899,10 +899,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "199a9ed9-2aff-448c-a7af-21ec8966ef10"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "669155be-2d98-4c81-b8f7-5526c4c93ae5"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "3a51d795-65ee-4456-b3ca-92447085bd63"}}'
+      {"uuid": "f67a249b-9fb7-486d-bb28-d2cc12351253"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -914,9 +914,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de","nummer":"0000000004","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.265009Z","afgehandeldOp":null}'
+      string: '{"uuid":"314f1f04-d14f-4b33-a5a1-0773e10b383b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/314f1f04-d14f-4b33-a5a1-0773e10b383b","nummer":"0000000004","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.696085Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -925,17 +925,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/314f1f04-d14f-4b33-a5a1-0773e10b383b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -953,11 +953,11 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8
   response:
     body:
-      string: '{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
+      string: '{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"2bf20b6c-afea-4b79-9635-94eb4110cad6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6"}],"leiddeTotInterneTaken":[{"uuid":"af7cd33a-3c3d-4195-979a-70723a0b8abf","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/af7cd33a-3c3d-4195-979a-70723a0b8abf"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 76e01806-9467-41ac-bba8-df532c1d4296,
         part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -967,11 +967,11 @@ interactions:
       Content-Length:
       - '846'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -1001,7 +1001,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+      string: '{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
         and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -1011,17 +1011,17 @@ interactions:
       Content-Length:
       - '497'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1034,8 +1034,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "89a7baba-368b-470a-8513-d821b1b4063a"},
-      "initiator": true, "wasPartij": {"uuid": "65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},
+    body: '{"rol": "klant", "hadKlantcontact": {"uuid": "3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"},
+      "initiator": true, "wasPartij": {"uuid": "76e01806-9467-41ac-bba8-df532c1d4296"},
       "organisatienaam": "Open Inwoner Platform"}'
     headers:
       Authorization:
@@ -1048,7 +1048,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"d42b2979-774c-43a0-ad43-1a52e34213aa","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d42b2979-774c-43a0-ad43-1a52e34213aa","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -1058,17 +1058,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/d42b2979-774c-43a0-ad43-1a52e34213aa
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1081,8 +1081,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "89a7baba-368b-470a-8513-d821b1b4063a"}, "wasKlantcontact":
-      {"uuid": "250a734c-93f0-46a9-adf8-b3a2a28c7dc8"}}'
+    body: '{"klantcontact": {"uuid": "3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"}, "wasKlantcontact":
+      {"uuid": "8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -1094,7 +1094,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff","klantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"wasKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"7ce9b532-6f70-428b-b47e-b6b8cd09bbe5","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7ce9b532-6f70-428b-b47e-b6b8cd09bbe5","klantcontact":{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"},"wasKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -1103,17 +1103,17 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7ce9b532-6f70-428b-b47e-b6b8cd09bbe5
       Referrer-Policy:
       - same-origin
       Vary:
@@ -1134,46 +1134,46 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
   response:
     body:
-      string: '{"count":6,"next":null,"previous":null,"results":[{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a","gingOverOnderwerpobjecten":[{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"07b25294-b7a8-40c3-8555-4bf712694bff","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/07b25294-b7a8-40c3-8555-4bf712694bff","klantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"wasKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"89a7baba-368b-470a-8513-d821b1b4063a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/89a7baba-368b-470a-8513-d821b1b4063a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"},{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e"},{"uuid":"2172afef-1824-4a90-b7b4-e41a4f16256d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2172afef-1824-4a90-b7b4-e41a4f16256d"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"nog","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
-        Mr. McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e"}],"leiddeTotInterneTaken":[{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
-        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"4ef67121-69d1-4eee-af73-547e01d4b98e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4ef67121-69d1-4eee-af73-547e01d4b98e","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"3031e54d-122b-4c43-9331-c8e4190349de","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3031e54d-122b-4c43-9331-c8e4190349de","nummer":"0000000004","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"199a9ed9-2aff-448c-a7af-21ec8966ef10","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/199a9ed9-2aff-448c-a7af-21ec8966ef10"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.265009Z","afgehandeldOp":null}]}},{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae"}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 65a71768-e73c-4aa1-ae2e-ba32eaf5904d,
-        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"ed151837-adf3-401b-9483-82b5abde36ae","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ed151837-adf3-401b-9483-82b5abde36ae","wasPartij":{"uuid":"65a71768-e73c-4aa1-ae2e-ba32eaf5904d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65a71768-e73c-4aa1-ae2e-ba32eaf5904d"},"hadKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"42a69c4c-2db5-4714-a927-7a43885eff68","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/42a69c4c-2db5-4714-a927-7a43885eff68","nummer":"0000000003","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"250a734c-93f0-46a9-adf8-b3a2a28c7dc8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/250a734c-93f0-46a9-adf8-b3a2a28c7dc8"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.201602Z","afgehandeldOp":null}]}},{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203","gingOverOnderwerpobjecten":[{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"},{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153"},{"uuid":"ba4bf300-165a-47fd-8781-1adbabcacf96","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/ba4bf300-165a-47fd-8781-1adbabcacf96"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"phi","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153"}],"leiddeTotInterneTaken":[{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
-        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"6466ca88-93e2-487d-afd0-b17700b76153","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6466ca88-93e2-487d-afd0-b17700b76153","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"f8624f8d-493d-4701-a739-3c5dee634025","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/f8624f8d-493d-4701-a739-3c5dee634025","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5141001e-3354-435c-8f36-7d1d7a49fa7c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5141001e-3354-435c-8f36-7d1d7a49fa7c"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.085171Z","afgehandeldOp":null}]}},{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da"}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
-        and stuff","inhoud":"A question asked by 5ec394ad-f425-4ef0-99d3-1cbbddaaa005,
-        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d0647c2-b382-4bc6-ae3d-c92b5e7be8da","wasPartij":{"uuid":"5ec394ad-f425-4ef0-99d3-1cbbddaaa005","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5ec394ad-f425-4ef0-99d3-1cbbddaaa005"},"hadKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"814d099a-39f2-43d1-9b7f-f9156f46eca9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/814d099a-39f2-43d1-9b7f-f9156f46eca9","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"toegewezenAanActor":{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"},"toegewezenAanActoren":[{"uuid":"3a51d795-65ee-4456-b3ca-92447085bd63","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3a51d795-65ee-4456-b3ca-92447085bd63"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:55:59.029933Z","afgehandeldOp":null}]}}]}'
+      string: '{"count":6,"next":null,"previous":null,"results":[{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","gingOverOnderwerpobjecten":[{"uuid":"7ce9b532-6f70-428b-b47e-b6b8cd09bbe5","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7ce9b532-6f70-428b-b47e-b6b8cd09bbe5"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"d42b2979-774c-43a0-ad43-1a52e34213aa","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d42b2979-774c-43a0-ad43-1a52e34213aa"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"7ce9b532-6f70-428b-b47e-b6b8cd09bbe5","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7ce9b532-6f70-428b-b47e-b6b8cd09bbe5","klantcontact":{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"},"wasKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"d42b2979-774c-43a0-ad43-1a52e34213aa","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d42b2979-774c-43a0-ad43-1a52e34213aa","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"3eabc8e4-5c5e-4364-aeae-c98dc2c435e6","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3eabc8e4-5c5e-4364-aeae-c98dc2c435e6"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"2bf20b6c-afea-4b79-9635-94eb4110cad6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6"},{"uuid":"6dba3966-9e68-41a9-afa9-029f774c4323","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6dba3966-9e68-41a9-afa9-029f774c4323"},{"uuid":"d42b2979-774c-43a0-ad43-1a52e34213aa","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d42b2979-774c-43a0-ad43-1a52e34213aa"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"tum","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Ms.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"6dba3966-9e68-41a9-afa9-029f774c4323","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6dba3966-9e68-41a9-afa9-029f774c4323"}],"leiddeTotInterneTaken":[{"uuid":"314f1f04-d14f-4b33-a5a1-0773e10b383b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/314f1f04-d14f-4b33-a5a1-0773e10b383b"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 76e01806-9467-41ac-bba8-df532c1d4296,
+        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"6dba3966-9e68-41a9-afa9-029f774c4323","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6dba3966-9e68-41a9-afa9-029f774c4323","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"314f1f04-d14f-4b33-a5a1-0773e10b383b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/314f1f04-d14f-4b33-a5a1-0773e10b383b","nummer":"0000000004","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"669155be-2d98-4c81-b8f7-5526c4c93ae5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/669155be-2d98-4c81-b8f7-5526c4c93ae5"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.696085Z","afgehandeldOp":null}]}},{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"2bf20b6c-afea-4b79-9635-94eb4110cad6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6"}],"leiddeTotInterneTaken":[{"uuid":"af7cd33a-3c3d-4195-979a-70723a0b8abf","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/af7cd33a-3c3d-4195-979a-70723a0b8abf"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by 76e01806-9467-41ac-bba8-df532c1d4296,
+        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"2bf20b6c-afea-4b79-9635-94eb4110cad6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/2bf20b6c-afea-4b79-9635-94eb4110cad6","wasPartij":{"uuid":"76e01806-9467-41ac-bba8-df532c1d4296","url":"http://localhost:8338/klantinteracties/api/v1/partijen/76e01806-9467-41ac-bba8-df532c1d4296"},"hadKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"af7cd33a-3c3d-4195-979a-70723a0b8abf","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/af7cd33a-3c3d-4195-979a-70723a0b8abf","nummer":"0000000003","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"8fe771c9-cdc0-4341-91f9-7b8502a3e3b8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fe771c9-cdc0-4341-91f9-7b8502a3e3b8"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.630689Z","afgehandeldOp":null}]}},{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377","gingOverOnderwerpobjecten":[{"uuid":"293440ef-789d-425b-8036-da2750c6d460","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a6464637-fce4-40a2-9f7d-9c2f2d51a5a8"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"The answer is 42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"293440ef-789d-425b-8036-da2750c6d460","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460","klantcontact":{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377"},"wasKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"1d91847e-18d1-4390-aab4-e9ba3e44d05a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a"},{"uuid":"38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/38451be4-d7bc-4cb6-b9d8-79ebdc2fd933"},{"uuid":"a6464637-fce4-40a2-9f7d-9c2f2d51a5a8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a6464637-fce4-40a2-9f7d-9c2f2d51a5a8"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"fan","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Dr.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/38451be4-d7bc-4cb6-b9d8-79ebdc2fd933"}],"leiddeTotInterneTaken":[{"uuid":"ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e,
+        part 1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/38451be4-d7bc-4cb6-b9d8-79ebdc2fd933","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/ab2644e0-9aaa-46dd-ae97-cfa48c0a0d4d","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"1b30c08a-f8d8-40d7-8b0a-1b38e48fd264","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/1b30c08a-f8d8-40d7-8b0a-1b38e48fd264"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.510080Z","afgehandeldOp":null}]}},{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1d91847e-18d1-4390-aab4-e9ba3e44d05a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a"}],"leiddeTotInterneTaken":[{"uuid":"363bb140-f090-41bf-8c4f-4fd2400fdd38","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/363bb140-f090-41bf-8c4f-4fd2400fdd38"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+        and stuff","inhoud":"A question asked by fd2481bc-645f-4810-a92a-a4506192ae6e,
+        part 0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"1d91847e-18d1-4390-aab4-e9ba3e44d05a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1d91847e-18d1-4390-aab4-e9ba3e44d05a","wasPartij":{"uuid":"fd2481bc-645f-4810-a92a-a4506192ae6e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fd2481bc-645f-4810-a92a-a4506192ae6e"},"hadKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"363bb140-f090-41bf-8c4f-4fd2400fdd38","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/363bb140-f090-41bf-8c4f-4fd2400fdd38","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"toegewezenAanActor":{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"},"toegewezenAanActoren":[{"uuid":"f67a249b-9fb7-486d-bb28-d2cc12351253","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f67a249b-9fb7-486d-bb28-d2cc12351253"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:40.453393Z","afgehandeldOp":null}]}}]}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '19911'
+      - '19912'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -1195,10 +1195,10 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410
+    uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460
   response:
     body:
-      string: '{"uuid":"dcbc6a6e-774a-4e44-b694-28f24fc04410","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/dcbc6a6e-774a-4e44-b694-28f24fc04410","klantcontact":{"uuid":"fd8a022b-b5f5-44df-9f96-33ed6ab22203","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fd8a022b-b5f5-44df-9f96-33ed6ab22203"},"wasKlantcontact":{"uuid":"b93e5d1d-5088-4fed-961a-1bf8332cd102","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/b93e5d1d-5088-4fed-961a-1bf8332cd102"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      string: '{"uuid":"293440ef-789d-425b-8036-da2750c6d460","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/293440ef-789d-425b-8036-da2750c6d460","klantcontact":{"uuid":"ad99c577-91b2-47b6-8c19-13c8fa67a377","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ad99c577-91b2-47b6-8c19-13c8fa67a377"},"wasKlantcontact":{"uuid":"22e92b61-8593-4d73-8b17-d00571a72ad7","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22e92b61-8593-4d73-8b17-d00571a72ad7"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
     headers:
       API-version:
       - 0.1.2
@@ -1207,11 +1207,11 @@ interactions:
       Content-Length:
       - '605'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
@@ -13,7 +13,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"ffe144c7-8827-43db-8582-a1a49200e2e8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/ffe144c7-8827-43db-8582-a1a49200e2e8","naam":"Afdeling
+      string: '{"uuid":"66578b3f-09bd-4828-b6f4-404607a1b390","url":"http://localhost:8338/klantinteracties/api/v1/actoren/66578b3f-09bd-4828-b6f4-404607a1b390","naam":"Afdeling
         Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -23,17 +23,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/ffe144c7-8827-43db-8582-a1a49200e2e8
+      - http://localhost:8338/klantinteracties/api/v1/actoren/66578b3f-09bd-4828-b6f4-404607a1b390
       Referrer-Policy:
       - same-origin
       Vary:
@@ -48,41 +48,41 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
-      true, "voorkeurstaal": "frm", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Alice", "voorvoegselAchternaam":
-      "Mr.", "achternaam": "McAlice"}}}'
+      true, "voorkeurstaal": "gez", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Dr.", "achternaam": "McAlice"}}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '367'
+      - '365'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"frm","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Alice","voorvoegselAchternaam":"Mr.","achternaam":"McAlice"},"volledigeNaam":"Alice
-        Mr. McAlice"}}'
+      string: '{"uuid":"690d50fe-6292-4930-a023-ee0e9fafee74","url":"http://localhost:8338/klantinteracties/api/v1/partijen/690d50fe-6292-4930-a023-ee0e9fafee74","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"gez","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Dr.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Dr. McAlice"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1032'
+      - '1030'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450
+      - http://localhost:8338/klantinteracties/api/v1/partijen/690d50fe-6292-4930-a023-ee0e9fafee74
       Referrer-Policy:
       - same-origin
       Vary:
@@ -97,8 +97,8 @@ interactions:
 - request:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
-      true, "voorkeurstaal": "lad", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voorletters": "Mrs.", "voornaam": "Bob", "voorvoegselAchternaam":
+      false, "voorkeurstaal": "nav", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Bob", "voorvoegselAchternaam":
       "Mx.", "achternaam": "McBob"}}}'
     headers:
       Authorization:
@@ -111,7 +111,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"314c26b8-f7a0-4dcd-bd53-3dce301d2efe","url":"http://localhost:8338/klantinteracties/api/v1/partijen/314c26b8-f7a0-4dcd-bd53-3dce301d2efe","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"lad","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mrs.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+      string: '{"uuid":"65e72763-92dc-4bf7-882a-103a39dcc471","url":"http://localhost:8338/klantinteracties/api/v1/partijen/65e72763-92dc-4bf7-882a-103a39dcc471","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nav","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
         Mx. McBob"}}'
     headers:
       API-version:
@@ -121,17 +121,17 @@ interactions:
       Content-Length:
       - '1024'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/314c26b8-f7a0-4dcd-bd53-3dce301d2efe
+      - http://localhost:8338/klantinteracties/api/v1/partijen/65e72763-92dc-4bf7-882a-103a39dcc471
       Referrer-Policy:
       - same-origin
       Vary:
@@ -157,7 +157,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/actoren
   response:
     body:
-      string: '{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf","naam":"Afdeling
+      string: '{"uuid":"699650e3-011e-4631-9863-5c6ce985cb9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e","naam":"Afdeling
         klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
     headers:
       API-version:
@@ -167,17 +167,17 @@ interactions:
       Content-Length:
       - '366'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf
+      - http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -207,11 +207,11 @@ interactions:
       Content-Length:
       - '52'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -231,7 +231,7 @@ interactions:
     body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
       null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
       true, "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
-      {"contactnaam": {"voornaam": "Michael", "achternaam": "Smith", "voorletters":
+      {"contactnaam": {"voornaam": "Michael", "achternaam": "Fernandez", "voorletters":
       "", "voorvoegselAchternaam": ""}}, "partijIdentificatoren": [{"partijIdentificator":
       {"codeObjecttype": "natuurlijk_persoon", "codeSoortObjectId": "bsn", "objectId":
       "123456782", "codeRegister": "brp"}}]}'
@@ -239,34 +239,34 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
       Content-Length:
-      - '530'
+      - '534'
       Content-Type:
       - application/json
     method: POST
     uri: http://localhost:8338/klantinteracties/api/v1/partijen
   response:
     body:
-      string: '{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
-        Smith"}}'
+      string: '{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"5f7cfbb4-d607-43fa-8912-881817aa54a0","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/5f7cfbb4-d607-43fa-8912-881817aa54a0","identificeerdePartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Fernandez"},"volledigeNaam":"Michael
+        Fernandez"}}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1543'
+      - '1551'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62
+      - http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc
       Referrer-Policy:
       - same-origin
       Vary:
@@ -293,7 +293,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+      string: '{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
         voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -303,17 +303,17 @@ interactions:
       Content-Length:
       - '521'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57
       Referrer-Policy:
       - same-origin
       Vary:
@@ -326,8 +326,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"},
+    body: '{"wasPartij": {"uuid": "eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "e8c9e9fb-3c59-401c-b797-29877451ce57"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -341,7 +341,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6","wasPartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"hadKlantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -351,17 +351,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6
       Referrer-Policy:
       - same-origin
       Vary:
@@ -374,10 +374,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "e8c9e9fb-3c59-401c-b797-29877451ce57"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "06906acb-2aae-45d2-8241-e8d8611c6cbf"}}'
+      {"uuid": "699650e3-011e-4631-9863-5c6ce985cb9e"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -389,9 +389,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee","nummer":"0000000001","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"toegewezenAanActor":{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"},"toegewezenAanActoren":[{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:56:06.166151Z","afgehandeldOp":null}'
+      string: '{"uuid":"fe1c915e-15e1-4e98-8b90-60a5c933f1b1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/fe1c915e-15e1-4e98-8b90-60a5c933f1b1","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57"},"toegewezenAanActor":{"uuid":"699650e3-011e-4631-9863-5c6ce985cb9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e"},"toegewezenAanActoren":[{"uuid":"699650e3-011e-4631-9863-5c6ce985cb9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:47.739546Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -400,17 +400,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/fe1c915e-15e1-4e98-8b90-60a5c933f1b1
       Referrer-Policy:
       - same-origin
       Vary:
@@ -423,7 +423,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "5eec4392-65d4-48b9-ae4d-917125f191da"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "e8c9e9fb-3c59-401c-b797-29877451ce57"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -437,7 +437,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf","klantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"84e9acfd-9c13-4410-b37f-9bc94cafaeb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/84e9acfd-9c13-4410-b37f-9bc94cafaeb3","klantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
@@ -447,17 +447,17 @@ interactions:
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/84e9acfd-9c13-4410-b37f-9bc94cafaeb3
       Referrer-Policy:
       - same-origin
       Vary:
@@ -484,7 +484,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
   response:
     body:
-      string: '{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+      string: '{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
         voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
     headers:
       API-version:
@@ -494,17 +494,17 @@ interactions:
       Content-Length:
       - '521'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -517,8 +517,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"wasPartij": {"uuid": "ff19cc79-d7ed-4693-a6df-ae4ed319c450"}, "rol":
-      "klant", "hadKlantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},
+    body: '{"wasPartij": {"uuid": "690d50fe-6292-4930-a023-ee0e9fafee74"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "2d53a516-cd70-4d66-80e0-b86eae51e52a"},
       "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
       null}'
     headers:
@@ -532,7 +532,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
   response:
     body:
-      string: '{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415","wasPartij":{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450"},"hadKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"uuid":"b80d22d0-e722-4bb0-9a11-d72c4dd293b8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/b80d22d0-e722-4bb0-9a11-d72c4dd293b8","wasPartij":{"uuid":"690d50fe-6292-4930-a023-ee0e9fafee74","url":"http://localhost:8338/klantinteracties/api/v1/partijen/690d50fe-6292-4930-a023-ee0e9fafee74"},"hadKlantcontact":{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}'
     headers:
       API-version:
@@ -542,17 +542,17 @@ interactions:
       Content-Length:
       - '1065'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/b80d22d0-e722-4bb0-9a11-d72c4dd293b8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -565,10 +565,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aanleidinggevendKlantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "2d53a516-cd70-4d66-80e0-b86eae51e52a"},
       "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
       in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
-      {"uuid": "06906acb-2aae-45d2-8241-e8d8611c6cbf"}}'
+      {"uuid": "699650e3-011e-4631-9863-5c6ce985cb9e"}}'
     headers:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
@@ -580,9 +580,9 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/internetaken
   response:
     body:
-      string: '{"uuid":"be8bc615-c574-4b2f-89a3-d008518543a1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1","nummer":"0000000002","gevraagdeHandeling":"Vraag
-        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"toegewezenAanActor":{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"},"toegewezenAanActoren":[{"uuid":"06906acb-2aae-45d2-8241-e8d8611c6cbf","url":"http://localhost:8338/klantinteracties/api/v1/actoren/06906acb-2aae-45d2-8241-e8d8611c6cbf"}],"toelichting":"Beantwoorden
-        vraag","status":"te_verwerken","toegewezenOp":"2025-10-07T07:56:06.235792Z","afgehandeldOp":null}'
+      string: '{"uuid":"802d081b-ffaf-4d6e-8424-3f8815b591e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/802d081b-ffaf-4d6e-8424-3f8815b591e9","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a"},"toegewezenAanActor":{"uuid":"699650e3-011e-4631-9863-5c6ce985cb9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e"},"toegewezenAanActoren":[{"uuid":"699650e3-011e-4631-9863-5c6ce985cb9e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/699650e3-011e-4631-9863-5c6ce985cb9e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T10:12:47.816778Z","afgehandeldOp":null}'
     headers:
       API-version:
       - 0.1.2
@@ -591,17 +591,17 @@ interactions:
       Content-Length:
       - '900'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/802d081b-ffaf-4d6e-8424-3f8815b591e9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -614,7 +614,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"klantcontact": {"uuid": "90fecdb0-9f97-4f58-97a8-ca4ed9442dff"}, "wasKlantcontact":
+    body: '{"klantcontact": {"uuid": "2d53a516-cd70-4d66-80e0-b86eae51e52a"}, "wasKlantcontact":
       null, "onderwerpobjectidentificator": {"objectId": "Coffee zaak", "codeObjecttype":
       "zaak", "codeRegister": "openzaak", "codeSoortObjectId": "identificatie"}}'
     headers:
@@ -628,7 +628,7 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
   response:
     body:
-      string: '{"uuid":"ad1d1e51-b536-4045-9ec9-02025e94a4ed","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed","klantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
+      string: '{"uuid":"3a7dae33-8078-4ab7-bc5d-7596101f9306","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/3a7dae33-8078-4ab7-bc5d-7596101f9306","klantcontact":{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"Coffee
         zaak","codeObjecttype":"zaak","codeRegister":"openzaak","codeSoortObjectId":"identificatie"}}'
     headers:
       API-version:
@@ -638,17 +638,17 @@ interactions:
       Content-Length:
       - '492'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed
+      - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/3a7dae33-8078-4ab7-bc5d-7596101f9306
       Referrer-Policy:
       - same-origin
       Vary:
@@ -669,10 +669,10 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=Coffee+zaak&expand=hadBetrokkenen
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff","gingOverOnderwerpobjecten":[{"uuid":"ad1d1e51-b536-4045-9ec9-02025e94a4ed","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/ad1d1e51-b536-4045-9ec9-02025e94a4ed"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415"}],"leiddeTotInterneTaken":[{"uuid":"be8bc615-c574-4b2f-89a3-d008518543a1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/be8bc615-c574-4b2f-89a3-d008518543a1"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
-        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"706795ea-5646-43c4-b987-3fc7c614f415","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/706795ea-5646-43c4-b987-3fc7c614f415","wasPartij":{"uuid":"ff19cc79-d7ed-4693-a6df-ae4ed319c450","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ff19cc79-d7ed-4693-a6df-ae4ed319c450"},"hadKlantcontact":{"uuid":"90fecdb0-9f97-4f58-97a8-ca4ed9442dff","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/90fecdb0-9f97-4f58-97a8-ca4ed9442dff"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true}]}},{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"leiddeTotInterneTaken":[{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
-        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a","gingOverOnderwerpobjecten":[{"uuid":"3a7dae33-8078-4ab7-bc5d-7596101f9306","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/3a7dae33-8078-4ab7-bc5d-7596101f9306"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"b80d22d0-e722-4bb0-9a11-d72c4dd293b8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/b80d22d0-e722-4bb0-9a11-d72c4dd293b8"}],"leiddeTotInterneTaken":[{"uuid":"802d081b-ffaf-4d6e-8424-3f8815b591e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/802d081b-ffaf-4d6e-8424-3f8815b591e9"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"b80d22d0-e722-4bb0-9a11-d72c4dd293b8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/b80d22d0-e722-4bb0-9a11-d72c4dd293b8","wasPartij":{"uuid":"690d50fe-6292-4930-a023-ee0e9fafee74","url":"http://localhost:8338/klantinteracties/api/v1/partijen/690d50fe-6292-4930-a023-ee0e9fafee74"},"hadKlantcontact":{"uuid":"2d53a516-cd70-4d66-80e0-b86eae51e52a","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d53a516-cd70-4d66-80e0-b86eae51e52a"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true}]}},{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57","gingOverOnderwerpobjecten":[{"uuid":"84e9acfd-9c13-4410-b37f-9bc94cafaeb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/84e9acfd-9c13-4410-b37f-9bc94cafaeb3"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6"}],"leiddeTotInterneTaken":[{"uuid":"fe1c915e-15e1-4e98-8b90-60a5c933f1b1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/fe1c915e-15e1-4e98-8b90-60a5c933f1b1"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+        voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6","wasPartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"hadKlantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
         Inwoner Platform","initiator":true}]}}]}'
     headers:
       API-version:
@@ -682,11 +682,11 @@ interactions:
       Content-Length:
       - '4203'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -711,21 +711,21 @@ interactions:
     uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
-        Smith"},"_expand":{}}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"5f7cfbb4-d607-43fa-8912-881817aa54a0","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/5f7cfbb4-d607-43fa-8912-881817aa54a0","identificeerdePartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Fernandez"},"volledigeNaam":"Michael
+        Fernandez"},"_expand":{}}]}'
     headers:
       API-version:
       - 0.1.2
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '1758'
+      - '1766'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -747,12 +747,12 @@ interactions:
       Authorization:
       - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
     method: GET
-    uri: http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
   response:
     body:
-      string: '{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"4e4717fa-15a5-4d47-8ceb-b21e299fb084","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/4e4717fa-15a5-4d47-8ceb-b21e299fb084","identificeerdePartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"Michael
-        Smith"},"_expand":{"betrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","wasPartij":{"uuid":"2f85a2a9-5753-4d2e-9c85-bc104c1a9c62","url":"http://localhost:8338/klantinteracties/api/v1/partijen/2f85a2a9-5753-4d2e-9c85-bc104c1a9c62"},"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
-        Inwoner Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"5eec4392-65d4-48b9-ae4d-917125f191da","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/5eec4392-65d4-48b9-ae4d-917125f191da","gingOverOnderwerpobjecten":[{"uuid":"b9726d6d-5ef9-449b-a8db-0bda71c2aebf","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/b9726d6d-5ef9-449b-a8db-0bda71c2aebf"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/f7ab9deb-5fa7-4a9c-b3c4-0505b00e94f6"}],"leiddeTotInterneTaken":[{"uuid":"7bbc7451-af77-472c-b598-f656e0453eee","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7bbc7451-af77-472c-b598-f656e0453eee"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+      string: '{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"5f7cfbb4-d607-43fa-8912-881817aa54a0","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/5f7cfbb4-d607-43fa-8912-881817aa54a0","identificeerdePartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Michael","voorvoegselAchternaam":"","achternaam":"Fernandez"},"volledigeNaam":"Michael
+        Fernandez"},"_expand":{"betrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6","wasPartij":{"uuid":"eb0d0875-2aef-46f2-a3f3-ab5374dee5bc","url":"http://localhost:8338/klantinteracties/api/v1/partijen/eb0d0875-2aef-46f2-a3f3-ab5374dee5bc"},"hadKlantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"e8c9e9fb-3c59-401c-b797-29877451ce57","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/e8c9e9fb-3c59-401c-b797-29877451ce57","gingOverOnderwerpobjecten":[{"uuid":"84e9acfd-9c13-4410-b37f-9bc94cafaeb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/84e9acfd-9c13-4410-b37f-9bc94cafaeb3"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"7ebcb04b-a123-454e-b975-89d943eb7cc6","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/7ebcb04b-a123-454e-b975-89d943eb7cc6"}],"leiddeTotInterneTaken":[{"uuid":"fe1c915e-15e1-4e98-8b90-60a5c933f1b1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/fe1c915e-15e1-4e98-8b90-60a5c933f1b1"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
         voor zaak: Coffee zaak","inhoud":"A question asked by Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}}}],"digitaleAdressen":[]}}'
     headers:
       API-version:
@@ -760,13 +760,13 @@ interactions:
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       Content-Length:
-      - '3818'
+      - '3826'
       Content-Security-Policy:
-      - 'img-src ''self'' data: cdn.redoc.ly; form-action ''self''; style-src ''self''
-        ''unsafe-inline'' fonts.googleapis.com; worker-src ''self'' blob:; script-src
-        ''self'' ''unsafe-inline''; default-src ''self''; frame-ancestors ''none'';
-        frame-src ''self''; font-src ''self'' fonts.gstatic.com; object-src ''none'';
-        base-uri ''self'''
+      - 'form-action ''self''; default-src ''self''; object-src ''none''; base-uri
+        ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; frame-ancestors
+        ''none''; frame-src ''self''; script-src ''self'' ''unsafe-inline''; worker-src
+        ''self'' blob:; font-src ''self'' fonts.gstatic.com; img-src ''self'' data:
+        cdn.redoc.ly'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_questions_for_partij_ignores_anonymous_questions.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_questions_for_partij_ignores_anonymous_questions.yaml
@@ -1,0 +1,1377 @@
+interactions:
+- request:
+    body: '{"naam": "Afdeling Klantenservice", "soortActor": "organisatorische_eenheid",
+      "indicatieActief": true}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/actoren
+  response:
+    body:
+      string: '{"uuid":"3fc00e25-9ee4-4c50-b5a5-f4166df059a0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/3fc00e25-9ee4-4c50-b5a5-f4166df059a0","naam":"Afdeling
+        Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '366'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/actoren/3fc00e25-9ee4-4c50-b5a5-f4166df059a0
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "arw", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mrs.", "achternaam": "McAlice"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '366'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"b994fd48-b580-4a45-b647-ea1b3a8a103e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b994fd48-b580-4a45-b647-ea1b3a8a103e","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"arw","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1032'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/b994fd48-b580-4a45-b647-ea1b3a8a103e
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": false, "indicatieActief":
+      false, "voorkeurstaal": "bad", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Misc.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McBob"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '365'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"a8f83009-fee1-47c9-91a9-b2bffacc0b7d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a8f83009-fee1-47c9-91a9-b2bffacc0b7d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"bad","indicatieActief":false,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Misc.","voornaam":"Bob","voorvoegselAchternaam":"Mx.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mx. McBob"}}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1026'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/a8f83009-fee1-47c9-91a9-b2bffacc0b7d
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"naam": "Afdeling klantenservice", "indicatieActief": true, "soortActor":
+      "organisatorische_eenheid"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/actoren
+  response:
+    body:
+      string: '{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","naam":"Afdeling
+        klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '366'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inhoud": "A question from Alice", "onderwerp": "Alice''s question", "taal":
+      "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+      "2024-10-02T14:00:25.587564+00:00"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+  response:
+    body:
+      string: '{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+        question","inhoud":"A question from Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '504'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"wasPartij": {"uuid": "b994fd48-b580-4a45-b647-ea1b3a8a103e"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "30873921-5634-4525-9688-ee20d8ad452b"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '232'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+  response:
+    body:
+      string: '{"uuid":"0b3dddfd-24f7-408f-87e8-b6d0143eaa22","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0b3dddfd-24f7-408f-87e8-b6d0143eaa22","wasPartij":{"uuid":"b994fd48-b580-4a45-b647-ea1b3a8a103e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b994fd48-b580-4a45-b647-ea1b3a8a103e"},"hadKlantcontact":{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1065'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/0b3dddfd-24f7-408f-87e8-b6d0143eaa22
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "30873921-5634-4525-9688-ee20d8ad452b"},
+      "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
+      in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
+      {"uuid": "539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+  response:
+    body:
+      string: '{"uuid":"bbe70c06-b946-4cc5-ad1f-921acbcde42c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bbe70c06-b946-4cc5-ad1f-921acbcde42c","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b"},"toegewezenAanActor":{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"},"toegewezenAanActoren":[{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:07:26.036644Z","afgehandeldOp":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '900'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/bbe70c06-b946-4cc5-ad1f-921acbcde42c
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inhoud": "An anonymous question", "onderwerp": "Anonymous inquiry", "taal":
+      "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+      "2024-10-02T14:00:25.587564+00:00"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '193'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+  response:
+    body:
+      string: '{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+        inquiry","inhoud":"An anonymous question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '505'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      {"voornaam": "Anonymous", "achternaam": "User"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+  response:
+    body:
+      string: '{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd","wasPartij":null,"hadKlantcontact":{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+        User","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '949'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=9e769402-c609-4cb7-9432-6aba4d67c8bd
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"adres": "anon@example.com", "soortDigitaalAdres": "email", "isStandaardAdres":
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "9e769402-c609-4cb7-9432-6aba4d67c8bd"},
+      "verstrektDoorPartij": null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+  response:
+    body:
+      string: '{"uuid":"29140419-dc1c-4d96-b0cf-1356010142c4","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/29140419-dc1c-4d96-b0cf-1356010142c4","verstrektDoorBetrokkene":{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '509'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/29140419-dc1c-4d96-b0cf-1356010142c4
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=9e769402-c609-4cb7-9432-6aba4d67c8bd
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"29140419-dc1c-4d96-b0cf-1356010142c4","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/29140419-dc1c-4d96-b0cf-1356010142c4","verstrektDoorBetrokkene":{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '574'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "9e769402-c609-4cb7-9432-6aba4d67c8bd"},
+      "verstrektDoorPartij": null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '227'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+  response:
+    body:
+      string: '{"uuid":"5143bd32-81c3-402d-94c5-a4e03e326654","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5143bd32-81c3-402d-94c5-a4e03e326654","verstrektDoorBetrokkene":{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '512'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5143bd32-81c3-402d-94c5-a4e03e326654
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},
+      "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
+      in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
+      {"uuid": "539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+  response:
+    body:
+      string: '{"uuid":"a9dbf2d4-b233-42d3-92a4-27066dae203e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a9dbf2d4-b233-42d3-92a4-27066dae203e","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},"toegewezenAanActor":{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"},"toegewezenAanActoren":[{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:07:26.211170Z","afgehandeldOp":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '900'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/a9dbf2d4-b233-42d3-92a4-27066dae203e
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd"}],"leiddeTotInterneTaken":[{"uuid":"a9dbf2d4-b233-42d3-92a4-27066dae203e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a9dbf2d4-b233-42d3-92a4-27066dae203e"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+        inquiry","inhoud":"An anonymous question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"9e769402-c609-4cb7-9432-6aba4d67c8bd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e769402-c609-4cb7-9432-6aba4d67c8bd","wasPartij":null,"hadKlantcontact":{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},"digitaleAdressen":[{"uuid":"29140419-dc1c-4d96-b0cf-1356010142c4","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/29140419-dc1c-4d96-b0cf-1356010142c4"},{"uuid":"5143bd32-81c3-402d-94c5-a4e03e326654","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5143bd32-81c3-402d-94c5-a4e03e326654"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+        User","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"a9dbf2d4-b233-42d3-92a4-27066dae203e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a9dbf2d4-b233-42d3-92a4-27066dae203e","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"4a9dc49f-2777-4102-9b5a-a69b0469b3b5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a9dc49f-2777-4102-9b5a-a69b0469b3b5"},"toegewezenAanActor":{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"},"toegewezenAanActoren":[{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:07:26.211170Z","afgehandeldOp":null}]}},{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"0b3dddfd-24f7-408f-87e8-b6d0143eaa22","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0b3dddfd-24f7-408f-87e8-b6d0143eaa22"}],"leiddeTotInterneTaken":[{"uuid":"bbe70c06-b946-4cc5-ad1f-921acbcde42c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bbe70c06-b946-4cc5-ad1f-921acbcde42c"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+        question","inhoud":"A question from Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"0b3dddfd-24f7-408f-87e8-b6d0143eaa22","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0b3dddfd-24f7-408f-87e8-b6d0143eaa22","wasPartij":{"uuid":"b994fd48-b580-4a45-b647-ea1b3a8a103e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b994fd48-b580-4a45-b647-ea1b3a8a103e"},"hadKlantcontact":{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"b994fd48-b580-4a45-b647-ea1b3a8a103e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/b994fd48-b580-4a45-b647-ea1b3a8a103e","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"0b3dddfd-24f7-408f-87e8-b6d0143eaa22","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0b3dddfd-24f7-408f-87e8-b6d0143eaa22"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"arw","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Alice","voorvoegselAchternaam":"Mrs.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mrs. McAlice"}}}}],"leiddeTotInterneTaken":[{"uuid":"bbe70c06-b946-4cc5-ad1f-921acbcde42c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bbe70c06-b946-4cc5-ad1f-921acbcde42c","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"30873921-5634-4525-9688-ee20d8ad452b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/30873921-5634-4525-9688-ee20d8ad452b"},"toegewezenAanActor":{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"},"toegewezenAanActoren":[{"uuid":"539cec75-a8b0-4e77-b6f1-9e98d8e7d49e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/539cec75-a8b0-4e77-b6f1-9e98d8e7d49e"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:07:26.036644Z","afgehandeldOp":null}]}}]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '7205'
+      Content-Security-Policy:
+      - 'form-action ''self''; worker-src ''self'' blob:; default-src ''self''; font-src
+        ''self'' fonts.gstatic.com; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        object-src ''none''; frame-src ''self''; frame-ancestors ''none''; script-src
+        ''self'' ''unsafe-inline''; base-uri ''self''; img-src ''self'' data: cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"naam": "Afdeling Klantenservice", "soortActor": "organisatorische_eenheid",
+      "indicatieActief": true}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/actoren
+  response:
+    body:
+      string: '{"uuid":"e5127ffa-754d-453c-adb1-7badc0280f42","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e5127ffa-754d-453c-adb1-7badc0280f42","naam":"Afdeling
+        Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '366'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/actoren/e5127ffa-754d-453c-adb1-7badc0280f42
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "kan", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mx.", "voornaam": "Alice", "voorvoegselAchternaam":
+      "Mx.", "achternaam": "McAlice"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '365'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"4d5fd4e9-1548-418c-8983-0bcb962a84d0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d5fd4e9-1548-418c-8983-0bcb962a84d0","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"kan","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1030'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/4d5fd4e9-1548-418c-8983-0bcb962a84d0
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null, "rekeningnummers":
+      null, "voorkeursRekeningnummer": null, "indicatieGeheimhouding": true, "indicatieActief":
+      true, "voorkeurstaal": "ceb", "soortPartij": "persoon", "partijIdentificatie":
+      {"contactnaam": {"voorletters": "Mr.", "voornaam": "Bob", "voorvoegselAchternaam":
+      "Mr.", "achternaam": "McBob"}}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/partijen
+  response:
+    body:
+      string: '{"uuid":"02525312-005b-4829-a68f-e95c772d0772","url":"http://localhost:8338/klantinteracties/api/v1/partijen/02525312-005b-4829-a68f-e95c772d0772","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"ceb","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mr.","voornaam":"Bob","voorvoegselAchternaam":"Mr.","achternaam":"McBob"},"volledigeNaam":"Bob
+        Mr. McBob"}}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1022'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/partijen/02525312-005b-4829-a68f-e95c772d0772
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"naam": "Afdeling klantenservice", "indicatieActief": true, "soortActor":
+      "organisatorische_eenheid"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/actoren
+  response:
+    body:
+      string: '{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","naam":"Afdeling
+        klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '366'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inhoud": "A question from Alice", "onderwerp": "Alice''s question", "taal":
+      "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+      "2024-10-02T14:00:25.587564+00:00"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+  response:
+    body:
+      string: '{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+        question","inhoud":"A question from Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '504'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"wasPartij": {"uuid": "4d5fd4e9-1548-418c-8983-0bcb962a84d0"}, "rol":
+      "klant", "hadKlantcontact": {"uuid": "252135b1-b4ee-42cb-8bf5-68f177f2c622"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '232'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+  response:
+    body:
+      string: '{"uuid":"dd209466-73b2-4e3d-9787-2f17bcd81710","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/dd209466-73b2-4e3d-9787-2f17bcd81710","wasPartij":{"uuid":"4d5fd4e9-1548-418c-8983-0bcb962a84d0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d5fd4e9-1548-418c-8983-0bcb962a84d0"},"hadKlantcontact":{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1065'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/dd209466-73b2-4e3d-9787-2f17bcd81710
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "252135b1-b4ee-42cb-8bf5-68f177f2c622"},
+      "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
+      in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
+      {"uuid": "299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+  response:
+    body:
+      string: '{"uuid":"bf7d449f-9eee-4998-8797-940eed6ecbd5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bf7d449f-9eee-4998-8797-940eed6ecbd5","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622"},"toegewezenAanActor":{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"},"toegewezenAanActoren":[{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:08:33.859596Z","afgehandeldOp":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '900'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/bf7d449f-9eee-4998-8797-940eed6ecbd5
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"inhoud": "An anonymous question", "onderwerp": "Anonymous inquiry", "taal":
+      "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+      "2024-10-02T14:00:25.587564+00:00"}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '193'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+  response:
+    body:
+      string: '{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+        inquiry","inhoud":"An anonymous question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '505'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid": "274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},
+      "organisatienaam": "Open Inwoner Platform", "initiator": true, "contactnaam":
+      {"voornaam": "Anonymous", "achternaam": "User"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+  response:
+    body:
+      string: '{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49","wasPartij":null,"hadKlantcontact":{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+        User","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '949'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=4be07995-0c4f-41a3-ae9a-2a218a2bdf49
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"adres": "anon@example.com", "soortDigitaalAdres": "email", "isStandaardAdres":
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "4be07995-0c4f-41a3-ae9a-2a218a2bdf49"},
+      "verstrektDoorPartij": null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+  response:
+    body:
+      string: '{"uuid":"b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1","verstrektDoorBetrokkene":{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '509'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=4be07995-0c4f-41a3-ae9a-2a218a2bdf49
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1","verstrektDoorBetrokkene":{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '574'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer", "isStandaardAdres":
+      false, "omschrijving": "OIP profiel", "verstrektDoorBetrokkene": {"uuid": "4be07995-0c4f-41a3-ae9a-2a218a2bdf49"},
+      "verstrektDoorPartij": null}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '227'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+  response:
+    body:
+      string: '{"uuid":"91a72e71-6e6c-430b-b3d3-03f7e111469a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/91a72e71-6e6c-430b-b3d3-03f7e111469a","verstrektDoorBetrokkene":{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+        profiel","referentie":"","verificatieDatum":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '512'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/91a72e71-6e6c-430b-b3d3-03f7e111469a
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"aanleidinggevendKlantcontact": {"uuid": "274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},
+      "toelichting": "Beantwoorden vraag", "gevraagdeHandeling": "Vraag beantwoorden
+      in aanleiding gevend klant contact", "status": "te_verwerken", "toegewezenAanActor":
+      {"uuid": "299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}}'
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+  response:
+    body:
+      string: '{"uuid":"b362f68b-a838-4daa-8a00-821087eda3bc","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b362f68b-a838-4daa-8a00-821087eda3bc","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},"toegewezenAanActor":{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"},"toegewezenAanActoren":[{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:08:34.260544Z","afgehandeldOp":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '900'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8338/klantinteracties/api/v1/internetaken/b362f68b-a838-4daa-8a00-821087eda3bc
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Authorization:
+      - Token b2eb1da9861da88743d72a3fb4344288fe2cba44
+    method: GET
+    uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49"}],"leiddeTotInterneTaken":[{"uuid":"b362f68b-a838-4daa-8a00-821087eda3bc","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b362f68b-a838-4daa-8a00-821087eda3bc"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+        inquiry","inhoud":"An anonymous question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"4be07995-0c4f-41a3-ae9a-2a218a2bdf49","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4be07995-0c4f-41a3-ae9a-2a218a2bdf49","wasPartij":null,"hadKlantcontact":{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},"digitaleAdressen":[{"uuid":"b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b9fe028e-cdb0-4075-9d62-5c6bf6a15ed1"},{"uuid":"91a72e71-6e6c-430b-b3d3-03f7e111469a","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/91a72e71-6e6c-430b-b3d3-03f7e111469a"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+        User","rol":"klant","organisatienaam":"Open Inwoner Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"b362f68b-a838-4daa-8a00-821087eda3bc","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b362f68b-a838-4daa-8a00-821087eda3bc","nummer":"0000000002","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"274ddfb3-a7f6-4435-b93f-ed5e17d2262d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/274ddfb3-a7f6-4435-b93f-ed5e17d2262d"},"toegewezenAanActor":{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"},"toegewezenAanActoren":[{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:08:34.260544Z","afgehandeldOp":null}]}},{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"dd209466-73b2-4e3d-9787-2f17bcd81710","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/dd209466-73b2-4e3d-9787-2f17bcd81710"}],"leiddeTotInterneTaken":[{"uuid":"bf7d449f-9eee-4998-8797-940eed6ecbd5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bf7d449f-9eee-4998-8797-940eed6ecbd5"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+        question","inhoud":"A question from Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"dd209466-73b2-4e3d-9787-2f17bcd81710","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/dd209466-73b2-4e3d-9787-2f17bcd81710","wasPartij":{"uuid":"4d5fd4e9-1548-418c-8983-0bcb962a84d0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d5fd4e9-1548-418c-8983-0bcb962a84d0"},"hadKlantcontact":{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+        Inwoner Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"4d5fd4e9-1548-418c-8983-0bcb962a84d0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d5fd4e9-1548-418c-8983-0bcb962a84d0","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"dd209466-73b2-4e3d-9787-2f17bcd81710","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/dd209466-73b2-4e3d-9787-2f17bcd81710"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":true,"voorkeurstaal":"kan","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"Mx.","voornaam":"Alice","voorvoegselAchternaam":"Mx.","achternaam":"McAlice"},"volledigeNaam":"Alice
+        Mx. McAlice"}}}}],"leiddeTotInterneTaken":[{"uuid":"bf7d449f-9eee-4998-8797-940eed6ecbd5","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/bf7d449f-9eee-4998-8797-940eed6ecbd5","nummer":"0000000001","gevraagdeHandeling":"Vraag
+        beantwoorden in aanleiding gevend klant contact","aanleidinggevendKlantcontact":{"uuid":"252135b1-b4ee-42cb-8bf5-68f177f2c622","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/252135b1-b4ee-42cb-8bf5-68f177f2c622"},"toegewezenAanActor":{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"},"toegewezenAanActoren":[{"uuid":"299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95","url":"http://localhost:8338/klantinteracties/api/v1/actoren/299ca52c-bbd1-4f20-a9a7-51ff5ddf8c95"}],"toelichting":"Beantwoorden
+        vraag","status":"te_verwerken","toegewezenOp":"2025-10-13T14:08:33.859596Z","afgehandeldOp":null}]}}]}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '7203'
+      Content-Security-Policy:
+      - 'object-src ''none''; frame-ancestors ''none''; font-src ''self'' fonts.gstatic.com;
+        style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; worker-src ''self''
+        blob:; script-src ''self'' ''unsafe-inline''; form-action ''self''; frame-src
+        ''self''; base-uri ''self''; default-src ''self''; img-src ''self'' data:
+        cdn.redoc.ly'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -724,3 +724,38 @@ class QuestionAnswerTestCase(Openklant2ServiceTestCase):
                         email="test@example.com",
                         phonenumber="0612345678",
                     )
+
+    def test_questions_for_partij_ignores_anonymous_questions(self):
+        # Create a question for a partij
+        partij_question = self.service.create_question_for_partij(
+            self.een_persoon["uuid"],
+            question="A question from Alice",
+            subject="Alice's question",
+        )
+
+        # Create an anonymous question (betrokkene without wasPartij)
+        anonymous_question = self.service.create_question_with_betrokkene(
+            question="An anonymous question",
+            subject="Anonymous inquiry",
+            first_name="Anonymous",
+            last_name="User",
+            email="anon@example.com",
+            phonenumber="0612345678",
+        )
+
+        # Get questions for the partij - should only return partij's question, not anonymous
+        questions = self.service.questions_for_partij(self.een_persoon["uuid"])
+
+        self.assertEqual(
+            len(questions), 1, msg="Only the partij's question should be returned"
+        )
+        self.assertEqual(
+            questions[0].question_kcm_uuid,
+            partij_question.question_kcm_uuid,
+            msg="The returned question should be the partij's question",
+        )
+        self.assertNotEqual(
+            questions[0].question_kcm_uuid,
+            anonymous_question.question_kcm_uuid,
+            msg="Anonymous questions should be filtered out",
+        )


### PR DESCRIPTION
## Summary

When filtering OpenKlant2 questions for a partij, we hadn't counted on the fact that there might be anonymous questions in the list with a different shape (no `wasPartij`) than expected.

## Issue References

- Taiga Issue: [#3497](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3497)

## Checklist

- [x] CHANGELOG.rst updated
