### PR TITLE
[#2080] Refactor zgw classes, methods, variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Bugfixes
 Onderhoud
 ---------
 
+* [:taiga-us:`3615`]: zgw-klassen, methoden en variabelen hernoemd om Nederlandse
+  termen te gebruiken
+
 2.0.0 (2026-01-05)
 ==================
 

--- a/src/open_inwoner/cms/cases/forms.py
+++ b/src/open_inwoner/cms/cases/forms.py
@@ -20,26 +20,26 @@ class CaseUploadForm(forms.Form):
     )
     files = MultipleFileField(label=_("Bestand"))
 
-    def __init__(self, case, **kwargs):
+    def __init__(self, zaak, **kwargs):
         self.oz_config = OpenZaakConfig.get_solo()
         super().__init__(**kwargs)
 
         help_text = f"Grootte max. {self.oz_config.max_upload_size} MB, toegestane document formaten: {', '.join(self.oz_config.allowed_file_extensions)}."
 
         try:
-            ztc = ZaakTypeConfig.objects.filter_case_type(case.zaaktype).get()
+            ztc = ZaakTypeConfig.objects.filter_zaak_type(zaak.zaaktype).get()
             help_text = ztc.description or help_text
         except (AttributeError, ObjectDoesNotExist):
             pass
 
         self.fields["files"].help_text = help_text
 
