### PR TITLE
ci: run main tests on enhanced core runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   #
   tests:
     name: Run the Django test suite
-    runs-on: ubuntu-latest
+    runs-on: openinwoner-runner
     strategy:
       matrix:
         test-type: [main, elastic, openklant, sequential]


### PR DESCRIPTION
## Summary

Until we can properly diagnose the test suite slowness, @alextreme has blessed us with a more beefed up runner, which shaves almost 50% of the main CI run.
