### PR TITLE
fix: properly match the logout url to the login types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,6 +130,8 @@ Bugfixes
   kleuren) kunnen nu worden overschreven met de kleuren van de colorpicker.
 * [:taiga-dimpact:`358`, :pr:`2009`]: Het alternatieve telefoonnummer wordt nu correct verwerkt
   vanuit de eSuite.
+* [:taiga-is:`3588`, :pr:`2029`]: Ontbrekende logout URL voor reguliere gebruikers is
+  toegoevegd, en de logica voor alle login types is opgeschoond.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -1,5 +1,6 @@
 import os
 from datetime import timedelta
+from typing import Any, assert_never, cast
 from uuid import uuid4
 
 from django.conf import settings
@@ -678,23 +679,27 @@ class User(AbstractBaseUser, PermissionsMixin):
         return False
 
     def get_logout_url(self) -> str:
-        # Exit early, because for some reason reverse("logout") fails after checking
-        # the singletonmodels
-        if not (self.is_bsn_user or self.is_eherkenning_user or self.is_eidas_user):
-            return reverse("logout")
-
-        if self.login_type == LoginTypeChoices.digid:
-            if OpenIDDigiDConfig.get_solo().enabled:
-                return reverse("digid_oidc:logout")
-            return reverse("digid:logout")
-        elif self.login_type == LoginTypeChoices.eherkenning:
-            if OpenIDEHerkenningConfig.get_solo().enabled:
+        match self.login_type:
+            case LoginTypeChoices.digid:
+                return (
+                    reverse("digid_oidc:logout")
+                    if OpenIDDigiDConfig.get_solo().enabled
+                    else reverse("digid:logout")
+                )
+            case LoginTypeChoices.eherkenning:
                 return reverse("eherkenning_oidc:logout")
-            return reverse("logout")
-        elif self.is_eidas_user:
-            if OpenIDEIDASConfig.get_solo().enabled:
+            case LoginTypeChoices.oidc:
+                return reverse("oidc_logout")
+            case (
+                LoginTypeChoices.eidas_person_bsn
+                | LoginTypeChoices.eidas_person_pseudo_id
+                | LoginTypeChoices.eidas_company
+            ):
                 return reverse("eidas_oidc:logout")
-            return reverse("logout")
+            case LoginTypeChoices.default:
+                return reverse("logout")
+            case _ as unreachable:
+                assert_never(cast(Any, unreachable))
 
     @property
     def has_usable_email(self) -> bool:

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -120,47 +120,33 @@ class ProfileViewTests(WebTest):
 
                 self.assertEqual(logout_link.attr("href"), logout_url)
 
-    @patch("open_inwoner.accounts.models.OpenIDEHerkenningConfig.get_solo")
-    def test_show_correct_logout_button_for_login_type_eherkenning(self, mock_solo):
-        for oidc_enabled in [True, False]:
-            with self.subTest(oidc_enabled=oidc_enabled):
-                mock_solo.return_value.enabled = oidc_enabled
+    def test_show_correct_logout_button_for_login_type_eherkenning(self):
+        """eHerkenning always uses OIDC logout"""
+        logout_url = reverse("eherkenning_oidc:logout")
 
-                logout_url = (
-                    reverse("eherkenning_oidc:logout")
-                    if oidc_enabled
-                    else reverse("logout")
-                )
+        response = self.app.get(self.url, user=self.eherkenning_user)
 
-                response = self.app.get(self.url, user=self.eherkenning_user)
+        logout_title = _("Logout")
+        logout_link = response.pyquery.find(f"[title='{logout_title}']")
 
-                logout_title = _("Logout")
-                logout_link = response.pyquery.find(f"[title='{logout_title}']")
+        self.assertEqual(logout_link.attr("href"), logout_url)
 
-                self.assertEqual(logout_link.attr("href"), logout_url)
+    def test_show_correct_logout_button_for_login_type_eidas(self):
+        """eIDAS always uses OIDC logout"""
+        logout_url = reverse("eidas_oidc:logout")
 
