### PR TITLE
[#358] Use snake case consistently for 'phonenumber_alternative'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -122,6 +122,8 @@ Bugfixes
   objecten aan te maken.
 * [:taiga-is:`3507`: :pr:`1993`]: De vaste NLDS-huisstijlkleuren (primaire-, secundaire en accent-
   kleuren) kunnen nu worden overschreven met de kleuren van de colorpicker.
+* [:taiga-dimpact:`358`, :pr:`2009`]: Het alternatieve telefoonnummer wordt nu correct verwerkt
+  vanuit de eSuite.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openklant/api_models.py
+++ b/src/open_inwoner/openklant/api_models.py
@@ -36,7 +36,7 @@ class Klant(ZGWModel):
     voorvoegsel_achternaam: str = ""
     achternaam: str = ""
     telefoonnummer: str = ""
-    telefoonnummerAlternatief: str = ""
+    telefoonnummer_alternatief: str = ""
     emailadres: str = ""
     toestemming_zaak_notificaties_alleen_digitaal: bool | None = None
     bedrijfsnaam: str = ""

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -332,10 +332,10 @@ class eSuiteKlantenService(
             update_data["phonenumber"] = klant.telefoonnummer
 
         if (
-            klant.telefoonnummerAlternatief
-            and klant.telefoonnummerAlternatief != user.phonenumber_alternative
+            klant.telefoonnummer_alternatief
+            and klant.telefoonnummer_alternatief != user.phonenumber_alternative
         ):
-            update_data["phonenumber_alternative"] = klant.telefoonnummerAlternatief
+            update_data["phonenumber_alternative"] = klant.telefoonnummer_alternatief
 
         config = SiteConfiguration.get_solo()
         if config.enable_notification_channel_choice:

--- a/src/open_inwoner/openklant/tests/test_esuite_service.py
+++ b/src/open_inwoner/openklant/tests/test_esuite_service.py
@@ -72,6 +72,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
                 voorvoegsel_achternaam="van der",
                 achternaam="Doe",
                 telefoonnummer="0612345678",
+                telefoonnummer_alternatief="0687654321",
                 emailadres="foo@example.com",
                 toestemming_zaak_notificaties_alleen_digitaal=False,
                 bedrijfsnaam="",
@@ -103,6 +104,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
                 voorvoegsel_achternaam="",
                 achternaam="",
                 telefoonnummer="0687654321",
+                telefoonnummer_alternatief="0687654321",
                 emailadres="foo@bar.com",
                 toestemming_zaak_notificaties_alleen_digitaal=False,
                 bedrijfsnaam="AcmeCorp B.V.",
@@ -142,6 +144,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
                 voorvoegsel_achternaam="",
                 achternaam="",
                 telefoonnummer="0612345678",
+                telefoonnummer_alternatief="0687654321",
                 emailadres="foo@bar.com",
                 toestemming_zaak_notificaties_alleen_digitaal=False,
                 bedrijfsnaam="AcmeCorp B.V.",
@@ -181,7 +184,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
                 voorvoegsel_achternaam="van der",
                 achternaam="Doe",
                 telefoonnummer="0612345678",
-                telefoonnummerAlternatief="",
+                telefoonnummer_alternatief="0687654321",
                 emailadres="foo@example.com",
                 toestemming_zaak_notificaties_alleen_digitaal=False,
                 bedrijfsnaam="",
@@ -212,7 +215,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
             url: str
             emailadres: str
             telefoonnummer: str
-            telefoonnummerAlternatief: str
+            telefoonnummer_alternatief: str
             toestemmingZaakNotificatiesAlleenDigitaal: str
 
         klant = Klant(
@@ -224,7 +227,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
             url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="old@example.com",
             telefoonnummer="0100000000",
-            telefoonnummerAlternatief="0687654321",
+            telefoonnummer_alternatief="0687654321",
             toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
 
@@ -237,4 +240,4 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
                 update_fields=["telefoonnummer", "telefoonnummerAlternatief"],
             )
 
-            self.assertEqual(klant.telefoonnummerAlternatief, "")
+            self.assertEqual(klant.telefoonnummer_alternatief, "0687654321")

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -85,7 +85,7 @@ class UpdateUserFromLoginSignalAPITestCase(
 
         self.assertTimelineLog("retrieved klant for user")
         self.assertTimelineLog(
-            "updated user from klant API with fields: email, phonenumber"
+            "updated user from klant API with fields: email, phonenumber, phonenumber_alternative"
         )
 
     def test_update_notification_channel_choice_after_login(self, m):
@@ -184,6 +184,7 @@ class UpdateUserFromLoginSignalAPITestCase(
             ):
                 user.email = "old@example.com"
                 user.phonenumber = "0123456789"
+                user.phonenumber_alternative = ""
                 user.save()
                 self.clearTimelineLogs()
 
@@ -212,7 +213,7 @@ class UpdateUserFromLoginSignalAPITestCase(
 
                 self.assertTimelineLog("retrieved klant for user")
                 self.assertTimelineLog(
-                    "updated user from klant API with fields: email, phonenumber"
+                    "updated user from klant API with fields: email, phonenumber, phonenumber_alternative"
                 )
 
     def test_update_user_after_login_skips_existing_email(self, m):
@@ -244,7 +245,9 @@ class UpdateUserFromLoginSignalAPITestCase(
         self.assertEqual(user.phonenumber, "0612345678")
 
         self.assertTimelineLog("retrieved klant for user")
-        self.assertTimelineLog("updated user from klant API with fields: phonenumber")
+        self.assertTimelineLog(
+            "updated user from klant API with fields: phonenumber, phonenumber_alternative"
+        )
 
     def test_create_klant_for_digid_user(self, m):
         with requests_mock.mock(case_sensitive=True) as m:


### PR DESCRIPTION
## Summary

The `Klant` dataclass had the field named `telefoonnummerAlternatief` (camelCase), but the zgw_consumers library automatically converts API response keys from camelCase to snake_case when mapping to dataclass fields. This mismatch caused the alternative phone number from the eSuite API to be lost.

## Issue References

- Taiga Dimpact Issue: Refs: https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/358

## Checklist

- [ ] CHANGELOG.rst updated
  - [ ] Deployment notes added <!--e.g. because of migrations, config flags, etc. -->
  - [ ] Breaking changes flagged <!-- e.g. removed endpoints/commands, deprecated support -->
- [ ] Documentation updated <!-- If the PR changes admin/config pages-->
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
- [ ] Updated the `docker-compose.yml` environment variables
  - [ ] Created an issue in https://github.com/maykinmedia/charts/ for new environment
    variables
