### PR TITLE
:bug: [#3599] OIP tag conflict with Storybook CSS class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -154,6 +154,8 @@ Bugfixes
   navigatie menu zagen.
 * [:taiga-is:`3588`, :pr:`2029`]: Ontbrekende logout URL voor reguliere gebruikers is
   toegoevegd, en de logica voor alle login types is opgeschoond.
+* [:taiga-is:`3599`, :pr:`2045`]: Bij het bekijken van de bron code van componenten in Storybook
+  wordt nu de correcte styling getoond.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/components/templates/components/Tag/Tag.html
+++ b/src/open_inwoner/components/templates/components/Tag/Tag.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 
-<aside class="tag-list" aria-label="{% trans "Tag lijst" %}">
-    <ul class="tag-list__list">
+<aside class="oip-tag-list" aria-label="{% trans "Tag lijst" %}">
+    <ul class="oip-tag-list__list">
         {% for tag in tags %}
-            <li class="tag-list__list-item">
-                <span class="tag">{{ tag.name }}</span>
+            <li class="oip-tag-list__list-item">
+                <span class="oip-tag">{{ tag.name }}</span>
             </li>
         {% endfor %}
     </ul>

--- a/src/open_inwoner/scss/components/Tags/Tag.scss
+++ b/src/open_inwoner/scss/components/Tags/Tag.scss
@@ -1,4 +1,4 @@
-.tag {
+.oip-tag {
   border-radius: var(--border-radius-rounded);
   background-color: var(--color-info-lightest);
   color: var(--color-info-darker);

--- a/src/open_inwoner/scss/components/Tags/TagList.scss
+++ b/src/open_inwoner/scss/components/Tags/TagList.scss
@@ -1,4 +1,4 @@
-.tag-list {
+.oip-tag-list {
   margin-top: var(--spacing-large);
 
   &__list {

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -50,7 +50,7 @@
   margin-top: var(--font-line-height-body);
 }
 
-.tag-list + .utrecht-paragraph,
+.oip-tag-list + .utrecht-paragraph,
 .utrecht-paragraph + .form {
   margin-top: var(--spacing-extra-large);
 }


### PR DESCRIPTION
## Summary

Storybook uses the same generic .tag class as open-inwoner, leading to conflicting styles.
Every partial code element in the Storybook code viewer gets the open-inwoner info color background, making the code unreadable.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3599

## Checklist

- [x] CHANGELOG.rst updated

