### PR TITLE
Isolate migration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,14 @@ jobs:
               --parallel \
               --exclude-tag=e2e \
               --exclude-tag=elastic \
-              --exclude-tag=sequential
+              --exclude-tag=sequential \
+              --exclude-tag=migrations
           elif [ "${{ matrix.test-type }}" = "elastic" ]; then
-            coverage run -p src/manage.py test src --tag=elastic --exclude-tag=e2e
+            coverage run -p src/manage.py test src --tag=elastic --exclude-tag=e2e --exclude-tag=migrations
           elif [ "${{ matrix.test-type }}" = "openklant" ]; then
             coverage run -m pytest --block-network --record-mode=none -vvv src/openklant2
           elif [ "${{ matrix.test-type }}" = "sequential" ]; then
-            coverage run -p src/manage.py test src --tag=sequential
+            coverage run -p src/manage.py test src --tag=sequential --tag=migrations
           else
             echo "Error: Unknown test type '${{ matrix.test-type }}'"
             exit 1
@@ -132,6 +133,7 @@ jobs:
           mv coverages/elastic/.coverage* .
           mv coverages/openklant/.coverage* .
           mv coverages/sequential/.coverage* .
+          mv coverages/migrations/.coverage* .
           coverage combine
       - name: Publish coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   #
   tests:
     name: Run the Django test suite
-    runs-on: openinwoner-runner
+    runs-on: ${{ matrix.test-type == 'main' && 'openinwoner-runner' || 'ubuntu-latest' }}
     strategy:
       matrix:
         test-type: [main, elastic, openklant, sequential]
@@ -133,7 +133,6 @@ jobs:
           mv coverages/elastic/.coverage* .
           mv coverages/openklant/.coverage* .
           mv coverages/sequential/.coverage* .
-          mv coverages/migrations/.coverage* .
           coverage combine
       - name: Publish coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.test-type == 'main' && 'openinwoner-runner' || 'ubuntu-latest' }}
     strategy:
       matrix:
-        test-type: [main, elastic, openklant, sequential]
+        test-type: [main, elastic, openklant, migrations]
 
     services:
       postgres:
@@ -82,14 +82,16 @@ jobs:
               --parallel \
               --exclude-tag=e2e \
               --exclude-tag=elastic \
-              --exclude-tag=sequential \
               --exclude-tag=migrations
           elif [ "${{ matrix.test-type }}" = "elastic" ]; then
-            coverage run -p src/manage.py test src --tag=elastic --exclude-tag=e2e --exclude-tag=migrations
+            coverage run -p src/manage.py test src \
+              --tag=elastic \
+              --exclude-tag=e2e \
+              --exclude-tag=migrations
           elif [ "${{ matrix.test-type }}" = "openklant" ]; then
             coverage run -m pytest --block-network --record-mode=none -vvv src/openklant2
-          elif [ "${{ matrix.test-type }}" = "sequential" ]; then
-            coverage run -p src/manage.py test src --tag=sequential --tag=migrations
+          elif [ "${{ matrix.test-type }}" = "migrations" ]; then
+            coverage run -p src/manage.py test src --tag=migrations --parallel 2
           else
             echo "Error: Unknown test type '${{ matrix.test-type }}'"
             exit 1
@@ -132,7 +134,7 @@ jobs:
           mv coverages/main/.coverage* .
           mv coverages/elastic/.coverage* .
           mv coverages/openklant/.coverage* .
-          mv coverages/sequential/.coverage* .
+          mv coverages/migrations/.coverage* .
           coverage combine
       - name: Publish coverage report
         uses: codecov/codecov-action@v3

--- a/src/notifications/tests/test_migrations.py
+++ b/src/notifications/tests/test_migrations.py
@@ -1,9 +1,12 @@
+from django.test import tag
+
 from zgw_consumers.constants import APITypes
 
 from open_inwoner.openzaak.tests.factories import ServiceFactory
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class NotificationsAPILibraryMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0001_initial"
     migrate_to = "0002_migrate_data_from_notifications_api_common"

--- a/src/open_inwoner/accounts/tests/test_migrations.py
+++ b/src/open_inwoner/accounts/tests/test_migrations.py
@@ -1,9 +1,11 @@
 from django.db.models import F
 from django.db.utils import IntegrityError
