### PR TITLE
[#3600] Add signing requests to 'Data koppelingen' in admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,8 @@ Nieuwe features
   belangrijk kan zijn voor security audits (zoals PENTests) van bijvoorbeeld DigiD.
   Standaard blijven de hints ingeschakeld om het huidige gedrag te behouden.
 * [:taiga-us:`3580`, :pr:`2033`]: De zoekfunctie kan nu worden uitgeschakeld in de Algemene Configuratie.
+* [:taiga-is`3600`, :pr:`2046`]: 'Signing requets' toegevoegd aan admin. Beheerders kunnen nu een CSR
+  (Certificate Signing Request) genereren in de admin via 'Datakoppelingen > Ondertekeningsverzoeken'.
 
 Bugfixes
 --------

--- a/docs/beheerhandleiding/09_datakoppelingen.rst
+++ b/docs/beheerhandleiding/09_datakoppelingen.rst
@@ -488,10 +488,10 @@ Hier vult u de helptekst voor de kolommen in de jaaropgave PDF in. Deze helpteks
 
 Bij Services staan alle externe REST-API koppelingen met het Open Inwoner Platform ingesteld. Deze mogen niet worden gewijzigd.
 
-9.16. Statusvertalingen
+9.16. Signing requests
 =======================
 
-Bij Statusvertalingen kunt u de statussen personaliseren. Zo kunt u standaardteksten naar believen veranderen in statussen die beter passen bij de situatie. Het gaat hier dus niet om vertalingen van taal naar taal.
+Hier kunt u een CSR (Certificate Signing Request) genereren die kan worden ingediend bij een certificeringsinstantie (CA) voor de uitgifte van een digitaal certificaat.
 
 9.17. Webhook-abonnementen
 ==========================

--- a/src/open_inwoner/conf/fixtures/django-admin-index.json
+++ b/src/open_inwoner/conf/fixtures/django-admin-index.json
@@ -152,6 +152,7 @@
         ["openzaak", "zaaktypeinformatieobjecttypeconfig"],
         ["qmatic", "qmaticconfig"],
         ["simple_certmanager", "certificate"],
+        ["simple_certmanager", "signingrequest"],
         ["soap", "soapservice"],
         ["ssd", "ssdconfig"],
         ["zgw_consumers", "certificate"],


### PR DESCRIPTION
## Summary

The option to create a CSR (Certificate Signing Request) via simple-certmanager is added to "Data koppelingen" in the admin.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3600

## Checklist

- [x] CHANGELOG.rst updated
- [x] Documentation updated


<!-- readthedocs-preview open-inwoner start -->
----
📚 Documentation preview 📚: https://open-inwoner--2046.org.readthedocs.build/en/2046/

<!-- readthedocs-preview open-inwoner end -->