### PR TITLE
[#3572] Homogenise colors and styles on homepage (and elsewhere)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -152,6 +152,8 @@ Bugfixes
   vanuit de eSuite.
 * [:taiga-is:`3590`: :pr:`2030`]: Bug opgelost waarbij tablet gebruikers geen volledig uitgevuld
   navigatie menu zagen.
+* [:taiga-is:`3572`: :pr:`2019`]: De kleuren van call-to-action links en knoppen in tegels komen
+  nu overeen met de primaire kleur zoals die in de Figma designs vastgelegd is.
 * [:taiga-is:`3588`, :pr:`2029`]: Ontbrekende logout URL voor reguliere gebruikers is
   toegoevegd, en de logica voor alle login types is opgeschoond.
 * [:taiga-is:`3599`, :pr:`2045`]: Bij het bekijken van de bron code van componenten in Storybook

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,10 @@ Deployment aandachtspunten
   bevat die niet in de querystring van de user agent mogen verschijnen (bijvoorbeeld
   voor security compliance), kan deze variabele op ``false`` worden gezet om alleen naar
   het logout endpoint te redirecten zonder aanvullende parameters.
-
+* Wanneer via de color-picker of in CSS een secundaire kleur wordt ingesteld die anders is dan
+  de primaire kleur (CSS-variabelen ``--color-primary`` en ``--color-secondary``) is hier nu een
+  stijl verandering te zien. Call-to-action elementen gebruiken nu altijd de primaire kleur. Hierdoor
+  worden de knoppen in tegels niet langer in een afwijkende secundaire kleur weergegeven.
 
 Nieuwe features
 ---------------

--- a/src/open_inwoner/components/templates/components/Card/CategoryCard.html
+++ b/src/open_inwoner/components/templates/components/Card/CategoryCard.html
@@ -14,7 +14,7 @@
             {% with category as parent %}
                 <div class="card__categories">
                     {% get_product_url product as product_url %}
-                    {% link href=product_url icon='arrow_forward' icon_position='before' secondary=True text=product.name %}
+                    {% link href=product_url icon='arrow_forward' icon_position='before' primary=True text=product.name %}
                 </div>
             {% endwith %}
         {% endfor %}

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -19,7 +19,7 @@
         {% endif %}
 
         <span class="spacer"></span>
-        <span class="button button--icon-before button--transparent button--secondary">
+        <span class="button button--icon-before button--transparent button--primary">
         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
         </span>
     </div>

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -26,7 +26,7 @@
             {% endif %}
 
             <span class="spacer"></span>
-            <span class="button button--icon-before button--transparent button--secondary">
+            <span class="button button--icon-before button--transparent button--primary">
             {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
             </span>
 

--- a/src/open_inwoner/components/templates/components/Questionnaire/Questionnaire.html
+++ b/src/open_inwoner/components/templates/components/Questionnaire/Questionnaire.html
@@ -1,10 +1,10 @@
-{% load i18n link_tags %}
+{% load i18n button_tags link_tags %}
 
 <div class="questionnaire">
     <ul class="questionnaire__list">
         {% for node in root_nodes %}
             <li class="questionnaire__list-item">
-                {% link href=node.get_absolute_url icon='arrow_forward' icon_position='after' text=node.title|default:node.question secondary=True %}
+                {% button href=node.get_absolute_url text=node.title|default:node.question transparent=True icon="arrow_forward" icon_position="after" %}
             </li>
         {% endfor %}
     </ul>

--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -103,6 +103,7 @@
     background-color: transparent;
     border-color: transparent;
     color: var(--color-primary);
+    font-weight: bold;
 
     &.button--primary {
       border-color: transparent;

--- a/src/open_inwoner/scss/components/Card/Card.scss
+++ b/src/open_inwoner/scss/components/Card/Card.scss
@@ -310,10 +310,6 @@
     margin-top: var(--spacing-extra-large);
   }
 
-  .link .link__text {
-    font-weight: bold;
-  }
-
   /// Headings in cards
 
   &__heading-2,

--- a/src/open_inwoner/scss/components/Cases/Cases.scss
+++ b/src/open_inwoner/scss/components/Cases/Cases.scss
@@ -32,7 +32,7 @@
         padding: 0 var(--card-spacing-horizontal);
       }
 
-      .link--secondary {
+      .link--primary {
         order: 4;
         padding: 0 var(--card-spacing-horizontal);
       }

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -337,6 +337,11 @@ $vm: var(--spacing-large);
           }
         }
       }