+from django.test import tag
 
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class UserMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0080_user_phonenumber_alternative"
     migrate_to = (

--- a/src/open_inwoner/cms/footer/tests/test_migrations.py
+++ b/src/open_inwoner/cms/footer/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class FlatPageContentMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0002_migrate_flatpages_content_to_cms"
     migrate_to = "0005_cmsflatpagemodel_content_schema_2"

--- a/src/open_inwoner/cms/tests/test_migrations.py
+++ b/src/open_inwoner/cms/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class MenuIconsSuccessfulMigrations(TestSuccessfulMigrations):
     migrate_from = "0007_alter_commonextension_requires_auth_bsn_or_kvk"
     migrate_to = "0008_menu_icons"

--- a/src/open_inwoner/configurations/tests/test_migrations.py
+++ b/src/open_inwoner/configurations/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class PartialEditPermissionsMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0082_alter_siteconfigurationpage_cms_page"
     migrate_to = "0085_create_partial_admin_edit_permissions"
@@ -35,6 +38,7 @@ class PartialEditPermissionsMigrationTest(TestSuccessfulMigrations):
             self.assertTrue(qs.exists())
 
 
+@tag("migrations")
 class WarningBannerTextMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0085_create_partial_admin_edit_permissions"
     migrate_to = "0088_siteconfiguration_warning_banner_text_schema_2"
@@ -60,6 +64,7 @@ class WarningBannerTextMigrationTest(TestSuccessfulMigrations):
         self.assertFalse(hasattr(config, "warning_banner_text_tmp"))
 
 
+@tag("migrations")
 class LoginTextMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0088_siteconfiguration_warning_banner_text_schema_2"
     migrate_to = "0091_siteconfiguration_login_text_schema_2"
@@ -85,6 +90,7 @@ class LoginTextMigrationTest(TestSuccessfulMigrations):
         self.assertFalse(hasattr(config, "login_text_tmp"))
 
 
+@tag("migrations")
 class SearchZeroResultsTextMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0091_siteconfiguration_login_text_schema_2"
     migrate_to = "0094_siteconfiguration_search_zero_results_text_schema_2"

--- a/src/open_inwoner/kvk/tests/test_migrations.py
+++ b/src/open_inwoner/kvk/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class APIRootMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0002_alter_kvkconfig_api_root"
     migrate_to = "0003_api_root"

--- a/src/open_inwoner/openklant/tests/test_migrations.py
+++ b/src/open_inwoner/openklant/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class ContactFormSubjectConfigMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0025_esuiteklantconfig_send_klantcontact_confirmation_email"
     migrate_to = "0026_contactform_subject_config_default"
@@ -31,6 +34,7 @@ class ContactFormSubjectConfigMigrationTest(TestSuccessfulMigrations):
             )
 
 
+@tag("migrations")
 class ContactFormtConfigMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0027_alter_klantensysteemconfig_primary_backend"
     migrate_to = "0028_change_contactformconfig_descriptions"

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import user_logged_in
-from django.test import RequestFactory, tag
+from django.test import RequestFactory
+from django.test.testcases import SerializeMixin
 
 import requests_mock
 from django_webtest import WebTest
@@ -20,11 +21,16 @@ from open_inwoner.utils.test import (
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin
 
 
-@tag("sequential")
 @requests_mock.Mocker()
 class UpdateUserFromLoginSignalAPITestCase(
-    ClearCachesMixin, DisableRequestLogMixin, AssertTimelineLogMixin, WebTest
+    ClearCachesMixin,
+    DisableRequestLogMixin,
+    AssertTimelineLogMixin,
+    WebTest,
+    SerializeMixin,
 ):
+    lockfile = __file__
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()

--- a/src/open_inwoner/openzaak/tests/test_migrations.py
+++ b/src/open_inwoner/openzaak/tests/test_migrations.py
@@ -1,4 +1,5 @@
 from django.db import DataError
+from django.test import tag
 
 from zgw_consumers.constants import APITypes
 
@@ -14,6 +15,7 @@ from open_inwoner.utils.tests.test_migrations import (
 )
 
 
+@tag("migrations")
 class TestMultiZGWBackendMigrations(TestSuccessfulMigrations):
     migrate_from = "0047_delete_statustranslation"
     migrate_to = "0051_drop_root_zgw_fields"
@@ -88,6 +90,7 @@ class RequiredServiceToCatalogusConfigMigrationsTestCase:
         super().setUp()
 
 
+@tag("migrations")
 class TestRequiredCatalogusConfigServiceHappyPath(
     RequiredServiceToCatalogusConfigMigrationsTestCase, TestSuccessfulMigrations
 ):
@@ -107,6 +110,7 @@ class TestRequiredCatalogusConfigServiceHappyPath(
         )
 
 
+@tag("migrations")
 class TestRequiredCatalogusConfigServiceUnhappyPath(
     RequiredServiceToCatalogusConfigMigrationsTestCase, TestFailingMigrations
 ):
@@ -154,6 +158,7 @@ class TestRequiredCatalogusConfigServiceUnhappyPath(
         )
 
 
+@tag("migrations")
 class TestMakeZaakTypeConfigCatalogusRequired(TestFailingMigrations):
     migrate_from = "0052_add_catalogusconfig_service"
     migrate_to = "0053_zaaktypeconfig_catalogus_is_required"
@@ -175,6 +180,7 @@ class TestMakeZaakTypeConfigCatalogusRequired(TestFailingMigrations):
         )
 
 