-    @patch("open_inwoner.accounts.models.OpenIDEIDASConfig.get_solo")
-    def test_show_correct_logout_button_for_login_type_eidas(self, mock_solo):
-        for oidc_enabled in [True, False]:
-            with self.subTest(oidc_enabled=oidc_enabled):
-                mock_solo.return_value.enabled = oidc_enabled
+        eidas_user = UserFactory(
+            login_type=LoginTypeChoices.eidas_person_bsn,
+            bsn="123456789",
+            eidas_pseudo_id="eidas-test",
+        )
 
-                logout_url = (
-                    reverse("eidas_oidc:logout") if oidc_enabled else reverse("logout")
-                )
+        response = self.app.get(self.url, user=eidas_user)
 
-                eidas_user = UserFactory(
-                    login_type=LoginTypeChoices.eidas_person_bsn,
-                    bsn="123456789",
-                    eidas_pseudo_id=f"eidas-test-{oidc_enabled}",
-                )
+        logout_title = _("Logout")
+        logout_link = response.pyquery.find(f"[title='{logout_title}']")
 
-                response = self.app.get(self.url, user=eidas_user)
-
-                logout_title = _("Logout")
-                logout_link = response.pyquery.find(f"[title='{logout_title}']")
-
-                self.assertEqual(logout_link.attr("href"), logout_url)
+        self.assertEqual(logout_link.attr("href"), logout_url)
 
     @patch(
         "open_inwoner.cms.utils.page_display.inbox_page_is_published", return_value=True

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
+from django.urls import reverse
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.models import User
@@ -169,3 +172,52 @@ class UserTests(TestCase):
         eHerkenningVestigingUserFactory(kvk="12345678", vestiging="")
         with self.assertRaises(IntegrityError):
             eHerkenningVestigingUserFactory(kvk="12345678", vestiging="")
+
+    @patch("open_inwoner.accounts.models.OpenIDDigiDConfig")
+    def test_get_logout_url_digid_takes_oidc_config_into_account(
+        self, mock_digid_config
+    ):
+        user = UserFactory(login_type=LoginTypeChoices.digid)
+
+        # Test with OIDC enabled
+        mock_digid_config.get_solo.return_value.enabled = True
+        self.assertEqual(user.get_logout_url(), reverse("digid_oidc:logout"))
+
+        # Test with OIDC disabled
+        mock_digid_config.get_solo.return_value.enabled = False
+        self.assertEqual(user.get_logout_url(), reverse("digid:logout"))
+
+    def test_get_logout_url_returns_correct_option_for_login_type(self):
+        test_cases = [
+            (
+                LoginTypeChoices.eherkenning,
+                {"kvk": "12345678"},
+                reverse("eherkenning_oidc:logout"),
+            ),
+            (LoginTypeChoices.oidc, {}, reverse("oidc_logout")),
+            (
+                LoginTypeChoices.eidas_person_bsn,
+                {"bsn": "123456789", "eidas_pseudo_id": "test_eidas_bsn"},
+                reverse("eidas_oidc:logout"),
+            ),
+            (
+                LoginTypeChoices.eidas_person_pseudo_id,
+                {"eidas_pseudo_id": "test_eidas_pseudo"},
+                reverse("eidas_oidc:logout"),
+            ),
+            (
+                LoginTypeChoices.eidas_company,
+                {
+                    "kvk": "12345678",
+                    "eidas_pseudo_id": "test_eidas_company",
+                    "eidas_company_id": "test_company_id",
+                },
+                reverse("eidas_oidc:logout"),
+            ),
+            (LoginTypeChoices.default, {}, reverse("logout")),
+        ]
+
+        for login_type, extra_kwargs, expected_url in test_cases:
+            with self.subTest(login_type=login_type):
+                user = UserFactory(login_type=login_type, **extra_kwargs)
+                self.assertEqual(user.get_logout_url(), expected_url)


### PR DESCRIPTION
## Summary

Inadvertently broke the logout url during the EIDAS work. Ensured that we always return the default, and handles the special cases in a cleaner way.

## Issue References

<!-- Link to related Taiga stories/issues: remove if not applicable -->

- Taiga User Story:
- Taiga Issue: [#3588](https://taiga.maykinmedia.nl/project/open-inwoner/issue/3588)
- Taiga Dimpact Issue:
- Github Issue:

## Checklist

- [x] CHANGELOG.rst updated

