### PR TITLE
:bug: [#3521] Notificatie op mobiel werkt niet correct icm header text.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,8 @@ Bugfixes
   items worden weergegeven in het verkorte dropdown menu. Menu-items worden nu alleen
   getoond in het dropdown menu als er geen sidenav beschikbaar is en als ze expliciet
   zijn geconfigureerd (op dit moment alleen de link naar "Mijn Profiel").
+* [:taiga-is:`3521`, :pr:`1975`]: Probleem opgelost waar de notificatie en mobiele welkom tekst
+  overlay op de home pagina in elkaar overlopen.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/components/Grid/Grid.scss
+++ b/src/open_inwoner/scss/components/Grid/Grid.scss
@@ -37,8 +37,12 @@
       }
 
       &.banner__text {
-        $image-height-mobile: 140px;
-        margin-top: -$image-height-mobile;
+        .container:not(:has(.notifications .notification)) ~ .container & {
+          $image-height-mobile: 140px;
+          margin-top: -$image-height-mobile;
+        }
+
+        margin-top: 0;
         padding: var(--spacing-large);
         padding-bottom: 0;
         box-sizing: border-box;


### PR DESCRIPTION
## Summary

if you are logged in - on mobile - and you navigate to http://localhost:8000/accounts/register/ then you will see the notifications pushing things down (only on the Home page) so that's a problem.

Occurs in develop

## Issue References

https://taiga.maykinmedia.nl/project/open-inwoner/issue/3521

## Checklist

- [x] CHANGELOG.rst updated
