### PR TITLE
[#3516] add color-picker colors as override to NLDS values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,6 +113,8 @@ Bugfixes
 * [:taiga-ta:`3557`, :pr:`1987`]: Ontbrekende verplichte velden toegevoegd aan de
   Subscription detail admin, waardoor het weer mogelijk is om nieuwe Subscription
   objecten aan te maken.
+* [:taiga-is:`3507`: :pr:`1993`]: De vaste NLDS-huisstijlkleuren (primaire-, secundaire en accent-
+  kleuren) kunnen nu worden overschreven met de kleuren van de colorpicker.
 
 Onderhoud
 ---------

--- a/docs/beheerhandleiding/12_configuratie.rst
+++ b/docs/beheerhandleiding/12_configuratie.rst
@@ -435,6 +435,19 @@ Klik op 'Tonen' om deze opties uit te klappen.
 **Design/thema stylesheet**
 Hier kunt u extra CSS-stijlen invoegen die op de site gebruikt worden. Let op, er kan enkel gebruik worden gemaakt van een beperkte, veilige subset van CSS-eigenschappen. Niet alle CSS-stijlen worden door het systeem ondersteund. In de aangegeven lijst staan de toegestane CSS-attributen die men eventueel nog aan de site kan toevoegen.
 
+Indien meer flexibiliteit nodig is, kunt u hier ook een eigen CSS-bestand uploaden. Dit is tevens de plek waar NL Design System design tokens kunnen worden toegevoegd. Wanneer u een CSS-bestand met NLDS-waarden of -variabelen hier uploadt, zal dit bestand de bestaande stijlen overschrijven.
+
+In het onderstaande voorbeeld ziet u de NLDS-tokenwaarde voor de 'actieve' kleur van de zij-navigatie. Als er geen design tokens worden ingeladen, wordt de primaire kleur overgenomen uit de kleurkiezer (*'Algemene configuratie'* >> *'Kleur'*). Zodra design tokens wel worden toegepast, krijgen deze de prioriteit en bepalen zij de uiteindelijke kleur.
+
+*Voorbeeldbestand: design-tokens.css*
+
+.. code-block:: css
+
+    .openinwoner-theme {
+        --denhaag-side-navigation-link-active-color: aqua;
+    }
+
+
 **Custom JavaScript**
 Hier kunt u een eigen Javascript bestand uploaden dat automatisch op alle pagina's van de website wordt geladen.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@gemeente-denhaag/side-navigation": "^4.0.2",
         "@joeattardi/emoji-button": "^4.6.4",
         "@nl-design-system-candidate/number-badge-css": "^1.1.2",
-        "@open-inwoner/design-tokens": "^0.0.14-alpha.4",
+        "@open-inwoner/design-tokens": "^0.0.18",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "@utrecht/button-css": "^2.3.1",
         "@utrecht/document-css": "^1.5.1",
@@ -4550,9 +4550,9 @@
       }
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.14-alpha.4",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.14-alpha.4.tgz",
-      "integrity": "sha512-s5hnwPcWZ/vjQzrn4lUtbuR9TDGswBC4FwMKJCkHI53hyBs2ZuBJTcb/xNATyrJ5JIyAQ9qNnslHOTio0WAkvQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.18.tgz",
+      "integrity": "sha512-IwsDTMkCZGExsc7zBpZI3Zx0QmMEfDJwU42h+gKhV6+DQWH2jFGtLOK06aT7tBWDpd+MEDjZWhS+eolQ44fWrA==",
       "license": "EUPL-1.2"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -32940,9 +32940,9 @@
       }
     },
     "@open-inwoner/design-tokens": {
-      "version": "0.0.14-alpha.4",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.14-alpha.4.tgz",
-      "integrity": "sha512-s5hnwPcWZ/vjQzrn4lUtbuR9TDGswBC4FwMKJCkHI53hyBs2ZuBJTcb/xNATyrJ5JIyAQ9qNnslHOTio0WAkvQ=="
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.18.tgz",
+      "integrity": "sha512-IwsDTMkCZGExsc7zBpZI3Zx0QmMEfDJwU42h+gKhV6+DQWH2jFGtLOK06aT7tBWDpd+MEDjZWhS+eolQ44fWrA=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@gemeente-denhaag/side-navigation": "^4.0.2",
     "@joeattardi/emoji-button": "^4.6.4",
     "@nl-design-system-candidate/number-badge-css": "^1.1.2",
-    "@open-inwoner/design-tokens": "^0.0.14-alpha.4",
+    "@open-inwoner/design-tokens": "^0.0.18",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "@utrecht/button-css": "^2.3.1",
     "@utrecht/document-css": "^1.5.1",

--- a/src/open_inwoner/react/components/SideNav/SideNav.scss
+++ b/src/open_inwoner/react/components/SideNav/SideNav.scss
@@ -2,8 +2,6 @@
 
 :root {
   --denhaag-side-navigation-mobile-display: flex !important;
-  --denhaag-side-navigation-link-active-color: var(--color-primary);
-  --denhaag-side-navigation-link-hover-color: var(--color-primary);
 }
 
 .side-navigation--oip {

--- a/src/open_inwoner/react/components/SideNav/SideNav.tsx
+++ b/src/open_inwoner/react/components/SideNav/SideNav.tsx
@@ -4,6 +4,7 @@ import {
 } from '@gemeente-denhaag/side-navigation'
 import { MaterialIcon } from '@react/components/MaterialIcon'
 import { FC } from 'react'
+import './SideNav.scss'
 
 export interface MenuItem {
   href: string

--- a/src/open_inwoner/scss/components/Pagination/Pagination.scss
+++ b/src/open_inwoner/scss/components/Pagination/Pagination.scss
@@ -30,11 +30,12 @@
     text-decoration: none;
 
     &--active {
-      color: var(--color-white);
+      color: var(--color-font-primary);
       background-color: var(--color-primary);
       border-radius: var(--border-radius-rounded);
 
       &:hover {
+        color: var(--color-white);
         background-color: var(--color-body);
       }
     }

--- a/src/open_inwoner/scss/components/_index.scss
+++ b/src/open_inwoner/scss/components/_index.scss
@@ -98,7 +98,6 @@
 @import './Section/SectionBordered.scss';
 @import './SearchResults/SearchResults.scss';
 @import './SelectComboBox/SelectComboBox.scss';
-@import './SideNavigation/SideNavigation.scss';
 @import './Sitemap/sitemap.scss';
 @import './Social/Social.scss';
 @import './Spinner/Spinner.scss';

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -181,8 +181,8 @@
     var(--color-success-s),
     calc(var(--color-success-l) + 57%)
   );
-  // color-success-l was +50% but +57% is needed for 4.5:1 contrast
 
+  // Font-colors change depending on color-picker
   --color-font-primary: var(--color-white);
   --color-font-secondary: var(--color-white);
   --color-font-accent: var(--color-gray-dark);
@@ -225,6 +225,21 @@
   --font-weight-heading-4: var(--font-weight-heading);
 
   --font-size-heading-card: 18px;
+
+  /// Start overwrite of NLDS colors always through the color-picker colors
+  --oip-color-primary-h: var(--color-primary-h);
+  --oip-color-primary-s: var(--color-primary-s);
+  --oip-color-primary-l: var(--color-primary-l);
+  --oip-color-secondary-h: var(--color-secondary-h);
+  --oip-color-secondary-s: var(--color-secondary-s);
+  --oip-color-secondary-l: var(--color-secondary-l);
+  --oip-color-accent-h: var(--color-accent-h);
+  --oip-color-accent-s: var(--color-accent-s);
+  --oip-color-accent-l: var(--color-accent-l);
+  --oip-color-fg-font-primary: var(--color-font-primary);
+  --oip-color-fg-font-secondary: var(--color-font-secondary);
+  --oip-color-fg-font-accent: var(--color-font-accent);
+  // End overwrite of NLDS colors.
 
   // Font-family = 'Body' coming from both NLDS and/or the font-upload functionality
   --font-family-body: var(--utrecht-document-font-family);


### PR DESCRIPTION
## Summary

Connect OIP color-picker to HSL NLDS Design-tokens so that NLDS values are not set in stone and municipalities can use the color picker for their Huisstijl. The color picker always needs to be overwriting the NLDS values. And: “geavanceerde opties” in Admin then needs to again overwrite everything else, in case a municipality uses their own design-token values.

Review this by looking at the 'active' color in the SideNavigation and see if it responds to color picker changes.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3516


## Checklist

- [x] CHANGELOG.rst updated
- [x] Documentation updated docs/beheerhandleiding/12_configuratie.rst
