### PR TITLE
[#3574] Make number of requests to zaken API's configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ Deployment aandachtspunten
   kunnen langer duren dan normaal voor installaties met een groot aantal gebruikers. Dit
   is een gevolg van nieuwe database indices die zijn toegevoegd in het kader van de de
   nieuwe eIDAS ondersteuning.
+* Het aantal requests aan zaken API's is nu configureerbaar via een omgevingsvariabele ``ZGW_MAX_REQUESTS``
+  (standaardwaarde is 8).
+
 
 Nieuwe features
 ---------------
@@ -68,6 +71,9 @@ Nieuwe features
   voor links naar andere portalen gebouwd, inclusief nieuwe design-tokens volgens NLDS conventies. Opmaak is
   verbeterd voor inhoud met langere linkteksten die naar een nieuwe regel worden afgebroken.
 * [:taiga-us:`3509`, :pr:`1997`]: Ondersteuning voor eIDAS login via OIDC is toegevoegd.
+
+* [:taiga-us:`3574`, :pr:`2026`]: Aantal requests aan zaken API's configureerbaar gemaakt via
+  omgevingsvariabele.
 
 Bugfixes
 --------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ x-app-env: &x-app-env
   - UWSGI_MAX_REQUESTS
   - UWSGI_POST_BUFFERING
   - UWSGI_BUFFER_SIZE
+  # Overridable ZGW API settings
+  - ZGW_MAX_REQUESTS
   - STATIC_ROOT_VOLUME=/srv/static
   # Enabling Open Telemetry requires the services in docker/docker-compose.observability.yml
   # to be up and running.

--- a/dotenv.example
+++ b/dotenv.example
@@ -8,3 +8,10 @@ DB_USER="open_inwoner"
 DB_PASSWORD=""
 DB_HOST=""
 DB_PORT=""
+
+#
+# ZGW API Settings
+#
+# Maximum number of pagination requests to follow when fetching zaken from ZGW APIs
+# Default: 8
+ZGW_MAX_REQUESTS=4

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -115,6 +115,9 @@ SOLO_CACHE = "local"  # Avoid Redis overhead
 CACHE_ZGW_CATALOGI_TIMEOUT = config("CACHE_ZGW_CATALOGI_TIMEOUT", default=60 * 60 * 24)
 CACHE_ZGW_ZAKEN_TIMEOUT = config("CACHE_ZGW_ZAKEN_TIMEOUT", default=60 * 1)
 
+# Maximum number of pagination requests to follow when fetching zaken from ZGW APIs
+ZGW_MAX_REQUESTS = config("ZGW_MAX_REQUESTS", default=8)
+
 # Laposta API caching
 CACHE_LAPOSTA_API_TIMEOUT = config("CACHE_LAPOSTA_API_TIMEOUT", default=60 * 15)
 

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -71,7 +71,7 @@ class ZakenClient(ZgwAPIClient):
         user_bsn: str | None = None,
         user_kvk: str | None = None,
         user_rsin: str | None = None,
-        max_requests: int = 4,
+        max_requests: int | None = None,
         identificatie: str | None = None,
         vestigingsnummer: str | None = None,
     ):
@@ -83,12 +83,14 @@ class ZakenClient(ZgwAPIClient):
 
         if user_bsn:
             return self.fetch_cases_by_bsn(
-                user_bsn, max_requests=max_requests, identificatie=identificatie
+                user_bsn,
+                max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
+                identificatie=identificatie,
             )
 
         fetch_cases_for_company = functools.partial(
             self.fetch_cases_for_company,
-            max_requests=max_requests,
+            max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
             zaak_identificatie=identificatie,
         )
         if vestigingsnummer:
