### PR TITLE
:art: [#3507] CHANGE active/hover color for the side nav

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,6 +84,8 @@ Bugfixes
   Prosemirror-velden niet waren gekopieerd.
 * [:taiga-is:`3519`: :pr:`1966`]: Probleem opgelost in de side menu waarbij de
   'mijn vragen' item niet geselecteerd wordt als huidige pagina.
+* [:taiga-is:`3507`: :pr:`1963`]: Verander kleur van menu items bij actieve en hover status
+  naar de correcte primaire kleur.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/components/SideNavigation/SideNavigation.scss
+++ b/src/open_inwoner/scss/components/SideNavigation/SideNavigation.scss
@@ -2,6 +2,8 @@
 
 :root {
   --denhaag-side-navigation-mobile-display: flex !important;
+  --denhaag-side-navigation-link-active-color: var(--color-primary);
+  --denhaag-side-navigation-link-hover-color: var(--color-primary);
 }
 
 .side-navigation--oip {


### PR DESCRIPTION
## Summary

Als gebruiker wil ik dat de hover en active state kleuren van het sidenav in de huisstijl zijn die gekozen in door de gemeente.

## Notes

I changed it inside this repo, because this does not work: `Reference doesn't exist`

```json
"hover": {
  "color": {"value": "{color.primary}"}
},
"active": {
  "color": {"value": "{color.primary}"},
  "font-weight": {"value": "bold"}
}
```

## Issue References

[Taiga User Story](https://taiga.maykinmedia.nl/project/open-inwoner/us/3507?milestone=550)

## Checklist

- [x] CHANGELOG.rst updated