### PR TITLE
feat: make hints in OIDC frontend logout optional via env

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,12 @@ Deployment aandachtspunten
   nieuwe eIDAS ondersteuning.
 * Het aantal requests aan zaken API's is nu configureerbaar via een omgevingsvariabele ``ZGW_MAX_REQUESTS``
   (standaardwaarde is 8).
+* De nieuwe omgevingsvariabele ``OIDC_FRONTEND_LOGOUT_WITH_HINTS`` (standaard: ``true``)
+  bepaalt of hints zoals ``id_token_hint`` en ``post_logout_redirect_uri`` worden
+  meegegeven bij OIDC frontend logout redirects. Wanneer het ID token gevoelige claims
+  bevat die niet in de querystring van de user agent mogen verschijnen (bijvoorbeeld
+  voor security compliance), kan deze variabele op ``false`` worden gezet om alleen naar
+  het logout endpoint te redirecten zonder aanvullende parameters.
 
 
 Nieuwe features
@@ -76,6 +82,12 @@ Nieuwe features
 
 * [:taiga-us:`3574`, :pr:`2026`]: Aantal requests aan zaken API's configureerbaar gemaakt via
   omgevingsvariabele.
+* [:taiga-us:`3596`, :pr:`2036`]: Hints (zoals ``id_token_hint`` en
+  ``post_logout_redirect_uri``) bij OIDC frontend logout zijn nu optioneel
+  configureerbaar via de omgevingsvariabele ``OIDC_FRONTEND_LOGOUT_WITH_HINTS``. Dit
+  voorkomt dat gevoelige claims in de querystring van de user agent terechtkomen, wat
+  belangrijk kan zijn voor security audits (zoals PENTests) van bijvoorbeeld DigiD.
+  Standaard blijven de hints ingeschakeld om het huidige gedrag te behouden.
 
 Bugfixes
 --------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ x-app-env: &x-app-env
   - CELERY_RESULT_BACKEND=redis://redis:6379/0
   - CELERY_LOGLEVEL=DEBUG
   - ES_HOST=http://elasticsearch:9200
+  - OIDC_FRONTEND_LOGOUT_WITH_HINTS=true
   # Needed for Celery Flower to match the TIME_ZONE configured in the
   # settings used by workers and beat containers.
   - TZ=Europe/Amsterdam

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -634,44 +634,53 @@ class DigiDOIDCFlowTests(WebTest):
             id=1, enabled=True, oidc_op_logout_endpoint="http://localhost:8080/logout"
         ),
     )
-    def test_logout(self, mock_get_solo):
+    def test_frontend_logout_redirects_to_correct_url_with_optional_hints(
+        self, mock_get_solo
+    ):
         # set up a user with a non existing email address
         user = DigidUserFactory.create(
             bsn="123456782", email="existing_user@example.com"
         )
-        self.client.force_login(user)
-        session = self.client.session
-        session["oidc_states"] = {
-            "mock": {
-                "nonce": "nonce",
-                "config_class": "accounts.OpenIDDigiDConfig",
-            }
-        }
-        session["oidc_id_token"] = "foo"
-        session.save()
-        logout_url = reverse("digid_oidc:logout")
 
-        self.assertFalse(User.objects.filter(email="new_user@example.com").exists())
+        for logout_with_hints in (True, False):
+            with (
+                self.subTest(logout_with_hints=logout_with_hints),
+                override_settings(OIDC_FRONTEND_LOGOUT_WITH_HINTS=logout_with_hints),
+            ):
+                self.client.force_login(user)
+                session = self.client.session
+                session["oidc_states"] = {
+                    "mock": {
+                        "nonce": "nonce",
+                        "config_class": "accounts.OpenIDDigiDConfig",
+                    }
+                }
+                session["oidc_id_token"] = "foo"
+                session.save()
+                logout_url = reverse("digid_oidc:logout")
 
-        # enter the logout flow
-        logout_response = self.client.get(logout_url)
+                # enter the logout flow
+                logout_response = self.client.get(logout_url)
 
