### PR TITLE
Uitkering pages should have a minimal menu dropdown and show menu item as active on detail pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,8 @@ Bugfixes
   zijn geconfigureerd (op dit moment alleen de link naar "Mijn Profiel").
 * [:taiga-is:`3521`, :pr:`1975`]: Probleem opgelost waar de notificatie en mobiele welkom tekst
   overlay op de home pagina in elkaar overlopen.
+* [:taiga-is:`3530`: :pr:`1984`]: Uitkeringspagina's tonen nu correct het verkorte
+  dropdown menu wanneer er geen sidenav beschikbaar is.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/benefits/urls.py
+++ b/src/open_inwoner/cms/benefits/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
-from open_inwoner.ssd.views import MonthlyBenefitsFormView, YearlyBenefitsFormView
+from open_inwoner.ssd.views import (
+    MonthlyBenefitsFormView,
+    MonthlyBenefitsIndexView,
+    YearlyBenefitsFormView,
+)
 
 app_name = "ssd"
 
@@ -8,7 +12,7 @@ app_name = "ssd"
 urlpatterns = [
     path(
         "",
-        MonthlyBenefitsFormView.as_view(),
+        MonthlyBenefitsIndexView.as_view(),
         name="uitkeringen",
     ),
     path(

--- a/src/open_inwoner/components/templatetags/menu.py
+++ b/src/open_inwoner/components/templatetags/menu.py
@@ -222,6 +222,20 @@ class SideNavMenuData:
                     result="match" if is_match else "no match",
                 )
 
+            # Cases where detail pages also have a side menu
+            active_item_if_qualified_name = {
+                "ssd:uitkeringen": (
+                    "ssd:yearly_benefits_index",
+                    "ssd:monthly_benefits_index",
+                )
+            }
+
+            detail_routes = active_item_if_qualified_name.get(
+                node_qualified_name, tuple()
+            )
+            if current_qualified_name in detail_routes:
+                is_match = True
+
             logger.debug(
                 "Node URL name comparison with current page",
                 node=node,
@@ -464,6 +478,8 @@ def show_full_dropdown_menu(context) -> bool:
         "general_faq",
         "collaborate:plan_list",
         "ssd:uitkeringen",
+        "ssd:yearly_benefits_index",
+        "ssd:monthly_benefits_index",
         "products:category_list",
         "cases:index",
         "cases:contactmoment_list",

--- a/src/open_inwoner/components/templatetags/menu.py
+++ b/src/open_inwoner/components/templatetags/menu.py
@@ -96,7 +96,7 @@ class SideNavMenuData:
                         logger.debug(
                             "Found icon via CommonExtension",
                             page_type=page_type,
-                            icaon=common_ext.menu_icon,
+                            icon=common_ext.menu_icon,
                         )
                         return common_ext.menu_icon
                 except CommonExtension.DoesNotExist:

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
+from django.views.generic.base import RedirectView
 from django.views.generic.edit import FormView
 
 import structlog
@@ -21,6 +22,12 @@ from .exceptions import SSDClientException
 from .forms import MonthlyReportsForm, YearlyReportsForm
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+class MonthlyBenefitsIndexView(RedirectView):
+    permanent = False
+    query_string = True
+    pattern_name = "ssd:monthly_benefits_index"
 
 
 class BenefitsFormView(


### PR DESCRIPTION
## Summary

We forgot to include the ssd views in the list of minimal dropdown menu URLs. This is also a special case where the detail views also have a side menu, so we needed some extra logic around the active menu item check.

## Issue References

- Taiga Issue: [#3530](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3530)

## Checklist

- [x] CHANGELOG.rst updated
