### PR TITLE
[#3597] Check for anonymous user in zaken plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,8 +77,8 @@ Nieuwe features
   voor links naar andere portalen gebouwd, inclusief nieuwe design-tokens volgens NLDS conventies. Opmaak is
   verbeterd voor inhoud met langere linkteksten die naar een nieuwe regel worden afgebroken.
 * [:taiga-us:`3509`, :pr:`1997`]: Ondersteuning voor eIDAS login via OIDC is toegevoegd.
-* [:taiga-us:`3575`, :pr:`2020`]: CMS plug-in 'Mijn Zaken' angemaakt voor het ontsluiten van zaken
-  in de startpagina
+* [:taiga-us:`3575`, :pr:`2020`, :pr:`2037`]: CMS plug-in 'Mijn Zaken' angemaakt voor het
+  ontsluiten van zaken in de startpagina
 
 * [:taiga-us:`3574`, :pr:`2026`]: Aantal requests aan zaken API's configureerbaar gemaakt via
   omgevingsvariabele.

--- a/src/open_inwoner/cms/plugins/cms_plugins/zaken.py
+++ b/src/open_inwoner/cms/plugins/cms_plugins/zaken.py
@@ -23,7 +23,8 @@ class CMSZakenPlugin(CMSPluginBase):
         if not ZGWApiGroupConfig.objects.exists():
             return context
 
-        if not context["request"].user.is_bsn_user:
+        user = context["request"].user
+        if not user.is_authenticated or not user.is_bsn_user:
             return context
 
         # HTMX endpoint with num_zaken parameter

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -58,8 +58,19 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("/cms-plugins/zaken/", hxget)
         self.assertIn("/content/", hxget)
 
-    def test_plugin_does_not_render_for_unauthenticated_user(self):
-        """Test that the plugin doesn't render for users without appropriate login type"""
+    def test_plugin_does_not_render_for_anonymous_user(self):
+        ZGWApiGroupConfigFactory()
+
+        html, context = cms_tools.render_plugin(
+            CMSZakenPlugin,
+            plugin_data={"title": "Mijn Zaken"},
+            user=None,
+        )
+
+        self.assertNotIn("hxget", context)
+        self.assertEqual(html.strip(), "")
+
+    def test_plugin_does_not_render_for_user_with_wrong_login_type(self):
         user = UserFactory(login_type=LoginTypeChoices.default)
         html, context = cms_tools.render_plugin(
             CMSZakenPlugin,


### PR DESCRIPTION
## Summary

The zaken plugin failed to check for anonymous users, leading to `AttributeError` when checking `bsn`.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3597

## Checklist

- [x] CHANGELOG.rst updated