### PR TITLE
[#3321] Avoid duplicate entries in sitemap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,12 +53,11 @@ Nieuwe features
   Grafana.
 * [:taiga-us:`3511`, :pr:`1988`]: CMS-plugin toegevoegd voor links naar andere portalen van de
   gemeente.
-* [:taiga-us:`3511`, :pr: `2004`] : Er is nu documentatie over het gebruik van de
-  CMS-plugin voor links naar andere portalen
 * [:taiga-is:`3556`, :pr:`1995`]: Uitgaande requests worden nu gelogd als gestructureerde
   events met ``structlog``, waardoor ze beter verwerkt kunnen worden door observability tools.
 * [:taiga-us:`3512`, :pr:`2003`]: De taken die worden weergegeven onder 'Openstaande acties' en
   'Mijn taken' zijn nu samengevoegd en worden nu samen weergegeven onder 'Mijn taken'.
+* [:taiga-is:`3321`, :pr:`2008`]: Dubbele links in sitemap verwijderd.
 
 Bugfixes
 --------
@@ -119,8 +118,6 @@ Bugfixes
   objecten aan te maken.
 * [:taiga-is:`3507`: :pr:`1993`]: De vaste NLDS-huisstijlkleuren (primaire-, secundaire en accent-
   kleuren) kunnen nu worden overschreven met de kleuren van de colorpicker.
-* [:taiga-is:`3471`: :pr:`2007`]: De paginatitel van de sitemap verandert nu mee met de in de
-  configuratie meegegeven site-naam.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/core/tests/test_views.py
+++ b/src/open_inwoner/core/tests/test_views.py
@@ -1,13 +1,33 @@
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils.crypto import get_random_string
+from django.utils.translation import gettext as _
+
+from cms import api
 
 from open_inwoner.accounts.tests.factories import (
     DigidUserFactory,
+    UserFactory,
     eHerkenningUserFactory,
 )
+from open_inwoner.cms.benefits.cms_apps import SSDApphook
+from open_inwoner.cms.cases.cms_apps import CasesApphook
+from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
+from open_inwoner.cms.extensions.models import CommonExtension
+from open_inwoner.cms.inbox.cms_apps import InboxApphook
+from open_inwoner.cms.products.cms_apps import ProductsApphook
+from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
+from open_inwoner.cms.profile.cms_apps import ProfileApphook
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.cms.tests.cms_tools import create_apphook_page, create_homepage
+from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.core.views import _get_category_data_for_user
+from open_inwoner.openklant.constants import KlantenServiceType
+from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.pdc.tests.factories import CategoryFactory, ProductFactory
+from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
 
 
 class SitemapCategoryDataTest(TestCase):
@@ -271,3 +291,293 @@ class SitemapCategoryDataTest(TestCase):
                 res = _get_category_data_for_user(root_category, eherkenning_user)
 
                 self.assertEqual(len(res["sub_categories"]), res_company)
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class SitemapViewTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+
+        # Homepage is required for sitemap
+        create_homepage()
+
+        self.config = SiteConfiguration.objects.create(name="Test Site")
+
+    def test_sitemap_renders_for_anonymous_user(self):
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Platform", response.content)
+
+    def test_sitemap_renders_for_authenticated_user(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Platform", response.content)
+
+    def test_sitemap_includes_categories(self):
+        cms_tools.create_apphook_page(ProductsApphook)
+        category = CategoryFactory(published=True, visible_for_anonymous=True)
+
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(category.name.encode(), response.content)
+
+    def test_sitemap_includes_platform_pages(self):
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Home page"), content)
+        self.assertIn(_("Login or create an account"), content)
+
+    def test_sitemap_hides_login_for_authenticated_users(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Login or create an account"), content)
+
+    def test_sitemap_includes_contact_form_when_enabled(self):
+        config = KlantenSysteemConfig.get_solo()
+        config.register_contact_email = "test@test.nl"
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Contactformulier"), content)
+
+    def test_sitemap_excludes_contact_form_when_disabled(self):
+        config = KlantenSysteemConfig.get_solo()
+        config.register_contact_email = ""
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        response = self.client.get(reverse("sitemap"))
+        self.assertNotIn(b"Contactformulier", response.content)
+
+    def test_sitemap_includes_benefits_page_when_published(self):
+        create_apphook_page(SSDApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn uitkeringen"), content)
+
+    def test_sitemap_excludes_benefits_page_when_not_published(self):
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Mijn uitkeringen"), content)
+
+    def test_sitemap_includes_case_pages_when_published(self):
+        create_apphook_page(CasesApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn zaken"), content)
+        self.assertIn(_("Mijn vragen"), content)
+
+    def test_sitemap_includes_collaborate_page_when_published(self):
+        create_apphook_page(CollaborateApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn samenwerkingen"), content)
+
+    def test_sitemap_includes_inbox_page_when_published(self):
+        create_apphook_page(InboxApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn berichten"), content)
+
+    def test_sitemap_includes_products_page_when_published(self):
+        create_apphook_page(ProductsApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Zelftest"), content)
+
+    def test_sitemap_includes_profile_pages_when_published(self):
+        create_apphook_page(ProfileApphook)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn profiel"), content)
+
+    def test_sitemap_excludes_profile_section_for_anonymous_users(self):
+        create_apphook_page(ProfileApphook)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Mijn profiel"), content)
+
+    def test_sitemap_includes_profile_selected_categories(self):
+        create_apphook_page(ProfileApphook, config_args={"selected_categories": True})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn Interessegebieden"), content)
+
+    def test_sitemap_excludes_profile_selected_categories_when_disabled(self):
+        create_apphook_page(ProfileApphook, config_args={"selected_categories": False})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Mijn Interessegebieden"), content)
+
+    def test_sitemap_includes_profile_my_contacts(self):
+        create_apphook_page(ProfileApphook, config_args={"my_contacts": True})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Mijn contacten"), content)
+
+    def test_sitemap_excludes_profile_my_contacts_when_disabled(self):
+        create_apphook_page(ProfileApphook, config_args={"my_contacts": False})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Mijn contacten"), content)
+
+    def test_sitemap_includes_profile_selfdiagnose(self):
+        create_apphook_page(ProfileApphook, config_args={"selfdiagnose": True})
+        QuestionnaireStepFactory.create(published=True)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Zelfdiagnose"), content)
+
+    def test_sitemap_excludes_profile_selfdiagnose_when_no_questionnaires(self):
+        create_apphook_page(ProfileApphook, config_args={"selfdiagnose": True})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Zelfdiagnose"), content)
+
+    def test_sitemap_includes_profile_actions(self):
+        create_apphook_page(ProfileApphook, config_args={"actions": True})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Openstaande acties"), content)
+
+    def test_sitemap_excludes_profile_actions_when_disabled(self):
+        create_apphook_page(ProfileApphook, config_args={"actions": False})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Openstaande acties"), content)
+
+    def test_sitemap_includes_profile_notifications(self):
+        create_apphook_page(ProfileApphook, config_args={"notifications": True})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn(_("Notificatievoorkeuren"), content)
+
+    def test_sitemap_excludes_profile_notifications_when_disabled(self):
+        create_apphook_page(ProfileApphook, config_args={"notifications": False})
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn(_("Notificatievoorkeuren"), content)
+
+    def test_sitemap_handles_multiple_profile_configs_gracefully(self):
+        # Create first profile page with config
+        create_apphook_page(
+            ProfileApphook, config_args={"namespace": "profile1", "actions": True}
+        )
+        # Create second profile config
+        ProfileConfig.objects.create(namespace="profile2", actions=False)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_sitemap_includes_footer_cms_pages(self):
+        page = api.create_page(
+            "Privacy Policy", "cms/fullwidth.html", "nl", in_navigation=True
+        )
+        page.publish("nl")
+        self.config.cms_pages.add(page)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn("Privacy Policy", content)
+
+    def test_sitemap_excludes_auth_required_footer_pages_for_anonymous(self):
+        # Create a CMS page that requires auth
+        page = api.create_page(
+            "Members Only", "cms/fullwidth.html", "nl", in_navigation=True
+        )
+        page.publish("nl")
+        published_page = page.get_public_object()
+        CommonExtension.objects.create(
+            extended_object=published_page, requires_auth=True
+        )
+        # Add to site configuration
+        self.config.cms_pages.add(page)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertNotIn("Members Only", content)
+
+    def test_sitemap_includes_auth_required_footer_pages_for_authenticated(self):
+        # Create a CMS page that requires auth
+        page = api.create_page(
+            "Members Only", "cms/fullwidth.html", "nl", in_navigation=True
+        )
+        page.publish("nl")
+        published_page = page.get_public_object()
+        CommonExtension.objects.create(
+            extended_object=published_page, requires_auth=True
+        )
+        # Add to site configuration
+        self.config.cms_pages.add(page)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("sitemap"))
+        content = response.content.decode()
+
+        self.assertIn("Members Only", content)

--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -38,10 +38,189 @@ def _get_category_data_for_user(cat: Category, user: User) -> dict:
     }
 
 
+def _get_cms_pages() -> list:
+    """
+    Get app-specific CMS pages for the sitemap
+
+    Returns a list of app-specific page dictionaries (Mijn uitkeringen, Mijn zaken, etc.)
+    """
+    cms_pages = []
+
+    if benefits_page_is_published():
+        cms_pages.append(
+            {"url_name": "ssd:uitkeringen", "link_text": _("Mijn uitkeringen")}
+        )
+    if case_page_is_published():
+        cms_pages.append({"url_name": "cases:index", "link_text": _("Mijn zaken")})
+        cms_pages.append(
+            {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
+        )
+    if collaborate_page_is_published():
+        cms_pages.append(
+            {"url_name": "collaborate:plan_list", "link_text": _("Mijn samenwerkingen")}
+        )
+    if inbox_page_is_published():
+        cms_pages.append({"url_name": "inbox:index", "link_text": _("Mijn berichten")})
+    if products_page_is_published():
+        cms_pages.append(
+            {"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}
+        )
+
+    return cms_pages
+
+
+def _get_cms_profile_pages() -> list:
+    """
+    Get profile-related CMS pages for the sitemap
+
+    Returns a list of profile page dictionaries (Mijn profiel, Mijn contacten, etc.)
+    """
+    if not profile_page_is_published():
+        return []
+
+    cms_profile_pages = [
+        {"url_name": "profile:detail", "link_text": _("Mijn profiel")},
+    ]
+
+    # Conditionally add cms pages based on apphook configuration
+    try:
+        profile_config = ProfileConfig.objects.get()
+    except ProfileConfig.MultipleObjectsReturned:
+        logger.warning("Multiple instances of ProfileConfig apphook found")
+        profile_config = ProfileConfig.objects.first()
+
+    if profile_config.selected_categories:
+        cms_profile_pages.append(
+            {
+                "url_name": "profile:categories",
+                "link_text": _("Mijn Interessegebieden"),
+            },
+        )
+    if profile_config.mentors:
+        base_url = reverse("profile:contact_list")
+        begeleiders_url = f"{base_url}?{urlencode({'type': 'begeleider'})}"
+        cms_profile_pages.append(
+            {
+                "url": begeleiders_url,
+                "link_text": _("Mijn begeleiders"),
+            },
+        )
+    if profile_config.my_contacts:
+        cms_profile_pages.append(
+            {
+                "url_name": "profile:contact_list",
+                "link_text": _("Mijn contacten"),
+            },
+        )
+    if (
+        profile_config.selfdiagnose
+        and QuestionnaireStep.objects.filter(published=True).exists()
+    ):
+        cms_profile_pages.append(
+            {
+                "url_name": "products:questionnaire_list",
+                "link_text": _("Zelfdiagnose"),
+            }
+        )
+    if profile_config.actions:
+        cms_profile_pages.append(
+            {
+                "url_name": "profile:action_list",
+                "link_text": _("Openstaande acties"),
+            },
+        )
+    if profile_config.notifications:
+        cms_profile_pages.append(
+            {
+                "url_name": "profile:notifications",
+                "link_text": _("Notificatievoorkeuren"),
+            }
+        )
+    if profile_config.questions:
+        cms_profile_pages.append(
+            {
+                "url_name": "cases:contactmoment_list",
+                "link_text": _("Mijn vragen"),
+            }
+        )
+    if profile_config.ssd:
+        cms_profile_pages.append(
+            {
+                "url_name": "ssd:uitkeringen",
+                "link_text": _("Mijn uitkeringen"),
+            }
+        )
+    if profile_config.appointments:
+        cms_profile_pages.append(
+            {
+                "url_name": "profile:appointments",
+                "link_text": _("Mijn afspraken"),
+            },
+        )
+
+    return cms_profile_pages
+
+
+def _get_platform_pages(request) -> list:
+    """
+    Get platform pages (home, contact form, login) for the sitemap
+    """
+    platform_pages = [
+        {"url_name": "pages-root", "link_text": _("Home page")},
+    ]
+
+    klant_config = KlantenSysteemConfig.get_solo()
+    if klant_config.contact_registration_enabled:
+        platform_pages.append(
+            {
+                "url_name": "openklant:contactform",
+                "link_text": _("Contactformulier"),
+            },
+        )
+
+    # Hide login links for users that are logged in
+    if not request.user.is_authenticated:
+        platform_pages.append(
+            {"url_name": "login", "link_text": _("Login or create an account")}
+        )
+
+    return platform_pages
+
+
+def _get_cms_footer_pages(request) -> list:
+    """
+    Get footer CMS pages from site configuration for the sitemap
+    """
+    config = SiteConfiguration.get_solo()
+    cms_footer_pages = config.get_ordered_cms_pages()
+
+    # Filter out auth-required pages for anonymous users
+    if not request.user.is_authenticated:
+        cms_footer_pages = [
+            page
+            for page in cms_footer_pages
+            if not hasattr(page, "commonextension")
+            or not page.commonextension.requires_auth
+        ]
+
+    titles = [
+        Title.objects.get(page=page, language=page.languages)
+        for page in cms_footer_pages
+    ]
+
+    return [
+        {"url": page.get_absolute_url(), "link_text": title.title}
+        for page, title in zip(cms_footer_pages, titles)
+    ]
+
+
 def sitemap(request):
+    """
+    Collect internal links for display in footer
+    """
     template_name = "pages/sitemap/sitemap.html"
 
-    # add onderwerpen/categories
+    # Add onderwerpen/categories
     root_categories = (
         Category.get_root_nodes().published().visible_for_user(request.user)
     )
@@ -52,148 +231,9 @@ def sitemap(request):
         ],
     }
 
-    # add CMS pages
-    context["cms_pages"] = []
-    if benefits_page_is_published():
-        context["cms_pages"].append(
-            {"url_name": "ssd:uitkeringen", "link_text": _("Mijn uitkeringen")}
-        )
-    if case_page_is_published():
-        context["cms_pages"].append(
-            {"url_name": "cases:index", "link_text": _("Mijn zaken")}
-        )
-        context["cms_pages"].append(
-            {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
-        )
-    if collaborate_page_is_published():
-        context["cms_pages"].append(
-            {"url_name": "collaborate:plan_list", "link_text": _("Mijn samenwerkingen")}
-        )
-    if inbox_page_is_published():
-        context["cms_pages"].append(
-            {"url_name": "inbox:index", "link_text": _("Mijn berichten")}
-        )
-    if products_page_is_published():
-        context["cms_pages"].append(
-            {"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}
-        )
-    if profile_page_is_published():
-        context["cms_profile_pages"] = [
-            {"url_name": "profile:detail", "link_text": _("Mijn profiel")},
-        ]
-
-        # conditionally add cms pages based on apphook configuration
-        cms_pages = context["cms_profile_pages"]
-        try:
-            profile_config = ProfileConfig.objects.get()
-        except ProfileConfig.MultipleObjectsReturned:
-            logger.warning("Multiple instances of ProfileConfig apphook found")
-            profile_config = ProfileConfig.objects.first()
-        if profile_config.selected_categories:
-            cms_pages.append(
-                {
-                    "url_name": "profile:categories",
-                    "link_text": _("Mijn Interessegebieden"),
-                },
-            )
-        if profile_config.mentors:
-            base_url = reverse("profile:contact_list")
-            begeleiders_url = f"{base_url}?{urlencode({'type': 'begeleider'})}"
-            cms_pages.append(
-                {
-                    "url": begeleiders_url,
-                    "link_text": _("Mijn begeleiders"),
-                },
-            )
-        if profile_config.my_contacts:
-            cms_pages.append(
-                {
-                    "url_name": "profile:contact_list",
-                    "link_text": _("Mijn contacten"),
-                },
-            )
-        if (
-            profile_config.selfdiagnose
-            and QuestionnaireStep.objects.filter(published=True).exists()
-        ):
-            cms_pages.append(
-                {
-                    "url_name": "products:questionnaire_list",
-                    "link_text": _("Zelfdiagnose"),
-                }
-            )
-        if profile_config.actions:
-            cms_pages.append(
-                {
-                    "url_name": "profile:action_list",
-                    "link_text": _("Openstaande acties"),
-                },
-            )
-        if profile_config.notifications:
-            cms_pages.append(
-                {
-                    "url_name": "profile:notifications",
-                    "link_text": _("Notificatievoorkeuren"),
-                }
-            )
-        if profile_config.questions:
-            cms_pages.append(
-                {
-                    "url_name": "cases:contactmoment_list",
-                    "link_text": _("Mijn vragen"),
-                }
-            )
-        if profile_config.ssd:
-            cms_pages.append(
-                {
-                    "url_name": "ssd:uitkeringen",
-                    "link_text": _("Mijn uitkeringen"),
-                }
-            )
-        if profile_config.appointments:
-            cms_pages.append(
-                {
-                    "url_name": "profile:appointments",
-                    "link_text": _("Mijn afspraken"),
-                },
-            )
-
-    # add "platform pages" (conditional login/register page, cookie info etc.)
-    context["platform_pages"] = [
-        {"url_name": "pages-root", "link_text": _("Home page")},
-    ]
-
-    klant_config = KlantenSysteemConfig.get_solo()
-    if klant_config.contact_registration_enabled:
-        context["platform_pages"].append(
-            {
-                "url_name": "contactform",
-                "link_text": _("Contactformulier"),
-            },
-        )
-
-    # hide login links for users that are logged in
-    if not request.user.is_authenticated:
-        context["platform_pages"].append(
-            {"url_name": "login", "link_text": _("Login or create an account")}
-        )
-
-    # add cms_pages to platform_pages
-    config = SiteConfiguration.get_solo()
-    cms_pages = config.get_ordered_cms_pages()
-
-    if not request.user.is_authenticated:
-        for page in cms_pages:
-            if hasattr(page, "commonextension") and page.commonextension.requires_auth:
-                cms_pages.remove(page)
-
-    titles = [
-        Title.objects.get(page=page, language=page.languages) for page in cms_pages
-    ]
-
-    context["cms_pages"] = [
-        {"url": page.get_absolute_url(), "link_text": title.title}
-        for page, title in zip(cms_pages, titles)
-    ]
+    context["cms_pages"] = _get_cms_pages()
+    context["cms_profile_pages"] = _get_cms_profile_pages()
+    context["platform_pages"] = _get_platform_pages(request)
+    context["cms_footer_pages"] = _get_cms_footer_pages(request)
 
     return render(request, template_name, context)

--- a/src/open_inwoner/templates/pages/sitemap/sitemap.html
+++ b/src/open_inwoner/templates/pages/sitemap/sitemap.html
@@ -26,7 +26,7 @@
                         </li>
                     {% endif %}
                 {% endfor %}
-                {% for page in cms_pages %}
+                {% for page in cms_footer_pages %}
                     {% with text=page.link_text %}
                         <li class="utrecht-unordered-list__item">
                             <a href="{{ page.url }}" class="link--secondary">


### PR DESCRIPTION
## Summary

Some links (privacy, cookies) showed up both under "Platform links" and (incorrectly) under "Mijn Profiel". The PR fixes this and refactors the code to improve readability.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3321


## Checklist

- [x] CHANGELOG.rst updated