+
+      // Desktop menu toggle button
+      .button--transparent {
+        font-weight: normal;
+      }
     }
 
     // Unauthenticated tablet grid

--- a/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
+++ b/src/open_inwoner/scss/components/Questionnaire/Questionnaire.scss
@@ -47,11 +47,5 @@
     &__list-item:nth-child(2) {
       border-top: var(--border-width-thin) solid var(--color-gray);
     }
-
-    &__list-item {
-      .button {
-        padding: var(--spacing-giant) var(--spacing-medium);
-      }
-    }
   }
 }

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -40,6 +40,13 @@
 
       @media (min-width: 768px) {
         padding-left: var(--spacing-large);
+        padding-right: 0;
+      }
+    }
+
+    .questionnaire__list-item {
+      .button {
+        padding-left: 0;
       }
     }
   }

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -3,7 +3,7 @@
     <section class="plugin plugin__plans">
         <header class="oip-header-group">
             <h2 class="utrecht-heading-2">{% trans 'Samenwerken' %}</h2>
-            {% button href="collaborate:plan_list" text=_("Naar samenwerken") icon="arrow_forward" icon_position="after" %}
+            {% button href="collaborate:plan_list" text=_("Naar samenwerken") transparent=True icon="arrow_forward" icon_position="after" %}
         </header>
         {% if plans %}
         <div class="plans-cards card-container card-container--columns-4">
@@ -14,8 +14,8 @@
                     <p class="utrecht-paragraph">{{ plan.goal|truncatewords:20 }}</p>
                     <p class="utrecht-paragraph">{{ plan.description|truncatewords:20 }}</p>
                     <span class="spacer"></span>
