### PR TITLE
chore: remove deprecated mozilla-django-oidc-db settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -161,6 +161,7 @@ Onderhoud
   correct onderscheid tussen ``None`` en ``"None"`` waarden.
 * [:pr:`1991`, :taiga-is:`3626`] Vervang het woord "notificaties" met "meldingen"
   omwille van de B1 taaleis.
+* [:pr:`2031`] Verouderde ``mozilla-django-oidc-db`` cache-instellingen verwijderd.
 
 1.35.2 (2025-11-13)
 ===================

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -102,14 +102,6 @@ CACHES = {
             "IGNORE_EXCEPTIONS": True,
         },
     },
-    "oidc": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"redis://{config('CACHE_DEFAULT', 'localhost:6379/0')}",
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "IGNORE_EXCEPTIONS": True,
-        },
-    },
     "local": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
@@ -1062,8 +1054,7 @@ OIDC_CALLBACK_CLASS = "mozilla_django_oidc_db.views.OIDCCallbackView"
 OIDC_AUTHENTICATION_CALLBACK_URL = "oidc_authentication_callback"
 # ID token is required to enable OIDC logout
 OIDC_STORE_ID_TOKEN = True
-MOZILLA_DJANGO_OIDC_DB_CACHE = "oidc"
-MOZILLA_DJANGO_OIDC_DB_CACHE_TIMEOUT = 1
+
 
 # In order to support zaaktypeconfig admin screens with many statusses/results
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000

--- a/src/open_inwoner/conf/ci.py
+++ b/src/open_inwoner/conf/ci.py
@@ -35,7 +35,6 @@ CACHES.update(
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
         # See: https://github.com/jazzband/django-axes/blob/master/docs/configuration.rst#cache-problems
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
-        "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     }
 )
 

--- a/src/open_inwoner/conf/dev.py
+++ b/src/open_inwoner/conf/dev.py
@@ -74,7 +74,6 @@ LOGGING["loggers"].update(
 CACHES = {
     "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
-    "oidc": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
 }
 
 _MOCK_AUTHENTICATION_BACKENDS = {


### PR DESCRIPTION
## Summary

The OIDC caching settings have been deprecated since `mozilla-django-oidc-db>=0.17` (see https://github.com/maykinmedia/mozilla-django-oidc-db/pull/106).

## Checklist

- [x] CHANGELOG.rst updated
