### PR TITLE
[#3570] Use CMS page title for vragen

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -13,6 +13,8 @@ from django.views.generic import TemplateView
 
 import requests
 import structlog
+from cms.models import PageContent
+from djangocms_versioning.constants import PUBLISHED
 from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.accounts.models import User
@@ -90,6 +92,25 @@ class VragenService(Protocol):
 class KlantContactMomentBaseView(
     CommonPageMixin, BaseBreadcrumbMixin, KlantContactMomentAccessMixin, TemplateView
 ):
+    def get_redirect_page_title(self):
+        """
+        Find a CMS page that redirects to the contactmoment list and use its title.
+        This allows the contactmoment views to show a different title than the
+        apphook page (e.g., "Mijn vragen" instead of "Mijn Aanvragen").
+        """
+        contactmoment_url = reverse("cases:contactmoment_list")
+
+        redirect_page_content = PageContent._original_manager.filter(
+            redirect=contactmoment_url,
+            versions__state=PUBLISHED,
+        ).first()
+
+        if redirect_page_content:
+            return redirect_page_content.title
+
+        current_page = getattr(self.request, "current_page", None)
+        return current_page.get_title() if current_page else _("Mijn vragen")
+
     def get_service(self, service_type: KlantenServiceType) -> VragenService | None:
         if service_type == KlantenServiceType.OPENKLANT2:
             try:
@@ -135,14 +156,14 @@ class KlantContactMomentListView(
 
     @cached_property
     def crumbs(self):
-        return [(_("Mijn vragen"), reverse("cases:contactmoment_list"))]
+        return [(self.page_title(), reverse("cases:contactmoment_list"))]
 
     def page_title(self):
-        return _("Mijn vragen")
+        return self.get_redirect_page_title()
 
     def get_anchors(self) -> list:
         return [
-            ("#contactmomenten", _("Mijn vragen")),
+            ("#contactmomenten", self.page_title()),
         ]
 
     def get_context_data(self, **kwargs):
@@ -202,10 +223,12 @@ class KlantContactMomentDetailView(ContactmomentLogMixin, KlantContactMomentBase
 
     @cached_property
     def crumbs(self):
-        return [(_("Mijn vragen"), reverse("cases:contactmoment_list"))]
+        title = self.get_redirect_page_title()
+        return [(title, reverse("cases:contactmoment_list"))]
 
     def page_title(self):
-        return f"{_('Mijn vraag')} {self.question['identification']}"
+        page_title = self.get_redirect_page_title()
+        return f"{page_title} {self.question['identification']}"
 
     def get_anchors(self) -> list:
         return [

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -16,6 +16,8 @@ from zgw_consumers.api_models.base import factory
 
 from open_inwoner.accounts.signals import update_user_on_login
 from open_inwoner.accounts.tests.factories import DigidUserFactory, UserFactory
+from open_inwoner.cms.cases.cms_apps import CasesApphook
+from open_inwoner.cms.tests import cms_tools
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openklant.api_models import ContactMoment, Klant, KlantContactMoment
 from open_inwoner.openklant.constants import KlantenServiceType, Status
@@ -77,6 +79,12 @@ class ContactMomentViewsTestCase(
         self.config = KlantenSysteemConfig.get_solo()
         self.config.primary_backend = KlantenServiceType.ESUITE.value
         self.config.save()
+
+        # Create CMS pages for testing (required for request.current_page to be set)
+        cms_tools.create_homepage()
+        self.cases_page = cms_tools.create_apphook_page(
+            CasesApphook, title="Mijn Aanvragen"
+        )
 
     def test_contactmoment_list_bsn(
         self, m, mock_openklant2_service, mock_get_kcm_answer_mapping


### PR DESCRIPTION
## Summary

The title for vragen was hardcoded to 'Mijn vragen'. We now use the configurable title from the CMS page.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3570
- Jira: https://dimpact.atlassian.net/browse/PP-210