+@tag("migrations")
 class TestZGWApiGroupServicesRequiredFailingMigration(TestFailingMigrations):
     migrate_from = "0053_zaaktypeconfig_catalogus_is_required"
     migrate_to = "0054_zgw_api_group_requires_most_services"
@@ -204,6 +210,7 @@ class TestZGWApiGroupServicesRequiredFailingMigration(TestFailingMigrations):
         )
 
 
+@tag("migrations")
 class TestZGWApiGroupServicesRequiredSuccessfulMigration(TestSuccessfulMigrations):
     migrate_from = "0053_zaaktypeconfig_catalogus_is_required"
     migrate_to = "0054_zgw_api_group_requires_most_services"
@@ -247,6 +254,7 @@ class TestZGWApiGroupServicesRequiredSuccessfulMigration(TestSuccessfulMigration
         )
 
 
+@tag("migrations")
 class StatusTypeDescriptionsMigrationTest(TestSuccessfulMigrations):
     """Tests the migration of ZaakTypeStatusTypeConfig descriptions to ProsemirrorModelFields."""
 
@@ -278,6 +286,7 @@ class StatusTypeDescriptionsMigrationTest(TestSuccessfulMigrations):
         self.assertFalse(hasattr(statustype_config, "description_tmp"))
 
 
+@tag("migrations")
 class StatusTypeDocUploadDescriptionMigrationTest(TestSuccessfulMigrations):
     """Tests the migration of ZaakTypeStatusTypeConfig document_upload_description to ProsemirrorModelFields."""
 

--- a/src/open_inwoner/pdc/tests/test_migrations.py
+++ b/src/open_inwoner/pdc/tests/test_migrations.py
@@ -1,4 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import tag
 
 from filer.models import Image
 
@@ -6,6 +7,7 @@ from open_inwoner.utils.test import temp_media_root
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class QuestionAnswerMigrationTest(TestSuccessfulMigrations):
     """Tests the migration of Question answer field to ProsemirrorModelField."""
 
@@ -153,6 +155,7 @@ class QuestionAnswerMigrationTest(TestSuccessfulMigrations):
         self.assertFalse(hasattr(question, "answer_tmp"))
 
 
+@tag("migrations")
 class CategoryDescriptionMigrationTest(TestSuccessfulMigrations):
     """Tests the migration of Category description field to ProsemirrorModelField."""
 
@@ -380,6 +383,7 @@ class CategoryDescriptionMigrationTest(TestSuccessfulMigrations):
         self.assertFalse(hasattr(category, "description_tmp"))
 
 
+@tag("migrations")
 class ProductContentMigrationTest(TestSuccessfulMigrations):
     """Tests the migration of Product content field to ProsemirrorModelField."""
 

--- a/src/open_inwoner/questionnaire/tests/test_migrations.py
+++ b/src/open_inwoner/questionnaire/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class QuestionnaireStepContentMigrationTest(TestSuccessfulMigrations):
     migrate_from = "0021_alter_questionnairestep_category"
     migrate_to = "0024_questionnairestep_content_schema_2"

--- a/src/open_inwoner/ssd/tests/test_migrations.py
+++ b/src/open_inwoner/ssd/tests/test_migrations.py
@@ -1,6 +1,9 @@
+from django.test import tag
+
 from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
+@tag("migrations")
 class SSDConfigRichtTextMigrationTest(TestSuccessfulMigrations):
     migrate_from = (
         "0006_rename_jaaropgave_comments_ssdconfig_jaaropgave_pdf_comments_and_more"


### PR DESCRIPTION
## Summary

It turns out the slowness in the tests lies in the migrations. This PR splits this off, and also makes sure (only) the main run is executed on the 8-core runner. This doesn't solve the slowness, of course, but isolates it and will give you faster feedback on the main CI run.