### PR TITLE
:sparkles: [#2101] Convert multiple HomePlugin styles to design-tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Nieuwe features
 
 * [:taiga-us:`3607`, :pr:`2075`, :pr:`2079`]: Basisapp ‘Mijn Afval’ geïmplementeerd en
   geïntegreerd met Django CMS.
+* [:gh:`2101`, :oip-nlds:`30`, :oip-nlds:`34`]: Styling van tegels op de Home pagina en van externe-links plugin
+  op de Home pagina overgezet naar design-tokens zodat deze volgens de NLDS principes gebruikt kunnen worden.
 * [:gh:`2098`]: Nieuw accordion web component toegevoegd dat gebruikt wordt in Mijn
   Afval.
 * [:gh:`2096`, :oip-nlds:`32`]: Table component toegevoegd ten behoeve van de ‘Mijn

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@gemeente-denhaag/action": "^4.0.1",
         "@gemeente-denhaag/side-navigation": "^4.0.2",
-        "@open-inwoner/design-tokens": "^0.0.23",
+        "@open-inwoner/design-tokens": "^0.0.25",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "@utrecht/button-css": "^2.3.1",
         "@utrecht/document-css": "^1.5.1",
@@ -1365,7 +1365,9 @@
       "license": "MIT"
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.23",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.25.tgz",
+      "integrity": "sha512-aQCO0pB1UlzQ8/3zTmbzKYPSKFUgdnaYlTKxI+Oq8tuMjhgfuqVIMifFHi5AGQ5mYgKsptOVlDNOzt2BdcfdKQ==",
       "license": "EUPL-1.2"
     },
     "node_modules/@parcel/watcher": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@gemeente-denhaag/action": "^4.0.1",
     "@gemeente-denhaag/side-navigation": "^4.0.2",
-    "@open-inwoner/design-tokens": "^0.0.23",
+    "@open-inwoner/design-tokens": "^0.0.25",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "@utrecht/button-css": "^2.3.1",
     "@utrecht/document-css": "^1.5.1",

