### PR TITLE
[#3590] Improve grid for unauthenticated tablet view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -150,6 +150,8 @@ Bugfixes
   kleuren) kunnen nu worden overschreven met de kleuren van de colorpicker.
 * [:taiga-dimpact:`358`, :pr:`2009`]: Het alternatieve telefoonnummer wordt nu correct verwerkt
   vanuit de eSuite.
+* [:taiga-is:`3590`: :pr:`2030`]: Bug opgelost waarbij tablet gebruikers geen volledig uitgevuld
+  navigatie menu zagen.
 * [:taiga-is:`3588`, :pr:`2029`]: Ontbrekende logout URL voor reguliere gebruikers is
   toegoevegd, en de logica voor alle login types is opgeschoond.
 

--- a/src/open_inwoner/scss/components/Header/Header.scss
+++ b/src/open_inwoner/scss/components/Header/Header.scss
@@ -65,10 +65,11 @@ $vm: var(--spacing-large);
   &__container {
     box-sizing: border-box;
     display: grid;
-    grid-column-gap: var(--spacing-tiny);
+    grid-column-gap: 0;
     position: relative;
     grid-template-columns: 1fr;
     grid-template-rows: var(--header-height);
+    width: 100%;
 
     > .header__actions {
       display: none;
@@ -335,6 +336,13 @@ $vm: var(--spacing-large);
             }
           }
         }
+      }
+    }
+
+    // Unauthenticated tablet grid
+    @media (min-width: 768px) and (max-width: 910px) {
+      &__main {
+        grid-column: 9 / span 2;
       }
     }
   }


### PR DESCRIPTION
## Summary

On tablets header menu was not aligning correctly.

<img width="780" height="206" alt="header-menu" src="https://github.com/user-attachments/assets/dd2df7a5-8d91-48c4-adaa-7daac68d81a3" />


## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3590

## Checklist

- [x] CHANGELOG.rst updated