-        if case:
+        if zaak:
             self.fields[
                 "type"
             ].queryset = (
-                ZaakTypeInformatieObjectTypeConfig.objects.filter_enabled_for_case_type(
-                    case.zaaktype
+                ZaakTypeInformatieObjectTypeConfig.objects.filter_enabled_for_zaak_type(
+                    zaak.zaaktype
                 )
             )
 

--- a/src/open_inwoner/cms/cases/tests/test_contactform.py
+++ b/src/open_inwoner/cms/cases/tests/test_contactform.py
@@ -430,7 +430,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         response = self.app.get(self.case_detail_url, user=self.user)
         contact_form = response.pyquery("#contact-form")
 
-        self.assertTrue(response.context["case"]["contact_form_enabled"])
+        self.assertTrue(response.context["zaak"]["contact_form_enabled"])
         self.assertTrue(contact_form)
 
         mock_send_confirm.assert_not_called()
@@ -454,7 +454,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         response = self.app.get(self.case_detail_url, user=self.user)
         contact_form = response.pyquery("#contact-form")
 
-        self.assertTrue(response.context["case"]["contact_form_enabled"])
+        self.assertTrue(response.context["zaak"]["contact_form_enabled"])
         self.assertTrue(contact_form)
 
         mock_send_confirm.assert_not_called()
@@ -475,7 +475,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         response = self.app.get(self.case_detail_url, user=self.user)
         contact_form = response.pyquery("#contact-form")
 
-        self.assertTrue(response.context["case"]["contact_form_enabled"])
+        self.assertTrue(response.context["zaak"]["contact_form_enabled"])
         self.assertTrue(contact_form)
 
         mock_send_confirm.assert_not_called()
@@ -499,7 +499,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         response = self.app.get(self.case_detail_url, user=self.user)
         contact_form = response.pyquery("#contact-form")
 
-        self.assertFalse(response.context["case"]["contact_form_enabled"])
+        self.assertFalse(response.context["zaak"]["contact_form_enabled"])
         self.assertFalse(contact_form)
 
         mock_send_confirm.assert_not_called()
@@ -522,7 +522,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         response = self.app.get(self.case_detail_url, user=self.user)
         contact_form = response.pyquery("#contact-form")
 
-        self.assertFalse(response.context["case"]["contact_form_enabled"])
+        self.assertFalse(response.context["zaak"]["contact_form_enabled"])
         self.assertFalse(contact_form)
 
         mock_send_confirm.assert_not_called()

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -71,11 +71,11 @@ class InnerCaseListView(
 
         # update ctx with formulieren and cases (possibly filtered)
         formulieren: Sequence[UniformCase] = case_service.get_formulieren()
-        preprocessed_cases: Sequence[UniformCase] = case_service.get_cases()
+        preprocessed_zaken: Sequence[UniformCase] = case_service.get_zaken()
 
         if config.zaken_filter_enabled:
-            case_status_frequencies = case_service.get_case_status_frequencies(
-                cases=preprocessed_cases,
+            case_status_frequencies = case_service.get_zaak_status_frequencies(
+                zaken=preprocessed_zaken,
                 formulieren=formulieren,
             )
             # Separate frequency data from statusname
@@ -101,22 +101,22 @@ class InnerCaseListView(
                 formulieren = (
                     formulieren if CaseFilterFormOption.FORMULIER in statuses else []
                 )
-                preprocessed_cases = [
-                    case
-                    for case in preprocessed_cases
-                    if case_service.get_case_filter_status(case.zaak) in statuses
+                preprocessed_zaken = [
+                    zaak
+                    for zaak in preprocessed_zaken
+                    if case_service.get_zaak_filter_status(zaak.zaak) in statuses
                 ]
 
-        paginator_dict = self.paginate_with_context([*formulieren, *preprocessed_cases])
-        case_dicts = [case.process_data() for case in paginator_dict["object_list"]]
+        paginator_dict = self.paginate_with_context([*formulieren, *preprocessed_zaken])
+        zaken_dicts = [case.process_data() for case in paginator_dict["object_list"]]
 
-        context["cases"] = case_dicts
+        context["zaken"] = zaken_dicts
         context.update(paginator_dict)
 
         # other data
         context["hxget"] = reverse("cases:cases_content")
         context["title_text"] = config.title_text
 
-        self.log_case_list_accessed(case_dicts)
+        self.log_case_list_accessed(zaken_dicts)
 
         return context

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -28,7 +28,7 @@ class CaseLogMixin(LogMixin):
 
         self.log_user_action(
             self.request.user,
-            _("Zaken bekeken: {cases}").format(cases=", ".join(case_ids)),
+            _("Zaken bekeken: {zaken}").format(zaken=", ".join(case_ids)),
         )
         case_list_views.add(1, {"num_cases_viewed": len(case_ids)})
 
@@ -130,16 +130,16 @@ class CaseAccessMixin(AccessMixin):
                 raise Http404 from exc
 
             client = api_group.zaken_client
-            self.case = client.fetch_single_case(object_id)
-            if self.case:
+            self.zaak = client.fetch_single_zaak(object_id)
+            if self.zaak:
                 # check if we have a role in this case
                 if request.user.bsn:
-                    if not client.fetch_roles_for_case_and_bsn(
-                        self.case.url, request.user.bsn
+                    if not client.fetch_roles_for_zaak_and_bsn(
+                        self.zaak.url, request.user.bsn
                     ):
                         logger.info(
                             "CaseAccessMixin - permission denied via bsn: no role for the case",
-                            zaak_url=self.case.url,
+                            zaak_url=self.zaak.url,
                         )
                         return self.handle_no_permission()
                 elif request.user.kvk:
@@ -150,41 +150,41 @@ class CaseAccessMixin(AccessMixin):
 
                     vestigingsnummer = request.user.vestiging
                     if vestigingsnummer:
-                        if not client.fetch_roles_for_case_and_vestigingsnummer(
-                            self.case.url, vestigingsnummer
+                        if not client.fetch_roles_for_zaak_and_vestigingsnummer(
+                            self.zaak.url, vestigingsnummer
                         ):
                             logger.info(
                                 "CaseAccessMixin - permission denied via vestigingsnummer: no role for the case",
-                                zaak_url=self.case.url,
+                                zaak_url=self.zaak.url,
                             )
                             return self.handle_no_permission()
                     else:
-                        if not client.fetch_roles_for_case_and_kvk_or_rsin(
-                            self.case.url, identifier
+                        if not client.fetch_roles_for_zaak_and_kvk_or_rsin(
+                            self.zaak.url, identifier
                         ):
                             logger.info(
                                 "CaseAccessMixin - permission denied via kvk/rsin: no role for the case",
-                                zaak_url=self.case.url,
+                                zaak_url=self.zaak.url,
                             )
                             return self.handle_no_permission()
 
                 # resolve case-type
                 catalogi_client = api_group.catalogi_client
-                self.case.zaaktype = catalogi_client.fetch_single_case_type(
-                    self.case.zaaktype
+                self.zaak.zaaktype = catalogi_client.fetch_single_zaaktype(
+                    self.zaak.zaaktype
                 )
-                if not self.case.zaaktype:
+                if not self.zaak.zaaktype:
                     logger.info(
                         "CaseAccessMixin - permission denied: no case type for case",
-                        zaak_url=self.case.url,
+                        zaak_url=self.zaak.url,
                     )
                     return self.handle_no_permission()
 
                 # check if case + case-type are visible
-                if not is_zaak_visible(self.case):
+                if not is_zaak_visible(self.zaak):
                     logger.info(
                         "CaseAccessMixin - permission denied: case  is not visible",
-                        zaak_url=self.case.url,
+                        zaak_url=self.zaak.url,
                     )
                     return self.handle_no_permission()
 

--- a/src/open_inwoner/cms/cases/views/services.py
+++ b/src/open_inwoner/cms/cases/views/services.py
@@ -84,8 +84,8 @@ class FormulierWithApiGroup:
 
 
 class Timeouts(TypedDict):
-    fetch_raw_cases: int | float
-    resolve_cases: int | float
+    fetch_raw_zaken: int | float
+    resolve_zaken: int | float
     fetch_formulieren: int | float
 
 
@@ -97,8 +97,8 @@ class CaseListService:
     def __init__(self, request: HttpRequest):
         self.request = request
         self._timeouts = {
-            "fetch_raw_cases": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.3,
-            "resolve_cases": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.5,
+            "fetch_raw_zaken": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.3,
+            "resolve_zaken": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.5,
             "fetch_formulieren": settings.ZGW_CASE_LIST_FETCH_TIMEOUT * 0.2,
         }
         self._max_workers = settings.ZGW_CASE_LIST_NUM_WORKERS
@@ -169,7 +169,7 @@ class CaseListService:
                 try:
                     subs_with_api_group.extend(task.result())
                 except BaseException:
-                    logger.exception("Error fetching and pre-processing cases")
+                    logger.exception("Error fetching and pre-processing zaken")
         except concurrent.futures.TimeoutError:
             logger.warning("Timeout while fetching formulieren")
 
@@ -181,30 +181,30 @@ class CaseListService:
         return subs_with_api_group
 
     @staticmethod
-    def get_case_filter_status(zaak: Zaak) -> CaseFilterFormOption:
+    def get_zaak_filter_status(zaak: Zaak) -> CaseFilterFormOption:
         if zaak.einddatum:
             return CaseFilterFormOption.ZAAK_AFGEROND
 
         return CaseFilterFormOption.ZAAK_OPEN
 
-    def get_case_status_frequencies(
+    def get_zaak_status_frequencies(
         self,
-        cases: Iterable[ZaakWithApiGroup],
+        zaken: Iterable[ZaakWithApiGroup],
         formulieren: Iterable[FormulierWithApiGroup],
     ) -> dict[CaseFilterFormOption, int]:
-        case_statuses = [self.get_case_filter_status(case.zaak) for case in cases]
+        zaak_statuses = [self.get_zaak_filter_status(zaak.zaak) for zaak in zaken]
 
         # add static text for formulieren
-        case_statuses += [CaseFilterFormOption.FORMULIER for _ in formulieren]
+        zaak_statuses += [CaseFilterFormOption.FORMULIER for _ in formulieren]
 
         return {
-            status: case_statuses.count(status) for status in list(CaseFilterFormOption)
+            status: zaak_statuses.count(status) for status in list(CaseFilterFormOption)
         }
 
-    def _get_raw_cases_for_api_group(
+    def _get_raw_zaken_for_api_group(
         self, group: ZGWApiGroupConfig
     ) -> list[ZaakWithApiGroup]:
-        raw_cases = group.zaken_client.fetch_cases(
+        raw_zaken = group.zaken_client.fetch_zaken(
             **get_user_fetch_parameters(
                 self.request, use_rsin=group.fetch_eherkenning_zaken_with_rsin
             )
@@ -212,12 +212,12 @@ class CaseListService:
 
         return [
             ZaakWithApiGroup(
-                zaak=raw_cases, api_group=group, type_aanvraag=TypeAanvraag.ZAAK
+                zaak=raw_zaak, api_group=group, type_aanvraag=TypeAanvraag.ZAAK
             )
-            for raw_cases in raw_cases
+            for raw_zaak in raw_zaken
         ]
 
-    def get_cases(self) -> list[ZaakWithApiGroup]:
+    def get_zaken(self) -> list[ZaakWithApiGroup]:
         all_api_groups = list(
             ZGWApiGroupConfig.objects.select_related(
                 "zrc_service",
@@ -227,35 +227,35 @@ class CaseListService:
             ).all()
         )
 
-        # Get the raw cases for all groups
-        fetched_cases: list[ZaakWithApiGroup] = []
-        fetch_raw_cases_futures: list[
+        # Get the raw zaken for all groups
+        fetched_zaken: list[ZaakWithApiGroup] = []
+        fetch_raw_zaken_futures: list[
             concurrent.futures.Future[list[ZaakWithApiGroup]]
         ] = []
         with parallel(max_workers=self._max_workers) as executor:
-            fetch_raw_cases_futures.extend(
-                executor.submit(self._get_raw_cases_for_api_group, group)
+            fetch_raw_zaken_futures.extend(
+                executor.submit(self._get_raw_zaken_for_api_group, group)
                 for group in all_api_groups
             )
 
         try:
             for task in concurrent.futures.as_completed(
-                fetch_raw_cases_futures,
-                timeout=self._timeouts["fetch_raw_cases"],
+                fetch_raw_zaken_futures,
+                timeout=self._timeouts["fetch_raw_zaken"],
             ):
-                raw_cases_for_group = task.result()
-                fetched_cases.extend(raw_cases_for_group)
+                raw_zaken_for_group = task.result()
+                fetched_zaken.extend(raw_zaken_for_group)
         except concurrent.futures.TimeoutError:
             # This happens, but it is not an error as such. We also want to continue
-            # execution with the cases we _did_ manage to resolve.
-            logger.warning("Timed out fetching raw cases for group", exc_info=True)
+            # execution with the zaken we _did_ manage to resolve.
+            logger.warning("Timed out fetching raw zaken for group", exc_info=True)
         except BaseException:
-            logger.exception("Unhandled error fetching raw cases")
+            logger.exception("Unhandled error fetching raw zaken")
 
-        # Resolve cases
+        # Resolve zaken
         # Submit all futures and track which futures belong to which case
         all_futures: list[concurrent.futures.Future[None]] = []
-        case_futures: dict[ZaakWithApiGroup, list[concurrent.futures.Future[None]]] = (
+        zaak_futures: dict[ZaakWithApiGroup, list[concurrent.futures.Future[None]]] = (
             defaultdict(list)
         )
 
@@ -266,35 +266,35 @@ class CaseListService:
         ]
 
         with parallel(max_workers=self._max_workers) as executor:
-            for case_with_group in fetched_cases:
+            for zaak_with_group in fetched_zaken:
                 # We have three independent resolver functions we want to resolve
                 # concurrently. Only if all three tasks complete do we want to
-                # add the case to the final list of resolved cases. Therefore, we keep
-                # track of the futures on a per-case basis to be able to verify all
+                # add the zaak to the final list of resolved zaken. Therefore, we keep
+                # track of the futures on a per-zaak basis to be able to verify all
                 # futures completed once the timeout has elapsed.
                 for func in resolver_functions:
-                    future = executor.submit(func, case_with_group)
+                    future = executor.submit(func, zaak_with_group)
                     all_futures.append(future)
-                    case_futures[case_with_group].append(future)
+                    zaak_futures[zaak_with_group].append(future)
 
         # Wait for futures to complete or timeout
         try:
             concurrent.futures.wait(
                 all_futures,
-                timeout=self._timeouts["resolve_cases"],
+                timeout=self._timeouts["resolve_zaken"],
             )
         except concurrent.futures.TimeoutError:
             # This happens, but it is not an error as such. We also want to
-            # continue execution with the cases we _did_ manage to resolve.
-            logger.warning("Timed out resolving cases", exc_info=True)
+            # continue execution with the zaken we _did_ manage to resolve.
+            logger.warning("Timed out resolving zaken", exc_info=True)
         except BaseException:
             logger.exception("Unhandled error during zaak resolution")
 
-        # Now check which cases had all 3 futures complete successfully. If we did not
+        # Now check which zaken had all 3 futures complete successfully. If we did not
         # manage to complete the resolutions for zaak, status and resultaat type, we
         # exclude the case from the final list.
-        resolved_cases: list[ZaakWithApiGroup] = []
-        for zaak, futures in case_futures.items():
+        resolved_zaken: list[ZaakWithApiGroup] = []
+        for zaak, futures in zaak_futures.items():
             # Check if all 3 futures completed without exceptions...
             if not all(f.done() and not f.exception() for f in futures):
                 logger.warning(
@@ -309,24 +309,24 @@ class CaseListService:
             )
 
             if is_zaak_visible(zaak_with_resolved_zgw_refs.zaak):
-                resolved_cases.append(zaak_with_resolved_zgw_refs)
+                resolved_zaken.append(zaak_with_resolved_zgw_refs)
             else:
                 logger.debug(
                     "Culling zaak %s because it is invisible",
                     zaak_with_resolved_zgw_refs.identification,
                 )
 
-        # Filter and sort cases
-        resolved_cases.sort(key=lambda case: case.zaak.startdatum, reverse=True)
-        resolved_cases.sort(key=lambda c: all_api_groups.index(c.api_group))
-        return resolved_cases
+        # Filter and sort zaken
+        resolved_zaken.sort(key=lambda case: case.zaak.startdatum, reverse=True)
+        resolved_zaken.sort(key=lambda c: all_api_groups.index(c.api_group))
+        return resolved_zaken
 
     def _replace_catalogus_api_with_model_refs(
         self,
         zaak_with_api_group: ZaakWithApiGroup,
     ) -> ZaakWithApiGroup:
         try:
-            zaaktype_config = ZaakTypeConfig.objects.filter_case_type(
+            zaaktype_config = ZaakTypeConfig.objects.filter_zaak_type(
                 zaak_with_api_group.zaak.zaaktype
             ).get()
 
@@ -364,7 +364,7 @@ class CaseListService:
         """
         Resolve `case.zaaktype` (`str`) to a `ZaakType(ZGWModel)` object
 
-        Note: the result of `fetch_single_case_type` is cached, hence a request
+        Note: the result of `fetch_single_zaaktype` is cached, hence a request
             is only made for new case type urls
         """
         client = CaseListService._catalogi_client_factory(zaak_with_group.api_group)
@@ -375,14 +375,14 @@ class CaseListService:
             )
             return
 
-        case_type = client.fetch_single_case_type(zaak_with_group.zaak.zaaktype)
-        if not case_type:
+        zaaktype = client.fetch_single_zaaktype(zaak_with_group.zaak.zaaktype)
+        if not zaaktype:
             raise ResolveCaseException(
                 f"Unable to resolve zaaktype for url: {zaak_with_group.zaak.zaaktype}"
             )
 
         with self._zaak_update_lock:
-            zaak_with_group.zaak.zaaktype = case_type
+            zaak_with_group.zaak.zaaktype = zaaktype
 
     def _resolve_status_and_status_type(
         self,

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -94,16 +94,16 @@ class OuterCaseDetailView(
     TemplateView,
 ):
     template_name = "pages/cases/status_outer.html"
-    case: Zaak | None = None
+    zaak: Zaak | None = None
 
     @cached_property
     def crumbs(self):
-        # case is retrieved via CaseAccessMixin
-        if self.case:
+        # zaak is retrieved via CaseAccessMixin
+        if self.zaak:
             return [
                 (_("Mijn zaken"), reverse("cases:index")),
                 (
-                    f"{self.case.description} - {_('Status')}",
+                    f"{self.zaak.description} - {_('Status')}",
                     reverse("cases:case_detail", kwargs=self.kwargs),
                 ),
             ]
@@ -116,8 +116,8 @@ class OuterCaseDetailView(
         ]
 
     def page_title(self):
-        if self.case:
-            return f"{self.case.description} {self.case.identification} - {_('Status')}"
+        if self.zaak:
+            return f"{self.zaak.description} {self.zaak.identification} - {_('Status')}"
         else:
             return f"{_('Zaak')} - {_('Status')}"
 
@@ -147,7 +147,7 @@ class InnerCaseDetailView(
     template_name = "pages/cases/status_inner.html"
     form_class = CaseUploadForm
     contact_form_class = CaseContactForm
-    case: Zaak | None = None
+    zaak: Zaak | None = None
 
     def get_service(self, service_type: KlantenServiceType) -> VragenService | None:
         if service_type == KlantenServiceType.OPENKLANT2:
@@ -183,12 +183,12 @@ class InnerCaseDetailView(
 
     @cached_property
     def crumbs(self):
-        # case is retrieved via CaseAccessMixin
-        if self.case:
+        # zaak is retrieved via CaseAccessMixin
+        if self.zaak:
             return [
                 (_("Mijn zaken"), reverse("cases:index")),
                 (
-                    f"{self.case.description} - {_('Status')}",
+                    f"{self.zaak.description} - {_('Status')}",
                     reverse("cases:case_detail", kwargs=self.kwargs),
                 ),
             ]
@@ -201,32 +201,32 @@ class InnerCaseDetailView(
         ]
 
     def page_title(self):
-        return f"{self.case.description} {self.case.identification} - {_('Status')}"
+        return f"{self.zaak.description} {self.zaak.identification} - {_('Status')}"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # case is retrieved via CaseAccessMixin
-        if self.case:
-            self.log_case_detail_accessed(self.case)
+        # zaak is retrieved via CaseAccessMixin
+        if self.zaak:
+            self.log_case_detail_accessed(self.zaak)
 
             openzaak_config = OpenZaakConfig.get_solo()
 
             api_group = ZGWApiGroupConfig.objects.get(pk=self.kwargs["api_group_id"])
             zaken_client = api_group.zaken_client
 
-            # fetch data associated with `self.case`
-            documents = self.get_case_document_files(self.case, api_group)
-            statuses = zaken_client.fetch_status_history(self.case.url)
-            self.store_statustype_mapping(self.case.zaaktype.identificatie)
-            self.store_resulttype_mapping(self.case.zaaktype.identificatie)
+            # fetch data associated with `self.zaak`
+            documents = self.get_case_document_files(self.zaak, api_group)
+            statuses = zaken_client.fetch_status_history(self.zaak.url)
+            self.store_statustype_mapping(self.zaak.zaaktype.identificatie)
+            self.store_resulttype_mapping(self.zaak.zaaktype.identificatie)
 
             questions = []
             for service_type in KlantenServiceType:
                 if service := self.get_service(service_type=service_type):
                     try:
                         service_questions = service.list_questions_for_zaak(
-                            self.case, user=self.request.user
+                            self.zaak, user=self.request.user
                         )
                         questions.extend(service_questions)
                     except RequestException:
@@ -247,8 +247,8 @@ class InnerCaseDetailView(
 
             statustypen = []
             catalogi_client = api_group.catalogi_client
-            statustypen = catalogi_client.fetch_status_types_no_cache(
-                self.case.zaaktype.url
+            statustypen = catalogi_client.fetch_statustypes_no_cache(
+                self.zaak.zaaktype.url
             )
 
             # NOTE we cannot always sort on the Status.datum_status_gezet (datetime) because eSuite
@@ -266,7 +266,7 @@ class InnerCaseDetailView(
             else:
                 second_status_preview = None
 
-            # handle/transform data associated with `self.case`
+            # handle/transform data associated with `self.zaak`
             status_types_mapping = self.sync_statuses_with_status_types(
                 statuses, zaken_client, catalogi_client=catalogi_client
             )
@@ -275,28 +275,28 @@ class InnerCaseDetailView(
                 end_statustype=self.handle_end_statustype(statuses, statustypen),
             )
             result_data = self.get_result_data(
-                self.case,
+                self.zaak,
                 self.resulttype_config_mapping,
                 zaken_client,
                 catalogi_client,
             )
 
-            hooks.case_status_seen(self.request.user, self.case)
-            hooks.case_documents_seen(self.request.user, self.case)
+            hooks.case_status_seen(self.request.user, self.zaak)
+            hooks.case_documents_seen(self.request.user, self.zaak)
 
-            context["case"] = {
-                "id": str(self.case.uuid),
-                "identification": self.case.identification,
-                "initiator": self.get_initiator_display(self.case, api_group),
+            context["zaak"] = {
+                "id": str(self.zaak.uuid),
+                "identification": self.zaak.identification,
+                "initiator": self.get_initiator_display(self.zaak, api_group),
                 "result": result_data.get("display", ""),
                 "result_description": result_data.get("description", ""),
-                "start_date": self.case.startdatum,
-                "end_date": getattr(self.case, "einddatum", None),
-                "end_date_planned": getattr(self.case, "einddatum_gepland", None),
+                "start_date": self.zaak.startdatum,
+                "end_date": getattr(self.zaak, "einddatum", None),
+                "end_date_planned": getattr(self.zaak, "einddatum_gepland", None),
                 "end_date_legal": getattr(
-                    self.case, "uiterlijke_einddatum_afdoening", None
+                    self.zaak, "uiterlijke_einddatum_afdoening", None
                 ),
-                "description": self.case.description,
+                "description": self.zaak.description,
                 "statuses": self.get_statuses_data(
                     statuses, self.statustype_config_mapping
                 ),
@@ -313,7 +313,7 @@ class InnerCaseDetailView(
                 ),
                 "questions": questions,
             }
-            context["case"].update(self.get_upload_info_context(self.case))
+            context["zaak"].update(self.get_upload_info_context(self.zaak))
             context["anchors"] = self.get_anchors(statuses, documents)
             context["contact_form"] = self.contact_form_class()
             context["hxpost_contact_action"] = reverse(
@@ -325,22 +325,22 @@ class InnerCaseDetailView(
             context["metrics"] = [
                 {
                     "label": _("Zaaknummer:"),
-                    "value": context["case"].get("identification"),
+                    "value": context["zaak"].get("identification"),
                 },
                 {
                     "label": _("Zaak ingediend op:"),
-                    "value": context["case"].get("start_date"),
+                    "value": context["zaak"].get("start_date"),
                 },
             ]
-            if self.case.einddatum:
+            if self.zaak.einddatum:
                 context["metrics"].append(
                     {
                         "label": _("Besluit genomen op:"),
-                        "value": self.case.einddatum,
+                        "value": self.zaak.einddatum,
                     },
                 )
             else:
-                end_date = context["case"].get("end_date_legal") or context["case"].get(
+                end_date = context["zaak"].get("end_date_legal") or context["zaak"].get(
                     "end_date_planned"
                 )
                 context["metrics"].append(
@@ -352,13 +352,13 @@ class InnerCaseDetailView(
                     }
                 )
         else:
-            context["case"] = None
+            context["zaak"] = None
 
         return context
 
     def get_second_status_preview(self, statustypen: list) -> StatusType | None:
         """
-        Get the relevant status type to display preview of second case status
+        Get the relevant status type to display preview of second zaak status
 
         Note: we cannot assume that the "second" statustype has the `volgnummer` 2;
               hence we get all statustype_numbers, sort in ascending order, and let
@@ -370,13 +370,13 @@ class InnerCaseDetailView(
         if not all(statustype_numbers):
             return
 
-        # only 1 statustype for `self.case`
+        # only 1 statustype for `self.zaak`
         # (this scenario is blocked by openzaak, but not part of the zgw standard)
         if len(statustype_numbers) < 2:
             logger.info(
-                "Case has only one statustype",
-                case_identificatie=self.case.identification,
-                case_uuid=self.case.uuid,
+                "zaak has only one statustype",
+                case_identificatie=self.zaak.identification,
+                case_uuid=self.zaak.uuid,
             )
             return
 
@@ -398,9 +398,9 @@ class InnerCaseDetailView(
     ) -> dict[str, StatusType]:
         """
         Update `statuses` (including the status on this view) and sync with `status_types`:
-            - resolve `self.case.status` (a url/str) to a `Status` object
+            - resolve `self.zaak.status` (a url/str) to a `Status` object
             - resolve `status_type` url for each element in `statuses` to the corresponding
-              `StatusType` object (this also mutates `self.case.status`)
+              `StatusType` object (this also mutates `self.zaak.status`)
             - create mapping `{status_type_url: StatusType}`
 
         We create a preliminary mapping {status_type url: Status}, then loop over this mapping
@@ -408,7 +408,7 @@ class InnerCaseDetailView(
         `status_type` url on each `Status` instance to the corresponding `StatusType` object.
         Note that this works by mutating `statuses`.
 
-        Requires eSuite compatibility check for cases where the current status of our case is
+        Requires eSuite compatibility check for cases where the current status of our zaak is
         not returned as part of the statuslist retrieval.
         """
         status_types_mapping = defaultdict(list)
@@ -416,22 +416,22 @@ class InnerCaseDetailView(
         # preliminary mapping {status_type url: status}
         for status in statuses:
             status_types_mapping[status.statustype].append(status)
-            if self.case.status == status.url:
-                self.case.status = status
+            if self.zaak.status == status.url:
+                self.zaak.status = status
 
         # eSuite compatibility
-        if isinstance(self.case.status, str):
-            # OIP requests cases, user goes to detailview of case
-            # OIP requests the statusses of the case (the status history)
+        if isinstance(self.zaak.status, str):
+            # OIP requests cases, user goes to detailview of zaak
+            # OIP requests the statusses of the zaak (the status history)
             # OIP sees a zaak.status URL which doesn't occur in the status history, however requires this status to determine the statustype and configuration options related to this statustype (Taiga #2037, uploading documents was activated for statustype in the admin but wasn't active for users
             # Workaround: OIP requests the current zaak.status individually and adds the retrieved information to the statustype mapping
 
             logger.info(
-                "Issue #2037 -- Retrieving status individually for case because of eSuite",
-                case_identification=self.case.identification,
+                "Issue #2037 -- Retrieving status individually for zaak because of eSuite",
+                case_identification=self.zaak.identification,
             )
-            self.case.status = zaken_client.fetch_single_status(self.case.status)
-            status_types_mapping[self.case.status.statustype].append(self.case.status)
+            self.zaak.status = zaken_client.fetch_single_status(self.zaak.status)
+            status_types_mapping[self.zaak.status.statustype].append(self.zaak.status)
 
         # final mapping {status_type url: status_type}
         for status_type_url, _statuses in list(status_types_mapping.items()):
@@ -454,7 +454,7 @@ class InnerCaseDetailView(
         `isEindstatus: true`, we assume this is our end status.
         """
         # The end status data is not passed if the end status has been reached,
-        # because in that case the end status data is already included in `statuses`
+        # because in that zaak the end status data is already included in `statuses`
         end_statustype = next((s for s in statustypen if s.is_eindstatus), None)
 
         # eSuite compatibility
@@ -514,14 +514,14 @@ class InnerCaseDetailView(
     @property
     def is_file_upload_enabled_for_case_type(self) -> bool:
         case_upload_enabled = (
-            ZaakTypeInformatieObjectTypeConfig.objects.filter_enabled_for_case_type(
-                self.case.zaaktype
+            ZaakTypeInformatieObjectTypeConfig.objects.filter_enabled_for_zaak_type(
+                self.zaak.zaaktype
             ).exists()
         )
         logger.info(
-            "File upload status for case (enabled/disabled)",
-            case_identificatie=self.case.identification,
-            case_uuid=self.case.uuid,
+            "File upload status for zaak (enabled/disabled)",
+            case_identificatie=self.zaak.identification,
+            case_uuid=self.zaak.uuid,
             case_upload_enabled=case_upload_enabled,
         )
         return case_upload_enabled
@@ -530,25 +530,25 @@ class InnerCaseDetailView(
     def is_file_upload_enabled_for_statustype(self) -> bool:
         try:
             enabled_for_status_type = self.statustype_config_mapping[
-                self.case.status.statustype.url
+                self.zaak.status.statustype.url
             ].document_upload_enabled
         except AttributeError:
             logger.exception(
-                "Could not retrieve status type for case; the status has not been resolved to a ZGW model object",
-                case_identificatie=self.case.identification,
-                case_uuid=self.case.uuid,
+                "Could not retrieve status type for zaak; the status has not been resolved to a ZGW model object",
+                case_identificatie=self.zaak.identification,
+                case_uuid=self.zaak.uuid,
             )
             return True
         except KeyError:
             logger.exception(
                 "Could not retrieve status type config for url",
-                statustype_url=self.case.status.statustype.url,
+                statustype_url=self.zaak.status.statustype.url,
             )
             return True
         logger.info(
-            "File upload for case statustype (enabled/disabled)",
-            case_url=self.case.url,
-            status_type=self.case.status.statustype,
+            "File upload for zaak statustype (enabled/disabled)",
+            case_url=self.zaak.url,
+            status_type=self.zaak.status.statustype,
             file_upload_enabled=enabled_for_status_type,
         )
         return enabled_for_status_type
@@ -560,8 +560,8 @@ class InnerCaseDetailView(
             and self.is_file_upload_enabled_for_statustype
         )
 
-    def get_upload_info_context(self, case: Zaak):
-        if not case:
+    def get_upload_info_context(self, zaak: Zaak):
+        if not zaak:
             return {}
 
         klanten_config = KlantenSysteemConfig.get_solo()
@@ -573,7 +573,7 @@ class InnerCaseDetailView(
         contact_form_enabled = False
 
         try:
-            ztc = ZaakTypeConfig.objects.filter_case_type(case.zaaktype).get()
+            ztc = ZaakTypeConfig.objects.filter_zaak_type(zaak.zaaktype).get()
         except ObjectDoesNotExist:
             pass
         else:
@@ -585,9 +585,9 @@ class InnerCaseDetailView(
 
             try:
                 zt_statustype_config = ztc.zaaktypestatustypeconfig_set.get(
-                    statustype_url=case.status.statustype.url
+                    statustype_url=zaak.status.statustype.url
                 )
-            # case has no status, or statustype config not found
+            # zaak has no status, or statustype config not found
             except (AttributeError, ObjectDoesNotExist):
                 pass
             else:
@@ -604,9 +604,9 @@ class InnerCaseDetailView(
             "case_type_config_description": case_type_config_description,
             "case_type_document_upload_description": case_type_document_upload_description,
             "internal_upload_enabled": self.is_internal_file_upload_enabled
-            and not getattr(self.case, "einddatum", None),
+            and not getattr(self.zaak, "einddatum", None),
             "external_upload_enabled": external_upload_enabled
-            and not getattr(self.case, "einddatum", None),
+            and not getattr(self.zaak, "einddatum", None),
             "external_upload_url": external_upload_url,
             "contact_form_enabled": (
                 contact_form_enabled and klanten_config.contact_registration_enabled
@@ -615,24 +615,24 @@ class InnerCaseDetailView(
 
     @staticmethod
     def get_result_data(
-        case: Zaak,
+        zaak: Zaak,
         result_type_config_mapping: dict,
         zaken_client: ZakenClient,
         catalogi_client: CatalogiClient,
     ) -> dict:
         """
-        Get display and description for the result of `case`
+        Get display and description for the result of `zaak`
 
         Note:
             For the description, we try the `esuite_compat_naam` attribute of the corresponding
-            resultaattype first. This is for E-suite compatibility in case the E-suite returns
+            resultaattype first. This is for E-suite compatibility in zaak the E-suite returns
             a description longer than 20 chars. Alternatively, we get the description from the
             config of the resultaattype.
         """
-        if not case.resultaat:
+        if not zaak.resultaat:
             return {}
 
-        result = zaken_client.fetch_single_result(case.resultaat)
+        result = zaken_client.fetch_single_result(zaak.resultaat)
         result_type = catalogi_client.fetch_single_resultaat_type(result.resultaattype)
 
         display = result.toelichting
@@ -645,7 +645,7 @@ class InnerCaseDetailView(
             "description": description,
         }
 
-    def get_initiator_display(self, case: Zaak, api_group: ZGWApiGroupConfig) -> str:
+    def get_initiator_display(self, zaak: Zaak, api_group: ZGWApiGroupConfig) -> str:
         """
         Fetch zaak roles filtered by the user's betrokkene type.
 
@@ -659,29 +659,29 @@ class InnerCaseDetailView(
 
         if api_group.fetch_rollen_with_betrokkene_type:
             if user.bsn:
-                roles = zaken_client.fetch_case_roles(
-                    case.url,
+                roles = zaken_client.fetch_zaak_roles(
+                    zaak.url,
                     betrokkene_type=RolTypes.natuurlijk_persoon,
                     role_desc_generic=RolOmschrijving.initiator,
                 )
             elif user.kvk:
                 if user.vestiging:
-                    roles = zaken_client.fetch_case_roles(
-                        case.url,
+                    roles = zaken_client.fetch_zaak_roles(
+                        zaak.url,
                         betrokkene_type=RolTypes.vestiging,
                         role_desc_generic=RolOmschrijving.initiator,
                     )
                 else:
-                    roles = zaken_client.fetch_case_roles(
-                        case.url,
+                    roles = zaken_client.fetch_zaak_roles(
+                        zaak.url,
                         betrokkene_type=RolTypes.niet_natuurlijk_persoon,
                         role_desc_generic=RolOmschrijving.initiator,
                     )
             else:
                 roles = []
         else:
-            roles = zaken_client.fetch_case_roles(
-                case.url, role_desc_generic=RolOmschrijving.initiator
+            roles = zaken_client.fetch_zaak_roles(
+                zaak.url, role_desc_generic=RolOmschrijving.initiator
             )
 
         return ", ".join(get_role_name_display(r) for r in roles)
@@ -736,12 +736,12 @@ class InnerCaseDetailView(
 
     @staticmethod
     def get_case_document_files(
-        case: Zaak, api_group: ZGWApiGroupConfig
+        zaak: Zaak, api_group: ZGWApiGroupConfig
     ) -> list[SimpleFile]:
         client = api_group.zaken_client
-        case_info_objects = client.fetch_case_information_objects(case.url)
+        case_info_objects = client.fetch_zaak_information_objects(zaak.url)
 
-        # get the information objects for the case objects
+        # get the information objects for the zaak objects
 
         # TODO we'd like to use parallel() but it is borked in tests
         # with parallel() as executor:
@@ -773,7 +773,7 @@ class InnerCaseDetailView(
                     url=reverse(
                         "cases:document_download",
                         kwargs={
-                            "object_id": case.uuid,
+                            "object_id": zaak.uuid,
                             "info_id": info_obj.uuid,
                             "api_group_id": api_group.id,
                         },
@@ -795,7 +795,7 @@ class InnerCaseDetailView(
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["case"] = self.case
+        kwargs["zaak"] = self.zaak
         return kwargs
 
     def get_anchors(self, statuses, documents):
@@ -812,7 +812,7 @@ class InnerCaseDetailView(
 
 class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
     def get(self, request, *args, **kwargs):
-        if not self.case:
+        if not self.zaak:
             raise Http404
 
         try:
@@ -828,9 +828,9 @@ class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
         if not info_object:
             raise Http404
 
-        # check if this info_object belongs to this case
-        if not api_group.zaken_client.fetch_case_information_objects_for_case_and_info(
-            self.case.url, info_object.url
+        # check if this info_object belongs to this zaak
+        if not api_group.zaken_client.fetch_zaak_information_objects_for_zaak_and_info(
+            self.zaak.url, info_object.url
         ):
             raise PermissionDenied()
 
@@ -848,7 +848,7 @@ class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
         if not content_stream:
             raise Http404
 
-        self.log_case_document_downloaded(self.case, info_object.bestandsnaam)
+        self.log_case_document_downloaded(self.zaak, info_object.bestandsnaam)
 
         headers = {
             "Content-Disposition": f'attachment; filename="{info_object.bestandsnaam}"',
@@ -871,7 +871,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
         form_class = self.get_form_class()
         form = self.get_form(form_class)
 
-        if form.is_valid() and not getattr(self.case, "einddatum", None):
+        if form.is_valid() and not getattr(self.zaak, "einddatum", None):
             return self.handle_document_upload(request, form)
         return self.form_invalid(form)
 
@@ -888,7 +888,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
             reverse(
                 "cases:case_detail",
                 kwargs={
-                    "object_id": str(self.case.uuid),
+                    "object_id": str(self.zaak.uuid),
                     "api_group_id": self.kwargs["api_group_id"],
                 },
             )
@@ -909,7 +909,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
         for file in files:
             title = file.name
             document_type = cleaned_data["type"]
-            source_organization = self.case.bronorganisatie
+            source_organization = self.zaak.bronorganisatie
 
             created_document = api_group.documenten_client.upload_document(
                 request.user,
@@ -922,12 +922,12 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
                 return self.handle_document_error(request, file)
 
             created_relationship = api_group.zaken_client.connect_case_with_document(
-                self.case.url, created_document.get("url")
+                self.zaak.url, created_document.get("url")
             )
             if not created_relationship:
                 return self.handle_document_error(request, file)
 
-            self.log_case_document_uploaded(self.case, file.name)
+            self.log_case_document_uploaded(self.zaak, file.name)
             created_documents.append(created_document)
 
         success_message = (
@@ -950,7 +950,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
             reverse(
                 "cases:case_detail",
                 kwargs={
-                    "object_id": str(self.case.uuid),
+                    "object_id": str(self.zaak.uuid),
                     "api_group_id": self.kwargs["api_group_id"],
                 },
             )
@@ -958,14 +958,14 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["case"] = self.case
+        kwargs["zaak"] = self.zaak
         return kwargs
 
     def get_success_url(self):
         return reverse(
             "cases:case_detail_document_form",
             kwargs={
-                "object_id": str(self.case.uuid),
+                "object_id": str(self.zaak.uuid),
                 "api_group_id": self.kwargs["api_group_id"],
             },
         )
@@ -1001,7 +1001,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
 
             if klant_config.register_contact_email:
                 form.cleaned_data["question"] += (
-                    f"\n\nCase number: {self.case.identificatie}"
+                    f"\n\nCase number: {self.zaak.identificatie}"
                 )
                 email_success = self.register_by_email(
                     form, klant_config.register_contact_email
@@ -1015,8 +1015,8 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
                 # else keep the send_confirmation if email set it
 
             if send_confirmation:
-                subject = _("Case: {case_identification}").format(
-                    case_identification=self.case.identificatie
+                subject = _("zaak: {case_identification}").format(
+                    case_identification=self.zaak.identificatie
                 )
                 send_contact_confirmation_mail(self.request.user.email, subject)
 
@@ -1026,7 +1026,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
                 reverse(
                     "cases:case_detail",
                     kwargs={
-                        "object_id": str(self.case.uuid),
+                        "object_id": str(self.zaak.uuid),
                         "api_group_id": self.kwargs["api_group_id"],
                     },
                 )
@@ -1036,7 +1036,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
 
     def get_success_url(self):
         return reverse(
-            "cases:case_detail_contact_form", kwargs={"object_id": str(self.case.uuid)}
+            "cases:case_detail_contact_form", kwargs={"object_id": str(self.zaak.uuid)}
         )
 
     def set_result_message(self, success: bool):
@@ -1053,8 +1053,8 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
         template = find_template("contactform_registration")
 
         context = {
-            "subject": _("Case: {case_identification}").format(
-                case_identification=self.case.identificatie
+            "subject": _("zaak: {case_identification}").format(
+                case_identification=self.zaak.identificatie
             ),
             "email": self.request.user.email,
             "phonenumber": self.request.user.phonenumber,
@@ -1101,7 +1101,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
         question = service.create_question_for_zaak(
             partij_uuid=partij["uuid"],
             question=question,
-            zaak=self.case,
+            zaak=self.zaak,
         )
 
         return bool(question)
@@ -1111,7 +1111,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
             raise ImproperlyConfigured("Missing eSuite API configuration")
 
         try:
-            ztc = ZaakTypeConfig.objects.filter_case_type(self.case.zaaktype).get()
+            ztc = ZaakTypeConfig.objects.filter_zaak_type(self.zaak.zaaktype).get()
         except ObjectDoesNotExist:
             ztc = None
 
@@ -1157,7 +1157,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
             return False
 
         objectcontactmoment = service.create_objectcontactmoment(
-            contactmoment, self.case
+            contactmoment, self.zaak
         )
         self.log_contactmoment_for_zaak_registered_by_api(
             contactmoment_success=True,
@@ -1165,7 +1165,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
         )
 
         # We'll mark this call as successful if the cotactmoment is created, independent of
-        # whether we've successfully associated the contactmoment with the case, because we
+        # whether we've successfully associated the contactmoment with the zaak, because we
         # still want the notification email to be sent.
         return True
 
@@ -1179,7 +1179,7 @@ class CaseContactFormView(CaseAccessMixin, CaseLogMixin, FormView):
 
 
 class LegacyCaseDetailHandler(View):
-    """Redirect the legacy case detail to the current version with ZGW API group ref."""
+    """Redirect the legacy zaak detail to the current version with ZGW API group ref."""
 
     def get(
         self,
@@ -1202,12 +1202,12 @@ class LegacyCaseDetailHandler(View):
                     request,
                     messages.ERROR,
                     _(
-                        "The link you clicked on has expired. Please find your case in the"
+                        "The link you clicked on has expired. Please find your zaak in the"
                         " list below."
                     ),
                 )
                 logger.warning(
-                    "Could not automatically handle legacy case detail URL due to multiple"
+                    "Could not automatically handle legacy zaak detail URL due to multiple"
                     " ZGWApiGroupConfig objects"
                 )
                 redirect_url = reverse("cases:index")

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -136,7 +136,7 @@ class CMSZakenPluginTest(TestCase):
         self.assertEqual(response.status_code, 400)
 
     @patch(
-        "open_inwoner.cms.plugins.views.CaseListService.get_cases",
+        "open_inwoner.cms.plugins.views.CaseListService.get_zaken",
         return_value=[],
     )
     @patch(
@@ -144,7 +144,7 @@ class CMSZakenPluginTest(TestCase):
         return_value=[],
     )
     def test_htmx_content_endpoint_returns_empty_state(
-        self, mock_formulieren, mock_cases
+        self, mock_formulieren, mock_zaken
     ):
         ServiceFactory(api_root=ZAKEN_ROOT)
         ZGWApiGroupConfigFactory()
@@ -163,23 +163,23 @@ class CMSZakenPluginTest(TestCase):
         # Should have no zaak items
         self.assertNotIn("oip-home-plugin-card", content)
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch(
         "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_htmx_content_endpoint_returns_cases(self, mock_formulieren, mock_cases):
+    def test_htmx_content_endpoint_returns_cases(self, mock_formulieren, mock_zaken):
         api_group = ZGWApiGroupConfigFactory()
 
-        mock_case = MagicMock()
-        mock_case.process_data.return_value = {
+        mock_zaak = MagicMock()
+        mock_zaak.process_data.return_value = {
             "uuid": "test-uuid-123",
             "identification": "ZAAK-001",
             "naam": "Test zaak beschrijving",
             "api_group": api_group,
             "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
-        mock_cases.return_value = [mock_case]
+        mock_zaken.return_value = [mock_zaak]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -205,10 +205,10 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("ZAAK-001", zaak_item.attr("description"))
         self.assertIn("test-uuid-123", zaak_item.attr("detail-url"))
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
-    def test_htmx_content_endpoint_complete_failure(self, mock_formulieren, mock_cases):
-        mock_cases.side_effect = Exception("Cases API error")
+    def test_htmx_content_endpoint_complete_failure(self, mock_formulieren, mock_zaken):
+        mock_zaken.side_effect = Exception("Cases API error")
         mock_formulieren.side_effect = Exception("formulieren API error")
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
@@ -226,24 +226,24 @@ class CMSZakenPluginTest(TestCase):
         # Should have no zaak items
         self.assertNotIn("oip-home-plugin-card", content)
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
-    def test_htmx_content_endpoint_partial_failure(self, mock_formulieren, mock_cases):
+    def test_htmx_content_endpoint_partial_failure(self, mock_formulieren, mock_zaken):
         api_group = ZGWApiGroupConfigFactory()
 
         # formulieren fail
         mock_formulieren.side_effect = Exception("Formulieren API error")
 
         # Cases succeed
-        mock_case = MagicMock()
-        mock_case.process_data.return_value = {
+        mock_zaak = MagicMock()
+        mock_zaak.process_data.return_value = {
             "uuid": "test-uuid-123",
             "identification": "ZAAK-001",
             "naam": "Test zaak",
             "api_group": api_group,
             "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
-        mock_cases.return_value = [mock_case]
+        mock_zaken.return_value = [mock_zaak]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -267,27 +267,27 @@ class CMSZakenPluginTest(TestCase):
         self.assertEqual(len(error_slot), 1)
         self.assertIn("technisch probleem", error_slot.text().lower())
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch(
         "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_num_zaken_parameter_limits_results(self, mock_formulieren, mock_cases):
+    def test_num_zaken_parameter_limits_results(self, mock_formulieren, mock_zaken):
         api_group = ZGWApiGroupConfigFactory()
 
         mock_cases_list = []
         for i in range(10):
-            mock_case = MagicMock()
-            mock_case.process_data.return_value = {
+            mock_zaak = MagicMock()
+            mock_zaak.process_data.return_value = {
                 "uuid": f"test-uuid-{i}",
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
                 "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
-            mock_cases_list.append(mock_case)
+            mock_cases_list.append(mock_zaak)
 
-        mock_cases.return_value = mock_cases_list
+        mock_zaken.return_value = mock_cases_list
 
         plugin_model = cms_tools._init_plugin(
             CMSZakenPlugin, {"title": "Mijn Zaken", "num_zaken": 3}
@@ -315,10 +315,10 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("ZAAK-001", identifications)
         self.assertIn("ZAAK-002", identifications)
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
     def test_num_zaken_parameter_with_mixed_formulieren_and_cases(
-        self, mock_formulieren, mock_cases
+        self, mock_formulieren, mock_zaken
     ):
         api_group = ZGWApiGroupConfigFactory()
 
@@ -336,20 +336,20 @@ class CMSZakenPluginTest(TestCase):
             mock_formulieren_list.append(mock_submission)
 
         # 7 mock cases
-        mock_cases_list = []
+        mock_zaken_list = []
         for i in range(7):
-            mock_case = MagicMock()
-            mock_case.process_data.return_value = {
+            mock_zaak = MagicMock()
+            mock_zaak.process_data.return_value = {
                 "uuid": f"case-uuid-{i}",
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
                 "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
-            mock_cases_list.append(mock_case)
+            mock_zaken_list.append(mock_zaak)
 
         mock_formulieren.return_value = mock_formulieren_list
-        mock_cases.return_value = mock_cases_list
+        mock_zaken.return_value = mock_zaken_list
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -359,7 +359,7 @@ class CMSZakenPluginTest(TestCase):
 
         self.client.force_login(self.user)
 
-        # Test with num_zaken=5 (should get 3 formulieren + 2 cases)
+        # Test with num_zaken=5 (should get 3 formulieren + 2 zaken)
         response = self.client.get(url, {"num_zaken": "5"}, HTTP_HX_REQUEST="true")
 
         pyquery = PyQuery(response.content.decode("utf-8"))
@@ -375,34 +375,34 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("SUBMISSION-000", identifications)
         self.assertIn("SUBMISSION-001", identifications)
         self.assertIn("SUBMISSION-002", identifications)
-        # Then cases
+        # Then zaken
         self.assertIn("ZAAK-000", identifications)
         self.assertIn("ZAAK-001", identifications)
         # But not the 3rd case
         self.assertNotIn("ZAAK-002", identifications)
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch(
         "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_num_zaken_parameter_invalid_input(self, mock_formulieren, mock_cases):
+    def test_num_zaken_parameter_invalid_input(self, mock_formulieren, mock_zaken):
         """Test that invalid values for num_zaken fall back to MAX_CASES_DEFAULT"""
         api_group = ZGWApiGroupConfigFactory()
 
-        mock_cases_list = []
+        mock_zaken_list = []
         for i in range(15):
-            mock_case = MagicMock()
-            mock_case.process_data.return_value = {
+            mock_zaak = MagicMock()
+            mock_zaak.process_data.return_value = {
                 "uuid": f"test-uuid-{i}",
                 "identification": f"ZAAK-{i:03d}",
                 "naam": f"Test zaak {i}",
                 "api_group": api_group,
                 "type_aanvraag": TypeAanvraag.ZAAK.value,
             }
-            mock_cases_list.append(mock_case)
+            mock_zaken_list.append(mock_zaak)
 
-        mock_cases.return_value = mock_cases_list
+        mock_zaken.return_value = mock_zaken_list
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -426,23 +426,23 @@ class CMSZakenPluginTest(TestCase):
                 # Should return MAX_CASES_DEFAULT
                 self.assertEqual(len(zaak_items), MAX_CASES_DEFAULT)
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch(
         "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
-    def test_htmx_content_maps_naam_to_description(self, mock_formulieren, mock_cases):
+    def test_htmx_content_maps_naam_to_description(self, mock_formulieren, mock_zaken):
         api_group = ZGWApiGroupConfigFactory()
 
-        mock_case = MagicMock()
-        mock_case.process_data.return_value = {
+        mock_zaak = MagicMock()
+        mock_zaak.process_data.return_value = {
             "uuid": "test-uuid-123",
             "identification": "ZAAK-001",
             "naam": "Dit is de naam van de zaak",
             "api_group": api_group,
             "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
-        mock_cases.return_value = [mock_case]
+        mock_zaken.return_value = [mock_zaak]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -462,25 +462,25 @@ class CMSZakenPluginTest(TestCase):
         self.assertIn("Zaaknummer:", zaak_item.attr("description"))
         self.assertIn("ZAAK-001", zaak_item.attr("description"))
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch(
         "open_inwoner.cms.plugins.views.CaseListService.get_formulieren",
         return_value=[],
     )
     def test_htmx_content_handles_missing_optional_fields(
-        self, mock_formulieren, mock_cases
+        self, mock_formulieren, mock_zaken
     ):
         api_group = ZGWApiGroupConfigFactory()
 
-        mock_case = MagicMock()
+        mock_zaak = MagicMock()
         # Return minimal data - identification is required for logging
-        mock_case.process_data.return_value = {
+        mock_zaak.process_data.return_value = {
             "uuid": "test-uuid-123",
             "identification": "",  # Required for logging
             "api_group": api_group,
             "type_aanvraag": TypeAanvraag.ZAAK.value,
         }
-        mock_cases.return_value = [mock_case]
+        mock_zaken.return_value = [mock_zaak]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 
@@ -500,10 +500,10 @@ class CMSZakenPluginTest(TestCase):
         self.assertEqual(zaak_item.attr("identificatie"), "")
         self.assertEqual(zaak_item.attr("description"), "")
 
-    @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
+    @patch("open_inwoner.cms.plugins.views.CaseListService.get_zaken")
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_formulieren")
     def test_htmx_content_handles_both_naam_and_description_fields(
-        self, mock_formulieren, mock_cases
+        self, mock_formulieren, mock_zaken
     ):
         """
         Test that both 'naam' field (from formulieren) and 'description' field
@@ -523,8 +523,8 @@ class CMSZakenPluginTest(TestCase):
         }
 
         # Mock regular case with "description"
-        mock_case = MagicMock()
-        mock_case.process_data.return_value = {
+        mock_zaak = MagicMock()
+        mock_zaak.process_data.return_value = {
             "uuid": "case-uuid-1",
             "identification": "ZAAK-001",
             "description": "Regular case met description field",
@@ -533,7 +533,7 @@ class CMSZakenPluginTest(TestCase):
         }
 
         mock_formulieren.return_value = [mock_submission]
-        mock_cases.return_value = [mock_case]
+        mock_zaken.return_value = [mock_zaak]
 
         plugin_model = cms_tools._init_plugin(CMSZakenPlugin, {"title": "Mijn Zaken"})
 

--- a/src/open_inwoner/cms/plugins/views.py
+++ b/src/open_inwoner/cms/plugins/views.py
@@ -81,12 +81,12 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
             formulieren = None
             msg = partial_error_msg
         try:
-            preprocessed_cases: Sequence[UniformCase] | None = case_service.get_cases()
+            preprocessed_zaken: Sequence[UniformCase] | None = case_service.get_zaken()
         except Exception:
             logger.error("Failed to retrieve zaken", user=request.user)
-            preprocessed_cases = None
-            msg = partial_error_msg
-        if formulieren is None and preprocessed_cases is None:
+            preprocessed_zaken = None
+
+        if formulieren is None and preprocessed_zaken is None:
             context = {
                 "show_zaken_plugin": True,
                 "zaken": [],
@@ -100,7 +100,7 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
         zaken_dicts = [
             zaak.process_data()
             for zaak in itertools.islice(
-                itertools.chain(formulieren or [], preprocessed_cases or []),
+                itertools.chain(formulieren or [], preprocessed_zaken or []),
                 num_zaken,
             )
         ]

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -799,7 +799,7 @@ class eSuiteVragenService(KlantenService):
                 klant_backend=KlantenServiceType.ESUITE.value
             )
             proxy = MultiZgwClientProxy([group.zaken_client for group in groups])
-            proxy_response = proxy.fetch_case_by_url_no_cache(zaak_url)
+            proxy_response = proxy.fetch_zaak_by_url_no_cache(zaak_url)
             cases_found = proxy_response.truthy_responses
             if (case_count := len(cases_found)) == 0:
                 logger.error(
@@ -807,16 +807,16 @@ class eSuiteVragenService(KlantenService):
                 )
             else:
                 if case_count > 1:
-                    logger.error("Case found in multiple backends", case_url=zaak_url)
+                    logger.error("Zaak found in multiple backends", zaak_url=zaak_url)
 
                 zaak_with_api_group = next(
                     ZaakWithApiGroup(
-                        zaak=case.result,
+                        zaak=zaak.result,
                         api_group=ZGWApiGroupConfig.objects.resolve_group_from_hints(
-                            client=case.client
+                            client=zaak.client
                         ),
                     )
-                    for case in cases_found
+                    for zaak in cases_found
                 )
 
         return self._build_question_dto(kcm), zaak_with_api_group
@@ -1816,7 +1816,7 @@ class OpenKlant2Service(
             klant_backend=KlantenServiceType.OPENKLANT2.value
         )
         proxy = MultiZgwClientProxy([group.zaken_client for group in groups])
-        proxy_response = proxy.fetch_cases(user_bsn=user.bsn)
+        proxy_response = proxy.fetch_zaken(user_bsn=user.bsn)
 
         if not (truthy_responses := proxy_response.truthy_responses):
             logger.info(

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -74,7 +74,7 @@ class ZakenClient(ZgwAPIClient):
         self.use_openzaak_120_params = use_openzaak_120_params
         self.fetch_rollen_with_betrokkene_type = fetch_rollen_with_betrokkene_type
 
-    def fetch_cases(
+    def fetch_zaken(
         self,
         user_bsn: str | None = None,
         user_kvk: str | None = None,
@@ -90,44 +90,44 @@ class ZakenClient(ZgwAPIClient):
             )
 
         if user_bsn:
-            return self.fetch_cases_by_bsn(
+            return self.fetch_zaken_by_bsn(
                 user_bsn,
                 max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
                 identificatie=identificatie,
             )
 
-        fetch_cases_for_company = functools.partial(
-            self.fetch_cases_for_company,
+        fetch_zaken_for_company = functools.partial(
+            self.fetch_zaken_for_company,
             max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
             zaak_identificatie=identificatie,
         )
         if vestigingsnummer:
-            return fetch_cases_for_company(
+            return fetch_zaken_for_company(
                 vestigingsnummer=vestigingsnummer,
             )
         if user_kvk or user_rsin:
             user_kvk_or_rsin = user_rsin if user_rsin else user_kvk
-            return fetch_cases_for_company(
+            return fetch_zaken_for_company(
                 kvk_or_rsin=user_kvk_or_rsin,
             )
 
         raise ValueError("You must supply either a bsn or kvk/rsin/vestigingsnummer")
 
     @cache_result(
-        "{self.base_url}:cases:{user_bsn}:{max_requests}:{identificatie}",
+        "{self.base_url}:zaken:{user_bsn}:{max_requests}:{identificatie}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_cases_by_bsn(
+    def fetch_zaken_by_bsn(
         self,
         user_bsn: str,
         max_requests: int | None = None,
         identificatie: str | None = None,
     ) -> list[Zaak]:
         """
-        retrieve cases for particular user with allowed confidentiality level
+        retrieve zaken for particular user with allowed confidentiality level
 
         :param:max_requests - used to limit the number of requests to list_zaken resource.
-        :param:identificatie - used to filter the cases by a specific identification
+        :param:identificatie - used to filter the zaken by a specific identification
         """
         config = OpenZaakConfig.get_solo()
 
@@ -165,15 +165,15 @@ class ZakenClient(ZgwAPIClient):
             )
             return []
 
-        cases = factory(Zaak, all_data)
+        zaken = factory(Zaak, all_data)
 
-        return cases
+        return zaken
 
     @cache_result(
-        "{self.base_url}:cases:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}",
+        "{self.base_url}:zaken:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_cases_for_company(
+    def fetch_zaken_for_company(
         self,
         kvk_or_rsin: str | None = None,
         max_requests: int | None = None,
@@ -181,12 +181,12 @@ class ZakenClient(ZgwAPIClient):
         vestigingsnummer: str | None = None,
     ) -> list[Zaak]:
         """
-        retrieve cases for particular company with allowed confidentiality level
+        retrieve zaken for particular company with allowed confidentiality level
 
-        :param kvk_or_rsin: - used to filter the cases by a KVK number or RSIN (configured via OpenZaakConfig)
+        :param kvk_or_rsin: - used to filter the zaken by a KVK number or RSIN (configured via OpenZaakConfig)
         :param max_requests: - used to limit the number of requests to list_zaken resource.
-        :param zaak_identificatie: - used to filter the cases by a unique Zaak identification number
-        :param vestigingsnummer: - used to filter the cases by a vestigingsnummer
+        :param zaak_identificatie: - used to filter the zaken by a unique Zaak identification number
+        :param vestigingsnummer: - used to filter the zaken by a vestigingsnummer
         """
 
         config = OpenZaakConfig.get_solo()
@@ -247,49 +247,49 @@ class ZakenClient(ZgwAPIClient):
             )
             return []
 
-        cases = factory(Zaak, all_data)
+        zaken = factory(Zaak, all_data)
 
-        return cases
+        return zaken
 
     @cache_result(
-        "{self.base_url}:single_case:{case_uuid}",
+        "{self.base_url}:single_zaak:{zaak_uuid}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_single_case(self, case_uuid: str) -> Zaak | None:
+    def fetch_single_zaak(self, zaak_uuid: str) -> Zaak | None:
         try:
-            response = self.get(f"zaken/{case_uuid}", headers=CRS_HEADERS)
+            response = self.get(f"zaken/{zaak_uuid}", headers=CRS_HEADERS)
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception(
-                "Failed to retrieve case",
-                case_uuid=case_uuid,
+                "Failed to retrieve zaak",
+                zaak_uuid=zaak_uuid,
             )
             return
 
-        case = factory(Zaak, data)
+        zaak = factory(Zaak, data)
 
-        return case
+        return zaak
 
-    def fetch_case_by_url_no_cache(self, case_url: str) -> Zaak | None:
+    def fetch_zaak_by_url_no_cache(self, zaak_url: str) -> Zaak | None:
         try:
-            response = self.get(url=case_url, headers=CRS_HEADERS)
+            response = self.get(url=zaak_url, headers=CRS_HEADERS)
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception(
-                "Failed to retrieve case",
-                case_url=case_url,
+                "Failed to retrieve zaak",
+                zaak_url=zaak_url,
             )
             return
 
-        case = factory(Zaak, data)
+        zaak = factory(Zaak, data)
 
-        return case
+        return zaak
 
     @cache_result(
-        "{self.base_url}:single_case_information_object:{url}",
+        "{self.base_url}:single_zaak_information_object:{url}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_single_case_information_object(
+    def fetch_single_zaak_information_object(
         self, url: str
     ) -> ZaakInformatieObject | None:
         try:
@@ -302,38 +302,38 @@ class ZakenClient(ZgwAPIClient):
             )
             return
 
-        case = factory(ZaakInformatieObject, data)
+        zaak_info_object = factory(ZaakInformatieObject, data)
 
-        return case
+        return zaak_info_object
 
-    def fetch_case_information_objects(
-        self, case_url: str
+    def fetch_zaak_information_objects(
+        self, zaak_url: str
     ) -> list[ZaakInformatieObject]:
         try:
             response = self.get(
                 "zaakinformatieobjecten",
-                params={"zaak": case_url},
+                params={"zaak": zaak_url},
             )
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception(
-                "Failed to retrieve informatieobjecten for case",
-                zaak_url=case_url,
+                "Failed to retrieve informatieobjecten for zaak",
+                zaak_url=zaak_url,
             )
             return []
 
-        case_info_objects = factory(ZaakInformatieObject, data)
+        zaak_info_objects = factory(ZaakInformatieObject, data)
 
-        return case_info_objects
+        return zaak_info_objects
 
-    def fetch_status_history_no_cache(self, case_url: str) -> list[Status]:
+    def fetch_status_history_no_cache(self, zaak_url: str) -> list[Status]:
         try:
-            response = self.get("statussen", params={"zaak": case_url})
+            response = self.get("statussen", params={"zaak": zaak_url})
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception(
                 "Failed to retrieve statussen for zaak",
-                zaak_url=case_url,
+                zaak_url=zaak_url,
             )
             return []
 
@@ -343,11 +343,11 @@ class ZakenClient(ZgwAPIClient):
         return statuses
 
     @cache_result(
-        "{self.base_url}:status_history:{case_url}",
+        "{self.base_url}:status_history:{zaak_url}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_status_history(self, case_url: str) -> list[Status]:
-        return self.fetch_status_history_no_cache(case_url)
+    def fetch_status_history(self, zaak_url: str) -> list[Status]:
+        return self.fetch_status_history_no_cache(zaak_url)
 
     @cache_result("{self.base_url}:status:{status_url}", timeout=60 * 60)
     def fetch_single_status(self, status_url: str) -> Status | None:
@@ -366,23 +366,17 @@ class ZakenClient(ZgwAPIClient):
         return status
 
     @cache_result(
-        "{self.base_url}:case_roles:{case_url}:{betrokkene_type}:{role_desc_generic}",
+        "{self.base_url}:zaak_roles:{zaak_url}:{role_desc_generic}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
-    def fetch_case_roles(
+    def fetch_zaak_roles(
         self,
-        case_url: str,
-        *,
-        betrokkene_type: Literal[
-            "natuurlijk_persoon",
-            "niet_natuurlijk_persoon",
-            "vestiging",
-        ]
-        | None = None,
+        zaak_url: str,
         role_desc_generic: str | None = None,
+        betrokkene_type: str | None = None,
     ) -> list[Rol]:
         params = {
-            "zaak": case_url,
+            "zaak": zaak_url,
         }
         if role_desc_generic:
             if role_desc_generic not in RolOmschrijving.values:
@@ -390,11 +384,8 @@ class ZakenClient(ZgwAPIClient):
 
             params["omschrijvingGeneriek"] = role_desc_generic
 
-        if self.fetch_rollen_with_betrokkene_type:
-            if not betrokkene_type:
-                raise ValueError(
-                    "Betrokkene type mandatory if fetch_rollen_with_betrokkene_type set"
-                )
+        # Add betrokkene_type to params if provided
+        if betrokkene_type:
             params["betrokkeneType"] = betrokkene_type
 
         try:
@@ -406,8 +397,8 @@ class ZakenClient(ZgwAPIClient):
             all_data = list(pagination_helper(self, data))
         except (RequestException, ClientError):
             logger.exception(
-                "Failed to retrieve case roles",
-                zaak_url=case_url,
+                "Failed to retrieve zaak roles",
+                zaak_url=zaak_url,
             )
             return []
 
@@ -419,22 +410,20 @@ class ZakenClient(ZgwAPIClient):
 
         return roles
 
-    # implicitly cached because it uses fetch_case_roles()
-    def fetch_roles_for_case_and_bsn(self, case_url: str, bsn: str) -> list[Rol]:
+    # implicitly cached because it uses fetch_zaak_roles()
+    def fetch_roles_for_zaak_and_bsn(self, zaak_url: str, bsn: str) -> list[Rol]:
         """
-        note we do a query on all case_roles and then manually filter our roles from the result,
+        note we do a query on all zaak_roles and then manually filter our roles from the result,
         because e-Suite doesn't support querying on both "zaak" AND "betrokkeneIdentificatie__natuurlijkPersoon__inpBsn"
 
         see Taiga #948
         """
-        case_roles = self.fetch_case_roles(
-            case_url, betrokkene_type="natuurlijk_persoon"
-        )
-        if not case_roles:
+        zaak_roles = self.fetch_zaak_roles(zaak_url)
+        if not zaak_roles:
             return []
 
         bsn_roles = []
-        for role in case_roles:
+        for role in zaak_roles:
             if role.betrokkene_type == RolTypes.natuurlijk_persoon:
                 inp_bsn = role.betrokkene_identificatie.get("inp_bsn")
                 if inp_bsn and inp_bsn == bsn:
@@ -442,24 +431,22 @@ class ZakenClient(ZgwAPIClient):
 
         return bsn_roles
 
-    # implicitly cached because it uses fetch_case_roles()
-    def fetch_roles_for_case_and_kvk_or_rsin(
-        self, case_url: str, kvk_or_rsin: str
+    # implicitly cached because it uses fetch_zaak_roles()
+    def fetch_roles_for_zaak_and_kvk_or_rsin(
+        self, zaak_url: str, kvk_or_rsin: str
     ) -> list[Rol]:
         """
-        note we do a query on all case_roles and then manually filter our roles from the result,
+        note we do a query on all zaak_roles and then manually filter our roles from the result,
         because e-Suite doesn't support querying on both "zaak" AND "betrokkeneIdentificatie__nietNatuurlijkPersoon__inn_nnp_id"
 
         see Taiga #948
         """
-        case_roles = self.fetch_case_roles(
-            case_url, betrokkene_type="niet_natuurlijk_persoon"
-        )
-        if not case_roles:
+        zaak_roles = self.fetch_zaak_roles(zaak_url)
+        if not zaak_roles:
             return []
 
         roles = []
-        for role in case_roles:
+        for role in zaak_roles:
             if role.betrokkene_type == RolTypes.niet_natuurlijk_persoon:
                 nnp_id = role.betrokkene_identificatie.get("inn_nnp_id")
                 if nnp_id and nnp_id == kvk_or_rsin:
@@ -467,22 +454,22 @@ class ZakenClient(ZgwAPIClient):
 
         return roles
 
-    # implicitly cached because it uses fetch_case_roles()
-    def fetch_roles_for_case_and_vestigingsnummer(
-        self, case_url: str, vestigingsnummer: str
+    # implicitly cached because it uses fetch_zaak_roles()
+    def fetch_roles_for_zaak_and_vestigingsnummer(
+        self, zaak_url: str, vestigingsnummer: str
     ) -> list[Rol]:
         """
-        note we do a query on all case_roles and then manually filter our roles from the result,
+        note we do a query on all zaak_roles and then manually filter our roles from the result,
         because e-Suite doesn't support querying on both "zaak" AND "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer"
 
         see Taiga #948
         """
-        case_roles = self.fetch_case_roles(case_url, betrokkene_type="vestiging")
-        if not case_roles:
+        zaak_roles = self.fetch_zaak_roles(zaak_url)
+        if not zaak_roles:
             return []
 
         roles = []
-        for role in case_roles:
+        for role in zaak_roles:
             if role.betrokkene_type == RolTypes.vestiging:
                 identifier = role.betrokkene_identificatie.get("vestigings_nummer")
                 if identifier and identifier == vestigingsnummer:
@@ -491,14 +478,14 @@ class ZakenClient(ZgwAPIClient):
         return roles
 
     # not cached because currently only used in info-object download view
-    def fetch_case_information_objects_for_case_and_info(
-        self, case_url: str, info_object_url: str
+    def fetch_zaak_information_objects_for_zaak_and_info(
+        self, zaak_url: str, info_object_url: str
     ) -> list[ZaakInformatieObject]:
         try:
             response = self.get(
                 "zaakinformatieobjecten",
                 params={
-                    "zaak": case_url,
+                    "zaak": zaak_url,
                     "informatieobject": info_object_url,
                 },
             )
@@ -506,14 +493,14 @@ class ZakenClient(ZgwAPIClient):
         except (RequestException, ClientError) as e:
             logger.exception(
                 "Failed to retrieve informatieobjecten for zaak",
-                zaak_url=case_url,
+                zaak_url=zaak_url,
                 informatieobject_url=info_object_url,
             )
             return []
 
-        case_info_objects = factory(ZaakInformatieObject, data)
+        zaak_info_objects = factory(ZaakInformatieObject, data)
 
-        return case_info_objects
+        return zaak_info_objects
 
     @cache_result(
         "{self.base_url}:single_result:{result_url}",
@@ -535,18 +522,18 @@ class ZakenClient(ZgwAPIClient):
         return result
 
     def connect_case_with_document(
-        self, case_url: str, document_url: str
+        self, zaak_url: str, document_url: str
     ) -> dict | None:
         try:
             response = self.post(
                 "zaakinformatieobjecten",
-                json={"zaak": case_url, "informatieobject": document_url},
+                json={"zaak": zaak_url, "informatieobject": document_url},
             )
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception(
                 "Failed to connect zaak with document",
-                zaak_url=case_url,
+                zaak_url=zaak_url,
                 document_url=document_url,
             )
             return
@@ -557,11 +544,11 @@ class ZakenClient(ZgwAPIClient):
 class CatalogiClient(ZgwAPIClient):
     # not cached because only used by tools,
     # and because caching (stale) listings can break lookups
-    def fetch_status_types_no_cache(self, case_type_url: str) -> list[StatusType]:
+    def fetch_statustypes_no_cache(self, zaaktype_url: str) -> list[StatusType]:
         try:
             response = self.get(
                 "statustypen",
-                params={"zaaktype": case_type_url},
+                params={"zaaktype": zaaktype_url},
             )
             data = get_json_response(response)
             all_data = list(pagination_helper(self, data))
@@ -575,11 +562,11 @@ class CatalogiClient(ZgwAPIClient):
 
     # not cached because only used by tools,
     # and because caching (stale) listings can break lookups
-    def fetch_result_types_no_cache(self, case_type_url: str) -> list[ResultaatType]:
+    def fetch_resultaattypes_no_cache(self, zaaktype_url: str) -> list[ResultaatType]:
         try:
             response = self.get(
                 "resultaattypen",
-                params={"zaaktype": case_type_url},
+                params={"zaaktype": zaaktype_url},
             )
             data = get_json_response(response)
             all_data = list(pagination_helper(self, data))
@@ -645,20 +632,20 @@ class CatalogiClient(ZgwAPIClient):
         return zaak_types
 
     @cache_result(
-        "{self.base_url}:case_type:{case_type_url}",
+        "{self.base_url}:zaaktype:{zaaktype_url}",
         timeout=settings.CACHE_ZGW_CATALOGI_TIMEOUT,
     )
-    def fetch_single_case_type(self, case_type_url: str) -> ZaakType | None:
+    def fetch_single_zaaktype(self, zaaktype_url: str) -> ZaakType | None:
         try:
-            response = self.get(url=case_type_url)
+            response = self.get(url=zaaktype_url)
             data = get_json_response(response)
         except (RequestException, ClientError):
             logger.exception("exception while making request")
             return
 
-        case_type = factory(ZaakType, data)
+        zaaktype = factory(ZaakType, data)
 
-        return case_type
+        return zaaktype
 
     def fetch_catalogs_no_cache(self) -> list[Catalogus]:
         """

--- a/src/open_inwoner/openzaak/managers.py
+++ b/src/open_inwoner/openzaak/managers.py
@@ -20,14 +20,14 @@ class UserCaseNotificationBaseManager(models.Manager):
     def has_received_similar_notes_within(
         self,
         user: User,
-        case_uuid,
+        zaak_uuid,
         delta: timedelta,
         collision_key: str,
         not_record_id: int | None = None,
     ) -> bool:
         qs = self.filter(
             user=user,
-            case_uuid=case_uuid,
+            case_uuid=zaak_uuid,
             created_on__gte=timezone.now() - delta,
             is_sent=True,
             collision_key=collision_key,
@@ -48,7 +48,7 @@ class UserCaseStatusNotificationManager(UserCaseNotificationBaseManager):
     def record_if_unique_notification(
         self,
         user: User,
-        case_uuid: UUID,
+        zaak_uuid: UUID,
         status_uuid: UUID,
         collision_key: str,
     ) -> "UserCaseStatusNotification | None":
@@ -57,7 +57,7 @@ class UserCaseStatusNotificationManager(UserCaseNotificationBaseManager):
         """
         kwargs = {
             "user": user,
-            "case_uuid": case_uuid,
+            "case_uuid": zaak_uuid,
             "status_uuid": status_uuid,
             "collision_key": collision_key,
         }
@@ -68,7 +68,7 @@ class UserCaseInfoObjectNotificationManager(UserCaseNotificationBaseManager):
     def record_if_unique_notification(
         self,
         user: User,
-        case_uuid: UUID,
+        zaak_uuid: UUID,
         zaak_info_object_uuid: UUID,
         collision_key: str,
     ) -> "UserCaseInfoObjectNotification | None":
@@ -77,7 +77,7 @@ class UserCaseInfoObjectNotificationManager(UserCaseNotificationBaseManager):
         """
         kwargs = {
             "user": user,
-            "case_uuid": case_uuid,
+            "case_uuid": zaak_uuid,
             "zaak_info_object_uuid": zaak_info_object_uuid,
             "collision_key": collision_key,
         }
@@ -108,39 +108,39 @@ class ZaakTypeInformatieObjectTypeConfigQueryset(models.QuerySet):
             omschrijving=omschrijving,
         )
 
-    def filter_catalogus(self, case_type: ZaakType):
+    def filter_catalogus(self, zaak_type: ZaakType):
         # support both url and resolved dataclass
         catalogus_url = (
-            case_type.catalogus
-            if isinstance(case_type.catalogus, str)
-            else case_type.catalogus.url
+            zaak_type.catalogus
+            if isinstance(zaak_type.catalogus, str)
+            else zaak_type.catalogus.url
         )
         return self.filter(
             zaaktype_config__catalogus__url=catalogus_url,
         )
 
-    def filter_case_type(self, case_type: ZaakType):
-        return self.filter_catalogus(case_type).filter(
-            zaaktype_uuids__contains=[case_type.uuid],
-            zaaktype_config__identificatie=case_type.identificatie,
+    def filter_zaak_type(self, zaak_type: ZaakType):
+        return self.filter_catalogus(zaak_type).filter(
+            zaaktype_uuids__contains=[zaak_type.uuid],
+            zaaktype_config__identificatie=zaak_type.identificatie,
         )
 
-    def filter_enabled_for_case_type(self, case_type: ZaakType):
+    def filter_enabled_for_zaak_type(self, zaak_type: ZaakType):
         """
         Returns all ZaakTypeInformatieObjectTypeConfig instances which allow
-        documents upload and are based on a specific case and case type.
+        documents upload and are based on a specific zaak and zaak type.
         """
-        if not case_type:
+        if not zaak_type:
             return self.none()
 
-        return self.filter_case_type(case_type).filter(
+        return self.filter_zaak_type(zaak_type).filter(
             document_upload_enabled=True,
         )
 
-    def get_for_case_and_info_type(
-        self, case_type: ZaakType, info_object_type_url: str
+    def get_for_zaak_and_info_type(
+        self, zaak_type: ZaakType, info_object_type_url: str
     ):
-        return self.filter_case_type(case_type).get(
+        return self.filter_zaak_type(zaak_type).get(
             informatieobjecttype_url=info_object_type_url,
         )
 
@@ -153,52 +153,52 @@ class ZaakTypeConfigQueryset(models.QuerySet):
             catalogus__rsin=catalogus_rsin,
         )
 
-    def filter_catalogus(self, case_type: ZaakType):
+    def filter_catalogus(self, zaak_type: ZaakType):
         # support both url and resolved dataclass
         catalogus_url = (
-            case_type.catalogus
-            if isinstance(case_type.catalogus, str)
-            else case_type.catalogus.url
+            zaak_type.catalogus
+            if isinstance(zaak_type.catalogus, str)
+            else zaak_type.catalogus.url
         )
         return self.filter(
             catalogus__url=catalogus_url,
         )
 
-    def filter_case_type(self, case_type: ZaakType):
-        return self.filter_catalogus(case_type).filter(
-            identificatie=case_type.identificatie,
+    def filter_zaak_type(self, zaak_type: ZaakType):
+        return self.filter_catalogus(zaak_type).filter(
+            identificatie=zaak_type.identificatie,
         )
 
-    def filter_from_str(self, catalogus_url: str, case_type_identificatie: str):
+    def filter_from_str(self, catalogus_url: str, zaak_type_identificatie: str):
         return self.filter(
             catalogus__url=catalogus_url,
-            identificatie=case_type_identificatie,
+            identificatie=zaak_type_identificatie,
         )
 
-    def filter_enabled_for_case_type(self, case_type: ZaakType):
+    def filter_enabled_for_zaak_type(self, zaak_type: ZaakType):
         """
         Returns all ZaakTypeConfig instances which allow external documents
-        upload, have a url set and are based on a specific case type identificatie.
+        upload, have a url set and are based on a specific zaak type identificatie.
         """
-        if not case_type:
+        if not zaak_type:
             return self.none()
 
         return (
-            self.filter_case_type(case_type)
+            self.filter_zaak_type(zaak_type)
             .filter(
                 document_upload_enabled=True,
             )
             .exclude(external_document_upload_url="")
         )
 
-    def filter_questions_enabled_for_case_type(self, case_type: ZaakType):
+    def filter_questions_enabled_for_zaak_type(self, zaak_type: ZaakType):
         """
         Returns all ZaakTypeConfig instances which allow questions via OpenKlant API.
         """
-        if not case_type:
+        if not zaak_type:
             return self.none()
 
-        return self.filter_case_type(case_type).filter(questions_enabled=True)
+        return self.filter_zaak_type(zaak_type).filter(questions_enabled=True)
 
 
 class ZaakTypeStatusTypeConfigQuerySet(models.QuerySet):
@@ -220,24 +220,24 @@ class ZaakTypeStatusTypeConfigQuerySet(models.QuerySet):
             omschrijving=omschrijving,
         )
 
-    def find_for(self, case: Zaak, status: Status):
-        return self.find_for_types(case.zaaktype, status.statustype)
+    def find_for(self, zaak: Zaak, status: Status):
+        return self.find_for_types(zaak.zaaktype, status.statustype)
 
-    def find_for_types(self, case_type: ZaakType, status_type: StatusType):
+    def find_for_types(self, zaak_type: ZaakType, status_type: StatusType):
         from .models import ZaakTypeConfig
 
-        ztc = ZaakTypeConfig.objects.filter_case_type(case_type)
+        ztc = ZaakTypeConfig.objects.filter_zaak_type(zaak_type)
         return self.filter(
             zaaktype_config__in=ztc, statustype_url=status_type.url
         ).first()
 
     def find_for_types_from_str(
-        self, catalogus_url: str, case_type_identificatie: str, status_type_url: str
+        self, catalogus_url: str, zaak_type_identificatie: str, status_type_url: str
     ):
         from .models import ZaakTypeConfig
 
         ztc = ZaakTypeConfig.objects.filter_from_str(
-            catalogus_url, case_type_identificatie
+            catalogus_url, zaak_type_identificatie
         )
         return self.filter(
             zaaktype_config__in=ztc, statustype_url=status_type_url

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -58,7 +58,7 @@ def handle_zaken_notification(notification: Notification):
         )
 
     # on the 'zaken' channel the hoofd_object is always the zaak
-    case_url = notification.hoofd_object
+    zaak_url = notification.hoofd_object
 
     # we're only interested in some updates
     resources = ("status", "zaakinformatieobject")
@@ -67,23 +67,23 @@ def handle_zaken_notification(notification: Notification):
     if notification.resource not in resources:
         log_system_action(
             f"ignored {r} notification: resource is not "
-            f"{_wrap_join(resources, 'or')} but '{notification.resource}' for case {case_url}",
+            f"{_wrap_join(resources, 'or')} but '{notification.resource}' for zaak {zaak_url}",
             log_level=logging.INFO,
         )
         return
 
     try:
-        api_group = ZGWApiGroupConfig.objects.resolve_group_from_hints(url=case_url)
+        api_group = ZGWApiGroupConfig.objects.resolve_group_from_hints(url=zaak_url)
     except ZGWApiGroupConfig.DoesNotExist:
-        logger.error("No API group defined for case", case_url=case_url)
+        logger.error("No API group defined for zaak", zaak_url=zaak_url)
         return
 
     zaken_client = api_group.zaken_client
 
     # check if we have users that need to be informed about this case
-    if not (roles := zaken_client.fetch_case_roles(case_url)):
+    if not (roles := zaken_client.fetch_zaak_roles(zaak_url)):
         log_system_action(
-            f"ignored {r} notification: cannot retrieve rollen for case {case_url}",
+            f"ignored {r} notification: cannot retrieve rollen for zaak {zaak_url}",
             # NOTE this used to be logging.ERROR, but as this is also our first call
             # we get a lot of 403 "Niet geautoriseerd voor zaaktype"
             log_level=logging.INFO,
@@ -93,43 +93,43 @@ def handle_zaken_notification(notification: Notification):
     inform_users = _get_initiator_users_from_roles(roles, api_group=api_group)
     if not inform_users:
         log_system_action(
-            f"ignored {r} notification: no users with bsn/nnp_id as (mede)initiators in case {case_url}",
+            f"ignored {r} notification: no users with bsn/nnp_id as (mede)initiators in zaak {zaak_url}",
             log_level=logging.INFO,
         )
         return
 
     # check if this case is visible
-    if not (case := zaken_client.fetch_case_by_url_no_cache(case_url)):
+    if not (zaak := zaken_client.fetch_zaak_by_url_no_cache(zaak_url)):
         log_system_action(
-            f"ignored {r} notification: cannot retrieve case {case_url}",
+            f"ignored {r} notification: cannot retrieve zaak {zaak_url}",
             log_level=logging.ERROR,
         )
         return
 
-    case_type = api_group.catalogi_client.fetch_single_case_type(case.zaaktype)
+    zaaktype = api_group.catalogi_client.fetch_single_zaaktype(zaak.zaaktype)
 
-    if not case_type:
+    if not zaaktype:
         log_system_action(
-            f"ignored {r} notification: cannot retrieve case_type {case.zaaktype} for case {case_url}",
+            f"ignored {r} notification: cannot retrieve zaaktype {zaak.zaaktype} for zaak {zaak_url}",
             log_level=logging.ERROR,
         )
         return
 
-    case.zaaktype = case_type
+    zaak.zaaktype = zaaktype
 
-    if not is_zaak_visible(case):
+    if not is_zaak_visible(zaak):
         log_system_action(
-            f"ignored {r} notification: case not visible after applying website "
-            f"visibility filter for case {case_url}",
+            f"ignored {r} notification: zaak not visible after applying website "
+            f"visibility filter for zaak {zaak_url}",
             log_level=logging.INFO,
         )
         return
 
     if notification.resource == "status":
-        _handle_status_notification(notification, case, inform_users, api_group)
+        _handle_status_notification(notification, zaak, inform_users, api_group)
     elif notification.resource == "zaakinformatieobject":
         _handle_zaakinformatieobject_notification(
-            notification, case, inform_users, api_group
+            notification, zaak, inform_users, api_group
         )
     else:
         raise NotImplementedError("programmer error in earlier resource filter")
@@ -137,7 +137,7 @@ def handle_zaken_notification(notification: Notification):
 
 def send_case_update_email(
     user: User,
-    case: Zaak,
+    zaak: Zaak,
     template_name: str,
     api_group: ZGWApiGroupConfig,
     status: Status | None = None,
@@ -149,7 +149,7 @@ def send_case_update_email(
     case_detail_url = build_absolute_url(
         reverse(
             "cases:case_detail",
-            kwargs={"object_id": str(case.uuid), "api_group_id": api_group.id},
+            kwargs={"object_id": str(zaak.uuid), "api_group_id": api_group.id},
         )
     )
 
@@ -157,10 +157,10 @@ def send_case_update_email(
 
     template = find_template(template_name)
     context = {
-        "identification": case.identification,
-        "case_description": case.omschrijving,
-        "type_description": case.zaaktype.omschrijving,
-        "start_date": case.startdatum,
+        "identification": zaak.identification,
+        "case_description": zaak.omschrijving,
+        "type_description": zaak.zaaktype.omschrijving,
+        "start_date": zaak.startdatum,
         "end_date": date.today() + timedelta(days=config.action_required_deadline_days),
         "case_link": case_detail_url,
     }
@@ -195,7 +195,7 @@ def _wrap_join(iter, glue="") -> str:
 #
 def _handle_zaakinformatieobject_notification(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     inform_users: list[User],
     api_group: ZGWApiGroupConfig,
 ):
@@ -205,11 +205,11 @@ def _handle_zaakinformatieobject_notification(
     # check if this is a zaakinformatieobject we want to inform on
     ziobj_url = notification.resource_url
 
-    ziobj = api_group.zaken_client.fetch_single_case_information_object(ziobj_url)
+    ziobj = api_group.zaken_client.fetch_single_zaak_information_object(ziobj_url)
 
     if not ziobj:
         log_system_action(
-            f"ignored {r} notification: cannot retrieve zaakinformatieobject {ziobj_url} for case {case.url}",
+            f"ignored {r} notification: cannot retrieve zaakinformatieobject {ziobj_url} for zaak {zaak.url}",
             log_level=logging.ERROR,
         )
         return
@@ -220,7 +220,7 @@ def _handle_zaakinformatieobject_notification(
     if not info_object:
         log_system_action(
             f"ignored {r} notification: cannot retrieve informatieobject "
-            f"{ziobj.informatieobject} for case {case.url}",
+            f"{ziobj.informatieobject} for zaak {zaak.url}",
             log_level=logging.ERROR,
         )
         return
@@ -230,19 +230,19 @@ def _handle_zaakinformatieobject_notification(
     if not is_info_object_visible(info_object, oz_config.document_max_confidentiality):
         log_system_action(
             f"ignored {r} notification: informatieobject not visible after "
-            f"applying website visibility filter for case {case.url}",
+            f"applying website visibility filter for zaak {zaak.url}",
             log_level=logging.INFO,
         )
         return
 
     # NOTE for documents we don't check the statustype.informeren
     ztiotc = get_zaak_type_info_object_type_config(
-        case.zaaktype, info_object.informatieobjecttype
+        zaak.zaaktype, info_object.informatieobjecttype
     )
     if not ztiotc:
         log_system_action(
             f"ignored {r} notification: cannot retrieve info_type "
-            f"configuration {info_object.informatieobjecttype} and case {case.url}",
+            f"configuration {info_object.informatieobjecttype} and zaak {zaak.url}",
             log_level=logging.INFO,
         )
         return
@@ -250,44 +250,44 @@ def _handle_zaakinformatieobject_notification(
         log_system_action(
             f"ignored {r} notification: info_type configuration "
             f"'{ztiotc.omschrijving}' {info_object.informatieobjecttype} "
-            f"found but 'document_notification_enabled' is False for case {case.url}",
+            f"found but 'document_notification_enabled' is False for zaak {zaak.url}",
             log_level=logging.INFO,
         )
         return
 
     # reaching here means we're going to inform users
-    _log_helper.log_notification_accepted(notification, inform_users, case.url)
+    _log_helper.log_notification_accepted(notification, inform_users, zaak.url)
     for user in inform_users:
-        _handle_zaakinformatieobject_update(notification, user, case, ziobj, api_group)
+        _handle_zaakinformatieobject_update(notification, user, zaak, ziobj, api_group)
 
 
 def _handle_zaakinformatieobject_update(
     notification: Notification,
     user: User,
-    case: Zaak,
+    zaak: Zaak,
     zaak_info_object: ZaakInformatieObject,
     api_group: ZGWApiGroupConfig,
 ):
     template_name = "case_document_notification"
 
     # hook into userfeed
-    hooks.case_document_added_notification_received(user, case, zaak_info_object)
+    hooks.case_document_added_notification_received(user, zaak, zaak_info_object)
 
     if not user.cases_notifications or not user.get_contact_email():
         _log_helper.log_notification_email_blocked_by_user(
-            notification, user, zaak_info_object.url, case.url
+            notification, user, zaak_info_object.url, zaak.url
         )
         return
 
     note = UserCaseInfoObjectNotification.objects.record_if_unique_notification(
         user,
-        case.uuid,
+        zaak.uuid,
         zaak_info_object.uuid,
         template_name,
     )
     if not note:
         _log_helper.log_notification_email_duplicate(
-            notification, user, zaak_info_object.url, case.url
+            notification, user, zaak_info_object.url, zaak.url
         )
         return
 
@@ -295,15 +295,15 @@ def _handle_zaakinformatieobject_update(
     period = timedelta(seconds=settings.ZGW_LIMIT_NOTIFICATIONS_FREQUENCY)
     if note.has_received_similar_notes_within(period, template_name):
         _log_helper.log_notification_email_rate_limited(
-            notification, user, zaak_info_object.url, case.url
+            notification, user, zaak_info_object.url, zaak.url
         )
         return
 
-    send_case_update_email(user, case, template_name, api_group=api_group)
+    send_case_update_email(user, zaak, template_name, api_group=api_group)
     note.mark_sent()
 
     _log_helper.log_notification_email_sent(
-        notification, user, zaak_info_object.url, case.url
+        notification, user, zaak_info_object.url, zaak.url
     )
 
 
@@ -311,24 +311,24 @@ def _handle_zaakinformatieobject_update(
 # Helper functions for status update notifications
 #
 def _check_status_history(
-    notification: Notification, case: Zaak, client: ZakenClient
+    notification: Notification, zaak: Zaak, client: ZakenClient
 ) -> list[Status] | None:
     """
-    Check if more than one status exists for `case` (else notifications are skipped)
+    Check if more than one status exists for `zaak` (else notifications are skipped)
     """
     resource = notification.resource
-    status_history = client.fetch_status_history_no_cache(case.url)
+    status_history = client.fetch_status_history_no_cache(zaak.url)
 
     if not status_history:
         log_system_action(
-            f"ignored {resource} notification: cannot retrieve status_history for case {case.url}",
+            f"ignored {resource} notification: cannot retrieve status_history for zaak {zaak.url}",
             log_level=logging.ERROR,
         )
         return None
 
     if len(status_history) == 1:
         log_system_action(
-            f"ignored {resource} notification: skip initial status notification for case {case.url}",
+            f"ignored {resource} notification: skip initial status notification for zaak {zaak.url}",
             log_level=logging.INFO,
         )
         return None
@@ -338,7 +338,7 @@ def _check_status_history(
 
 def _check_status(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     status_history: list[Status],
     client: ZakenClient,
 ) -> Status | None:
@@ -359,7 +359,7 @@ def _check_status(
 
     if not status:
         log_system_action(
-            f"ignored {resource} notification: cannot retrieve status {status_url} for case {case.url}",
+            f"ignored {resource} notification: cannot retrieve status {status_url} for zaak {zaak.url}",
             log_level=logging.ERROR,
         )
         return None
@@ -369,7 +369,7 @@ def _check_status(
 
 def _check_status_type(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     status: Status,
     oz_config: OpenZaakConfig,
     catalogi_client: CatalogiClient,
@@ -383,7 +383,7 @@ def _check_status_type(
     if not status_type:
         log_system_action(
             f"ignored {resource} notification: cannot retrieve status_type "
-            f"{status.statustype} for case {case.url}",
+            f"{status.statustype} for zaak {zaak.url}",
             log_level=logging.ERROR,
         )
         return None
@@ -394,7 +394,7 @@ def _check_status_type(
     ):
         log_system_action(
             f"ignored {resource} notification: status_type.informeren is false for "
-            f"status {status.url} and case {case.url}",
+            f"status {status.url} and zaak {zaak.url}",
             log_level=logging.INFO,
         )
         return None
@@ -404,29 +404,29 @@ def _check_status_type(
 
 def _check_zaaktype_config(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     oz_config: OpenZaakConfig,
 ) -> ZaakTypeConfig | None:
     """
     Check if zaaktype_config exists and notifications are enabled
     """
     resource = notification.resource
-    ztc = get_zaak_type_config(case.zaaktype)
+    ztc = get_zaak_type_config(zaak.zaaktype)
 
     if oz_config.skip_notification_statustype_informeren:
         if not ztc:
             log_system_action(
                 f"ignored {resource} notification: 'skip_notification_statustype_informeren' "
-                f"is True but cannot retrieve case_type configuration '{case.zaaktype.identificatie}' "
-                f"for case {case.url}",
+                f"is True but cannot retrieve zaaktype configuration '{zaak.zaaktype.identificatie}' "
+                f"for zaak {zaak.url}",
                 log_level=logging.INFO,
             )
             return None
         elif not ztc.notify_status_changes:
             log_system_action(
-                f"ignored {resource} notification: case_type configuration "
-                f"'{case.zaaktype.identificatie}' found but 'notify_status_changes' is False "
-                f"for case {case.url}",
+                f"ignored {resource} notification: zaaktype configuration "
+                f"'{zaak.zaaktype.identificatie}' found but 'notify_status_changes' is False "
+                f"for zaak {zaak.url}",
                 log_level=logging.INFO,
             )
             return None
@@ -436,14 +436,14 @@ def _check_zaaktype_config(
 
 def _check_statustype_config(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     ztc: ZaakTypeConfig,
 ) -> ZaakTypeStatusTypeConfig | None:
     """
     Check if statustype_config exists and notifications are enabled
     """
     resource = notification.resource
-    statustype_url = case.status.statustype
+    statustype_url = zaak.status.statustype
 
     try:
         statustype_config = ZaakTypeStatusTypeConfig.objects.get(
@@ -461,7 +461,7 @@ def _check_statustype_config(
     if not statustype_config.notify_status_change:
         log_system_action(
             f"ignored {resource} notification: 'notify_status_change' is False for "
-            f"the status type configuration of the status of this case ({case.url})",
+            f"the status type configuration of the status of this zaak ({zaak.url})",
             log_level=logging.INFO,
         )
         return None
@@ -472,7 +472,7 @@ def _check_statustype_config(
 def _check_user_status_notitifactions(
     notification: Notification,
     user: User,
-    case: Zaak,
+    zaak: Zaak,
     status: Status,
     status_type_config: ZaakTypeStatusTypeConfig,
 ) -> bool:
@@ -486,7 +486,7 @@ def _check_user_status_notitifactions(
 
     if not user.cases_notifications or not user.get_contact_email():
         _log_helper.log_notification_email_blocked_by_user(
-            notification, user, status.url, case.url
+            notification, user, status.url, zaak.url
         )
         return False
 
@@ -495,7 +495,7 @@ def _check_user_status_notitifactions(
 
 def _handle_status_notification(
     notification: Notification,
-    case: Zaak,
+    zaak: Zaak,
     inform_users: list[User],
     api_group: ZGWApiGroupConfig,
 ):
@@ -506,52 +506,52 @@ def _handle_status_notification(
     catalogi_client = api_group.catalogi_client
     zaken_client = api_group.zaken_client
 
-    if not (status_history := _check_status_history(notification, case, zaken_client)):
+    if not (status_history := _check_status_history(notification, zaak, zaken_client)):
         return
 
-    if not (status := _check_status(notification, case, status_history, zaken_client)):
+    if not (status := _check_status(notification, zaak, status_history, zaken_client)):
         return
 
     if not (
         status_type := _check_status_type(
-            notification, case, status, oz_config, catalogi_client
+            notification, zaak, status, oz_config, catalogi_client
         )
     ):
         return
 
-    if not (ztc := _check_zaaktype_config(notification, case, oz_config)):
+    if not (ztc := _check_zaaktype_config(notification, zaak, oz_config)):
         return
 
-    status = zaken_client.fetch_single_status(case.status)
+    status = zaken_client.fetch_single_status(zaak.status)
     if not status:
         # TODO: check if should we return or continue if the case has no status
-        logger.error("Unable to fetch status", status_url=case.status)
+        logger.error("Unable to fetch status", status_url=zaak.status)
         return
 
-    case.status = status
-    if not (status_type_config := _check_statustype_config(notification, case, ztc)):
+    zaak.status = status
+    if not (status_type_config := _check_statustype_config(notification, zaak, ztc)):
         return
 
     status.statustype = status_type
 
     for user in inform_users:
         if not _check_user_status_notitifactions(
-            notification, user, case, status, status_type_config
+            notification, user, zaak, status, status_type_config
         ):
             return
 
         # all checks have passed
-        _log_helper.log_notification_accepted(notification, inform_users, case.url)
+        _log_helper.log_notification_accepted(notification, inform_users, zaak.url)
         # TODO: replace with notify_about_status_update(...args, method: Callable)
         _handle_status_update(
-            notification, user, case, status, status_type_config, api_group
+            notification, user, zaak, status, status_type_config, api_group
         )
 
 
 def _handle_status_update(
     notification: Notification,
     user: User,
-    case: Zaak,
+    zaak: Zaak,
     status: Status,
     status_type_config: ZaakTypeStatusTypeConfig,
     api_group: ZGWApiGroupConfig,
@@ -563,18 +563,18 @@ def _handle_status_update(
         template_name = "case_status_notification"
 
     # hook into userfeed
-    hooks.case_status_notification_received(user, case, status)
+    hooks.case_status_notification_received(user, zaak, status)
 
     # email notification
     note = UserCaseStatusNotification.objects.record_if_unique_notification(
         user,
-        case.uuid,
+        zaak.uuid,
         status.uuid,
         template_name,
     )
     if not note:
         _log_helper.log_notification_email_duplicate(
-            notification, user, status.url, case.url
+            notification, user, status.url, zaak.url
         )
         return
 
@@ -582,16 +582,16 @@ def _handle_status_update(
     period = timedelta(seconds=settings.ZGW_LIMIT_NOTIFICATIONS_FREQUENCY)
     if note.has_received_similar_notes_within(period, template_name):
         _log_helper.log_notification_email_rate_limited(
-            notification, user, status.url, case.url
+            notification, user, status.url, zaak.url
         )
         return
 
     send_case_update_email(
-        user, case, template_name, api_group=api_group, status=status
+        user, zaak, template_name, api_group=api_group, status=status
     )
     note.mark_sent()
 
-    _log_helper.log_notification_email_sent(notification, user, status.url, case.url)
+    _log_helper.log_notification_email_sent(notification, user, status.url, zaak.url)
 
 
 # - - - - -

--- a/src/open_inwoner/openzaak/tests/factories.py
+++ b/src/open_inwoner/openzaak/tests/factories.py
@@ -170,7 +170,6 @@ class UserCaseStatusNotificationFactory(factory.django.DjangoModelFactory):
 
 class UserCaseInfoObjectNotificationFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
-    case_uuid = factory.Faker("uuid4")
     zaak_info_object_uuid = factory.Faker("uuid4")
 
     class Meta:

--- a/src/open_inwoner/openzaak/tests/test_api_models.py
+++ b/src/open_inwoner/openzaak/tests/test_api_models.py
@@ -37,50 +37,50 @@ class ZaakAPIModelTest(TestCase):
         }
 
     def test_status_text(self):
-        case = factory(Zaak, data=self.zaak_data)
+        zaak = factory(Zaak, data=self.zaak_data)
 
-        data = case.process_data()
+        data = zaak.process_data()
         self.assertEqual(data["current_status"], "statustekst")
 
-        case.status["statustype"]["statustekst"] = ""
-        data = case.process_data()
+        zaak.status["statustype"]["statustekst"] = ""
+        data = zaak.process_data()
         self.assertEqual(data["current_status"], "omschrijving")
 
     def test_result_text(self):
-        case = factory(Zaak, data=self.zaak_data)
+        zaak = factory(Zaak, data=self.zaak_data)
 
-        data = case.process_data()
+        data = zaak.process_data()
         self.assertEqual(data["result"], "resultaat naam")
 
-        resultaattype = case.resultaat["resultaattype"]
+        resultaattype = zaak.resultaat["resultaattype"]
 
         resultaattype["naam"] = ""
-        data = case.process_data()
+        data = zaak.process_data()
         self.assertEqual(data["result"], "resultaat omschrijving")
 
         resultaattype["omschrijving"] = ""
-        data = case.process_data()
+        data = zaak.process_data()
         self.assertEqual(data["result"], "resultaat omschrijving_generiek")
 
         resultaattype["omschrijving_generiek"] = ""
-        data = case.process_data()
+        data = zaak.process_data()
         self.assertEqual(data["result"], "resultaattypeomschrijving")
 
     def test_status_text_no_end_date(self):
         zaak_data_no_end_date = self.zaak_data
         zaak_data_no_end_date["einddatum"] = None
-        case = factory(Zaak, data=zaak_data_no_end_date)
+        zaak = factory(Zaak, data=zaak_data_no_end_date)
 
-        data = case.process_data()
+        data = zaak.process_data()
 
         self.assertEqual(data["result"], "")
 
     def test_status_text_default(self):
-        case = factory(Zaak, data=self.zaak_data)
-        case.status["statustype"]["statustekst"] = ""
-        case.status["statustype"]["omschrijving"] = ""
+        zaak = factory(Zaak, data=self.zaak_data)
+        zaak.status["statustype"]["statustekst"] = ""
+        zaak.status["statustype"]["omschrijving"] = ""
 
-        data = case.process_data()
+        data = zaak.process_data()
 
         self.assertEqual(data["current_status"], _("No data available"))
 
@@ -107,9 +107,9 @@ class ZaakAPIModelTest(TestCase):
         self.zaak_data["zaaktype"] = zaaktype
         self.zaak_data["omschrijving"] = "Vergunning voor Joeri"
 
-        case = factory(Zaak, data=self.zaak_data)
+        zaak = factory(Zaak, data=self.zaak_data)
 
-        self.assertEqual(case.description, "Vergunning")
+        self.assertEqual(zaak.description, "Vergunning")
 
         zaak_config = OpenZaakConfig.get_solo()
 
@@ -126,4 +126,4 @@ class ZaakAPIModelTest(TestCase):
                 zaak_config.derive_zaak_titel_from = config_setting
                 zaak_config.save()
 
-                self.assertEqual(case.description, expected_value)
+                self.assertEqual(zaak.description, expected_value)

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -198,7 +198,12 @@ class TestCaseDetailView(
             beginGeldigheid="2020-09-25",
             versiedatum="2020-09-25",
         )
+        # Reuse the ztc_service to avoid creating duplicate services in subtests
+        catalogus_config = CatalogusConfigFactory.create(
+            service=self.api_group.ztc_service
+        )
         self.zaaktype_config = ZaakTypeConfigFactory.create(
+            catalogus=catalogus_config,
             identificatie=self.zaaktype["identificatie"],
         )
         self.status_type_new = generate_oas_component_cached(
@@ -1118,7 +1123,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        case = response.context.get("case")
+        case = response.context.get("zaak")
 
         self.assertEqual(
             case,
@@ -1326,7 +1331,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        case = response.context.get("case")
+        case = response.context.get("zaak")
         self.assertEqual(
             case,
             {
@@ -1419,7 +1424,7 @@ class TestCaseDetailView(
         request = RequestFactory().get("/")
         detail_view = InnerCaseDetailView()
         detail_view.setup(request)
-        detail_view.case = factory(Zaak, self.zaak)
+        detail_view.zaak = factory(Zaak, self.zaak)
 
         st1 = StatusType(
             url="http://statustype_2.com",
@@ -1505,7 +1510,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        case = response.context.get("case")
+        case = response.context.get("zaak")
         first_status = case["statuses"][0]
 
         self.assertEqual(first_status["status_indicator_text"], "foo")
@@ -1606,7 +1611,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        documents = response.context.get("case")["documents"]
+        documents = response.context.get("zaak")["documents"]
         self.assertEqual(len(documents), 3)
 
         # order should be reverse of list order from response
@@ -1667,7 +1672,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        documents = response.context.get("case")["documents"]
+        documents = response.context.get("zaak")["documents"]
 
         # order of #1 and #2 should be reversed
         self.assertEqual(documents[0].name, self.informatie_object_2["titel"])
@@ -1680,7 +1685,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        self.assertEqual(response.context.get("case")["new_docs"], True)
+        self.assertEqual(response.context.get("zaak")["new_docs"], True)
 
     def test_page_displays_expected_data(self, m):
         self._setUpMocks(m)
@@ -1802,7 +1807,7 @@ class TestCaseDetailView(
         self._setUpMocks(m)
 
         response = self.app.get(self.case_detail_url, user=self.user)
-        documents = response.context.get("case", {}).get("documents")
+        documents = response.context.get("zaak", {}).get("documents")
         self.assertEqual(len(documents), 2)
         self.assertEqual(
             documents,
@@ -2053,7 +2058,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        self.assertIsNone(response.context.get("case"))
+        self.assertIsNone(response.context.get("zaak"))
         self.assertContains(response, _("There is no available data at the moment."))
 
     def test_no_data_is_retrieved_when_http_500(self, m):
@@ -2061,7 +2066,7 @@ class TestCaseDetailView(
 
         response = self.app.get(self.case_detail_url, user=self.user)
 
-        self.assertIsNone(response.context.get("case"))
+        self.assertIsNone(response.context.get("zaak"))
         self.assertContains(response, _("There is no available data at the moment."))
 
     def test_no_access_when_case_is_confidential(self, m):
@@ -3093,7 +3098,7 @@ class TestCaseDetailView(
         self.zaak_config.save()
 
         response = self.app.get(self.case_detail_url, user=self.user)
-        case = response.context.get("case")
+        case = response.context.get("zaak")
 
         self.assertEqual(case["statuses"][0]["label"], "Registered")
         self.assertEqual(case["statuses"][1]["label"], "Modified")

--- a/src/open_inwoner/openzaak/tests/test_case_detail_redirects.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail_redirects.py
@@ -1,6 +1,7 @@
 from django.contrib.messages import get_messages
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
 
@@ -44,8 +45,10 @@ class LegacyCaseDetailUrlRedirectTest(TestCase):
         self.assertEqual(
             messages,
             [
-                "De link die u gebruikte, is verlopen. Uw zaak is via onderstaand "
-                "overzicht te vinden."
+                _(
+                    "The link you clicked on has expired. Please find your zaak in the"
+                    " list below."
+                )
             ],
         )
 

--- a/src/open_inwoner/openzaak/tests/test_case_request.py
+++ b/src/open_inwoner/openzaak/tests/test_case_request.py
@@ -36,7 +36,7 @@ class TestFetchSpecificCase(ClearCachesMixin, TestCase):
     def test_case_is_retrieved(self, m):
         m.get(self.zaak["url"], json=self.zaak)
 
-        case = self.zaken_client.fetch_single_case(
+        case = self.zaken_client.fetch_single_zaak(
             "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"
         )
 
@@ -48,7 +48,7 @@ class TestFetchSpecificCase(ClearCachesMixin, TestCase):
     def test_no_case_is_retrieved_when_http_404(self, m):
         m.get(self.zaak["url"], status_code=404)
 
-        case = self.zaken_client.fetch_single_case(
+        case = self.zaken_client.fetch_single_zaak(
             "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"
         )
 
@@ -60,7 +60,7 @@ class TestFetchSpecificCase(ClearCachesMixin, TestCase):
             status_code=500,
         )
 
-        case = self.zaken_client.fetch_single_case(
+        case = self.zaken_client.fetch_single_zaak(
             "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"
         )
 

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -113,7 +113,7 @@ class CaseListAccessTests(AssertRedirectsMixin, ClearCachesMixin, TransactionWeb
         )
         self.app.get(self.outer_url, user=user, status=403)
 
-    def test_anonymous_user_has_no_access_to_cases_page(self):
+    def test_anonymous_user_has_no_access_to_zaken_page(self):
         user = AnonymousUser()
 
         response = self.app.get(self.outer_url, user=user)
@@ -130,7 +130,7 @@ class CaseListAccessTests(AssertRedirectsMixin, ClearCachesMixin, TransactionWeb
         self.app.get(self.inner_url, user=user, status=400)
 
     @requests_mock.Mocker()
-    def test_no_cases_are_retrieved_when_http_404(self, m):
+    def test_no_zaken_are_retrieved_when_http_404(self, m):
         user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="john@smith.nl"
         )
@@ -143,10 +143,10 @@ class CaseListAccessTests(AssertRedirectsMixin, ClearCachesMixin, TransactionWeb
             self.inner_url, user=user, headers={"HX-Request": "true"}
         )
 
-        self.assertListEqual(response.context.get("cases"), [])
+        self.assertListEqual(response.context.get("zaken"), [])
 
     @requests_mock.Mocker()
-    def test_no_cases_are_retrieved_when_http_500(self, m):
+    def test_no_zaken_are_retrieved_when_http_500(self, m):
         user = UserFactory(
             login_type=LoginTypeChoices.digid, bsn="900222086", email="john@smith.nl"
         )
@@ -159,7 +159,7 @@ class CaseListAccessTests(AssertRedirectsMixin, ClearCachesMixin, TransactionWeb
             self.inner_url, user=user, headers={"HX-Request": "true"}
         )
 
-        self.assertListEqual(response.context.get("cases"), [])
+        self.assertListEqual(response.context.get("zaken"), [])
 
 
 class CaseListMocks:
@@ -541,7 +541,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 )
             )
 
-    def test_list_cases(self, m):
+    def test_list_zaken(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -562,9 +562,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.client.force_login(user=self.user)
         response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        expected_cases = []
+        expected_zaken = []
         for i, mock in enumerate(self.mocks):
-            expected_cases.extend(
+            expected_zaken.extend(
                 [
                     {
                         "uuid": mock.zaak2["uuid"],
@@ -631,10 +631,10 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 ]
             )
 
-        cases = response.context["cases"]
+        zaken = response.context["zaken"]
 
-        self.assertListEqual(response.context["cases"], expected_cases)
-        # don't show internal cases
+        self.assertListEqual(response.context["zaken"], expected_zaken)
+        # don't show internal zaken
         for mock in self.mocks:
             self.assertNotContains(response, mock.zaak_intern["omschrijving"])
             self.assertNotContains(response, text=mock.zaak_intern["identificatie"])
@@ -659,7 +659,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 },
             )
 
-        # case filter form is disabled by default
+        # zaak filter form is disabled by default
         self.assertFalse(response.context.get("filter_form_enabled"))
 
         # check status/result label
@@ -671,24 +671,24 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.assertEqual(len(status_labels), 4)
         self.assertEqual(len(result_labels), 4)
 
-    def test_digid_user_and_eidas_bsn_user_receive_same_cases(self, m):
+    def test_digid_user_and_eidas_bsn_user_receive_same_zaken(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
-        # Get cases for DigiD user
+        # Get zaken for DigiD user
         self.client.force_login(user=self.user)
         digid_response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
-        digid_cases = digid_response.context["cases"]
+        digid_zaken = digid_response.context["zaken"]
 
-        # Get cases for eIDAS BSN user (same BSN)
+        # Get zaken for eIDAS BSN user (same BSN)
         self.client.force_login(user=self.eidas_bsn_user)
         eidas_response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
-        eidas_cases = eidas_response.context["cases"]
+        eidas_zaken = eidas_response.context["zaken"]
 
         self.assertEqual(
-            digid_cases,
-            eidas_cases,
-            msg="DigiD and EIDAS BSN users should receive exactly the same cases",
+            digid_zaken,
+            eidas_zaken,
+            msg="DigiD and EIDAS BSN users should receive exactly the same zaken",
         )
 
     def test_filter_widget_is_controlled_by_zaken_filter_enabled(self, m):
@@ -718,7 +718,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         parts = [urlencode({"status": status.value}) for status in statuses]
         return "&".join(parts)
 
-    def test_filter_cases_simple(self, m):
+    def test_filter_zaken_simple(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -730,14 +730,14 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
         response = self.client.get(inner_url, HTTP_HX_REQUEST="true")
 
-        # check cases
-        cases = response.context["cases"]
+        # check zaken
+        zaken = response.context["zaken"]
 
-        self.assertEqual(len(cases), 4)
-        for case in cases:
-            self.assertIsNone(case["end_date"])
+        self.assertEqual(len(zaken), 4)
+        for zaak in zaken:
+            self.assertIsNone(zaak["end_date"])
 
-    def test_filter_cases_multiple(self, m):
+    def test_filter_zaken_multiple(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -752,14 +752,14 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
         response = self.client.get(inner_url, HTTP_HX_REQUEST="true")
 
-        # check cases
-        cases = response.context["cases"]
+        # check zaak
+        zaken = response.context["zaken"]
 
-        self.assertEqual(len(cases), 4)
-        for case in cases:
-            self.assertIsNotNone(case["end_date"])
+        self.assertEqual(len(zaken), 4)
+        for zaak in zaken:
+            self.assertIsNotNone(zaak["end_date"])
 
-    def test_list_cases_for_eherkenning_user(self, m):
+    def test_list_zaken_for_eherkenning_user(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -778,9 +778,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 self.client.force_login(user=self.eherkenning_user)
                 response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-                expected_cases = []
+                expected_zaken = []
                 for i, mock in enumerate(self.mocks):
-                    expected_cases.extend(
+                    expected_zaken.extend(
                         [
                             {
                                 "uuid": mock.zaak_eherkenning2["uuid"],
@@ -823,10 +823,10 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                         ]
                     )
 
-                self.assertListEqual(response.context["cases"], expected_cases)
+                self.assertListEqual(response.context["zaken"], expected_zaken)
 
                 for mock in self.mocks:
-                    # don't show internal cases
+                    # don't show internal zaken
                     self.assertNotContains(response, mock.zaak_intern["omschrijving"])
                     self.assertNotContains(response, mock.zaak_intern["identificatie"])
 
@@ -938,7 +938,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
                     self.assertEqual(used_urls, expected_urls)
 
-    def test_list_cases_for_kvk_user_with_vestigingsnummer(self, m):
+    def test_list_zaken_for_kvk_user_with_vestigingsnummer(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -947,7 +947,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         m.reset_mock()
 
         response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
-        expected_cases = [
+        expected_zaken = [
             {
                 "uuid": mock.zaak_eherkenning1["uuid"],
                 "start_date": datetime.date.fromisoformat(
@@ -966,11 +966,11 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
             for i, mock in enumerate(self.mocks)
         ]
         self.assertListEqual(
-            response.context["cases"],
-            expected_cases,
+            response.context["zaken"],
+            expected_zaken,
         )
         for mock in self.mocks:
-            # don't show internal cases
+            # don't show internal zaken
             self.assertNotContains(response, mock.zaak_intern["omschrijving"])
             self.assertNotContains(response, mock.zaak_intern["identificatie"])
 
@@ -995,7 +995,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 },
             )
 
-    def test_list_cases_for_rsin_user_with_vestigingsnummer(self, m):
+    def test_list_zaken_for_rsin_user_with_vestigingsnummer(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -1005,7 +1005,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
         response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        expected_cases = [
+        expected_zaken = [
             {
                 "uuid": mock.zaak_eherkenning1["uuid"],
                 "start_date": datetime.date.fromisoformat(
@@ -1024,11 +1024,11 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
             for i, mock in enumerate(self.mocks)
         ]
         self.assertListEqual(
-            response.context["cases"],
-            expected_cases,
+            response.context["zaken"],
+            expected_zaken,
         )
         for mock in self.mocks:
-            # don't show internal cases
+            # don't show internal zaken
             self.assertNotContains(response, mock.zaak_intern["omschrijving"])
             self.assertNotContains(response, mock.zaak_intern["identificatie"])
 
@@ -1053,7 +1053,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 },
             )
 
-    def test_list_cases_for_eherkenning_user_missing_rsin(self, m):
+    def test_list_zaken_for_eherkenning_user_missing_rsin(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -1069,9 +1069,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.client.force_login(user=self.eherkenning_user)
         response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        self.assertListEqual(response.context["cases"], [])
+        self.assertListEqual(response.context["zaken"], [])
         for mock in self.mocks:
-            # don't show internal cases
+            # don't show internal zaken
             self.assertNotContains(response, mock.zaak_intern["omschrijving"])
             self.assertNotContains(response, mock.zaak_intern["identificatie"])
 
@@ -1084,7 +1084,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
             ]
             self.assertEqual(len(list_zaken_req), 0)
 
-    def test_list_cases_for_initiator_only(self, m):
+    def test_list_zaken_for_initiator_only(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -1108,9 +1108,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.client.force_login(user=self.user)
         response = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        expected_cases = []
+        expected_zaken = []
         for i, mock in enumerate(self.mocks):
-            expected_cases.extend(
+            expected_zaken.extend(
                 [
                     {
                         "uuid": mock.zaak1["uuid"],
@@ -1130,7 +1130,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 ]
             )
 
-        self.assertListEqual(response.context["cases"], expected_cases)
+        self.assertListEqual(response.context["zaken"], expected_zaken)
 
         # check zaken request query parameters
         for zaken_root in ("zaken.nl", "andere-zaken.nl"):
@@ -1167,9 +1167,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
             for mock in self.mocks:
                 for e_suite_case in (
-                    case
-                    for case in response.context["cases"]
-                    if case["uuid"] == mock.zaak2["uuid"]
+                    zaak
+                    for zaak in response.context["zaken"]
+                    if zaak["uuid"] == mock.zaak2["uuid"]
                 ):
                     self.assertEqual(e_suite_case["identification"], "6639-2022")
 
@@ -1181,9 +1181,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
 
             for mock in self.mocks:
                 for e_suite_case in (
-                    case
-                    for case in response.context["cases"]
-                    if case["uuid"] == mock.zaak2["uuid"]
+                    zaak
+                    for zaak in response.context["zaken"]
+                    if zaak["uuid"] == mock.zaak2["uuid"]
                 ):
                     self.assertEqual(
                         e_suite_case["identification"], "0014ESUITE66392022"
@@ -1203,37 +1203,37 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 actual = Zaak._reformat_esuite_zaak_identificatie(value)
                 self.assertEqual(actual, expected)
 
-    def test_list_cases_logs_displayed_case_ids(self, m):
+    def test_list_zaken_logs_displayed_case_ids(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
         self.client.force_login(user=self.user)
         self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        # check access logs for displayed cases
+        # check access logs for displayed zaken
         logs = list(TimelineLog.objects.all())
 
-        case_log = [
+        zaak_log = [
             l
             for l in logs
             for mock in self.mocks
             if mock.zaak1["identificatie"] in l.extra_data["message"]
         ]
-        self.assertEqual(len(case_log), 2)
-        self.assertTrue(all(l.user == self.user for l in case_log))
-        self.assertTrue(all(l.content_object == self.user for l in case_log))
+        self.assertEqual(len(zaak_log), 2)
+        self.assertTrue(all(l.user == self.user for l in zaak_log))
+        self.assertTrue(all(l.content_object == self.user for l in zaak_log))
 
-        case_log = [
+        zaak_log = [
             l
             for l in logs
             for mock in self.mocks
             if mock.zaak2["identificatie"] in l.extra_data["message"]
         ]
-        self.assertEqual(len(case_log), 2)
-        self.assertTrue(all(l.user == self.user for l in case_log))
-        self.assertTrue(all(l.content_object == self.user for l in case_log))
+        self.assertEqual(len(zaak_log), 2)
+        self.assertTrue(all(l.user == self.user for l in zaak_log))
+        self.assertTrue(all(l.content_object == self.user for l in zaak_log))
 
-        # no logs for internal, hence non-displayed cases
+        # no logs for internal, hence non-displayed zaken
         for log in logs:
             for mock in self.mocks:
                 self.assertNotIn(
@@ -1241,9 +1241,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 )
 
     @patch.object(InnerCaseListView, "paginate_by", 4)
-    def test_list_cases_paginated(self, m):
+    def test_list_zaken_paginated(self, m):
         """
-        show only cases from the first backend and url to the next page
+        show only zaken from the first backend and url to the next page
         """
         for mock in self.mocks:
             mock._setUpMocks(m)
@@ -1252,7 +1252,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         self.client.force_login(user=self.user)
         response_1 = self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-        expected_cases = [
+        expected_zaken = [
             [
                 {
                     "uuid": mock.zaak2["uuid"],
@@ -1312,7 +1312,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
             for i, mock in enumerate(self.mocks)
         ]
 
-        self.assertListEqual(response_1.context.get("cases"), expected_cases[0])
+        self.assertListEqual(response_1.context.get("zaken"), expected_zaken[0])
         self.assertNotContains(response_1, self.mocks[0].zaak2["url"])
         self.assertContains(response_1, "?page=2")
 
@@ -1320,12 +1320,12 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
         next_page = f"{self.inner_url}?page=2"
         response_2 = self.client.get(next_page, HTTP_HX_REQUEST="true")
 
-        self.assertListEqual(response_2.context.get("cases"), expected_cases[1])
+        self.assertListEqual(response_2.context.get("zaken"), expected_zaken[1])
         self.assertNotContains(response_2, self.mocks[1].zaak2["url"])
         self.assertContains(response_2, "?page=1")
 
     @patch.object(InnerCaseListView, "paginate_by", 4)
-    def test_list_cases_paginated_logs_displayed_case_ids(self, m):
+    def test_list_zaken_paginated_logs_displayed_case_ids(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
 
@@ -1343,7 +1343,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     mock.zaak_result["uuid"],
                 ]
                 self.assertListEqual(
-                    [c["uuid"] for c in response.context.get("cases")], expected_uuids
+                    [c["uuid"] for c in response.context.get("zaken")], expected_uuids
                 )
 
                 expected_identifications = [
@@ -1403,32 +1403,32 @@ class FormulierTest(TransactionWebTest):
             self.inner_url, user=digid_user, headers={"HX-Request": "true"}
         )
 
-        cases = response.context["cases"]
+        zaken = response.context["zaken"]
 
-        self.assertEqual(len(cases), 3)
+        self.assertEqual(len(zaken), 3)
 
-        # submission cases are sorted in reverse by `last modified`
-        self.assertEqual(cases[0]["url"], data_alt.submission_3["url"])
-        self.assertEqual(cases[0]["uuid"], data_alt.submission_3["uuid"])
-        self.assertEqual(cases[0]["naam"], data_alt.submission_3["naam"])
-        self.assertEqual(cases[0]["vervolg_link"], data_alt.submission_3["vervolgLink"])
+        # submission zaken are sorted in reverse by `last modified`
+        self.assertEqual(zaken[0]["url"], data_alt.submission_3["url"])
+        self.assertEqual(zaken[0]["uuid"], data_alt.submission_3["uuid"])
+        self.assertEqual(zaken[0]["naam"], data_alt.submission_3["naam"])
+        self.assertEqual(zaken[0]["vervolg_link"], data_alt.submission_3["vervolgLink"])
         self.assertEqual(
-            cases[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            zaken[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data_alt.submission_3["datumLaatsteWijziging"],
         )
         # Verify case_type is "Formulier"
-        self.assertEqual(cases[0]["type_aanvraag"], "Formulier")
+        self.assertEqual(zaken[0]["type_aanvraag"], "Formulier")
 
-        self.assertEqual(cases[1]["url"], data.submission_2["url"])
-        self.assertEqual(cases[1]["uuid"], data.submission_2["uuid"])
-        self.assertEqual(cases[1]["naam"], data.submission_2["naam"])
-        self.assertEqual(cases[1]["vervolg_link"], data.submission_2["vervolgLink"])
+        self.assertEqual(zaken[1]["url"], data.submission_2["url"])
+        self.assertEqual(zaken[1]["uuid"], data.submission_2["uuid"])
+        self.assertEqual(zaken[1]["naam"], data.submission_2["naam"])
+        self.assertEqual(zaken[1]["vervolg_link"], data.submission_2["vervolgLink"])
         self.assertEqual(
-            cases[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            zaken[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data.submission_2["datumLaatsteWijziging"],
         )
         # Verify case_type
-        self.assertEqual(cases[1]["type_aanvraag"], "Formulier")
+        self.assertEqual(zaken[1]["type_aanvraag"], "Formulier")
 
         # Verify the HTML contains the formulier-specific text
         self.assertIn("Formulier afronden", response.text)
@@ -1451,25 +1451,25 @@ class FormulierTest(TransactionWebTest):
             self.inner_url, user=user, headers={"HX-Request": "true"}
         )
 
-        cases = response.context["cases"]
+        zaken = response.context["zaken"]
 
-        self.assertEqual(len(cases), 3)
+        self.assertEqual(len(zaken), 3)
 
-        # submission cases are sorted in reverse by `last modified`
-        self.assertEqual(cases[0]["url"], data_alt.submission_3["url"])
-        self.assertEqual(cases[0]["uuid"], data_alt.submission_3["uuid"])
-        self.assertEqual(cases[0]["naam"], data_alt.submission_3["naam"])
-        self.assertEqual(cases[0]["vervolg_link"], data_alt.submission_3["vervolgLink"])
+        # submission zaken are sorted in reverse by `last modified`
+        self.assertEqual(zaken[0]["url"], data_alt.submission_3["url"])
+        self.assertEqual(zaken[0]["uuid"], data_alt.submission_3["uuid"])
+        self.assertEqual(zaken[0]["naam"], data_alt.submission_3["naam"])
+        self.assertEqual(zaken[0]["vervolg_link"], data_alt.submission_3["vervolgLink"])
         self.assertEqual(
-            cases[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            zaken[0]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data_alt.submission_3["datumLaatsteWijziging"],
         )
 
-        self.assertEqual(cases[1]["url"], data.submission_2["url"])
-        self.assertEqual(cases[1]["uuid"], data.submission_2["uuid"])
-        self.assertEqual(cases[1]["naam"], data.submission_2["naam"])
-        self.assertEqual(cases[1]["vervolg_link"], data.submission_2["vervolgLink"])
+        self.assertEqual(zaken[1]["url"], data.submission_2["url"])
+        self.assertEqual(zaken[1]["uuid"], data.submission_2["uuid"])
+        self.assertEqual(zaken[1]["naam"], data.submission_2["naam"])
+        self.assertEqual(zaken[1]["vervolg_link"], data.submission_2["vervolgLink"])
         self.assertEqual(
-            cases[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            zaken[1]["datum_laatste_wijziging"].strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             data.submission_2["datumLaatsteWijziging"],
         )

--- a/src/open_inwoner/openzaak/tests/test_clients.py
+++ b/src/open_inwoner/openzaak/tests/test_clients.py
@@ -230,7 +230,7 @@ class ZGWApiGroupConfigFilterTests(TestCase):
             )
 
     @requests_mock.Mocker()
-    def test_fetch_case_roles_with_betrokkene_type_filter(self, m):
+    def test_fetch_zaak_roles_with_betrokkene_type_filter(self, m):
         api_group = self.api_groups[0]
         api_group.fetch_rollen_with_betrokkene_type = True
         api_group.save()
@@ -302,7 +302,7 @@ class ZGWApiGroupConfigFilterTests(TestCase):
                 # Track the number of requests before this iteration
                 request_count_before = len(m.request_history)
 
-                roles = zaken_client.fetch_case_roles(
+                roles = zaken_client.fetch_zaak_roles(
                     case_url, betrokkene_type=betrokkene_type.value
                 )
 
@@ -317,30 +317,6 @@ class ZGWApiGroupConfigFilterTests(TestCase):
                 # Check the most recent request
                 request = m.request_history[-1]
                 self.assertIn(f"betrokkeneType={betrokkene_type.value}", request.url)
-
-    @requests_mock.Mocker()
-    def test_fetch_case_roles_raises_if_betrokkene_filter_set_but_param_missing(
-        self, m
-    ):
-        api_group = self.api_groups[0]
-        api_group.fetch_rollen_with_betrokkene_type = True
-        api_group.save()
-
-        zaken_client = build_zgw_client_from_service(
-            api_group.zrc_service,
-            use_openzaak_120_params=False,
-            fetch_rollen_with_betrokkene_type=api_group.fetch_rollen_with_betrokkene_type,
-        )
-
-        case_url = f"{ZAKEN_ROOT}zaken/12345678-1234-1234-1234-123456789012"
-
-        with self.assertRaises(ValueError) as cm:
-            zaken_client.fetch_case_roles(case_url)
-
-        self.assertEqual(
-            str(cm.exception),
-            "Betrokkene type mandatory if fetch_rollen_with_betrokkene_type set",
-        )
 
 
 @requests_mock.Mocker()

--- a/src/open_inwoner/openzaak/tests/test_models.py
+++ b/src/open_inwoner/openzaak/tests/test_models.py
@@ -70,7 +70,7 @@ class ZaakTypeConfigModelTestCase(TestCase):
             catalogus=catalog,
             identificatie="AAAA",
         )
-        case_type = factory(
+        zaaktype = factory(
             ZaakType,
             generate_oas_component(
                 "ztc",
@@ -82,7 +82,7 @@ class ZaakTypeConfigModelTestCase(TestCase):
             ),
         )
 
-        actual = list(ZaakTypeConfig.objects.filter_case_type(case_type))
+        actual = list(ZaakTypeConfig.objects.filter_zaak_type(zaaktype))
         self.assertEqual(actual, [zaak_type_config])
 
 
@@ -200,7 +200,7 @@ class ZaakTypeInformatieObjectTypeConfigFactoryModelTestCase(TestCase):
             informatieobjecttype_url="https://example.com/v1/infoobject/bbb",
             zaaktype_uuids=["aaaaaaaa-aaaa-bbbb-aaaa-aaaaaaaaaaaa"],
         )
-        case_type = factory(
+        zaaktype = factory(
             ZaakType,
             generate_oas_component(
                 "ztc",
@@ -213,7 +213,7 @@ class ZaakTypeInformatieObjectTypeConfigFactoryModelTestCase(TestCase):
         )
 
         actual = list(
-            ZaakTypeInformatieObjectTypeConfig.objects.filter_case_type(case_type)
+            ZaakTypeInformatieObjectTypeConfig.objects.filter_zaak_type(zaaktype)
         )
         self.assertEqual(actual, [a1])
 
@@ -221,25 +221,25 @@ class ZaakTypeInformatieObjectTypeConfigFactoryModelTestCase(TestCase):
 class UserCaseStatusNotificationTests(TestCase):
     def test_status_has_received_similar_notes_within(self):
         user = UserFactory()
-        case_uuid = uuid4()
+        zaak_uuid = uuid4()
         other_case_uuid = uuid4()
 
         with freeze_time("2023-01-01 01:00:00"):
             # create unrelated sent note for different case
             UserCaseStatusNotificationFactory(
-                user=user, case_uuid=other_case_uuid, is_sent=True
+                user=user, status_uuid=other_case_uuid, is_sent=True
             )
             # create a related note we didn't send
             UserCaseStatusNotificationFactory(
                 user=user,
-                case_uuid=case_uuid,
+                case_uuid=zaak_uuid,
                 is_sent=False,
                 collision_key="case_status_notification",
             )
             # create our note
             note = UserCaseStatusNotificationFactory(
                 user=user,
-                case_uuid=case_uuid,
+                case_uuid=zaak_uuid,
                 is_sent=True,
                 collision_key="case_status_notification",
             )
@@ -253,7 +253,7 @@ class UserCaseStatusNotificationTests(TestCase):
         # advance half hour
         with freeze_time("2023-01-01 01:30:00"):
             note = UserCaseStatusNotificationFactory(
-                user=user, case_uuid=case_uuid, is_sent=True
+                user=user, case_uuid=zaak_uuid, is_sent=True
             )
             # nothing is past 10 minutes
             self.assertFalse(
@@ -270,7 +270,7 @@ class UserCaseStatusNotificationTests(TestCase):
 
     def test_case_info_has_received_similar_notes_within(self):
         user = UserFactory()
-        case_uuid = uuid4()
+        zaak_uuid = uuid4()
         other_case_uuid = uuid4()
 
         with freeze_time("2023-01-01 01:00:00"):
@@ -284,14 +284,14 @@ class UserCaseStatusNotificationTests(TestCase):
             # create a related note we didn't send
             UserCaseInfoObjectNotificationFactory(
                 user=user,
-                case_uuid=case_uuid,
+                case_uuid=zaak_uuid,
                 is_sent=False,
                 collision_key="case_document_notification",
             )
             # create our note
             note = UserCaseInfoObjectNotificationFactory(
                 user=user,
-                case_uuid=case_uuid,
+                case_uuid=zaak_uuid,
                 is_sent=True,
                 collision_key="case_document_notification",
             )
@@ -306,7 +306,7 @@ class UserCaseStatusNotificationTests(TestCase):
         with freeze_time("2023-01-01 01:30:00"):
             note = UserCaseInfoObjectNotificationFactory(
                 user=user,
-                case_uuid=case_uuid,
+                case_uuid=zaak_uuid,
                 is_sent=True,
                 collision_key="case_document_notification",
             )

--- a/src/open_inwoner/openzaak/tests/test_notification_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_utils.py
@@ -36,29 +36,29 @@ class NotificationHandlerUtilsTestCase(TestCase):
 
         user = data.user_initiator
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         status = factory(Status, data.status_final)
         status.statustype = factory(StatusType, data.status_type_final)
 
-        case.status = status
+        zaak.status = status
 
-        case_url = reverse(
+        zaak_url = reverse(
             "cases:case_detail",
-            kwargs={"object_id": str(case.uuid), "api_group_id": self.api_group.id},
+            kwargs={"object_id": str(zaak.uuid), "api_group_id": self.api_group.id},
         )
 
         # mock `_format_zaak_identificatie`, but then continue with result of actual call
         # (test redirect for invalid BSN that passes pattern validation)
-        ret_val = case._format_zaak_identificatie()
+        ret_val = zaak._format_zaak_identificatie()
         with mock.patch.object(
             Zaak, "_format_zaak_identificatie"
         ) as format_identificatie:
             format_identificatie.return_value = ret_val
             send_case_update_email(
                 user,
-                case,
+                zaak,
                 "case_status_notification",
                 status=status,
                 api_group=self.api_group,
@@ -72,10 +72,10 @@ class NotificationHandlerUtilsTestCase(TestCase):
         self.assertIn(config.name, email.subject)
 
         body_html = email.alternatives[0][0]
-        self.assertIn(case.identificatie, body_html)
-        self.assertIn(case.zaaktype.omschrijving, body_html)
+        self.assertIn(zaak.identificatie, body_html)
+        self.assertIn(zaak.zaaktype.omschrijving, body_html)
         self.assertIn(status.statustype.statustekst, body_html)
-        self.assertIn(case_url, body_html)
+        self.assertIn(zaak_url, body_html)
         self.assertIn(config.name, body_html)
 
     def test_send_case_update_email__no_status(self):
@@ -84,16 +84,16 @@ class NotificationHandlerUtilsTestCase(TestCase):
 
         user = data.user_initiator
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
-        case_url = reverse(
+        zaak_url = reverse(
             "cases:case_detail",
-            kwargs={"object_id": str(case.uuid), "api_group_id": self.api_group.id},
+            kwargs={"object_id": str(zaak.uuid), "api_group_id": self.api_group.id},
         )
 
         send_case_update_email(
-            user, case, "case_document_notification", api_group=self.api_group
+            user, zaak, "case_document_notification", api_group=self.api_group
         )
 
         self.assertEqual(len(mail.outbox), 1)
@@ -102,9 +102,9 @@ class NotificationHandlerUtilsTestCase(TestCase):
         self.assertIn(config.name, email.subject)
 
         body_html = email.alternatives[0][0]
-        self.assertIn(case.identificatie, body_html)
-        self.assertIn(case.zaaktype.omschrijving, body_html)
-        self.assertIn(case_url, body_html)
+        self.assertIn(zaak.identificatie, body_html)
+        self.assertIn(zaak.zaaktype.omschrijving, body_html)
+        self.assertIn(zaak_url, body_html)
         self.assertIn(config.name, body_html)
 
     # TODO we're missing a similar test for get_nnp_initiator_nnp_id_from_roles()

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
@@ -166,7 +166,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored not_status notification: resource is not 'status' or 'zaakinformatieobject' but 'not_status' for case https://",
+            "ignored not_status notification: resource is not 'status' or 'zaakinformatieobject' but 'not_status' for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -179,7 +179,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: cannot retrieve rollen for case https://",
+            "ignored zaakinformatieobject notification: cannot retrieve rollen for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -195,7 +195,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: no users with bsn/nnp_id as (mede)initiators in case https://",
+            "ignored zaakinformatieobject notification: no users with bsn/nnp_id as (mede)initiators in zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -208,7 +208,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: cannot retrieve case https://",
+            "ignored zaakinformatieobject notification: cannot retrieve zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -221,7 +221,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: cannot retrieve case_type https://",
+            "ignored zaakinformatieobject notification: cannot retrieve zaaktype https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -237,7 +237,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: case not visible after applying website visibility filter for case https://",
+            "ignored zaakinformatieobject notification: zaak not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -253,7 +253,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: case not visible after applying website visibility filter for case https://",
+            "ignored zaakinformatieobject notification: zaak not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -271,7 +271,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored zaakinformatieobject notification: cannot retrieve zaakinformatieobject {data.zaak_informatie_object['url']} for case https://",
+            f"ignored zaakinformatieobject notification: cannot retrieve zaakinformatieobject {data.zaak_informatie_object['url']} for zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -284,7 +284,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored zaakinformatieobject notification: cannot retrieve informatieobject {data.informatie_object['url']} for case https://",
+            f"ignored zaakinformatieobject notification: cannot retrieve informatieobject {data.informatie_object['url']} for zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -302,7 +302,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: informatieobject not visible after applying website visibility filter for case https://",
+            "ignored zaakinformatieobject notification: informatieobject not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -318,7 +318,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored zaakinformatieobject notification: informatieobject not visible after applying website visibility filter for case https://",
+            "ignored zaakinformatieobject notification: informatieobject not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -332,7 +332,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored zaakinformatieobject notification: cannot retrieve info_type configuration {data.informatie_object['informatieobjecttype']} and case https://",
+            f"ignored zaakinformatieobject notification: cannot retrieve info_type configuration {data.informatie_object['informatieobjecttype']} and zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -353,7 +353,7 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored zaakinformatieobject notification: info_type configuration 'important document' {data.informatie_object['informatieobjecttype']} found but 'document_notification_enabled' is False for case https://",
+            f"ignored zaakinformatieobject notification: info_type configuration 'important document' {data.informatie_object['informatieobjecttype']} found but 'document_notification_enabled' is False for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -384,14 +384,14 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         user.cases_notifications = False  # opt-out
         user.save()
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
         _handle_zaakinformatieobject_update(
-            data.zio_notification, user, case, zio, api_group=data.api_group
+            data.zio_notification, user, zaak, zio, api_group=data.api_group
         )
 
         # not called because disabled notifications
@@ -419,14 +419,14 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         user.email = "user@example.org"
         user.save()
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
         _handle_zaakinformatieobject_update(
-            data.zio_notification, user, case, zio, api_group=data.api_group
+            data.zio_notification, user, zaak, zio, api_group=data.api_group
         )
 
         # not called because bad email
@@ -452,21 +452,21 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         data = MockAPIData()
         user = data.user_initiator
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         zio = factory(ZaakInformatieObject, data.zaak_informatie_object)
         zio.informatieobject = factory(InformatieObject, data.informatie_object)
 
         # first call
         _handle_zaakinformatieobject_update(
-            data.zio_notification, user, case, zio, api_group=data.api_group
+            data.zio_notification, user, zaak, zio, api_group=data.api_group
         )
 
         mock_send.assert_called_once()
         mock_send.assert_called_with(
             user,
-            case,
+            zaak,
             template_name="case_document_notification",
             api_group=data.api_group,
         )
@@ -477,7 +477,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         # check call arguments
         args = mock_send.call_args.args
         self.assertEqual(args[0], user)
-        self.assertEqual(args[1].url, case.url)
+        self.assertEqual(args[1].url, zaak.url)
         self.assertEqual(args[2], "case_document_notification")
 
         mock_send.reset_mock()
@@ -492,12 +492,12 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             1, UserCaseInfoObjectNotification.objects.filter(is_sent=True).count()
         )
 
-        # second call with same case/status
+        # second call with same zaak/status
         _handle_zaakinformatieobject_update(
-            data.zio_notification, user, case, zio, api_group=data.api_group
+            data.zio_notification, user, zaak, zio, api_group=data.api_group
         )
 
-        # no duplicate mail for this user/case/status
+        # no duplicate mail for this user/zaak/status
         mock_send.assert_not_called()
 
         self.assertTimelineLog(
@@ -509,7 +509,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         # other user is fine
         other_user = UserFactory.create()
         _handle_zaakinformatieobject_update(
-            data.zio_notification, other_user, case, zio, api_group=data.api_group
+            data.zio_notification, other_user, zaak, zio, api_group=data.api_group
         )
 
         mock_send.assert_called_once()
@@ -530,7 +530,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         )
 
         _handle_zaakinformatieobject_update(
-            data.zio_notification, user, case, zio, api_group=data.api_group
+            data.zio_notification, user, zaak, zio, api_group=data.api_group
         )
 
         # not sent because we already send to this user within the frequency
@@ -551,7 +551,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
                 InformatieObject, copy_with_new_uuid(data.informatie_object)
             )
             _handle_zaakinformatieobject_update(
-                data.zio_notification, user, case, zio, api_group=data.api_group
+                data.zio_notification, user, zaak, zio, api_group=data.api_group
             )
 
             # this one succeeds

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
@@ -192,7 +192,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored not_status notification: resource is not 'status' or 'zaakinformatieobject' but 'not_status' for case https://",
+            "ignored not_status notification: resource is not 'status' or 'zaakinformatieobject' but 'not_status' for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -205,7 +205,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: cannot retrieve rollen for case https://",
+            "ignored status notification: cannot retrieve rollen for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -221,7 +221,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: no users with bsn/nnp_id as (mede)initiators in case https://",
+            "ignored status notification: no users with bsn/nnp_id as (mede)initiators in zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -234,7 +234,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: cannot retrieve case https://",
+            "ignored status notification: cannot retrieve zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -247,7 +247,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: cannot retrieve case_type https://",
+            "ignored status notification: cannot retrieve zaaktype https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -263,7 +263,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: case not visible after applying website visibility filter for case https://",
+            "ignored status notification: zaak not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -279,7 +279,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: case not visible after applying website visibility filter for case https://",
+            "ignored status notification: zaak not visible after applying website visibility filter for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -296,7 +296,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: cannot retrieve status_history for case https://",
+            "ignored status notification: cannot retrieve status_history for zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -312,7 +312,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            "ignored status notification: skip initial status notification for case https://",
+            "ignored status notification: skip initial status notification for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -325,7 +325,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: cannot retrieve status_type {data.status_type_final['url']} for case https://",
+            f"ignored status notification: cannot retrieve status_type {data.status_type_final['url']} for zaak https://",
             lookup=Lookups.startswith,
             level=logging.ERROR,
         )
@@ -341,7 +341,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: status_type.informeren is false for status {data.status_final['url']} and case https://",
+            f"ignored status notification: status_type.informeren is false for status {data.status_final['url']} and zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -360,7 +360,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve case_type configuration '{data.zaak_type['identificatie']}' for case https://",
+            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve zaaktype configuration '{data.zaak_type['identificatie']}' for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -379,7 +379,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve case_type configuration '{data.zaak_type['identificatie']}' for case https://",
+            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve zaaktype configuration '{data.zaak_type['identificatie']}' for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -482,7 +482,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: case_type configuration '{data.zaak_type['identificatie']}' found but 'notify_status_changes' is False for case https://",
+            f"ignored status notification: zaaktype configuration '{data.zaak_type['identificatie']}' found but 'notify_status_changes' is False for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -507,7 +507,7 @@ class StatusNotificationHandlerTestCase(
 
         mock_handle.assert_not_called()
         self.assertTimelineLog(
-            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve case_type configuration '{data.zaak_type['identificatie']}' for case https://",
+            f"ignored status notification: 'skip_notification_statustype_informeren' is True but cannot retrieve zaaktype configuration '{data.zaak_type['identificatie']}' for zaak https://",
             lookup=Lookups.startswith,
             level=logging.INFO,
         )
@@ -620,8 +620,8 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         data = MockAPIData()
         user = data.user_initiator
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         status_initial = factory(Status, data.status_initial)
         status_initial.statustype = factory(StatusType, data.status_type_initial)
@@ -652,7 +652,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         _handle_status_update(
             data.status_notification,
             user,
-            case,
+            zaak,
             status_initial,
             status_type_config_initial,
             data.api_group,
@@ -661,7 +661,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         mock_send.assert_called_once()
         mock_send.assert_called_with(
             user,
-            case,
+            zaak,
             template_name="case_status_notification",
             api_group=data.api_group,
             status=status_initial,
@@ -675,7 +675,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         kwargs = mock_send.call_args.kwargs
 
         self.assertEqual(args[0], user)
-        self.assertEqual(args[1].url, case.url)
+        self.assertEqual(args[1].url, zaak.url)
         self.assertEqual(args[2], "case_status_notification")
         self.assertEqual(kwargs["status"], status_initial)
 
@@ -690,17 +690,17 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             1, UserCaseStatusNotification.objects.filter(is_sent=True).count()
         )
 
-        # second call with same case/status
+        # second call with same zaak/status
         _handle_status_update(
             data.status_notification,
             user,
-            case,
+            zaak,
             status_initial,
             status_type_config_initial,
             data.api_group,
         )
 
-        # no duplicate mail for this user/case/status
+        # no duplicate mail for this user/zaak/status
         mock_send.assert_not_called()
 
         with self.subTest("mails are throttled based on template_name"):
@@ -708,7 +708,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             _handle_status_update(
                 data.status_notification,
                 user,
-                case,
+                zaak,
                 status_final,
                 status_type_config_final,
                 data.api_group,
@@ -721,7 +721,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             kwargs = mock_send.call_args.kwargs
 
             self.assertEqual(args[0], user)
-            self.assertEqual(args[1].url, case.url)
+            self.assertEqual(args[1].url, zaak.url)
             self.assertEqual(args[2], "case_status_notification_action_required")
             self.assertEqual(kwargs["status"], status_final)
 
@@ -737,7 +737,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         _handle_status_update(
             data.status_notification,
             other_user,
-            case,
+            zaak,
             status_initial,
             status_type_config_initial,
             data.api_group,
@@ -760,7 +760,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         _handle_status_update(
             data.status_notification,
             user,
-            case,
+            zaak,
             status,
             status_type_config_initial,
             data.api_group,
@@ -784,7 +784,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
             _handle_status_update(
                 data.status_notification,
                 user,
-                case,
+                zaak,
                 status,
                 status_type_config_initial,
                 data.api_group,
@@ -801,8 +801,8 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         data = MockAPIData()
         user = data.user_initiator
 
-        case = factory(Zaak, data.zaak)
-        case.zaaktype = factory(ZaakType, data.zaak_type)
+        zaak = factory(Zaak, data.zaak)
+        zaak.zaaktype = factory(ZaakType, data.zaak_type)
 
         status = factory(Status, data.status_final)
         status.statustype = factory(StatusType, data.status_type_final)
@@ -823,7 +823,7 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         _handle_status_update(
             data.status_notification,
             user,
-            case,
+            zaak,
             status,
             status_type_config,
             data.api_group,
@@ -835,6 +835,6 @@ class NotificationHandlerUserMessageTestCase(AssertTimelineLogMixin, TestCase):
         kwargs = mock_send.call_args.kwargs
 
         self.assertEqual(args[0], user)
-        self.assertEqual(args[1].url, case.url)
+        self.assertEqual(args[1].url, zaak.url)
         self.assertEqual(args[2], "case_status_notification_action_required")
         self.assertEqual(kwargs["status"], status)

--- a/src/open_inwoner/openzaak/utils.py
+++ b/src/open_inwoner/openzaak/utils.py
@@ -37,7 +37,7 @@ def is_info_object_visible(
     info_object: InformatieObject, max_confidentiality_level: str
 ) -> bool:
     """
-    Test if a InformatieObject (case info object) should be visible to the user.
+    Test if a InformatieObject (zaak info object) should be visible to the user.
 
     We check on its definitive or archived status, and a maximum confidentiality
     level (compared the ordering from the VertrouwelijkheidsAanduidingen.choices)
@@ -132,16 +132,16 @@ def get_role_name_display(rol: Rol) -> str:
         return display
 
 
-def get_zaak_type_config(case_type: ZaakType) -> ZaakTypeConfig | None:
+def get_zaak_type_config(zaak_type: ZaakType) -> ZaakTypeConfig | None:
     try:
-        return ZaakTypeConfig.objects.filter_case_type(case_type).get()
+        return ZaakTypeConfig.objects.filter_zaak_type(zaak_type).get()
     except ZaakTypeConfig.DoesNotExist:
-        logger.info("No ZaakTypeConfig found for zaaktype", zaaktype_url=case_type.url)
+        logger.info("No ZaakTypeConfig found for zaaktype", zaaktype_url=zaak_type.url)
         return None
 
 
 def get_zaak_type_info_object_type_config(
-    case_type: ZaakType,
+    zaak_type: ZaakType,
     info_object_type_url: str,
 ) -> ZaakTypeInformatieObjectTypeConfig | None:
     if not isinstance(info_object_type_url, str):
@@ -150,13 +150,13 @@ def get_zaak_type_info_object_type_config(
         )
 
     try:
-        return ZaakTypeInformatieObjectTypeConfig.objects.get_for_case_and_info_type(
-            case_type, info_object_type_url
+        return ZaakTypeInformatieObjectTypeConfig.objects.get_for_zaak_and_info_type(
+            zaak_type, info_object_type_url
         )
     except ZaakTypeInformatieObjectTypeConfig.DoesNotExist:
         logger.info(
             "No ZaakTypeInformatieObjectTypeConfig found for zaaktype",
-            zaaktype_url=case_type.url,
+            zaaktype_url=zaak_type.url,
         )
         return None
 

--- a/src/open_inwoner/pdc/managers.py
+++ b/src/open_inwoner/pdc/managers.py
@@ -57,7 +57,7 @@ class CategoryPublishedQueryset(LogMixin, MP_NodeQuerySet):
 
         clients = build_zaken_clients()
         proxy_result = MultiZgwClientProxy(clients)
-        proxy_result = proxy_result.fetch_cases(**get_user_fetch_parameters(request))
+        proxy_result = proxy_result.fetch_zaken(**get_user_fetch_parameters(request))
         if proxy_result.has_errors:
             self.log_system_action("unable to retrieve cases", user=request.user)
 

--- a/src/open_inwoner/search/views.py
+++ b/src/open_inwoner/search/views.py
@@ -88,7 +88,7 @@ class SearchView(
             clients = build_zaken_clients()
             if clients:
                 proxy_result = MultiZgwClientProxy(clients)
-                proxy_result = proxy_result.fetch_cases(
+                proxy_result = proxy_result.fetch_zaken(
                     **search_params,
                     identificatie=query,
                 )
@@ -109,7 +109,7 @@ class SearchView(
                             client=case_result.client
                         )
                         for zaak in case_result.result:
-                            zaaktype = api_group.catalogi_client.fetch_single_case_type(
+                            zaaktype = api_group.catalogi_client.fetch_single_zaaktype(
                                 zaak.zaaktype
                             )
                             zaak.zaaktype = zaaktype

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -33,24 +33,24 @@
 
 <div class="card__grid">
 {% render_grid %}
-    {% if not cases %}
+    {% if not zaken %}
         <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen lopende zaken." %}</strong></p>
     {% endif %}
 
-    {% for case in cases %}
+    {% for zaak in zaken %}
         {% render_column start=forloop.counter_0|multiply:4 span=4 %}
             {# "openstaande formulieren/inzendingen" #}
-            {% if case.type_aanvraag == "Formulier" %}
-                <a href="{{ case.vervolg_link }}" class="card card card__description-card card--stretch" target="_blank">
+            {% if zaak.type_aanvraag == "Formulier" %}
+                <a href="{{ zaak.vervolg_link }}" class="card card card__description-card card--stretch" target="_blank">
                     <div class="card__body">
 
-                        <h2 class="card__heading-2">{{ case.naam }}</h2>
+                        <h2 class="card__heading-2">{{ zaak.naam }}</h2>
                         {# Meaningful sequence for accessibility: any text belonging to a heading must be below the heading #}
-                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=case.statustype_config.status_indicator status_indicator_text=case.statustype_config.status_indicator_text %}
+                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=zaak.statustype_config.status_indicator status_indicator_text=zaak.statustype_config.status_indicator_text %}
 
                         {% render_list %}
                             <li class="list-item list-item--compact">
-                                {% with date_modified=case.datum_laatste_wijziging|date %}
+                                {% with date_modified=zaak.datum_laatste_wijziging|date %}
                                     <p class="card__caption card__text--small"><span>{% trans "Laatst gewijzigd op:" %}</span><span class="card__text--dark">{{ date_modified }}</span></p>
                                 {% endwith %}
                             </li>
@@ -64,30 +64,30 @@
                 </a>
             {# other aanvragen #}
             {% else %}
-                <a href="{% url 'cases:case_detail' api_group_id=case.api_group.id  object_id=case.uuid %}" class="card card card__description-card card--stretch">
+                <a href="{% url 'cases:case_detail' api_group_id=zaak.api_group.id  object_id=zaak.uuid %}" class="card card card__description-card card--stretch">
                     <div class="card__body">
 
-                        <h2 class="card__heading-2">{{ case.description }}</h2>
+                        <h2 class="card__heading-2">{{ zaak.description }}</h2>
                         {# Meaningful sequence for accessibility: any text belonging to a heading must be below the heading #}
-                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=case.statustype_config.status_indicator status_indicator_text=case.statustype_config.status_indicator_text %}
+                        {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=zaak.statustype_config.status_indicator status_indicator_text=zaak.statustype_config.status_indicator_text %}
 
                         {% render_list %}
                             <li class="list-item list-item--compact">
-                                <p class="card__caption card__text--small"><span>{% trans "Zaak ingediend op:" %}</span><span class="card__text--dark">{{ case.start_date }}</span></p>
+                                <p class="card__caption card__text--small"><span>{% trans "Zaak ingediend op:" %}</span><span class="card__text--dark">{{ zaak.start_date }}</span></p>
                             </li>
-                            {% if case.result %}
-                                {% list_item case.result caption=_("Resultaat") compact=True strong=False %}
+                            {% if zaak.result %}
+                                {% list_item zaak.result caption=_("Resultaat") compact=True strong=False %}
                             {% else %}
-                                {% list_item case.current_status caption=_("Status") compact=True strong=False %}
+                                {% list_item zaak.current_status caption=_("Status") compact=True strong=False %}
                             {% endif %}
                             <li class="list-item list-item--compact">
                                <p class="utrecht-paragraph list-item__caption">Zaaknummer</p>
-                               <p class="utrecht-paragraph skip-phone-parsing">&zwj;{{ case.identification }}</p>
+                               <p class="utrecht-paragraph skip-phone-parsing">&zwj;{{ zaak.identification }}</p>
                             </li>
                         {% endrender_list %}
 
                         <span class="link link--icon link--bold link--primary">
-                        <span class="link__text">{{ case.statustype_config.case_link_text|default:"Bekijk zaak" }}</span>
+                        <span class="link__text">{{ zaak.statustype_config.case_link_text|default:"Bekijk zaak" }}</span>
                         {% icon icon="arrow_forward" icon_position="after" primary=True outlined=True %}
                     </span>
                     </div>
@@ -99,6 +99,6 @@
 {% endrender_grid %}
 </div>
 
-{% if cases %}
+{% if zaken %}
     {% pagination page_obj=page_obj paginator=paginator request=request hxget=hxget hxtarget='#cases-content' %}
 {% endif %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -8,11 +8,11 @@
 {% get_solo 'openzaak.OpenZaakConfig' as openzaak_config %}
 
 <div class="case__grid">
-{% if case %}
+{% if zaak %}
     {% render_grid %}
         {% render_column span=12 %}
             {# Title/dashboard #}
-            <h1 class="utrecht-heading-1" id="title">{{ case.description }}</h1>
+            <h1 class="utrecht-heading-1" id="title">{{ zaak.description }}</h1>
             {% include "components/Dashboard/Dashboard.html" with metrics=metrics only %}
         {% endrender_column %}
 
@@ -22,7 +22,7 @@
                 {% include 'pages/cases/statuses.html' %}
             </section>
 
-            {% if case.internal_upload_enabled %}
+            {% if zaak.internal_upload_enabled %}
                 <h2 class="utrecht-heading-2" id="documents-upload">{% trans "Documenten" %}</h2>
                 <h3 class="utrecht-heading-3 documents-upload__h3">{% trans "Voeg documenten toe" %}</h3>
 
@@ -31,12 +31,12 @@
                 </div>
 
 
-                {% if case.case_type_document_upload_description.html %}
+                {% if zaak.case_type_document_upload_description.html %}
                 <div class="card card--compact card--info">
                     <div class="card__body document-upload-description">
                         {% icon icon="info" icon_position="after" extra_classes="icon--info" outlined=True %}
 
-                        <div class="document-upload-description__text wysiwyg">{{ case.case_type_document_upload_description.html|safe }}</div>
+                        <div class="document-upload-description__text wysiwyg">{{ zaak.case_type_document_upload_description.html|safe }}</div>
                     </div>
                 </div>
                 {% endif %}
@@ -46,35 +46,35 @@
                     {% include 'pages/cases/document_form.html' %}
                 </section>
 
-            {% elif case.external_upload_enabled %}
+            {% elif zaak.external_upload_enabled %}
                 <h2 class="utrecht-heading-2" id="documents-upload">{% trans "Document toevoegen" %}</h2>
-                {% if case.case_type_config_description %}
-                    <p class="utrecht-paragraph">{{ case.case_type_config_description }}</p>
+                {% if zaak.case_type_config_description %}
+                    <p class="utrecht-paragraph">{{ zaak.case_type_config_description }}</p>
                 {% else %}
                     <p class="utrecht-paragraph">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
                 {% endif %}
                 {% button_row %}
-                    {% button href=case.external_upload_url text=_("Document uploaden") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
+                    {% button href=zaak.external_upload_url text=_("Document uploaden") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
                 {% endbutton_row %}
             {% endif %}
 
             {#  Documents #}
-            {% if case.documents %}
+            {% if zaak.documents %}
                 <section class="case-detail__documents">
                     <div class="heading-2__indicator">
-                        <h2 class="utrecht-heading-2 {% if case.new_docs %}indicator{% endif %}" id="documents">{% trans 'Eerder toegevoegde documenten' %}</h2>
-                        {% if case.new_docs %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
+                        <h2 class="utrecht-heading-2 {% if zaak.new_docs %}indicator{% endif %}" id="documents">{% trans 'Eerder toegevoegde documenten' %}</h2>
+                        {% if zaak.new_docs %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
                     </div>
-                    {% case_document_list case.documents %}
+                    {% case_document_list zaak.documents %}
                 </section>
             {% endif %}
 
             {# Questions/contactmomenten #}
-            {% if case.questions %}
-                {% include "pages/partials/questions.html" with questions=case.questions only %}
-                {% if case.questions|length > 3 %}
+            {% if zaak.questions %}
+                {% include "pages/partials/questions.html" with questions=zaak.questions only %}
+                {% if zaak.questions|length > 3 %}
                     <div class="expand">
-                        <a id="toggle-hide-elements" class="button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ case.questions|length }} aria-expanded=false>
+                        <a id="toggle-hide-elements" class="button button--textless button--icon button--icon-after button--secondary button--transparent" data-label-reveal="{% trans 'Toon alle vragen' %}" data-label-collapse="{% trans 'Toon minder' %}" data-label-num-elems={{ zaak.questions|length }} aria-expanded=false>
                             {% icon extra_classes="expand-icon" icon="expand_more" icon_position="after" icon_outlined=True %}
                         </a>
                     </div>
@@ -82,7 +82,7 @@
             {% endif %}
 
             {#  Contact form #}
-            {% if case.contact_form_enabled %}
+            {% if zaak.contact_form_enabled %}
             <section id="cases-contact-form" class="form_contact">
                 <div id="cases-contact-form-content" class="spaced">
                     {% include 'pages/cases/contact_form.html' %}

--- a/src/open_inwoner/templates/pages/cases/statuses.html
+++ b/src/open_inwoner/templates/pages/cases/statuses.html
@@ -1,15 +1,15 @@
 {% load i18n button_tags icon_tags %}
 
-{% if case.statuses %}
+{% if zaak.statuses %}
 <h2 class="utrecht-heading-2" id="statuses">{% trans 'Status' %}</h2>
 
 <aside class="status-list" aria-label="{% trans "Status lijst" %}">
     <ul class="status-list__list">
-        {% for status in case.statuses %}
+        {% for status in zaak.statuses %}
 
             {% if forloop.last %}
                 {# Current active status class #}
-                <li class="status-list__list-item {% if case.end_statustype_data %}status--current status-list__list-item--{{ status.status_indicator }} status--open{% endif %} {# Final status class #}{% if not case.end_statustype_data %}status--final status-list__list-item--info status--open{% endif %}">
+                <li class="status-list__list-item {% if zaak.end_statustype_data %}status--current status-list__list-item--{{ status.status_indicator }} status--open{% endif %} {# Final status class #}{% if not case.end_statustype_data %}status--final status-list__list-item--info status--open{% endif %}">
                 {% firstof case.id|slugify as id %}
                 {% firstof 'content-'|add:id|add:'-id' as content_id %}
                     {% icon icon="circle" extra_classes="status-step" %}
@@ -17,7 +17,7 @@
                     <div class="status-list__notification status-list__notification--{{ status.status_indicator }}">
                         <h3 class="utrecht-heading-3 utrecht-accordion__header">
                             {# Interactive accordion when case is ongoing, and active status is shown as expanded  #}
-                            {% if case.end_statustype_data %}
+                            {% if zaak.end_statustype_data %}
                                 <button class="button--borderless status-list__button" aria-controls="{{ content_id }}" aria-expanded="true" id="{{ id }}">
                                     <span class="link link--bold">{{ status.label }}</span>
                                     {% icon icon="expand_more" icon_position="after" outlined=True %}
@@ -31,18 +31,18 @@
                             {% endif %}
                         </h3>
 
-                        <div class="status-list__notification-content {% if case.end_statustype_data %}status-content--open{% endif %} {% if not case.end_statustype_data %}status-content--open{% endif %}" id="{{ content_id }}">
+                        <div class="status-list__notification-content {% if zaak.end_statustype_data %}status-content--open{% endif %} {% if not case.end_statustype_data %}status-content--open{% endif %}" id="{{ content_id }}">
                             <p class="utrecht-paragraph status-list__text utrecht-paragraph--oip utrecht-paragraph--oip-compact">
                                 {# Configurable texts #}
-                                {% if case.end_statustype_data %}<span>{{ status.description|default:"" }}</span>{% endif %}
-                                {% if not case.end_statustype_data %}<span class="status--result">{{ case.result_description|default:"" }}</span>{% endif %}
+                                {% if zaak.end_statustype_data %}<span>{{ status.description|default:"" }}</span>{% endif %}
+                                {% if not case.end_statustype_data %}<span class="status--result">{{ zaak.result_description|default:"" }}</span>{% endif %}
                             </p>
                             <p class="utrecht-paragraph status-list__date utrecht-paragraph--oip utrecht-paragraph--oip-compact">{{ status.date|date }}</p>
 			    {% if status.call_to_action_url %}
                                 {% button href=status.call_to_action_url text=status.call_to_action_text title=status.call_to_action_text primary=True icon="arrow_forward" icon_position="after" %}
                             {% else %}
-                                <p class="utrecht-paragraph status-list__upload {% if case.end_statustype_data %}status-list__upload--enabled{% endif %}">
-                                {% if case.internal_upload_enabled or case.external_upload_enabled %}
+                                <p class="utrecht-paragraph status-list__upload {% if zaak.end_statustype_data %}status-list__upload--enabled{% endif %}">
+                                {% if zaak.internal_upload_enabled or case.external_upload_enabled %}
                                     {% button href="#documents-upload" text=_("Scroll omlaag") title=_("Ga direct naar document upload sectie.") primary=True icon="arrow_downward" icon_position="after" %}
                                 {% endif %}
 				</p>
@@ -75,23 +75,23 @@
         {% endfor %}
 
         {# Preview of upcoming second status #}
-        {% if case.second_status_preview %}
+        {% if zaak.second_status_preview %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
                 <span class="sr-only">{% trans "Toekomstige status" %}</span>
                 <div class="status-list__notification status-list__notification">
-                    <div class="status-list__open"><span class="link link-future">{{ case.second_status_preview.omschrijving }}</span></div>
+                    <div class="status-list__open"><span class="link link-future">{{ zaak.second_status_preview.omschrijving }}</span></div>
                 </div>
             </li>
         {% endif %}
 
         {# Future end status #}
-        {% if case.end_statustype_data %}
+        {% if zaak.end_statustype_data %}
             <li class="status--future status-list__list-item status-list__list-item--future">
                 {% icon icon="circle_outlined" outlined=True %}
                 <span class="sr-only">{% trans "Toekomstige voltooide status" %}</span>
                 <div class="status-list__notification status-list__notification--future">
-                    <div class="status-list__open"><span class="link link-future">{{ case.end_statustype_data.label }}</span></div>
+                    <div class="status-list__open"><span class="link link-future">{{ zaak.end_statustype_data.label }}</span></div>
                 </div>
             </li>
         {% endif %}


### PR DESCRIPTION
## Summary

The latest commit of this PR continues the refactoring started in https://github.com/maykinmedia/open-inwoner/pull/2051.

The goal is to replace occurences of and references to `case` with occurences of and references to `zaak` (e.g. `case_uuid` -> `zaak_uuid`, `fetch_cases_for_bsn` -> `fetch_zaken_for_bsn`). This was out of scope for the original PR.


## Issue References

Closes #2080 

## Checklist

- [x] CHANGELOG.rst updated