--- a/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.scss
+++ b/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.scss
@@ -1,31 +1,5 @@
 .oip-home-plugin-card {
-  // TODO: to give these back to NLDS community, add these variables to OIP design-tokens package
-  --oip-plugin-card-background-color: #fff;
-  --oip-plugin-card-color: #333;
-  --oip-plugin-card-max-inline-size: 100%;
-  --oip-plugin-card-inline-size: 100%;
-  --oip-plugin-card-border-width: 1px;
-  --oip-plugin-card-border-style: solid;
-  --oip-plugin-card-border-color: #d2d2d2;
-  --oip-plugin-card-border-radius: 3px;
-  --oip-plugin-card-box-shadow: none;
-  --oip-plugin-card-display: flex;
-  --oip-plugin-card-row-gap: 24px;
-  --oip-plugin-card-heading-color: #000;
-  --oip-plugin-card-heading-padding-inline-start: 16px;
-  --oip-plugin-card-heading-padding-inline-end: 16px;
-  --oip-plugin-card-body-display: flex;
-  --oip-plugin-card-link-display: flex;
-  --oip-plugin-card-link-hover-text-decoration-thickness: 1px;
-  --oip-plugin-card-link-hover-text-decoration-line: underline;
-  --oip-plugin-card-link-hover-text-underline-offset: auto;
-  --oip-plugin-card-link-padding: 0;
-  --oip-plugin-card-content-gap: 16px;
-  --oip-plugin-card-content-padding-block-start: 16px;
-  --oip-plugin-card-content-padding-block-end: 16px;
-  --oip-plugin-card-body-padding-inline-start: 16px;
-  --oip-plugin-card-body-padding-inline-end: 16px;
-
+  // Some values below (like 'cursor') are advised to not be put inside design-tokens
   cursor: pointer;
   border: var(--oip-plugin-card-border-width)
     var(--oip-plugin-card-border-style) var(--oip-plugin-card-border-color);
@@ -36,7 +10,7 @@
   box-shadow: var(--oip-plugin-card-box-shadow);
   color: var(--oip-plugin-card-color);
   font-family: 'Body', Arial, sans-serif;
-  display: var(--oip-plugin-card-display);
+  display: flex;
   flex-direction: row;
   height: 100%;
   inline-size: var(--oip-plugin-card-inline-size);
@@ -46,7 +20,7 @@
   text-decoration: none;
 
   &__content {
-    display: var(--oip-plugin-card-link-display);
+    display: flex;
     gap: var(--oip-plugin-card-content-gap);
     padding: var(--oip-plugin-card-content-padding-block-start)
       var(--oip-plugin-card-content-padding-block-end);
@@ -59,7 +33,7 @@
   }
 
   &__body {
-    display: var(--oip-plugin-card-body-display);
+    display: flex;
     flex-direction: column;
     gap: var(--oip-plugin-card-content-gap);
     justify-content: space-between;

--- a/src/open_inwoner/react/components/HomePluginSection/HomePluginSection.scss
+++ b/src/open_inwoner/react/components/HomePluginSection/HomePluginSection.scss
@@ -1,64 +1,36 @@
-.plugin {
-  //TODO: remove only this plugin style when switching to Preact, since this needs to be defined by porent grid
-  padding-top: var(--row-height);
-}
-
-//TODO: re-usable component styles, keep these when switching to Preact
 .plugin__header {
-  // TODO: to give these back to NLDS community, add these variables to OIP design-tokens package
-  --oip-plugin-header-margin: 0 0 var(--spacing-medium);
-  --oip-plugin-header-display: flex;
-  --oip-plugin-header-font-family: 'Heading', Arial, sans-serif;
-  --oip-plugin-header-align-items: center;
-  --oip-plugin-header-justify-content: space-between;
-  --oip-plugin-header-flex-direction-mobile: column;
-  --oip-plugin-header-align-items-mobile: flex-start;
-  --oip-plugin-header-word-break-mobile: normal;
-  --oip-plugin-header-overflow-wrap-mobile: break-word;
-  // Indicator tokens
-  --oip-plugin-header-indicator-display: flex;
-  --oip-plugin-header-indicator-flex-direction: row;
-  --oip-plugin-header-notification-indicator-color: #e50026;
-  --oip-plugin-header-notification-indicator-font-size: 12px;
-  --oip-plugin-header-notification-indicator-vertical-align: super;
-  --oip-plugin-header-indicator-display-inline: inline-block;
-  --oip-plugin-header-indicator-justify-content: flex-start;
-  --oip-plugin-header-indicator-overflow: visible;
-  --oip-plugin-header-indicator-position: relative;
-  // Heading tokens
-  --oip-plugin-header-heading-color: var(--font-color-heading);
-  --oip-plugin-header-heading-font-family: 'Heading', Arial, sans-serif;
-  --oip-plugin-header-heading-margin: 0;
-
-  margin: var(--oip-plugin-header-margin);
-  display: var(--oip-plugin-header-display);
+  // Some values below (like 'display') are advised to not be put inside design-tokens
+  display: flex;
   font-family: var(--oip-plugin-header-font-family);
   align-items: var(--oip-plugin-header-align-items);
-  justify-content: var(--oip-plugin-header-justify-content);
+  justify-content: space-between;
+  padding: 0 0 var(--oip-plugin-header-padding-inline-end) 0;
 
   &__indicator {
-    display: var(--oip-plugin-header-indicator-display);
-    flex-direction: var(--oip-plugin-header-indicator-flex-direction);
+    display: flex;
+    flex-direction: row;
   }
 
   .plugin__notification-indicator {
-    color: var(--oip-plugin-header-notification-indicator-color);
-    font-size: var(--oip-plugin-header-notification-indicator-font-size);
+    color: var(--oip-plugin-header-indicator-notification-indicator-color);
+    font-size: var(
+      --oip-plugin-header-indicator-notification-indicator-font-size
+    );
     vertical-align: var(
-      --oip-plugin-header-notification-indicator-vertical-align
+      --oip-plugin-header-indicator-notification-indicator-vertical-align
     );
   }
 
   .indicator {
     display: var(--oip-plugin-header-indicator-display-inline);
-    justify-content: var(--oip-plugin-header-indicator-justify-content);
+    justify-content: flex-start;
     overflow: var(--oip-plugin-header-indicator-overflow);
     position: var(--oip-plugin-header-indicator-position);
   }
 
   @media (max-width: 768px) {
-    flex-direction: var(--oip-plugin-header-flex-direction-mobile);
-    align-items: var(--oip-plugin-header-align-items-mobile);
+    flex-direction: column;
+    align-items: flex-start;
     word-break: var(--oip-plugin-header-word-break-mobile);
     overflow-wrap: var(--oip-plugin-header-overflow-wrap-mobile);
   }
@@ -66,7 +38,10 @@
   .utrecht-heading-2 {
     color: var(--oip-plugin-header-heading-color);
     font-family: var(--oip-plugin-header-heading-font-family);
-    margin: var(--oip-plugin-header-heading-margin);
+    margin-block-start: var(--oip-plugin-header-heading-margin-block-start);
+    margin-block-end: var(--oip-plugin-header-heading-margin-block-end);
+    margin-inline-start: var(--oip-plugin-header-heading-margin-inline-start);
+    margin-inline-end: var(--oip-plugin-header-heading-margin-inline-end);
   }
 
   .button {
@@ -109,25 +84,11 @@
 
 // Plugin grid layout
 .plugin__grid {
-  // TODO: to give these back to NLDS community, add these variables to OIP design-tokens package
-  --oip-plugin-grid-display: grid;
-  --oip-plugin-grid-template-columns-mobile: repeat(1, 1fr);
-  --oip-plugin-grid-template-columns-desktop: repeat(
-    var(--plugin-columns, 2),
-    1fr
-  );
-  --oip-plugin-grid-list-style-type: none;
-  --oip-plugin-grid-margin-block-start: 0;
-  --oip-plugin-grid-margin-block-end: 0;
-  --oip-plugin-grid-padding-inline-start: 0;
-  --oip-plugin-grid-row-gap: var(--spacing-medium);
-  --oip-plugin-grid-column-gap: var(--spacing-giant);
-
-  display: var(--oip-plugin-grid-display);
-  grid-template-columns: var(--oip-plugin-grid-template-columns-mobile);
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
 
   @media (min-width: 768px) {
-    grid-template-columns: var(--oip-plugin-grid-template-columns-desktop);
+    grid-template-columns: repeat(var(--plugin-columns, 2), 1fr);
   }
 
   list-style-type: var(--oip-plugin-grid-list-style-type);

--- a/src/open_inwoner/react/components/Table/Table.scss
+++ b/src/open_inwoner/react/components/Table/Table.scss
@@ -17,6 +17,11 @@
     color: var(--oip-color-fg);
   }
 
+  &__row:hover .utrecht-table__cell {
+    // TODO: --utrecht-table-row-hover-cell-background-color does not exist in the NLDS Utrecht source yet
+    background-color: var(--utrecht-table-row-alternate-even-background-color);
+  }
+
   &__footer {
     .utrecht-table__row {
       .utrecht-table__cell {

--- a/src/open_inwoner/scss/components/ExternalLink/ExternalLink.scss
+++ b/src/open_inwoner/scss/components/ExternalLink/ExternalLink.scss
@@ -12,7 +12,7 @@
     margin-block-start: var(--spacing-extra-large);
     margin-block-end: 0;
     padding-inline-start: 0;
-    grid-row-gap: var(--spacing-medium);
+    grid-row-gap: var(--spacing-large);
     grid-column-gap: var(--spacing-giant);
   }
 
@@ -49,6 +49,11 @@
     padding-block-end: var(--oip-external-link-body-padding-block-end);
     padding-inline-start: var(--oip-external-link-body-padding-inline-start);
     padding-inline-end: var(--oip-external-link-body-padding-inline-end);
+    margin:
+      var(--oip-external-link-body-margin-block-start),
+      var(--oip-external-link-body-margin-block-end),
+      var(--oip-external-link-body-margin-inline-start),
+      var(--oip-external-link-body-margin-inline-end);
     background-color: var(--oip-external-link-background-color);
     font-family: var(--oip-external-link-font-family);
     font-size: var(--oip-external-link-content-font-size);


### PR DESCRIPTION
## Summary

Convert OIP styles to design-tokens and add them to both the package as well as the project.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3630
- Github package: https://github.com/maykinmedia/open-inwoner-design-tokens/pull/30 = already merged
- corrections in new PR: https://github.com/maykinmedia/open-inwoner-design-tokens/pull/34 

## Checklist

- [x] CHANGELOG.rst updated


