### PR TITLE
fix: CMS Categories plugin should only query zaken of a backend is co…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,8 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:taiga-is:`3561`, :pr:`1995`]: CMS Categories plugin probeert nu niet meer om zaken
+  op te halen wanneer er geen ZGW backend is geconfigureerd.
 * [:taiga-is:`2522`:, :pr:`1969`]: Zaken die niet volledig opgehaald kunnen worden uit
   het zaaksysteem worden nu gefilterd uit de zakenlijst om te voorkomen dat de gehele
   lijst van Mijn Zaken toegankelijk blijft.

--- a/src/open_inwoner/cms/products/cms_plugins.py
+++ b/src/open_inwoner/cms/products/cms_plugins.py
@@ -7,7 +7,7 @@ from cms.plugin_pool import plugin_pool
 
 from open_inwoner.cms.utils.plugin_mixins import CMSActiveAppMixin
 from open_inwoner.components.templatetags.menu import react_sidenav_data
-from open_inwoner.openzaak.models import OpenZaakConfig
+from open_inwoner.openzaak.models import OpenZaakConfig, ZGWApiGroupConfig
 from open_inwoner.pdc.forms import ProductFinderForm
 from open_inwoner.pdc.models import Category, ProductCondition, ProductLocation
 from open_inwoner.questionnaire.models import QuestionnaireStep
@@ -77,6 +77,9 @@ class CategoriesPlugin(CMSActiveAppMixin, CMSPluginBase):
                 config.enable_categories_filtering_with_zaken
                 and request.user.is_authenticated
                 and (request.user.bsn or request.user.kvk)
+                # The plugin is usable without a ZGW backend, so ensure one exists
+                # before making any zaak-related queries.
+                and ZGWApiGroupConfig.objects.exists()
             ):
                 categories |= visible_categories.filter_by_zaken_for_request(request)
 

--- a/src/open_inwoner/cms/products/tests/test_plugin_categories.py
+++ b/src/open_inwoner/cms/products/tests/test_plugin_categories.py
@@ -22,7 +22,7 @@ from open_inwoner.cms.products.cms_plugins import CategoriesPlugin
 from open_inwoner.cms.profile.cms_apps import ProfileApphook
 from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.openzaak.models import OpenZaakConfig
+from open_inwoner.openzaak.models import OpenZaakConfig, ZGWApiGroupConfig
 from open_inwoner.openzaak.tests.factories import (
     ZaakTypeConfigFactory,
     ZGWApiGroupConfigFactory,
@@ -711,3 +711,17 @@ class TestCategoriesCaseFiltering(ClearCachesMixin, TransactionWebTest):
 
         self.assertEqual(context["categories"].count(), 2)
         self.assertEqual(context["categories"].first(), self.category6)
+
+    def test_categories_no_zgw_api_group_configured(self):
+        """
+        When no ZGW API group is configured, zaak-based filtering should not occur
+        and only highlighted categories should be shown
+        """
+        ZGWApiGroupConfig.objects.all().delete()
+
+        html, context = cms_tools.render_plugin(CategoriesPlugin, user=self.user)
+
+        # Only highlighted categories should be shown (category6 and category7)
+        self.assertEqual(context["categories"].count(), 2)
+        self.assertEqual(context["categories"].first(), self.category6)
+        self.assertEqual(context["categories"][1], self.category7)


### PR DESCRIPTION
## Summary

Not all instances have a ZGW backend configured, and some of those have the CMS plugin configured. However, initializing a ZGW client without groups triggers an exception. This PR ensures we only fetch cases if there is a backend with which to do so.

## Issue References

- Taiga Issue: [#3561](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3561)


## Checklist

- [x] CHANGELOG.rst updated

