### PR TITLE
Avoid removal of newlines when running 'npm run build'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -148,6 +148,7 @@ Onderhoud
   correct onderscheid tussen ``None`` en ``"None"`` waarden.
 * [:pr:`1991`, :taiga-is:`3626`] Vervang het woord "notificaties" met "meldingen"
   omwille van de B1 taaleis.
+* [:pr:`2005`] Update opmaak van gecompileerde berichten (Voeg een nieuwe regel toe).
 
 1.35.0 (2025-09-18)
 ===================

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bundle:react": "vite build && npm run makemessages && npm run compilemessages",
     "check-linting": "prettier src/open_inwoner/js src/open_inwoner/scss src/open_inwoner/react src/open_inwoner/webcomponents -c",
     "collect": "cp -r node_modules/leaflet/dist/images src/open_inwoner/static/bundles && cp -r node_modules/material-icons/iconfont/*.woff src/open_inwoner/static/bundles && cp -r node_modules/material-icons/iconfont/*.woff2 src/open_inwoner/static/bundles && cp -r node_modules/@fortawesome/fontawesome-free/webfonts src/open_inwoner/static/",
-    "compilemessages": "formatjs compile-folder --ast src/open_inwoner/react/i18n/locales src/open_inwoner/react/i18n/compiled",
+    "compilemessages": "formatjs compile-folder --ast src/open_inwoner/react/i18n/locales src/open_inwoner/react/i18n/compiled && pre-commit run end-of-file-fixer --files src/open_inwoner/react/i18n/compiled/*.json || true",
     "fix-linting": "prettier src/open_inwoner/js src/open_inwoner/scss src/open_inwoner/react src/open_inwoner/webcomponents -w",
     "makemessages": "conc npm:makemessages:*",
     "makemessages:nl": "formatjs extract 'src/open_inwoner/react/**/*.{js,ts,tsx}' --ignore='**/*.d.ts' --format src/open_inwoner/react/i18n/i18n-formatter.js --out-file src/open_inwoner/react/i18n/locales/nl.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'",


### PR DESCRIPTION
'npm run build' triggers 'npm run compilemessages', which in turn runs 'formatjs'. The latter removes trailing newlines, ignoring .editorconfig and all other config options. Added a command to add trailing newlines when running 'formatjs'.

## Summary

<!-- Brief description of the changes in this PR -->

## Issue References

<!-- Link to related Taiga stories/issues: remove if not applicable -->

- Taiga User Story:
- Taiga Issue:
- Taiga Dimpact Issue:
- Github Issue:

## Checklist

- [ ] CHANGELOG.rst updated
  - [ ] Deployment notes added <!--e.g. because of migrations, config flags, etc. -->
  - [ ] Breaking changes flagged <!-- e.g. removed endpoints/commands, deprecated support -->
- [ ] Documentation updated <!-- If the PR changes admin/config pages-->
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
- [ ] Updated the `docker-compose.yml` environment variables
  - [ ] Created an issue in https://github.com/maykinmedia/charts/ for new environment
    variables
