### PR TITLE
Emit outgoing request log messages as structured events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,8 @@ Nieuwe features
   Grafana.
 * [:taiga-us:`3511`, :pr:`1988`]: CMS-plugin toegevoegd voor links naar andere portalen van de
   gemeente.
+* [:taiga-is:`3556`, :pr:`1995`]: Uitgaande requests worden nu gelogd als gestructureerde
+  events met ``structlog``, waardoor ze beter verwerkt kunnen worden door observability tools.
 
 Bugfixes
 --------

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -467,7 +467,7 @@ LOGGING = {
         "log_outgoing_requests": {
             "level": "DEBUG",
             "formatter": "outgoing_requests",
-            "class": "logging.StreamHandler",
+            "class": "open_inwoner.utils.logging.StructlogOutgoingRequestsHandler",
         },
         "save_outgoing_requests": {
             "level": "DEBUG",

--- a/src/open_inwoner/utils/logging.py
+++ b/src/open_inwoner/utils/logging.py
@@ -1,0 +1,131 @@
+import time
+from collections import OrderedDict
+from datetime import timedelta
+from logging import Handler  # noqa: TID251 -- needed for base class of handler
+from typing import Mapping, Optional, cast
+from urllib.parse import urlparse
+
+from django.utils import timezone
+
+import structlog
+from log_outgoing_requests.compat import format_exception
+from log_outgoing_requests.typing import (
+    AnyLogRecord,
+    ErrorRequestLogRecord,
+    RequestLogRecord,
+    is_request_log_record,
+)
+from requests import PreparedRequest, Request, RequestException, Response
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+class StructlogOutgoingRequestsHandler(Handler):
+    """Emit an outgoing request log as structured data."""
+
+    def emit(self, record: AnyLogRecord):
+        # skip requests not coming from the library requests
+        if not record or not is_request_log_record(record):
+            return
+
+        from log_outgoing_requests.models import OutgoingRequestsLogConfig
+        from log_outgoing_requests.utils import process_body
+
+        config = cast(OutgoingRequestsLogConfig, OutgoingRequestsLogConfig.get_solo())
+        record = cast(RequestLogRecord, record)
+
+        # check if we're dealing with success or error state
+        request: PreparedRequest | Request | None
+        response: Response | None
+        exception = record.exc_info[1] if record.exc_info else None
+        if (response := getattr(record, "res", None)) is not None:
+            # we have a response - this is the 'happy' flow (connectivity is okay)
+            request = record.req
+        elif isinstance(exception, RequestException):
+            record = cast(ErrorRequestLogRecord, record)
+            # we have an requests-specific exception
+            request = exception.request or None
+            response: Optional[Response] = exception.response  # likely None
+        else:
+            logger.debug("Received log record that cannot be handled", record=record)
+            return
+
+        scrubbed_req_headers = request.headers.copy() if request else {}
+        if "Authorization" in scrubbed_req_headers:
+            scrubbed_req_headers["Authorization"] = "***hidden***"
+
+        parsed_url = urlparse(request.url) if request else None
+
+        # ensure we have a timezone aware timestamp. time.time() is platform dependent
+        # about being UTC or a local time. A robust way is checking how many seconds ago
+        # this record was created, and subtracting that from the current tz aware time.
+        time_delta_logged_seconds = time.time() - record.created
+        timestamp = timezone.now() - timedelta(seconds=time_delta_logged_seconds)
+
+        kwargs = OrderedDict(
+            {
+                "status_code": response.status_code if response is not None else None,
+                "method": request.method if request else "(unknown)",
+                "url": request.url if request else "(unknown)",
+                "hostname": parsed_url.netloc if parsed_url else "(unknown)",
+                "timestamp": timestamp,
+                "response_ms": (
+                    int(response.elapsed.total_seconds() * 1000)
+                    if response is not None
+                    else None
+                ),
+                "trace": "\n".join(format_exception(exception)) if exception else None,
+                "params": parsed_url.params if parsed_url else "(unknown)",
+                "query": parsed_url.query if parsed_url else "(unknown)",
+            }
+        )
+        kwargs.update(self._headers_to_dict(scrubbed_req_headers, "req"))
+        kwargs.update(
+            self._headers_to_dict(
+                response.headers if response is not None else {}, "resp"
+            )
+        )
+
+        # check request
+        if (
+            request
+            and (
+                processed_request_body := process_body(request, config)
+            ).allow_saving_to_db
+        ):
+            kwargs.update(
+                {
+                    "req_content_type": processed_request_body.content_type,
+                    "req_body": processed_request_body.content,
+                    "req_body_encoding": processed_request_body.encoding,
+                }
+            )
+
+        # check response
+        if (
+            response is not None
+            and (
+                processed_response_body := process_body(response, config)
+            ).allow_saving_to_db
+        ):
+            kwargs.update(
+                {
+                    "res_content_type": processed_response_body.content_type,
+                    "res_body": processed_response_body.content,
+                    "res_body_encoding": processed_response_body.encoding,
+                }
+            )
+
+        # Emit the actual log message
+        logger.debug("outgoing_request", **kwargs)
+
+    @staticmethod
+    def _headers_to_dict(headers: Mapping[str, str], type_prefix: str):
+        mapped_headers = {}
+
+        for header_name, header_value in headers.items():
+            mapped_headers[
+                f"{type_prefix}_header__" + header_name.lower().replace("-", "_")
+            ] = header_value
+
+        return mapped_headers

--- a/src/open_inwoner/utils/tests/test_utils.py
+++ b/src/open_inwoner/utils/tests/test_utils.py
@@ -1,13 +1,16 @@
 from datetime import timedelta
-from unittest import mock
+from logging import LogRecord  # noqa: TID251 -- needed for testing
+from unittest import TestCase, mock
 
 from django.core.cache import caches
 from django.core.cache.backends.dummy import DummyCache
 from django.test import TestCase as DjangoTestCase, override_settings
 
 import freezegun
+from requests import PreparedRequest, RequestException, Response
 
 from open_inwoner.utils.decorators import _CACHE_MISS, _DEFAULT_CACHE_TIMEOUT, cache
+from open_inwoner.utils.logging import StructlogOutgoingRequestsHandler
 
 MockCache = mock.create_autospec(DummyCache)
 
@@ -288,3 +291,156 @@ class CacheBehaviorTest(DjangoTestCase):
         self.assertEqual(result1, "result:None")
         self.assertEqual(result2, "result:")
         self.assertEqual(result3, "result:None")
+
+
+@mock.patch("open_inwoner.utils.logging.logger")
+class StructlogOutgoingRequestsHandlerTest(TestCase):
+    @staticmethod
+    def create_mock_request_response_record(
+        method="POST",
+        url="https://api.example.com/secure",
+        request_headers=None,
+        status_code=201,
+        response_headers=None,
+        response_content=None,
+        elapsed_ms=200,
+    ) -> tuple[PreparedRequest, Response, LogRecord]:
+        request = PreparedRequest()
+        request.method = method
+        request.url = url
+        request.headers = request_headers or {"Content-Type": "application/json"}
+
+        response = Response()
+        response.status_code = status_code
+        response.headers = response_headers or {"Content-Type": "application/json"}
+        if response_content is not None:
+            response._content = response_content
+        response.elapsed = timedelta(milliseconds=elapsed_ms)
+
+        record = LogRecord(
+            name="log_outgoing_requests",
+            level=20,
+            pathname="test.py",
+            lineno=1,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+        record.req = request
+        record.res = response
+        record._is_log_outgoing_requests = True
+
+        return request, response, record
+
+    def test_emit_with_non_request_log_record(self, mock_logger):
+        handler = StructlogOutgoingRequestsHandler()
+        record = LogRecord(
+            name="test",
+            level=20,
+            pathname="test.py",
+            lineno=1,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+        record._is_log_outgoing_requests = False
+
+        handler.emit(record)
+
+        mock_logger.debug.assert_not_called()
+
+    def test_emit_with_successful_request(self, mock_logger):
+        handler = StructlogOutgoingRequestsHandler()
+
+        request, response, record = self.create_mock_request_response_record(
+            method="GET",
+            url="https://example.com/api/endpoint?foo=bar",
+            status_code=200,
+            response_content=b'{"result": "success"}',
+            elapsed_ms=150,
+        )
+        record._is_log_outgoing_requests = True
+
+        handler.emit(record)
+
+        mock_logger.debug.assert_called_once()
+        call_args = mock_logger.debug.call_args
+        self.assertEqual(call_args[0][0], "outgoing_request")
+
+        kwargs = call_args[1]
+        self.assertEqual(kwargs["status_code"], 200)
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertEqual(kwargs["url"], "https://example.com/api/endpoint?foo=bar")
+        self.assertEqual(kwargs["hostname"], "example.com")
+        self.assertEqual(kwargs["response_ms"], 150)
+        self.assertIsNone(kwargs["trace"])
+
+    def test_emit_with_authorization_header_scrubbing(self, mock_logger):
+        handler = StructlogOutgoingRequestsHandler()
+
+        request, response, record = self.create_mock_request_response_record(
+            request_headers={
+                "Authorization": "Bearer secret-token-12345",
+                "Content-Type": "application/json",
+            }
+        )
+        record._is_log_outgoing_requests = True
+
+        handler.emit(record)
+
+        call_args = mock_logger.debug.call_args
+        kwargs = call_args[1]
+
+        self.assertNotIn("Bearer secret-token-12345", str(kwargs))
+
+    def test_emit_with_request_exception(self, mock_logger):
+        handler = StructlogOutgoingRequestsHandler()
+
+        request, _, _ = self.create_mock_request_response_record(
+            method="GET",
+            url="https://example.com/api/endpoint",
+        )
+
+        exception = RequestException("Connection timeout")
+        exception.request = request
+        exception.response = None
+
+        record = LogRecord(
+            name="log_outgoing_requests",
+            level=40,
+            pathname="test.py",
+            lineno=1,
+            msg="test message",
+            args=(),
+            exc_info=(RequestException, exception, None),
+        )
+        record._is_log_outgoing_requests = True
+
+        handler.emit(record)
+
+        mock_logger.debug.assert_called_once()
+        call_args = mock_logger.debug.call_args
+        kwargs = call_args[1]
+
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertEqual(kwargs["url"], "https://example.com/api/endpoint")
+        self.assertIsNone(kwargs["status_code"])
+        self.assertIsNone(kwargs["response_ms"])
+        self.assertIsNotNone(kwargs["trace"])
+
+    def test_headers_to_dict(self, mock_logger):
+        headers = {
+            "Content-Type": "application/json",
+            "X-Request-ID": "12345",
+            "Accept-Encoding": "gzip, deflate",
+        }
+
+        result = StructlogOutgoingRequestsHandler._headers_to_dict(headers, "req")
+
+        expected = {
+            "req_header__content_type": "application/json",
+            "req_header__x_request_id": "12345",
+            "req_header__accept_encoding": "gzip, deflate",
+        }
+
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## Summary

This PR adds a handler to emit outgoing requests as debug entries with all the attributes passed as parameters that `structlog` can then format. We might want more granularity in due course (especially avoiding the inclusion of bodies, which might include sensitive data).

## Issue References

- Taiga Issue: [#3556](https://taiga.maykinmedia.nl/project/open-inwoner/task/3556)

## Checklist

- [x] CHANGELOG.rst updated

