### PR TITLE
ci: use CI conf in docs build to avoid logging related errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,9 @@ jobs:
           export OPENSSL_CONF=$(pwd)/openssl.conf
           pytest check_sphinx.py -v --tb=auto
         working-directory: docs
+        env:
+          DJANGO_SETTINGS_MODULE: open_inwoner.conf.ci
+
 
   #
   # Docker


### PR DESCRIPTION
To ensure our documentation build does not use logging handlers that requires a database connection (e.g. the various outgoing request log handlers), we ensure that we specify the CI settings which have logging disabled, so we do not get spurious failures on building the docs.