### PR TITLE
ci: ignore nodejs.org in linkcheck due to false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,9 @@ jobs:
           export OPENSSL_CONF=$(pwd)/openssl.conf
           pytest check_sphinx.py -v --tb=auto
         working-directory: docs
+        env:
+          DJANGO_SETTINGS_MODULE: open_inwoner.conf.ci
+
 
   #
   # Docker

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ linkcheck_ignore = [
     # 403s when running on github actions:
     r"https?://stackoverflow\.com/.*",
     r"https?://www\.npmjs\.com/.*",
+    r"https?://nodejs\.org/.*",
 ]
 
 extlinks = {


### PR DESCRIPTION


<!-- readthedocs-preview open-inwoner start -->
----
📚 Documentation preview 📚: https://open-inwoner--2006.org.readthedocs.build/en/2006/

<!-- readthedocs-preview open-inwoner end -->