@@ -110,7 +112,7 @@ class ZakenClient(ZgwAPIClient):
     def fetch_cases_by_bsn(
         self,
         user_bsn: str,
-        max_requests: int | None = 4,
+        max_requests: int | None = None,
         identificatie: str | None = None,
     ) -> list[Zaak]:
         """
@@ -143,7 +145,7 @@ class ZakenClient(ZgwAPIClient):
                 pagination_helper(
                     self,
                     data,
-                    max_requests=max_requests,
+                    max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
                     headers=CRS_HEADERS,
                 )
             )
@@ -166,7 +168,7 @@ class ZakenClient(ZgwAPIClient):
     def fetch_cases_for_company(
         self,
         kvk_or_rsin: str | None = None,
-        max_requests: int | None = 4,
+        max_requests: int | None = None,
         zaak_identificatie: str | None = None,
         vestigingsnummer: str | None = None,
     ) -> list[Zaak]:
@@ -224,7 +226,7 @@ class ZakenClient(ZgwAPIClient):
                 pagination_helper(
                     self,
                     data,
-                    max_requests=max_requests,
+                    max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
                     headers=CRS_HEADERS,
                 )
             )
@@ -751,7 +753,7 @@ class FormClient(ZgwAPIClient):
         user_bsn: str | None = None,
         user_kvk: str | None = None,
         vestigingsnummer: str | None = None,
-        max_requests: int = 4,
+        max_requests: int | None = None,
         **kwargs,
     ) -> list[OpenSubmission]:
         if user_bsn and (user_kvk or vestigingsnummer):
@@ -762,13 +764,13 @@ class FormClient(ZgwAPIClient):
 
         if user_bsn:
             return self.fetch_open_submissions_by_bsn(
-                user_bsn, max_requests=max_requests
+                user_bsn, max_requests=max_requests or settings.ZGW_MAX_REQUESTS
             )
 
         if user_kvk:
             return self.fetch_open_submissions_by_kvk(
                 user_kvk,
-                max_requests=max_requests,
+                max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
                 vestigingsnummer=vestigingsnummer,
             )
 
@@ -777,7 +779,7 @@ class FormClient(ZgwAPIClient):
     def fetch_open_submissions_by_bsn(
         self,
         user_bsn: str,
-        max_requests: int,
+        max_requests: int | None = None,
     ) -> list[OpenSubmission]:
         try:
             response = self.get(
@@ -785,7 +787,11 @@ class FormClient(ZgwAPIClient):
                 params={"bsn": user_bsn},
             )
             data = get_json_response(response)
-            all_data = list(pagination_helper(self, data, max_requests=max_requests))
+            all_data = list(
+                pagination_helper(
+                    self, data, max_requests=max_requests or settings.ZGW_MAX_REQUESTS
+                )
+            )
         except (RequestException, ClientError):
             logger.exception("exception while making request")
             return []
@@ -798,7 +804,7 @@ class FormClient(ZgwAPIClient):
         self,
         user_kvk: str,
         vestigingsnummer: str | None,
-        max_requests: int,
+        max_requests: int | None = None,
     ) -> list[OpenSubmission]:
         request_params = {"kvk": user_kvk}
         if vestigingsnummer:
@@ -810,7 +816,11 @@ class FormClient(ZgwAPIClient):
                 params=request_params,
             )
             data = get_json_response(response)
-            all_data = list(pagination_helper(self, data, max_requests=max_requests))
+            all_data = list(
+                pagination_helper(
+                    self, data, max_requests=max_requests or settings.ZGW_MAX_REQUESTS
+                )
+            )
         except (RequestException, ClientError):
             logger.exception("exception while making request")
             return []


### PR DESCRIPTION
## Summary

The number of requests to zaken API's is made configurable via  the environment variable `ZGW_MAX_REQUESTS`

## Issue References

- Taiga User Story: https://taiga.maykinmedia.nl/project/open-inwoner/us/3574
- Issue for updating environment variables: https://github.com/maykinmedia/charts/issues/327

## Checklist

- [x] CHANGELOG.rst updated
  - [x] Deployment notes added
- [x] Updated the `docker-compose.yml` environment variables
  - [x] Created an issue in https://github.com/maykinmedia/charts/ for new
        environment variables
