### PR TITLE
Resolve bug where HTML comment breaks accessibility speak functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,7 @@ Nieuwe features
   voor links naar andere portalen gebouwd, inclusief nieuwe design-tokens volgens NLDS conventies. Opmaak is
   verbeterd voor inhoud met langere linkteksten die naar een nieuwe regel worden afgebroken.
 * [:taiga-us:`3509`, :pr:`1997`]: Ondersteuning voor eIDAS login via OIDC is toegevoegd.
-* [:taiga-us:`3575`, :pr:`2020`, :pr:`2037`, :pr:`2042`]: CMS plug-in 'Mijn Zaken' aangemaakt voor het
+* [:taiga-us:`3575`, :pr:`2020`, :pr:`2037`, :pr:`2042`, :pr:`2058`]: CMS plug-in 'Mijn Zaken' aangemaakt voor het
   ontsluiten van zaken in de startpagina.
 * [:taiga-us:`3574`, :pr:`2026`]: Aantal requests aan zaken API's configureerbaar gemaakt via
   omgevingsvariabele.

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -66,11 +66,9 @@ class CMSZakenPluginTest(TestCase):
         self.assertNotIn("hx_get_url", context)
         self.assertNotIn("show_zaken_plugin", context)
 
-        # Template always renders HTML comments, but no content when show_zaken_plugin is not set
-        self.assertIn("<!-- start zaken plugin -->", html)
-        self.assertIn("<!-- end zaken plugin -->", html)
         # Should not contain any actual plugin content
         self.assertNotIn("oip-home-plugin-section", html)
+        self.assertNotIn("oip-home-plugin-card", html)
 
     def test_plugin_does_not_render_for_anonymous_user(self):
         ZGWApiGroupConfigFactory()

--- a/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
+++ b/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
@@ -1,6 +1,5 @@
 {% load i18n icon_tags button_tags django_htmx %}
 
-<!-- start zaken plugin -->
 {% if show_zaken_plugin %}
     {% if request.htmx %}
         <oip-home-plugin-section
@@ -37,8 +36,4 @@
             </oip-home-plugin-section>
         </div>
     {% endif %}
-    <!-- end zaken plugin -->
-{% else %}
-    <!-- Unable to render Mijn Zaken Plugin due to a configuration issue-->
 {% endif %}
-<!-- end zaken plugin -->


### PR DESCRIPTION
## Summary

This PR fixes a bug where HTML comment breaks accessibility speak functionality

This bug occurred since we have the new ZakenHomePlugin (not yet in production).


### Deep dive

Error in browser console:
```
Uncaught TypeError: node.getAttribute is not a function
    at ReadOut.getText (
```

What happens is that js tries to use `getAttribute()` method from a HTML comment - which does not exists.


## Checklist

- [x] CHANGELOG.rst updated