### PR TITLE
[#3589] Check for existing permissions when reverting migration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -224,6 +224,9 @@ Bugfixes
   items worden weergegeven in het verkorte dropdown menu. Menu-items worden nu alleen
   getoond in het dropdown menu als er geen sidenav beschikbaar is en als ze expliciet
   zijn geconfigureerd (op dit moment alleen de link naar "Mijn Profiel").
+* [:taiga-is:`3589`, :pr:`2028`]: de omgekeerde migratie voor het toevoegen van
+  gedeeltelijke rechten  voor de algemene configuratie geeft geen foutmelding meer
+  wanneer er geen rechten bestaan
 
 Onderhoud
 ---------

--- a/src/open_inwoner/configurations/migrations/0085_create_partial_admin_edit_permissions.py
+++ b/src/open_inwoner/configurations/migrations/0085_create_partial_admin_edit_permissions.py
@@ -2,6 +2,10 @@
 
 from django.db import migrations
 
+import structlog
+
+logger = structlog.stdlib.get_logger(__name__)
+
 
 def create_partial_admin_edit_permissions(apps, _):
     SiteConfiguration = apps.get_model("configurations", "SiteConfiguration")
@@ -34,7 +38,13 @@ def delete_partial_admin_edit_permissions(apps, _):
         "siteconfig_fieldset_page_texts",
         "siteconfig_fieldset_help_texts",
     ):
-        Permission.objects.get(codename=codename).delete()
+        deleted_count, _ = Permission.objects.filter(codename=codename).delete()
+        if deleted_count:
+            logger.info(
+                "Deleted Permission objects for SiteConfiguration",
+                siteconfig_part=codename,
+                deleted_count=deleted_count,
+            )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Summary

The function for reverting the migration which introduced 'Permission' instances for editing parts of the 'SiteConfiguration' failed to check if Permission instances exist.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3589

## Checklist

- [x] CHANGELOG.rst updated