### PR TITLE
ci: fix name reference for custom runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
   tests:
     name: Run the Django test suite
     runs-on:
-      ${{ matrix.test-type == 'main' && 'openinwoner-runner' || 'ubuntu-latest'
-      }}
+      ${{ matrix.test-type == 'main' && 'maykin-runner' || 'ubuntu-latest' }}
     strategy:
       matrix:
         test-type: [main, elastic, openklant, migrations]


### PR DESCRIPTION
## Summary

The custom runner was renamed by @alextreme to allow Open Archiefbeheer to make use of the multi-core goodness. However, because we refer to runners by name, this broke our `main` CI build (we use regular ubuntu for the other tests in the matrix). We agreed to give the runner a generic name, `maykin-runner`, and this PR applies this change.
