### PR TITLE
fix: add missing required fields to Subscription detail admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -99,6 +99,9 @@ Bugfixes
   overlay op de home pagina in elkaar overlopen.
 * [:taiga-is:`3530`: :pr:`1984`]: Uitkeringspagina's tonen nu correct het verkorte
   dropdown menu wanneer er geen sidenav beschikbaar is.
+* [:taiga-ta:`3557`, :pr:`1987`]: Ontbrekende verplichte velden toegevoegd aan de
+  Subscription detail admin, waardoor het weer mogelijk is om nieuwe Subscription
+  objecten aan te maken.
 
 Onderhoud
 ---------

--- a/src/notifications/admin.py
+++ b/src/notifications/admin.py
@@ -84,9 +84,11 @@ class SubscriptionAdmin(admin.ModelAdmin):
     )
     fields = (
         "id",
+        "notifications_api_config",
         "callback_url",
         "channels",
         "client_id",
+        "secret",
         "_subscription",
     )
     actions = [register_webhook, deregister_webhook]


### PR DESCRIPTION
When refactoring the admin, we forgot to specify all the required fields for the detail view, making it impossible to add new Subscription objects.

## Issue References

- Taiga Issue: [#3557](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3557)

## Checklist

- [x] CHANGELOG.rst updated