-        self.assertRedirects(
-            logout_response,
-            "http://localhost:8080/logout"
-            + "?"
-            + urlencode(
-                dict(
-                    id_token_hint="foo",
-                    post_logout_redirect_uri=f"http://testserver{settings.LOGOUT_REDIRECT_URL}",
+                expected_redirect_url = "http://localhost:8080/logout"
+                if logout_with_hints:
+                    params = urlencode(
+                        dict(
+                            id_token_hint="foo",
+                            post_logout_redirect_uri=f"http://testserver{settings.LOGOUT_REDIRECT_URL}",
+                        )
+                    )
+                    expected_redirect_url += f"?{params}"
+
+                self.assertRedirects(
+                    logout_response,
+                    expected_redirect_url,
+                    fetch_redirect_response=False,
                 )
-            ),
-            fetch_redirect_response=False,
-        )
 
-        self.assertNotIn("oidc_states", self.client.session)
-        self.assertNotIn("oidc_id_token", self.client.session)
-        self.assertFalse(logout_response.wsgi_request.user.is_authenticated)
+                self.assertNotIn("oidc_states", self.client.session)
+                self.assertNotIn("oidc_id_token", self.client.session)
+                self.assertFalse(logout_response.wsgi_request.user.is_authenticated)
 
     @patch(
         "open_inwoner.accounts.models.OpenIDDigiDConfig.get_solo",

--- a/src/open_inwoner/accounts/views/auth_oidc.py
+++ b/src/open_inwoner/accounts/views/auth_oidc.py
@@ -122,19 +122,21 @@ class OIDCLogoutView(View):
 
         # Try to initiate a frontchannel redirect
         if logout_endpoint := config.oidc_op_logout_endpoint:
-            params = {
-                # The value MUST have been previously registered with the
-                # OP, either using the post_logout_redirect_uri
-                # registration parameter or via another mechanism.
-                "post_logout_redirect_uri": self.request.build_absolute_uri(
-                    self.get_success_url()
-                ),
-            }
-            if id_token:
-                params["id_token_hint"] = id_token
+            if settings.OIDC_FRONTEND_LOGOUT_WITH_HINTS:
+                params = {
+                    # The value MUST have been previously registered with the
+                    # OP, either using the post_logout_redirect_uri
+                    # registration parameter or via another mechanism.
+                    "post_logout_redirect_uri": self.request.build_absolute_uri(
+                        self.get_success_url()
+                    ),
+                }
+                if id_token:
+                    params["id_token_hint"] = id_token
 
-            logout_url = f"{logout_endpoint}?{urlencode(params)}"
-            return HttpResponseRedirect(logout_url)
+                logout_endpoint += f"?{urlencode(params)}"
+
+            return HttpResponseRedirect(logout_endpoint)
 
         logger.warning("No OIDC logout endpoint defined")
         return HttpResponseRedirect(self.get_success_url())

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -589,6 +589,7 @@ SESSION_COOKIE_AGE = 900  # Set to 15 minutes or less for testing
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
 
+OIDC_FRONTEND_LOGOUT_WITH_HINTS = config("OIDC_FRONTEND_LOGOUT_WITH_HINTS", True)
 
 #
 # SECURITY settings


### PR DESCRIPTION
## Summary

Because the ID token might include sensitive claims, and because these
might end-up in the querystring of client's user agent, this commit
adds an environment variable to optionally disable the hints when
redirecting the user to an OIDC frontend logout URL to avoid exposing
sensitive claims when needed. This can be required in PENTests for e.g.
DigiD.

The default remains to include the hints to avoid changing the
current behaviour.

The specs stipulate that the hints are optional, and if the token hint
is absent, the logout redirect must also be absent. In such cases,
the broker is supposed to prompt the user whether they indeed want
to logout (though we have seen brokers in the wild that treat the hints
as mandatory).

## Issue References

<!-- Link to related Taiga stories/issues: remove if not applicable -->

- Taiga User Story: [#3596](https://taiga.maykinmedia.nl/project/open-inwoner/us/3596?milestone=556)

## Checklist

- [x] CHANGELOG.rst updated
  - [x] Deployment notes added
- [x] Updated the `docker-compose.yml` environment variables
  - [x] Created an issue in https://github.com/maykinmedia/charts/ for new
        environment variables
