### PR TITLE
[#3603] Use different action + status texts for zaken/formulieren

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,6 +104,8 @@ Nieuwe features
   uit de API correct worden overgenomen in de lokale versie van de catalogus.
 * [:taiga-us:`3578`, :pr:`2043`]: Nieuw Front-end ontwerp voor CMS plug-in 'Balie Afspraken' gebouwd met
   design-tokens volgens het NLDS principe.
+* [:taiga-us:`3606`, :pr:`2051`]: Zaken en open formulieren hebben nu verschillende teksten voor de status
+  en actieknop/link.
 
 Bugfixes
 --------

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -69,14 +69,14 @@ class InnerCaseListView(
         case_service = CaseListService(self.request)
         context["filter_form_enabled"] = config.zaken_filter_enabled
 
-        # update ctx with open submissions and cases (possibly fitered)
-        open_submissions: Sequence[UniformCase] = case_service.get_submissions()
+        # update ctx with formulieren and cases (possibly filtered)
+        formulieren: Sequence[UniformCase] = case_service.get_formulieren()
         preprocessed_cases: Sequence[UniformCase] = case_service.get_cases()
 
         if config.zaken_filter_enabled:
             case_status_frequencies = case_service.get_case_status_frequencies(
                 cases=preprocessed_cases,
-                submissions=open_submissions,
+                formulieren=formulieren,
             )
             # Separate frequency data from statusname
             context["status_freqs"] = [
@@ -96,12 +96,10 @@ class InnerCaseListView(
                         user=self.request.user,
                     )
 
-            # Actually filter the submissions
+            # Actually filter the formulieren
             if statuses:
-                open_submissions = (
-                    open_submissions
-                    if CaseFilterFormOption.FORMULIER in statuses
-                    else []
+                formulieren = (
+                    formulieren if CaseFilterFormOption.FORMULIER in statuses else []
                 )
                 preprocessed_cases = [
                     case
@@ -109,9 +107,7 @@ class InnerCaseListView(
                     if case_service.get_case_filter_status(case.zaak) in statuses
                 ]
 
-        paginator_dict = self.paginate_with_context(
-            [*open_submissions, *preprocessed_cases]
-        )
+        paginator_dict = self.paginate_with_context([*formulieren, *preprocessed_cases])
         case_dicts = [case.process_data() for case in paginator_dict["object_list"]]
 
         context["cases"] = case_dicts

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -100,7 +100,7 @@ class InnerCaseListView(
             if statuses:
                 open_submissions = (
                     open_submissions
-                    if CaseFilterFormOption.OPEN_SUBMISSION in statuses
+                    if CaseFilterFormOption.FORMULIER in statuses
                     else []
                 )
                 preprocessed_cases = [

--- a/src/open_inwoner/cms/cases/views/services.py
+++ b/src/open_inwoner/cms/cases/views/services.py
@@ -18,6 +18,7 @@ from open_inwoner.openzaak.clients import (
     ZakenClient,
     build_zgw_client_from_service,
 )
+from open_inwoner.openzaak.constants import TypeAanvraag
 from open_inwoner.openzaak.models import (
     ZaakTypeConfig,
     ZaakTypeStatusTypeConfig,
@@ -44,13 +45,18 @@ class CaseFilterFormOption(enum.Enum):
 class ZaakWithApiGroup:
     zaak: Zaak
     api_group: ZGWApiGroupConfig
+    type_aanvraag: TypeAanvraag
 
     @property
     def identification(self) -> str:
         return self.zaak.url
 
     def process_data(self) -> dict:
-        return {**self.zaak.process_data(), "api_group": self.api_group}
+        return {
+            **self.zaak.process_data(),
+            "api_group": self.api_group,
+            "type_aanvraag": self.type_aanvraag.value,
+        }
 
     def __hash__(self):
         return hash((self.identification, self.api_group.pk))
@@ -60,13 +66,18 @@ class ZaakWithApiGroup:
 class SubmissionWithApiGroup:
     submission: OpenSubmission
     api_group: ZGWApiGroupConfig
+    type_aanvraag: TypeAanvraag
 
     @property
     def identification(self) -> str:
         return self.submission.url
 
     def process_data(self) -> dict:
-        return {**self.submission.process_data(), "api_group": self.api_group}
+        return {
+            **self.submission.process_data(),
+            "api_group": self.api_group,
+            "type_aanvraag": self.type_aanvraag.value,
+        }
 
     def __hash__(self):
         return hash((self.identification, self.api_group.pk))
@@ -123,7 +134,9 @@ class CaseListService:
             raise ValueError(f"{group} has no `forms_client`")
 
         return [
-            SubmissionWithApiGroup(submission=sub, api_group=group)
+            SubmissionWithApiGroup(
+                submission=sub, api_group=group, type_aanvraag=TypeAanvraag.FORMULIER
+            )
             for sub in group.forms_client.fetch_open_submissions(
                 **get_user_fetch_parameters(
                     self.request, use_rsin=group.fetch_eherkenning_zaken_with_rsin
@@ -195,7 +208,10 @@ class CaseListService:
         )
 
         return [
-            ZaakWithApiGroup(zaak=raw_cases, api_group=group) for raw_cases in raw_cases
+            ZaakWithApiGroup(
+                zaak=raw_cases, api_group=group, type_aanvraag=TypeAanvraag.ZAAK
+            )
+            for raw_cases in raw_cases
         ]
 
     def get_cases(self) -> list[ZaakWithApiGroup]:

--- a/src/open_inwoner/cms/cases/views/services.py
+++ b/src/open_inwoner/cms/cases/views/services.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 import structlog
 from zgw_consumers.concurrent import parallel
 
-from open_inwoner.openzaak.api_models import OpenSubmission, Zaak
+from open_inwoner.openzaak.api_models import Formulier, Zaak
 from open_inwoner.openzaak.clients import (
     CatalogiClient,
     ZakenClient,
@@ -36,9 +36,9 @@ class ResolveCaseException(Exception):
 
 
 class CaseFilterFormOption(enum.Enum):
-    OPEN_SUBMISSION = _("Openstaande formulieren")
-    OPEN_CASE = _("Lopende aanvragen")
-    CLOSED_CASE = _("Afgeronde aanvragen")
+    FORMULIER = _("Openstaande formulieren")
+    ZAAK_OPEN = _("Lopende aanvragen")
+    ZAAK_AFGEROND = _("Afgeronde aanvragen")
 
 
 @dataclass(frozen=True)
@@ -63,18 +63,18 @@ class ZaakWithApiGroup:
 
 
 @dataclass(frozen=True)
-class SubmissionWithApiGroup:
-    submission: OpenSubmission
+class FormulierWithApiGroup:
+    formulier: Formulier
     api_group: ZGWApiGroupConfig
     type_aanvraag: TypeAanvraag
 
     @property
     def identification(self) -> str:
-        return self.submission.url
+        return self.formulier.url
 
     def process_data(self) -> dict:
         return {
-            **self.submission.process_data(),
+            **self.formulier.process_data(),
             "api_group": self.api_group,
             "type_aanvraag": self.type_aanvraag.value,
         }
@@ -129,12 +129,12 @@ class CaseListService:
 
     def _get_submissions_for_api_group(
         self, group: ZGWApiGroupConfig
-    ) -> list[SubmissionWithApiGroup]:
+    ) -> list[FormulierWithApiGroup]:
         if not group.forms_client:
             raise ValueError(f"{group} has no `forms_client`")
 
         return [
-            SubmissionWithApiGroup(
+            FormulierWithApiGroup(
                 submission=sub, api_group=group, type_aanvraag=TypeAanvraag.FORMULIER
             )
             for sub in group.forms_client.fetch_open_submissions(
@@ -144,14 +144,14 @@ class CaseListService:
             )
         ]
 
-    def get_submissions(self) -> list[SubmissionWithApiGroup]:
+    def get_submissions(self) -> list[FormulierWithApiGroup]:
         all_api_groups = list(
             ZGWApiGroupConfig.objects.filter(form_service__isnull=False).select_related(
                 "form_service",
             )
         )
 
-        subs_with_api_group: list[SubmissionWithApiGroup] = []
+        subs_with_api_group: list[FormulierWithApiGroup] = []
         with parallel(max_workers=self._max_workers) as executor:
             futures = [
                 executor.submit(self._get_submissions_for_api_group, group)
@@ -172,7 +172,7 @@ class CaseListService:
 
         # Sort submissions by date modified
         subs_with_api_group.sort(
-            key=lambda sub: sub.submission.datum_laatste_wijziging, reverse=True
+            key=lambda sub: sub.formulier.datum_laatste_wijziging, reverse=True
         )
 
         return subs_with_api_group
@@ -180,19 +180,19 @@ class CaseListService:
     @staticmethod
     def get_case_filter_status(zaak: Zaak) -> CaseFilterFormOption:
         if zaak.einddatum:
-            return CaseFilterFormOption.CLOSED_CASE
+            return CaseFilterFormOption.ZAAK_AFGEROND
 
-        return CaseFilterFormOption.OPEN_CASE
+        return CaseFilterFormOption.ZAAK_OPEN
 
     def get_case_status_frequencies(
         self,
         cases: Iterable[ZaakWithApiGroup],
-        submissions: Iterable[SubmissionWithApiGroup],
+        submissions: Iterable[FormulierWithApiGroup],
     ) -> dict[CaseFilterFormOption, int]:
         case_statuses = [self.get_case_filter_status(case.zaak) for case in cases]
 
         # add static text for open submissions
-        case_statuses += [CaseFilterFormOption.OPEN_SUBMISSION for _ in submissions]
+        case_statuses += [CaseFilterFormOption.FORMULIER for _ in submissions]
 
         return {
             status: case_statuses.count(status) for status in list(CaseFilterFormOption)

--- a/src/open_inwoner/cms/cases/views/services.py
+++ b/src/open_inwoner/cms/cases/views/services.py
@@ -86,7 +86,7 @@ class FormulierWithApiGroup:
 class Timeouts(TypedDict):
     fetch_raw_cases: int | float
     resolve_cases: int | float
-    fetch_submissions: int | float
+    fetch_formulieren: int | float
 
 
 class CaseListService:
@@ -99,7 +99,7 @@ class CaseListService:
         self._timeouts = {
             "fetch_raw_cases": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.3,
             "resolve_cases": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.5,
-            "fetch_submissions": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.2,
+            "fetch_formulieren": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.2,
         }
         self._max_workers = settings.ZGW_CASE_LIST_NUM_WORKERS
 
@@ -127,7 +127,7 @@ class CaseListService:
     def _catalogi_client_factory(group: ZGWApiGroupConfig):
         return cast(CatalogiClient, build_zgw_client_from_service(group.ztc_service))
 
-    def _get_submissions_for_api_group(
+    def _get_formulieren_for_api_group(
         self, group: ZGWApiGroupConfig
     ) -> list[FormulierWithApiGroup]:
         if not group.forms_client:
@@ -135,16 +135,18 @@ class CaseListService:
 
         return [
             FormulierWithApiGroup(
-                submission=sub, api_group=group, type_aanvraag=TypeAanvraag.FORMULIER
+                formulier=formulier,
+                api_group=group,
+                type_aanvraag=TypeAanvraag.FORMULIER,
             )
-            for sub in group.forms_client.fetch_open_submissions(
+            for formulier in group.forms_client.fetch_formulieren(
                 **get_user_fetch_parameters(
                     self.request, use_rsin=group.fetch_eherkenning_zaken_with_rsin
                 )
             )
         ]
 
-    def get_submissions(self) -> list[FormulierWithApiGroup]:
+    def get_formulieren(self) -> list[FormulierWithApiGroup]:
         all_api_groups = list(
             ZGWApiGroupConfig.objects.filter(form_service__isnull=False).select_related(
                 "form_service",
@@ -154,23 +156,23 @@ class CaseListService:
         subs_with_api_group: list[FormulierWithApiGroup] = []
         with parallel(max_workers=self._max_workers) as executor:
             futures = [
-                executor.submit(self._get_submissions_for_api_group, group)
+                executor.submit(self._get_formulieren_for_api_group, group)
                 for group in all_api_groups
             ]
 
         try:
             for task in concurrent.futures.as_completed(
                 futures,
-                timeout=self._timeouts["fetch_submissions"],
+                timeout=self._timeouts["fetch_formulieren"],
             ):
                 try:
                     subs_with_api_group.extend(task.result())
                 except BaseException:
                     logger.exception("Error fetching and pre-processing cases")
         except concurrent.futures.TimeoutError:
-            logger.warning("Timeout while fetching submissions")
+            logger.warning("Timeout while fetching formulieren")
 
-        # Sort submissions by date modified
+        # Sort formulieren by date modified
         subs_with_api_group.sort(
             key=lambda sub: sub.formulier.datum_laatste_wijziging, reverse=True
         )
@@ -187,12 +189,12 @@ class CaseListService:
     def get_case_status_frequencies(
         self,
         cases: Iterable[ZaakWithApiGroup],
-        submissions: Iterable[FormulierWithApiGroup],
+        formulieren: Iterable[FormulierWithApiGroup],
     ) -> dict[CaseFilterFormOption, int]:
         case_statuses = [self.get_case_filter_status(case.zaak) for case in cases]
 
-        # add static text for open submissions
-        case_statuses += [CaseFilterFormOption.FORMULIER for _ in submissions]
+        # add static text for formulieren
+        case_statuses += [CaseFilterFormOption.FORMULIER for _ in formulieren]
 
         return {
             status: case_statuses.count(status) for status in list(CaseFilterFormOption)

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -142,11 +142,11 @@ class CMSZakenPluginTest(TestCase):
         return_value=[],
     )
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
     def test_htmx_content_endpoint_returns_empty_state(
-        self, mock_submissions, mock_cases
+        self, mock_formulieren, mock_cases
     ):
         ServiceFactory(api_root=ZAKEN_ROOT)
         ZGWApiGroupConfigFactory()
@@ -167,10 +167,10 @@ class CMSZakenPluginTest(TestCase):
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_htmx_content_endpoint_returns_cases(self, mock_submissions, mock_cases):
+    def test_htmx_content_endpoint_returns_cases(self, mock_formulieren, mock_cases):
         api_group = ZGWApiGroupConfigFactory()
 
         mock_case = MagicMock()
@@ -207,10 +207,10 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("test-uuid-123", zaak_item.attr("detail-url"))
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_submissions")
-    def test_htmx_content_endpoint_complete_failure(self, mock_submissions, mock_cases):
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
+    def test_htmx_content_endpoint_complete_failure(self, mock_formulieren, mock_cases):
         mock_cases.side_effect = Exception("Cases API error")
-        mock_submissions.side_effect = Exception("Submissions API error")
+        mock_formulieren.side_effect = Exception("formulieren API error")
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -228,12 +228,12 @@ class CMSZakenPluginTest(TestCase):
         self.assertNotIn("oip-home-plugin-card", content)
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_submissions")
-    def test_htmx_content_endpoint_partial_failure(self, mock_submissions, mock_cases):
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
+    def test_htmx_content_endpoint_partial_failure(self, mock_formulieren, mock_cases):
         api_group = ZGWApiGroupConfigFactory()
 
-        # Submissions fail
-        mock_submissions.side_effect = Exception("Submissions API error")
+        # formulieren fail
+        mock_formulieren.side_effect = Exception("Formulieren API error")
 
         # Cases succeed
         mock_case = MagicMock()
@@ -270,10 +270,10 @@ class CMSZakenPluginTest(TestCase):
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_num_zaken_parameter_limits_results(self, mock_submissions, mock_cases):
+    def test_num_zaken_parameter_limits_results(self, mock_formulieren, mock_cases):
         api_group = ZGWApiGroupConfigFactory()
 
         mock_cases_list = []
@@ -317,14 +317,14 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("ZAAK-002", identifications)
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_submissions")
-    def test_num_zaken_parameter_with_mixed_submissions_and_cases(
-        self, mock_submissions, mock_cases
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
+    def test_num_zaken_parameter_with_mixed_formulieren_and_cases(
+        self, mock_formulieren, mock_cases
     ):
         api_group = ZGWApiGroupConfigFactory()
 
-        # 3 mock submissions
-        mock_submissions_list = []
+        # 3 mock formulieren
+        mock_formulieren_list = []
         for i in range(3):
             mock_submission = MagicMock()
             mock_submission.process_data.return_value = {
@@ -334,7 +334,7 @@ class CMSZakenPluginTest(TestCase):
                 "api_group": api_group,
                 "type_aanvraag": TypeAanvraag.FORMULIER.value,
             }
-            mock_submissions_list.append(mock_submission)
+            mock_formulieren_list.append(mock_submission)
 
         # 7 mock cases
         mock_cases_list = []
@@ -349,7 +349,7 @@ class CMSZakenPluginTest(TestCase):
             }
             mock_cases_list.append(mock_case)
 
-        mock_submissions.return_value = mock_submissions_list
+        mock_formulieren.return_value = mock_formulieren_list
         mock_cases.return_value = mock_cases_list
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
@@ -360,7 +360,7 @@ class CMSZakenPluginTest(TestCase):
 
         self.client.force_login(self.user)
 
-        # Test with num_zaken=5 (should get 3 submissions + 2 cases)
+        # Test with num_zaken=5 (should get 3 formulieren + 2 cases)
         response = self.client.get(url, {"num_zaken": "5"}, HTTP_HX_REQUEST="true")
 
         pyquery = PyQuery(response.content.decode("utf-8"))
@@ -372,7 +372,7 @@ class CMSZakenPluginTest(TestCase):
         # Extract identifications (note: template uses 'identificatie' attribute)
         identifications = [pyquery(item).attr("identificatie") for item in zaak_items]
 
-        # Verify submissions come first
+        # Verify formulieren come first
         self.assertIn("SUBMISSION-000", identifications)
         self.assertIn("SUBMISSION-001", identifications)
         self.assertIn("SUBMISSION-002", identifications)
@@ -384,10 +384,10 @@ class CMSZakenPluginTest(TestCase):
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_num_zaken_parameter_invalid_input(self, mock_submissions, mock_cases):
+    def test_num_zaken_parameter_invalid_input(self, mock_formulieren, mock_cases):
         """Test that invalid values for num_zaken fall back to MAX_CASES_DEFAULT"""
         api_group = ZGWApiGroupConfigFactory()
 
@@ -429,10 +429,10 @@ class CMSZakenPluginTest(TestCase):
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_htmx_content_maps_naam_to_description(self, mock_submissions, mock_cases):
+    def test_htmx_content_maps_naam_to_description(self, mock_formulieren, mock_cases):
         api_group = ZGWApiGroupConfigFactory()
 
         mock_case = MagicMock()
@@ -464,11 +464,11 @@ class CMSZakenPluginTest(TestCase):
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_submissions",
+        "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
     def test_htmx_content_handles_missing_optional_fields(
-        self, mock_submissions, mock_cases
+        self, mock_formulieren, mock_cases
     ):
         api_group = ZGWApiGroupConfigFactory()
 
@@ -501,22 +501,22 @@ class CMSZakenPluginTest(TestCase):
         self.assertEqual(zaak_item.attr("description"), "")
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_submissions")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
     def test_htmx_content_handles_both_naam_and_description_fields(
-        self, mock_submissions, mock_cases
+        self, mock_formulieren, mock_cases
     ):
         """
-        Test that both 'naam' field (from openstaande inzendingen) and 'description' field
+        Test that both 'naam' field (from formulieren) and 'description' field
         (from regular zaken) are correctly mapped to 'description' in the component output.
         """
         api_group = ZGWApiGroupConfigFactory()
 
-        # Mock open submission with "naam" field
+        # Mock formulier with "naam" field
         mock_submission = MagicMock()
         mock_submission.process_data.return_value = {
             "uuid": "submission-uuid-1",
             "identification": "SUBMISSION-001",
-            "naam": "Open submission met naam field",
+            "naam": "Formulier met naam field",
             "api_group": api_group,
             "type_aanvraag": TypeAanvraag.FORMULIER.value,
         }
@@ -531,7 +531,7 @@ class CMSZakenPluginTest(TestCase):
             "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
 
-        mock_submissions.return_value = [mock_submission]
+        mock_formulieren.return_value = [mock_submission]
         mock_cases.return_value = [mock_case]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
@@ -551,7 +551,7 @@ class CMSZakenPluginTest(TestCase):
         # Should have both items
         self.assertEqual(len(zaak_items), 2)
 
-        # First item should be the submission with "naam" field
+        # First item should be the formulier with "naam" field
         submission_item = zaak_items.eq(0)
         self.assertEqual(submission_item.attr("identificatie"), "SUBMISSION-001")
         self.assertEqual(

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -11,6 +11,7 @@ from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.cms.plugins.cms_plugins import CMSZakenPlugin
 from open_inwoner.cms.plugins.models.zaken import MAX_CASES_DEFAULT
 from open_inwoner.cms.tests import cms_tools
+from open_inwoner.openzaak.constants import TypeAanvraag
 from open_inwoner.openzaak.models import ZGWApiGroupConfig
 from open_inwoner.openzaak.tests.factories import (
     ServiceFactory,
@@ -178,6 +179,7 @@ class CMSZakenPluginTest(TestCase):
             "identification": "ZAAK-001",
             "naam": "Test zaak beschrijving",
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
         mock_cases.return_value = [mock_case]
 
@@ -240,6 +242,7 @@ class CMSZakenPluginTest(TestCase):
             "identification": "ZAAK-001",
             "naam": "Test zaak",
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
         mock_cases.return_value = [mock_case]
 
@@ -281,6 +284,7 @@ class CMSZakenPluginTest(TestCase):
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
+                "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
             mock_cases_list.append(mock_case)
 
@@ -328,6 +332,7 @@ class CMSZakenPluginTest(TestCase):
                 "identification": f"SUBMISSION-{i:03d}",
                 "naam": f"Test submission {i}",
                 "api_group": api_group,
+                "type_aanvraag": TypeAanvraag.FORMULIER.value,
             }
             mock_submissions_list.append(mock_submission)
 
@@ -340,6 +345,7 @@ class CMSZakenPluginTest(TestCase):
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
+                "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
             mock_cases_list.append(mock_case)
 
@@ -393,6 +399,7 @@ class CMSZakenPluginTest(TestCase):
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
+                "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
             mock_cases_list.append(mock_case)
 
@@ -434,6 +441,7 @@ class CMSZakenPluginTest(TestCase):
             "identification": "ZAAK-001",
             "naam": "Dit is de naam van de zaak",
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
         mock_cases.return_value = [mock_case]
 
@@ -470,6 +478,7 @@ class CMSZakenPluginTest(TestCase):
             "uuid": "test-uuid-123",
             "identification": "",  # Required for logging
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
         mock_cases.return_value = [mock_case]
 
@@ -509,6 +518,7 @@ class CMSZakenPluginTest(TestCase):
             "identification": "SUBMISSION-001",
             "naam": "Open submission met naam field",
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.FORMULIER.value,
         }
 
         # Mock regular case with "description"
@@ -518,6 +528,7 @@ class CMSZakenPluginTest(TestCase):
             "identification": "ZAAK-001",
             "description": "Regular case met description field",
             "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
 
         mock_submissions.return_value = [mock_submission]

--- a/src/open_inwoner/cms/plugins/views.py
+++ b/src/open_inwoner/cms/plugins/views.py
@@ -54,21 +54,17 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
             )
             num_zaken = MAX_CASES_DEFAULT
 
-        # fetch zaken + openstaande inzendingen
+        # fetch zaken + formulieren
         # note: we count the retrieval as success of one part is successfully retrieved
         msg = None
         partial_error_msg = _(
             "We're experiencing technical difficulties. Some results may be missing from your cases."
         )
         try:
-            open_submissions: Sequence[UniformCase] | None = (
-                case_service.get_submissions()
-            )
+            formulieren: Sequence[UniformCase] | None = case_service.get_formulieren()
         except Exception:
-            logger.error(
-                "Failed to retrieve openstaande inzendingen", user=request.user
-            )
-            open_submissions = None
+            logger.error("Failed to retrieve formulieren", user=request.user)
+            formulieren = None
             msg = partial_error_msg
         try:
             preprocessed_cases: Sequence[UniformCase] | None = case_service.get_cases()
@@ -76,7 +72,7 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
             logger.error("Failed to retrieve zaken", user=request.user)
             preprocessed_cases = None
             msg = partial_error_msg
-        if open_submissions is None and preprocessed_cases is None:
+        if formulieren is None and preprocessed_cases is None:
             context = {
                 "show_zaken_plugin": True,
                 "zaken": [],
@@ -90,7 +86,7 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
         zaken_dicts = [
             zaak.process_data()
             for zaak in itertools.islice(
-                itertools.chain(open_submissions or [], preprocessed_cases or []),
+                itertools.chain(formulieren or [], preprocessed_cases or []),
                 num_zaken,
             )
         ]
@@ -113,7 +109,7 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
                     "uuid": zaak["uuid"],
                     "url": f_url.url,
                     "identification": zaak.get("identification", ""),
-                    # for 'openstaande inzendingen/formulieren':
+                    # for 'formulieren':
                     # "naam" from API -> "description" for web component
                     "description": zaak.get("naam", zaak.get("description", "")),
                 }

--- a/src/open_inwoner/cms/plugins/views.py
+++ b/src/open_inwoner/cms/plugins/views.py
@@ -113,7 +113,8 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
                     "uuid": zaak["uuid"],
                     "url": f_url.url,
                     "identification": zaak.get("identification", ""),
-                    # for 'openstaande inzendingen': "naam" from API -> "description" for component
+                    # for 'openstaande inzendingen/formulieren':
+                    # "naam" from API -> "description" for web component
                     "description": zaak.get("naam", zaak.get("description", "")),
                 }
             except (AttributeError, KeyError):

--- a/src/open_inwoner/openzaak/api_models.py
+++ b/src/open_inwoner/openzaak/api_models.py
@@ -142,7 +142,6 @@ class Zaak(ZGWModel):
             "result": self.result_text,
             "zaaktype_config": getattr(self, "zaaktype_config", None),
             "statustype_config": getattr(self, "statustype_config", None),
-            "case_type": "Zaak",
         }
 
 
@@ -361,7 +360,6 @@ class OpenSubmission(Model):
             "vervolg_link": self.vervolg_link,
             "datum_laatste_wijziging": self.datum_laatste_wijziging,
             "eind_datum_geldigheid": self.eind_datum_geldigheid or "Geen",
-            "case_type": "OpenSubmission",
         }
 
 

--- a/src/open_inwoner/openzaak/api_models.py
+++ b/src/open_inwoner/openzaak/api_models.py
@@ -336,7 +336,7 @@ class Notification(Model):
 
 
 @dataclass
-class OpenSubmission(Model):
+class Formulier(Model):
     url: str
     uuid: str
     naam: str

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -27,9 +27,9 @@ from open_inwoner.utils.api import ClientError, get_json_response
 from open_inwoner.utils.decorators import cache as cache_result
 
 from .api_models import (
+    Formulier,
     InformatieObjectType,
     OpenstaandeTaak,
-    OpenSubmission,
     Resultaat,
     ResultaatType,
     Rol,
@@ -738,7 +738,7 @@ class FormClient(ZgwAPIClient):
         vestigingsnummer: str | None = None,
         max_requests: int | None = None,
         **kwargs,
-    ) -> list[OpenSubmission]:
+    ) -> list[Formulier]:
         if user_bsn and (user_kvk or vestigingsnummer):
             raise ValueError(
                 "either `user_bsn` or `user_kvk` (optionally with `vestigingsnummer`) "
@@ -763,7 +763,7 @@ class FormClient(ZgwAPIClient):
         self,
         user_bsn: str,
         max_requests: int | None = None,
-    ) -> list[OpenSubmission]:
+    ) -> list[Formulier]:
         try:
             response = self.get(
                 "openstaande-inzendingen",
@@ -779,7 +779,7 @@ class FormClient(ZgwAPIClient):
             logger.exception("exception while making request")
             return []
 
-        results = factory(OpenSubmission, all_data)
+        results = factory(Formulier, all_data)
 
         return results
 
@@ -788,7 +788,7 @@ class FormClient(ZgwAPIClient):
         user_kvk: str,
         vestigingsnummer: str | None,
         max_requests: int | None = None,
-    ) -> list[OpenSubmission]:
+    ) -> list[Formulier]:
         request_params = {"kvk": user_kvk}
         if vestigingsnummer:
             request_params["vestigingsnummer"] = vestigingsnummer
@@ -808,7 +808,7 @@ class FormClient(ZgwAPIClient):
             logger.exception("exception while making request")
             return []
 
-        results = factory(OpenSubmission, all_data)
+        results = factory(Formulier, all_data)
 
         return results
 

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -730,8 +730,8 @@ class DocumentenClient(ZgwAPIClient):
         return data
 
 
-class FormClient(ZgwAPIClient):
-    def fetch_open_submissions(
+class FormulierenClient(ZgwAPIClient):
+    def fetch_formulieren(
         self,
         user_bsn: str | None = None,
         user_kvk: str | None = None,
@@ -746,12 +746,12 @@ class FormClient(ZgwAPIClient):
             )
 
         if user_bsn:
-            return self.fetch_open_submissions_by_bsn(
+            return self.fetch_formulieren_by_bsn(
                 user_bsn, max_requests=max_requests or settings.ZGW_MAX_REQUESTS
             )
 
         if user_kvk:
-            return self.fetch_open_submissions_by_kvk(
+            return self.fetch_formulieren_by_kvk(
                 user_kvk,
                 max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
                 vestigingsnummer=vestigingsnummer,
@@ -759,7 +759,7 @@ class FormClient(ZgwAPIClient):
 
         return []
 
-    def fetch_open_submissions_by_bsn(
+    def fetch_formulieren_by_bsn(
         self,
         user_bsn: str,
         max_requests: int | None = None,
@@ -783,7 +783,7 @@ class FormClient(ZgwAPIClient):
 
         return results
 
-    def fetch_open_submissions_by_kvk(
+    def fetch_formulieren_by_kvk(
         self,
         user_kvk: str,
         vestigingsnummer: str | None,
@@ -938,7 +938,7 @@ class MultiZgwClientProxy:
 
 ZgwClientType = Literal["zaak", "catalogi", "document", "form"]
 ZgwClientFactoryReturn: TypeAlias = (
-    ZakenClient | CatalogiClient | DocumentenClient | FormClient
+    ZakenClient | CatalogiClient | DocumentenClient | FormulierenClient
 )
 
 
@@ -949,7 +949,7 @@ def build_zgw_client_from_service(
         APITypes.zrc: ZakenClient,
         APITypes.ztc: CatalogiClient,
         APITypes.drc: DocumentenClient,
-        APITypes.orc: FormClient,
+        APITypes.orc: FormulierenClient,
     }
 
     try:
@@ -970,7 +970,7 @@ def build_zgw_client_from_service(
 
 def _build_all_zgw_clients_for_type(
     type_: ZgwClientType,
-) -> list[ZakenClient | CatalogiClient | DocumentenClient | FormClient]:
+) -> list[ZakenClient | CatalogiClient | DocumentenClient | FormulierenClient]:
     config = OpenZaakConfig.get_solo()
     services_to_client_mapping: Mapping[ZgwClientType, str] = {
         "zaak": "zrc_service",
@@ -1008,5 +1008,5 @@ def build_documenten_clients() -> list[DocumentenClient]:
     return cast(list[DocumentenClient], _build_all_zgw_clients_for_type("document"))
 
 
-def build_forms_clients() -> list[FormClient]:
-    return cast(list[FormClient], _build_all_zgw_clients_for_type("form"))
+def build_forms_clients() -> list[FormulierenClient]:
+    return cast(list[FormulierenClient], _build_all_zgw_clients_for_type("form"))

--- a/src/open_inwoner/openzaak/constants.py
+++ b/src/open_inwoner/openzaak/constants.py
@@ -32,4 +32,4 @@ class ZaakBetrokkeneRol(models.TextChoices):
 
 class TypeAanvraag(Enum):
     ZAAK = "Zaak"
-    FORMULIER = "OpenSubmission"  # "openstaande inzending/formulier"
+    FORMULIER = "Formulier"  # "openstaande inzending/formulier"

--- a/src/open_inwoner/openzaak/constants.py
+++ b/src/open_inwoner/openzaak/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -26,3 +28,8 @@ class ZaakTitleDisplayChoices(models.TextChoices):
 
 class ZaakBetrokkeneRol(models.TextChoices):
     initiator = "initiator", _("Initiator")
+
+
+class TypeAanvraag(Enum):
+    ZAAK = "Zaak"
+    FORMULIER = "OpenSubmission"  # "openstaande inzending/formulier"

--- a/src/open_inwoner/openzaak/models.py
+++ b/src/open_inwoner/openzaak/models.py
@@ -134,7 +134,12 @@ class ZGWApiGroupConfigQuerySet(models.QuerySet):
         )
 
     def filter_by_zgw_client(self, client: _ZgwClient):
-        from .clients import CatalogiClient, DocumentenClient, FormClient, ZakenClient
+        from .clients import (
+            CatalogiClient,
+            DocumentenClient,
+            FormulierenClient,
+            ZakenClient,
+        )
 
         match client:
             case ZakenClient():
@@ -143,12 +148,12 @@ class ZGWApiGroupConfigQuerySet(models.QuerySet):
                 return self.filter(ztc_service=client.configured_from)
             case DocumentenClient():
                 return self.filter(drc_service=client.configured_from)
-            case FormClient():
+            case FormulierenClient():
                 return self.filter(form_service=client.configured_from)
             case _:
                 raise ValueError(
                     f"Client is of type {type(client)} but expected to be one of: "
-                    "ZakenClient, DocumentenClient, FormClient, CatalogiClient"
+                    "ZakenClient, DocumentenClient, FormulierenClient, CatalogiClient"
                 )
 
     def filter_by_url_root_overlap(self, url: str):
@@ -256,10 +261,10 @@ class ZGWApiGroupConfig(models.Model):
 
     @property
     def forms_client(self):
-        from .clients import FormClient
+        from .clients import FormulierenClient
 
         if self.form_service:
-            return cast(FormClient, self._build_client_from_attr("form_service"))
+            return cast(FormulierenClient, self._build_client_from_attr("form_service"))
 
     # backend-specific flags
     fetch_eherkenning_zaken_with_rsin = models.BooleanField(

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -27,7 +27,11 @@ from open_inwoner.accounts.tests.factories import (
 )
 from open_inwoner.cms.cases.views.cases import CaseFilterFormOption, InnerCaseListView
 from open_inwoner.openzaak.api_models import Zaak
-from open_inwoner.openzaak.constants import StatusIndicators, ZaakBetrokkeneRol
+from open_inwoner.openzaak.constants import (
+    StatusIndicators,
+    TypeAanvraag,
+    ZaakBetrokkeneRol,
+)
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 from open_inwoner.utils.tests.helpers import (
@@ -574,7 +578,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         "result": "",
                         "zaaktype_config": mock.zaaktype_config1,
                         "statustype_config": mock.zt_statustype_config1,
-                        "case_type": "Zaak",
+                        "type_aanvraag": TypeAanvraag.ZAAK.value,
                         "api_group": self.api_groups[i],
                     },
                     {
@@ -589,7 +593,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         "result": "",
                         "zaaktype_config": mock.zaaktype_config1,
                         "statustype_config": mock.zt_statustype_config1,
-                        "case_type": "Zaak",
+                        "type_aanvraag": TypeAanvraag.ZAAK.value,
                         "api_group": self.api_groups[i],
                     },
                     {
@@ -606,7 +610,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         "result": mock.resultaat_type["omschrijving"],
                         "zaaktype_config": mock.zaaktype_config1,
                         "statustype_config": None,
-                        "case_type": "Zaak",
+                        "type_aanvraag": TypeAanvraag.ZAAK.value,
                         "api_group": self.api_groups[i],
                     },
                     {
@@ -621,7 +625,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         "result": mock.resultaat_type["omschrijving"],
                         "zaaktype_config": mock.zaaktype_config1,
                         "statustype_config": mock.zt_statustype_config1,
-                        "case_type": "Zaak",
+                        "type_aanvraag": TypeAanvraag.ZAAK.value,
                         "api_group": self.api_groups[i],
                     },
                 ]
@@ -794,7 +798,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                                 "result": "",
                                 "zaaktype_config": mock.zaaktype_config1,
                                 "statustype_config": mock.zt_statustype_config1,
-                                "case_type": "Zaak",
+                                "type_aanvraag": TypeAanvraag.ZAAK.value,
                                 "api_group": self.api_groups[i],
                             },
                             {
@@ -813,7 +817,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                                 "result": "",
                                 "zaaktype_config": mock.zaaktype_config1,
                                 "statustype_config": mock.zt_statustype_config1,
-                                "case_type": "Zaak",
+                                "type_aanvraag": TypeAanvraag.ZAAK.value,
                                 "api_group": self.api_groups[i],
                             },
                         ]
@@ -956,7 +960,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 "result": "",
                 "zaaktype_config": mock.zaaktype_config1,
                 "statustype_config": mock.zt_statustype_config1,
-                "case_type": "Zaak",
+                "type_aanvraag": TypeAanvraag.ZAAK.value,
                 "api_group": self.api_groups[i],
             }
             for i, mock in enumerate(self.mocks)
@@ -1014,7 +1018,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 "result": "",
                 "zaaktype_config": mock.zaaktype_config1,
                 "statustype_config": mock.zt_statustype_config1,
-                "case_type": "Zaak",
+                "type_aanvraag": TypeAanvraag.ZAAK.value,
                 "api_group": self.api_groups[i],
             }
             for i, mock in enumerate(self.mocks)
@@ -1120,7 +1124,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         "result": "",
                         "zaaktype_config": mock.zaaktype_config1,
                         "statustype_config": mock.zt_statustype_config1,
-                        "case_type": "Zaak",
+                        "type_aanvraag": TypeAanvraag.ZAAK.value,
                         "api_group": self.api_groups[i],
                     }
                 ]
@@ -1260,7 +1264,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     "result": "",
                     "zaaktype_config": mock.zaaktype_config1,
                     "statustype_config": mock.zt_statustype_config1,
-                    "case_type": "Zaak",
+                    "type_aanvraag": TypeAanvraag.ZAAK.value,
                     "api_group": self.api_groups[i],
                 },
                 {
@@ -1273,7 +1277,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     "result": "",
                     "zaaktype_config": mock.zaaktype_config1,
                     "statustype_config": mock.zt_statustype_config1,
-                    "case_type": "Zaak",
+                    "type_aanvraag": TypeAanvraag.ZAAK.value,
                     "api_group": self.api_groups[i],
                 },
                 {
@@ -1286,7 +1290,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     "result": mock.resultaat_type["omschrijving"],
                     "zaaktype_config": mock.zaaktype_config1,
                     "statustype_config": None,
-                    "case_type": "Zaak",
+                    "type_aanvraag": TypeAanvraag.ZAAK.value,
                     "api_group": self.api_groups[i],
                 },
                 {
@@ -1301,7 +1305,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     "result": mock.resultaat_type["omschrijving"],
                     "zaaktype_config": mock.zaaktype_config1,
                     "statustype_config": mock.zt_statustype_config1,
-                    "case_type": "Zaak",
+                    "type_aanvraag": TypeAanvraag.ZAAK.value,
                     "api_group": self.api_groups[i],
                 },
             ]

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -726,7 +726,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.config.save()
 
         self.client.force_login(user=self.user)
-        inner_url = f"{reverse_lazy('cases:cases_content')}?{self._encode_statuses(CaseFilterFormOption.OPEN_CASE)}"
+        inner_url = f"{reverse_lazy('cases:cases_content')}?{self._encode_statuses(CaseFilterFormOption.ZAAK_OPEN)}"
 
         response = self.client.get(inner_url, HTTP_HX_REQUEST="true")
 
@@ -746,7 +746,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
         self.client.force_login(user=self.user)
         filter_param = self._encode_statuses(
-            [CaseFilterFormOption.CLOSED_CASE, CaseFilterFormOption.OPEN_SUBMISSION]
+            [CaseFilterFormOption.ZAAK_AFGEROND, CaseFilterFormOption.FORMULIER]
         )
         inner_url = f"{reverse_lazy('cases:cases_content')}?{filter_param}"
 
@@ -1416,6 +1416,8 @@ class CaseSubmissionTest(TransactionWebTest):
             cases[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data_alt.submission_3["datumLaatsteWijziging"],
         )
+        # Verify case_type is "Formulier" for submissions
+        self.assertEqual(cases[0]["case_type"], "Formulier")
 
         self.assertEqual(cases[1]["url"], data.submission_2["url"])
         self.assertEqual(cases[1]["uuid"], data.submission_2["uuid"])
@@ -1425,6 +1427,12 @@ class CaseSubmissionTest(TransactionWebTest):
             cases[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data.submission_2["datumLaatsteWijziging"],
         )
+        # Verify case_type is "Formulier" for submissions
+        self.assertEqual(cases[1]["case_type"], "Formulier")
+
+        # Verify the HTML contains the formulier-specific text
+        self.assertIn("Formulier afronden", response.text)
+        self.assertIn("Nog niet afgerond formulier", response.text)
 
     @requests_mock.Mocker()
     @patch("open_inwoner.kvk.middleware.KvKLoginMiddleware.requires_redirect")

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -1370,7 +1370,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
-class CaseSubmissionTest(TransactionWebTest):
+class FormulierTest(TransactionWebTest):
     inner_url = reverse_lazy("cases:cases_content")
 
     def setUp(self):
@@ -1386,7 +1386,7 @@ class CaseSubmissionTest(TransactionWebTest):
         )
 
     @requests_mock.Mocker()
-    def test_get_open_submissions_by_bsn(self, m):
+    def test_get_formulieren_by_bsn(self, m):
         digid_user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="john@smith.nl"
         )
@@ -1416,8 +1416,8 @@ class CaseSubmissionTest(TransactionWebTest):
             cases[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data_alt.submission_3["datumLaatsteWijziging"],
         )
-        # Verify case_type is "Formulier" for submissions
-        self.assertEqual(cases[0]["case_type"], "Formulier")
+        # Verify case_type is "Formulier"
+        self.assertEqual(cases[0]["type_aanvraag"], "Formulier")
 
         self.assertEqual(cases[1]["url"], data.submission_2["url"])
         self.assertEqual(cases[1]["uuid"], data.submission_2["uuid"])
@@ -1427,8 +1427,8 @@ class CaseSubmissionTest(TransactionWebTest):
             cases[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data.submission_2["datumLaatsteWijziging"],
         )
-        # Verify case_type is "Formulier" for submissions
-        self.assertEqual(cases[1]["case_type"], "Formulier")
+        # Verify case_type
+        self.assertEqual(cases[1]["type_aanvraag"], "Formulier")
 
         # Verify the HTML contains the formulier-specific text
         self.assertIn("Formulier afronden", response.text)
@@ -1436,7 +1436,7 @@ class CaseSubmissionTest(TransactionWebTest):
 
     @requests_mock.Mocker()
     @patch("open_inwoner.kvk.middleware.KvKLoginMiddleware.requires_redirect")
-    def test_get_open_submissions_by_kvk(self, m, mock_kvk_redirect):
+    def test_get_formulieren_by_kvk(self, m, mock_kvk_redirect):
         mock_kvk_redirect.return_value = False
 
         user = UserFactory(login_type=LoginTypeChoices.eherkenning, kvk="68750110")

--- a/src/open_inwoner/openzaak/types.py
+++ b/src/open_inwoner/openzaak/types.py
@@ -3,7 +3,7 @@ from typing import Protocol
 
 class UniformCase(Protocol):
     """
-    Zaken and open submissions are classified as "cases" if they have an
+    Zaken and formulieren are classified as "cases" if they have an
     `identification` property and a method `process_data` to prepare data
     for the template
     """

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -40,8 +40,8 @@
     {% for case in cases %}
         {% render_column start=forloop.counter_0|multiply:4 span=4 %}
 
-            {# open submissions ("openstaande aanvragen") #}
-            {% if case.case_type == "OpenSubmission" %}
+            {# open submissions ("openstaande formulieren/inzendingen") #}
+            {% if case.type_aanvraag == "OpenSubmission" %}
 
                 <a href="{{ case.vervolg_link }}" class="card card card__description-card card--stretch" target="_blank">
                     <div class="card__body">
@@ -56,10 +56,10 @@
                                     <p class="card__caption card__text--small"><span>{% trans "Laatst gewijzigd op:" %}</span><span class="card__text--dark">{{ date_modified }}</span></p>
                                 {% endwith %}
                             </li>
-                            {% list_item text=_("Openstaande zaak") caption=_("Status") compact=True strong=False %}
+                            {% list_item text=_("Nog niet afgerond formulier") caption=_("Status") compact=True strong=False %}
                         {% endrender_list %}
                         <span class="link link--icon link--bold link--primary">
-                        <span class="link__text">{% trans "Zaak afronden" %}</span>
+                        <span class="link__text">{% trans "Formulier afronden" %}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
                     </div>

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -39,10 +39,8 @@
 
     {% for case in cases %}
         {% render_column start=forloop.counter_0|multiply:4 span=4 %}
-
-            {# open submissions ("openstaande formulieren/inzendingen") #}
+            {# "openstaande formulieren/inzendingen" #}
             {% if case.type_aanvraag == "OpenSubmission" %}
-
                 <a href="{{ case.vervolg_link }}" class="card card card__description-card card--stretch" target="_blank">
                     <div class="card__body">
 

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -40,7 +40,7 @@
     {% for case in cases %}
         {% render_column start=forloop.counter_0|multiply:4 span=4 %}
             {# "openstaande formulieren/inzendingen" #}
-            {% if case.type_aanvraag == "OpenSubmission" %}
+            {% if case.type_aanvraag == "Formulier" %}
                 <a href="{{ case.vervolg_link }}" class="card card card__description-card card--stretch" target="_blank">
                     <div class="card__body">
 


### PR DESCRIPTION
## Summary

- 'Zaken' and 'Openstaande formulieren' receive different texts for the status as well as the action button/link. Also introduced an Enum to handle the case type ('Zaak' vs 'OpenSubmission').

- Refactored some classes, methods etc. to use Dutch terms referencing the domain (`submission` -> `formulier`, `SubmissionWithApiGroup` -> `FormulierWithApiGroup` etc.)

## Issue References

<!-- Link to related Taiga stories/issues: remove if not applicable -->

- Taiga User Story: https://taiga.maykinmedia.nl/project/open-inwoner/us/3603

## Checklist

- [x] CHANGELOG.rst updated