-                    <span class="button button--icon-before button--transparent button--secondary">
-                    {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
+                    <span class="button button--icon-before button--transparent">
+                    {% icon icon="arrow_forward" outlined=True %}
                     </span>
                 </div>
                 {% endrender_card %}

--- a/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
+++ b/src/open_inwoner/templates/cms/plugins/appointments/appointments.html
@@ -14,8 +14,8 @@
                     <h2 class="plugin-card__heading">
                         <span class="status">{{ appointment.services.0.name|default:appointment.title }}</span>
                     </h2>
-                    <span class="button button--icon-before button--transparent">
-                        {% icon icon="east" icon_position="after" primary=True outlined=True %}
+                    <span class="button button--icon-after button--transparent">
+                        {% icon icon="east" outlined=True %}
                     </span>
                 </div>
             </a>

--- a/src/open_inwoner/templates/cms/products/categories_plugin.html
+++ b/src/open_inwoner/templates/cms/products/categories_plugin.html
@@ -4,7 +4,7 @@
         <header class="oip-header-group">
             <h2 class="utrecht-heading-2">{{ configurable_text.home_page.home_theme_title }}</h2>
             {% trans "Alle onderwerpen" as button_text %}
-            {% button href='products:category_list' text=button_text icon="arrow_forward" icon_position="after" %}
+            {% button href='products:category_list' text=button_text transparent=True icon="arrow_forward" icon_position="after" %}
         </header>
 
         <p class="utrecht-paragraph">{{ configurable_text.home_page.home_theme_intro|linebreaksbr }}</p>

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -58,7 +58,7 @@
                             </li>
                             {% list_item text=_("Openstaande zaak") caption=_("Status") compact=True strong=False %}
                         {% endrender_list %}
-                        <span class="link link--icon link--secondary">
+                        <span class="link link--icon link--bold link--primary">
                         <span class="link__text">{% trans "Zaak afronden" %}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
@@ -88,7 +88,7 @@
                             </li>
                         {% endrender_list %}
 
-                        <span class="link link--icon link--secondary">
+                        <span class="link link--icon link--bold link--primary">
                         <span class="link__text">{{ case.statustype_config.case_link_text|default:"Bekijk zaak" }}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -202,7 +202,7 @@
                                 {% endfor %}
                             {% endrender_list %}
 
-                            <span class="link link--icon link--secondary" title="{% trans "Aanpassen" %}">
+                            <span class="link link--icon link--bold link--primary" title="{% trans "Aanpassen" %}">
                                 <span class="link__text">{% trans "Aanpassen" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -238,7 +238,7 @@
                                 {% endrender_list %}
 
                                 {% if inbox_page_is_published %}
-                                    <span class="link link--icon link--secondary" title="{% trans "Stuur een bericht" %}">
+                                    <span class="link link--icon link--bold link--primary" title="{% trans "Stuur een bericht" %}">
                                         <span class="link__text">{% trans "Stuur een bericht" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
@@ -261,7 +261,7 @@
                                     {% endfor %}
                                 {% endrender_list %}
 
-                                <span class="link link--icon link--secondary" title="{% trans "Beheer contacten" %}">
+                                <span class="link link--icon link--bold link--primary" title="{% trans "Beheer contacten" %}">
                                     <span class="link__text">{% trans "Beheer contacten" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
@@ -279,7 +279,7 @@
                                 {% render_list %}
                                     {% list_item text=action_text compact=True strong=False %}
                                 {% endrender_list %}
-                                <span class="link link--icon link--secondary" title="{% trans "Beheer acties" %}">
+                                <span class="link link--icon link--bold link--primary" title="{% trans "Beheer acties" %}">
                                     <span class="link__text">{% trans "Beheer acties" %}</span>
                                     {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                                 </span>
@@ -298,7 +298,7 @@
                                 {% list_item text="Jaaropgaven" compact=True strong=False active=False %}
                                 {% list_item text="Maandspecificaties" compact=True strong=False %}
                             {% endrender_list %}
-                            <span class="link link--icon link--secondary" title="{% trans "Bekijk uitkeringen" %}">
+                            <span class="link link--icon link--bold link--primary" title="{% trans "Bekijk uitkeringen" %}">
                                 <span class="link__text">{% trans "Bekijk uitkeringen" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -312,7 +312,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <p class="card__heading-4"><span class="link link__text">{% trans "Mijn vragen" %}</span></p>
-                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijken" %}">
+                            <span class="link link--icon link--bold link--primary profile-card__button" title="{% trans "Bekijken" %}">
                                 <span class="link__text">{% trans "Bekijken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -326,7 +326,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <p class="card__heading-4"><span class="link link__text">{% trans "Zelftest" %}</span></p>
-                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Start zelfdiagnose" %}">
+                            <span class="link link--icon link--bold link--primary profile-card__button" title="{% trans "Start zelfdiagnose" %}">
                                 <span class="link__text">{% trans "Start zelfdiagnose" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>
@@ -339,7 +339,7 @@
                     <div class="card__body">
                         <div class="ellipsis--none">
                             <p class="card__heading-4"><span class="link link__text">{% trans "Mijn afspraken" %}</span></p>
-                            <span class="link link--icon link--secondary profile-card__button" title="{% trans "Bekijk afspraken" %}">
+                            <span class="link link--icon link--bold link--primary profile-card__button" title="{% trans "Bekijk afspraken" %}">
                                 <span class="link__text">{% trans "Bekijk afspraken" %}</span>
                                 {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                             </span>


### PR DESCRIPTION
## Summary

Colors in code need to conform to the ones in Figma for 'call-to-action' buttons and "action" links (they should have the primary color and be bold instead).This is a bigger issue (since we do not have 'primary' styled Buttons-that-look-like-links) but at least this solves the color differences in styles on the Home page - in case a municipality uses a specific color for secondary colors, different from the primary color.
Also all Primary "action" links should be bold.
(like: the "Bewerk" links on Profile page)

## Issue References

- Taiga Issue (with screenshot): https://taiga.maykinmedia.nl/project/open-inwoner/issue/3572

## Checklist

- [x] CHANGELOG.rst updated
