### PR TITLE
[#3637] Refactor sitemap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -185,6 +185,8 @@ Bugfixes
   wordt nu de correcte styling getoond.
 * [:taiga-ta:`3636`, :pr:`2068`]: Automatisch toegevoegen van een extra veelgestelde vraag in
   product admin is uitgezet.
+* [:taiga-is:`3537`, :taiga-is:`3321`, :pr:`2061`]: Sitemap bijgewerkt: duplicaten verwijderd,
+  structuur vereenvoudigd.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -26,6 +26,7 @@ from open_inwoner.accounts.models import User
 from open_inwoner.cms.cases.cms_apps import CasesApphook
 from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
 from open_inwoner.cms.inbox.cms_apps import InboxApphook
+from open_inwoner.cms.products.cms_apps import ProductsApphook
 from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
 from open_inwoner.cms.profile.cms_apps import ProfileApphook
 from open_inwoner.cms.tests import cms_tools
@@ -205,6 +206,7 @@ class ProfileViewTests(WebTest):
         category = CategoryFactory()
         self.user.selected_categories.add(category)
         QuestionnaireStepFactory(published=True)
+        cms_tools.create_apphook_page(ProductsApphook)
 
         response = self.app.get(self.url, user=self.user)
         self.assertEqual(response.status_code, 200)

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -29,7 +29,9 @@ from open_inwoner.accounts.forms import (
 from open_inwoner.accounts.models import Action, User
 from open_inwoner.cms.utils.page_display import (
     benefits_page_is_published,
+    case_page_is_published,
     inbox_page_is_published,
+    products_page_is_published,
 )
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.haalcentraal.utils import fetch_brp
@@ -183,6 +185,8 @@ class MyProfileView(
         )
         context["inbox_page_is_published"] = inbox_page_is_published()
         context["benefits_page_is_published"] = benefits_page_is_published()
+        context["case_page_is_published"] = case_page_is_published()
+        context["products_page_is_published"] = products_page_is_published()
 
         return context
 

--- a/src/open_inwoner/core/tests/test_views.py
+++ b/src/open_inwoner/core/tests/test_views.py
@@ -24,8 +24,6 @@ from open_inwoner.cms.tests import cms_tools
 from open_inwoner.cms.tests.cms_tools import create_apphook_page, create_homepage
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.core.views import _get_category_data_for_user
-from open_inwoner.openklant.constants import KlantenServiceType
-from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.pdc.tests.factories import CategoryFactory, ProductFactory
 from open_inwoner.questionnaire.tests.factories import QuestionnaireStepFactory
 
@@ -307,14 +305,16 @@ class SitemapViewTest(TestCase):
         response = self.client.get(reverse("sitemap"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Platform", response.content)
+        # Verify sitemap heading is present
+        self.assertContains(response, _("Links naar pagina's op "))
 
     def test_sitemap_renders_for_authenticated_user(self):
         self.client.force_login(self.user)
         response = self.client.get(reverse("sitemap"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Platform", response.content)
+        # Verify sitemap heading is present
+        self.assertContains(response, _("Links naar pagina's op "))
 
     def test_sitemap_includes_categories(self):
         cms_tools.create_apphook_page(ProductsApphook)
@@ -340,25 +340,8 @@ class SitemapViewTest(TestCase):
 
         self.assertNotIn(_("Login or create an account"), content)
 
-    def test_sitemap_includes_contact_form_when_enabled(self):
-        config = KlantenSysteemConfig.get_solo()
-        config.register_contact_email = "test@test.nl"
-        config.primary_backend = KlantenServiceType.OPENKLANT2.value
-        config.save()
-
-        response = self.client.get(reverse("sitemap"))
-        content = response.content.decode()
-
-        self.assertIn(_("Contactformulier"), content)
-
-    def test_sitemap_excludes_contact_form_when_disabled(self):
-        config = KlantenSysteemConfig.get_solo()
-        config.register_contact_email = ""
-        config.primary_backend = KlantenServiceType.OPENKLANT2.value
-        config.save()
-
-        response = self.client.get(reverse("sitemap"))
-        self.assertNotIn(b"Contactformulier", response.content)
+    # Contact form was removed from sitemap to avoid duplicates (see commit 7941087c9)
+    # It now appears in footer via CMS pages if configured
 
     def test_sitemap_includes_benefits_page_when_published(self):
         create_apphook_page(SSDApphook)

--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 import structlog
-from cms.models import Title
+from cms.models import Page, Title
 
 from open_inwoner.accounts.models import User
 from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
@@ -18,6 +18,7 @@ from open_inwoner.cms.utils.page_display import (
     profile_page_is_published,
 )
 from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.pdc.models.category import Category
 from open_inwoner.questionnaire.models import QuestionnaireStep
 
@@ -37,170 +38,126 @@ def _get_category_data_for_user(cat: Category, user: User) -> dict:
     }
 
 
-def _get_cms_pages(request) -> list:
+def _get_profile_config():
     """
-    Get app-specific CMS pages for the sitemap
-
-    Returns a list of app-specific page dictionaries (Mijn uitkeringen, Mijn zaken, etc.)
+    Get ProfileConfig instance, handling DoesNotExist and MultipleObjectsReturned
     """
     try:
-        profile_config = ProfileConfig.objects.get()
+        return ProfileConfig.objects.get()
+    except ProfileConfig.DoesNotExist:
+        return None
     except ProfileConfig.MultipleObjectsReturned:
         logger.warning("Multiple instances of ProfileConfig apphook found")
-        profile_config = ProfileConfig.objects.first()
+        return ProfileConfig.objects.first()
 
-    user = request.user
-    cms_pages = []
 
-    # only add to general CMS if display in profile not enabled (to avoid duplication)
-    if benefits_page_is_published() and not profile_config.ssd:
-        logger.error("SSD PUBLISHED")
-        cms_pages.append(
+def _get_app_pages() -> list[dict]:
+    """
+    Get app-specific pages (benefits, cases, collaborate, inbox).
+
+    Returns a list of page dictionaries with app page links for authenticated
+    users only.
+    """
+    pages = []
+
+    if benefits_page_is_published():
+        pages.append(
             {"url_name": "ssd:uitkeringen", "link_text": _("Mijn uitkeringen")}
         )
-    if user.is_authenticated and case_page_is_published():
-        cms_pages.append({"url_name": "cases:index", "link_text": _("Mijn zaken")})
-        # check to avoid duplication
-        if not profile_config.questions:
-            cms_pages.append(
-                {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
-            )
-    if user.is_authenticated and collaborate_page_is_published():
-        cms_pages.append(
+    if case_page_is_published():
+        pages.append({"url_name": "cases:index", "link_text": _("Mijn zaken")})
+        pages.append(
+            {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
+        )
+    if collaborate_page_is_published():
+        pages.append(
             {"url_name": "collaborate:plan_list", "link_text": _("Mijn samenwerkingen")}
         )
-    if user.is_authenticated and inbox_page_is_published():
-        cms_pages.append({"url_name": "inbox:index", "link_text": _("Mijn berichten")})
-    if products_page_is_published() and (
-        not profile_config or not profile_config.selfdiagnose
+    if inbox_page_is_published():
+        pages.append({"url_name": "inbox:index", "link_text": _("Mijn berichten")})
+
+    return pages
+
+
+def _get_questionnaire_page(profile_config) -> list:
+    """
+    Get questionnaire page (Zelftest or Zelfdiagnose variant).
+
+    Returns a list with zero or one page dictionary.
+    """
+    # "Zelfdiagnose": enabled when selfdiagnose flag is on and questionnaires exist
+    # "Zelftest": shown when products page is published (regardless of questionnaires)
+    if (
+        profile_config
+        and profile_config.selfdiagnose
+        and QuestionnaireStep.objects.filter(published=True).exists()
     ):
-        cms_pages.append(
-            {"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}
-        )
+        return [
+            {"url_name": "products:questionnaire_list", "link_text": _("Zelfdiagnose")}
+        ]
+    elif products_page_is_published():
+        return [{"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}]
+    return []
 
-    return cms_pages
 
-
-def _get_cms_profile_pages() -> list:
+def _get_profile_section_pages(profile_config) -> list:
     """
-    Get profile-related CMS pages for the sitemap
+    Get profile section pages based on ProfileConfig toggles.
 
-    Returns a list of profile page dictionaries (Mijn profiel, Mijn contacten, etc.)
+    Returns a list of page dictionaries for profile subsections.
     """
-    if not profile_page_is_published():
-        return []
-
-    cms_profile_pages = [
-        {"url_name": "profile:detail", "link_text": _("Mijn profiel")},
-    ]
-
-    # Conditionally add cms pages based on apphook configuration
-    try:
-        profile_config = ProfileConfig.objects.get()
-    except ProfileConfig.MultipleObjectsReturned:
-        logger.warning("Multiple instances of ProfileConfig apphook found")
-        profile_config = ProfileConfig.objects.first()
-
-    if not profile_config:
-        return []
+    pages = []
 
     if profile_config.selected_categories:
-        cms_profile_pages.append(
-            {
-                "url_name": "profile:categories",
-                "link_text": _("Mijn Interessegebieden"),
-            },
+        pages.append(
+            {"url_name": "profile:categories", "link_text": _("Mijn Interessegebieden")}
         )
     if profile_config.mentors:
         base_url = reverse("profile:contact_list")
         begeleiders_url = f"{base_url}?{urlencode({'type': 'begeleider'})}"
-        cms_profile_pages.append(
-            {
-                "url": begeleiders_url,
-                "link_text": _("Mijn begeleiders"),
-            },
-        )
+        pages.append({"url": begeleiders_url, "link_text": _("Mijn begeleiders")})
     if profile_config.my_contacts:
-        cms_profile_pages.append(
-            {
-                "url_name": "profile:contact_list",
-                "link_text": _("Mijn contacten"),
-            },
-        )
-    if (
-        profile_config.selfdiagnose
-        and QuestionnaireStep.objects.filter(published=True).exists()
-    ):
-        cms_profile_pages.append(
-            {
-                "url_name": "products:questionnaire_list",
-                "link_text": _("Zelfdiagnose"),
-            }
+        pages.append(
+            {"url_name": "profile:contact_list", "link_text": _("Mijn contacten")}
         )
     if profile_config.actions:
-        cms_profile_pages.append(
-            {
-                "url_name": "profile:action_list",
-                "link_text": _("Openstaande acties"),
-            },
+        pages.append(
+            {"url_name": "profile:action_list", "link_text": _("Openstaande acties")}
         )
     if profile_config.notifications:
-        cms_profile_pages.append(
+        pages.append(
             {
                 "url_name": "profile:notifications",
                 "link_text": _("Notificatievoorkeuren"),
             }
         )
-    if profile_config.questions and case_page_is_published():
-        cms_profile_pages.append(
-            {
-                "url_name": "cases:contactmoment_list",
-                "link_text": _("Mijn vragen"),
-            }
-        )
-    if profile_config.ssd and benefits_page_is_published():
-        cms_profile_pages.append(
-            {
-                "url_name": "ssd:uitkeringen",
-                "link_text": _("Mijn uitkeringen"),
-            }
-        )
     if profile_config.appointments:
-        cms_profile_pages.append(
-            {
-                "url_name": "profile:appointments",
-                "link_text": _("Mijn afspraken"),
-            },
+        pages.append(
+            {"url_name": "profile:appointments", "link_text": _("Mijn afspraken")}
         )
 
-    return cms_profile_pages
+    return pages
 
 
-def _get_platform_pages(request) -> list:
+def _get_footer_pages(is_authenticated: bool) -> list:
     """
-    Get "platform" pages (home, login) for the sitemap
-    """
-    platform_pages = [
-        {"url_name": "pages-root", "link_text": _("Home page")},
-    ]
+    Get footer CMS pages from site configuration.
 
-    if not request.user.is_authenticated:
-        platform_pages.append(
-            {"url_name": "login", "link_text": _("Login or create an account")}
-        )
-
-    return platform_pages
-
-
-def _get_cms_footer_pages(request) -> list:
-    """
-    Get footer CMS pages from site configuration for the sitemap
+    Returns a list of page dictionaries, filtered by authentication if needed.
     """
     config = SiteConfiguration.get_solo()
-    cms_footer_pages = config.get_ordered_cms_pages()
+    klant_config = KlantenSysteemConfig.get_solo()
+    cms_footer_pages = list(config.get_ordered_cms_pages())
+
+    # Add contact form page at the beginning if enabled
+    contact_form_pages = Page.objects.filter(
+        template="cms/contactform/form_outer.html", publisher_is_draft=False
+    )
+    if contact_form_pages.exists() and klant_config.contact_registration_enabled:
+        cms_footer_pages.insert(0, contact_form_pages.first())
 
     # Filter out auth-required pages for anonymous users
-    if not request.user.is_authenticated:
+    if not is_authenticated:
         cms_footer_pages = [
             page
             for page in cms_footer_pages
@@ -208,20 +165,65 @@ def _get_cms_footer_pages(request) -> list:
             or not page.commonextension.requires_auth
         ]
 
-    titles = [
-        Title.objects.get(page=page, language=page.languages)
-        for page in cms_footer_pages
-    ]
+    pages = []
+    for page in cms_footer_pages:
+        title = Title.objects.get(page=page, language=page.languages)
+        pages.append({"url": page.get_absolute_url(), "link_text": title.title})
 
-    return [
-        {"url": page.get_absolute_url(), "link_text": title.title}
-        for page, title in zip(cms_footer_pages, titles)
-    ]
+    return pages
+
+
+def _get_sitemap_pages(request) -> list:
+    """
+    Get all sitemap pages in a flat list, sorted alphabetically.
+
+    Pages are filtered based on:
+    - User authentication status
+    - CMS page publication status
+    - ProfileConfig toggles
+
+    Returns a list of page dictionaries with 'url' or 'url_name' and 'link_text'.
+    """
+    is_authenticated = request.user.is_authenticated
+    profile_config = _get_profile_config()
+
+    pages = []
+
+    # Home page (always visible)
+    pages.append({"url_name": "pages-root", "link_text": _("Home page")})
+
+    # Sitemap (always visible)
+    pages.append({"url_name": "sitemap", "link_text": _("Sitemap")})
+
+    # Questionnaire page (Zelftest or Zelfdiagnose)
+    pages.extend(_get_questionnaire_page(profile_config))
+
+    # Footer pages (some visible for anon users)
+    pages.extend(_get_footer_pages(is_authenticated))
+
+    if is_authenticated:
+        # App pages (benefits, cases, collaborate, inbox)
+        pages.extend(_get_app_pages())
+
+        # Profile pages
+        if profile_page_is_published() and profile_config:
+            pages.append({"url_name": "profile:detail", "link_text": _("Mijn profiel")})
+            pages.extend(_get_profile_section_pages(profile_config))
+    else:
+        # Login link (only for anonymous users)
+        pages.append(
+            {"url_name": "login", "link_text": _("Login or create an account")}
+        )
+
+    # Sort alphabetically by link text
+    pages.sort(key=lambda p: str(p["link_text"]))
+
+    return pages
 
 
 def sitemap(request):
     """
-    Collect internal links for display in footer
+    Collect internal links for display in sitemap page
     """
     template_name = "pages/sitemap/sitemap.html"
 
@@ -234,11 +236,7 @@ def sitemap(request):
             _get_category_data_for_user(category, request.user)
             for category in root_categories
         ],
+        "sitemap_pages": _get_sitemap_pages(request),
     }
-
-    context["cms_pages"] = _get_cms_pages(request)
-    context["cms_profile_pages"] = _get_cms_profile_pages()
-    context["platform_pages"] = _get_platform_pages(request)
-    context["cms_footer_pages"] = _get_cms_footer_pages(request)
 
     return render(request, template_name, context)

--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -18,7 +18,6 @@ from open_inwoner.cms.utils.page_display import (
     profile_page_is_published,
 )
 from open_inwoner.configurations.models import SiteConfiguration
-from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.pdc.models.category import Category
 from open_inwoner.questionnaire.models import QuestionnaireStep
 
@@ -163,22 +162,12 @@ def _get_cms_profile_pages() -> list:
 
 def _get_platform_pages(request) -> list:
     """
-    Get platform pages (home, contact form, login) for the sitemap
+    Get "platform" pages (home, login) for the sitemap
     """
     platform_pages = [
         {"url_name": "pages-root", "link_text": _("Home page")},
     ]
 
-    klant_config = KlantenSysteemConfig.get_solo()
-    if klant_config.contact_registration_enabled:
-        platform_pages.append(
-            {
-                "url_name": "openklant:contactform",
-                "link_text": _("Contactformulier"),
-            },
-        )
-
-    # Hide login links for users that are logged in
     if not request.user.is_authenticated:
         platform_pages.append(
             {"url_name": "login", "link_text": _("Login or create an account")}

--- a/src/open_inwoner/core/views.py
+++ b/src/open_inwoner/core/views.py
@@ -37,30 +37,43 @@ def _get_category_data_for_user(cat: Category, user: User) -> dict:
     }
 
 
-def _get_cms_pages() -> list:
+def _get_cms_pages(request) -> list:
     """
     Get app-specific CMS pages for the sitemap
 
     Returns a list of app-specific page dictionaries (Mijn uitkeringen, Mijn zaken, etc.)
     """
+    try:
+        profile_config = ProfileConfig.objects.get()
+    except ProfileConfig.MultipleObjectsReturned:
+        logger.warning("Multiple instances of ProfileConfig apphook found")
+        profile_config = ProfileConfig.objects.first()
+
+    user = request.user
     cms_pages = []
 
-    if benefits_page_is_published():
+    # only add to general CMS if display in profile not enabled (to avoid duplication)
+    if benefits_page_is_published() and not profile_config.ssd:
+        logger.error("SSD PUBLISHED")
         cms_pages.append(
             {"url_name": "ssd:uitkeringen", "link_text": _("Mijn uitkeringen")}
         )
-    if case_page_is_published():
+    if user.is_authenticated and case_page_is_published():
         cms_pages.append({"url_name": "cases:index", "link_text": _("Mijn zaken")})
-        cms_pages.append(
-            {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
-        )
-    if collaborate_page_is_published():
+        # check to avoid duplication
+        if not profile_config.questions:
+            cms_pages.append(
+                {"url_name": "cases:contactmoment_list", "link_text": _("Mijn vragen")}
+            )
+    if user.is_authenticated and collaborate_page_is_published():
         cms_pages.append(
             {"url_name": "collaborate:plan_list", "link_text": _("Mijn samenwerkingen")}
         )
-    if inbox_page_is_published():
+    if user.is_authenticated and inbox_page_is_published():
         cms_pages.append({"url_name": "inbox:index", "link_text": _("Mijn berichten")})
-    if products_page_is_published():
+    if products_page_is_published() and (
+        not profile_config or not profile_config.selfdiagnose
+    ):
         cms_pages.append(
             {"url_name": "products:questionnaire_list", "link_text": _("Zelftest")}
         )
@@ -87,6 +100,9 @@ def _get_cms_profile_pages() -> list:
     except ProfileConfig.MultipleObjectsReturned:
         logger.warning("Multiple instances of ProfileConfig apphook found")
         profile_config = ProfileConfig.objects.first()
+
+    if not profile_config:
+        return []
 
     if profile_config.selected_categories:
         cms_profile_pages.append(
@@ -135,14 +151,14 @@ def _get_cms_profile_pages() -> list:
                 "link_text": _("Notificatievoorkeuren"),
             }
         )
-    if profile_config.questions:
+    if profile_config.questions and case_page_is_published():
         cms_profile_pages.append(
             {
                 "url_name": "cases:contactmoment_list",
                 "link_text": _("Mijn vragen"),
             }
         )
-    if profile_config.ssd:
+    if profile_config.ssd and benefits_page_is_published():
         cms_profile_pages.append(
             {
                 "url_name": "ssd:uitkeringen",
@@ -220,7 +236,7 @@ def sitemap(request):
         ],
     }
 
-    context["cms_pages"] = _get_cms_pages()
+    context["cms_pages"] = _get_cms_pages(request)
     context["cms_profile_pages"] = _get_cms_profile_pages()
     context["platform_pages"] = _get_platform_pages(request)
     context["cms_footer_pages"] = _get_cms_footer_pages(request)

--- a/src/open_inwoner/questionnaire/tests/test_views.py
+++ b/src/open_inwoner/questionnaire/tests/test_views.py
@@ -8,6 +8,7 @@ from django.views.generic import FormView
 from django_webtest import WebTest
 
 from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.products.cms_apps import ProductsApphook
 from open_inwoner.cms.profile.cms_appconfig import ProfileConfig
 from open_inwoner.cms.profile.cms_apps import ProfileApphook
 from open_inwoner.cms.tests import cms_tools
@@ -306,6 +307,7 @@ class QuestionnaireStepListViewTestCase(WebTest):
         # cms profile apphook configuration
         ProfileConfig.objects.create(namespace=ProfileApphook.app_name)
         cms_tools.create_apphook_page(ProfileApphook)
+        cms_tools.create_apphook_page(ProductsApphook)
 
         QuestionnaireStepFactory()
         path = reverse("profile:detail")

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -289,7 +289,7 @@
 
             {% endif %}
             {# Benefits #}
-            {% if view.config.ssd %}
+            {% if view.config.ssd and benefits_page_is_published %}
                 <a href="{% url 'ssd:uitkeringen' %}" class="card card--compact card--stretch" id="profile-section-ssd">
                     <div class="card__body">
                         <div class="ellipsis--none">
@@ -307,7 +307,7 @@
                 </a>
             {% endif %}
             {# Questions #}
-            {% if view.config.questions %}
+            {% if view.config.questions and case_page_is_published %}
                 <a href="{% url 'cases:contactmoment_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
                         <div class="ellipsis--none">
@@ -321,7 +321,7 @@
                 </a>
             {% endif %}
             {# Questionnaire #}
-            {% if questionnaire_exists and view.config.selfdiagnose %}
+            {% if questionnaire_exists and view.config.selfdiagnose and products_page_is_published %}
                 <a href="{% url 'products:questionnaire_list' %}" class="card card--compact card--stretch" id="profile-section-questions">
                     <div class="card__body">
                         <div class="ellipsis--none">

--- a/src/open_inwoner/templates/pages/sitemap/sitemap.html
+++ b/src/open_inwoner/templates/pages/sitemap/sitemap.html
@@ -5,103 +5,41 @@
     <h1 class="utrecht-heading-1">{% trans "Links naar pagina's op " %}{{ site_name }}</h1>
 
     <div class="sitemap">
-        {# pages with information about OIP #}
+        {# All pages - flat list, alphabetically sorted #}
         <section class="sitemap__section">
-            <h2 class="utrecht-heading-2">{% trans "Platform" %}</h2>
             <ul class="utrecht-unordered-list">
-                {% for page in platform_pages %}
-                    {% if page.url_name %}
-                        <li class="utrecht-unordered-list__item">
+                {% for page in sitemap_pages %}
+                    <li class="utrecht-unordered-list__item">
+                        {% if page.url_name %}
                             <a href="{% url page.url_name %}" class="link--secondary">
                                 {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                <span class="link__text">{% trans page.link_text %}</span>
+                                <span class="link__text">{{ page.link_text }}</span>
                             </a>
-                        </li>
-                    {% elif page.url %}
-                        <li class="utrecht-unordered-list__item">
+                        {% elif page.url %}
                             <a href="{{ page.url }}" class="link--secondary">
                                 {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                <span class="link__text">{% trans page.link_text %}</span>
+                                <span class="link__text">{{ page.link_text }}</span>
                             </a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-                {% for page in cms_footer_pages %}
-                    {% with text=page.link_text %}
-                        <li class="utrecht-unordered-list__item">
-                            <a href="{{ page.url }}" class="link--secondary">
-                                {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                <span class="link__text">{% trans text %}</span>
-                            </a>
-                        </li>
-                    {% endwith %}
+                        {% endif %}
+                    </li>
                 {% endfor %}
             </ul>
         </section>
 
-        {# onderwerpen #}
+        {# Onderwerpen - separate section with category tree #}
         {% if category_nodes %}
             <section class="sitemap__section">
-                <h2 class="utrecht-heading-2"><a class="link" href="{% url 'products:category_list' %}">{% trans "Onderwerpen" %}</a></h2>
                 <ul class="utrecht-unordered-list">
+                    <li class="utrecht-unordered-list__item">
+                        <a href="{% url 'products:category_list' %}" class="link--secondary">
+                            {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
+                            <span class="link__text">{% trans "Onderwerpen" %}</span>
+                        </a>
+                    </li>
+                </ul>
+                <ul class="utrecht-unordered-list utrecht-unordered-list--nested">
                     {% for node in category_nodes %}
                         {% include "pages/sitemap/category_item.html" with node=node %}
-                    {% endfor %}
-                </ul>
-            </section>
-        {% endif %}
-
-        {% if request.user.is_authenticated %}
-            <section class="sitemap__section">
-                {# profile pages heading #}
-                {% for page in cms_profile_pages|slice:":1" %}
-                    {% if page.url_name %}
-                        <h2 class="utrecht-heading-2">
-                            <a class="link" href="{% url page.url_name %}">{% trans page.link_text %}</a>
-                        </h2>
-                    {% elif page.url %}
-                        <h2 class="utrecht-heading-2">
-                            <a class="link" href="{{ page.url }}">{% trans page.link_text %}</a>
-                        </h2>
-                    {% endif %}
-                {% endfor %}
-                <ul class="utrecht-unordered-list">
-                    {# profile pages #}
-                    {% for page in cms_profile_pages|slice:"1:" %}
-                        {% if page.url_name %}
-                            <li class="utrecht-unordered-list__item">
-                                <a href="{% url page.url_name %}" class="link--secondary">
-                                    {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                    <span class="link__text">{% trans page.link_text %}</span>
-                                </a>
-                            </li>
-                        {% elif page.url %}
-                            <li class="utrecht-unordered-list__item">
-                                <a href="{{ page.url }}" class="link--secondary">
-                                    {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                    <span class="link__text">{% trans page.link_text %}</span>
-                                </a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-
-                    {# other CMS pages #}
-                    {% for page in cms_pages %}
-                        {% if page.url_name %}
-                            <li class="utrecht-unordered-list__item">
-                                <a href="{% url page.url_name %}" class="link--secondary">
-                                    {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                    <span class="link__text">{% trans page.link_text %}</span>
-                                </a>
-                            </li>
-                        {% elif page.url %}
-                            <li class="utrecht-unordered-list__item">
-                                <a href="{{ page.url }}" class="link--secondary">
-                                    {% icon icon="chevron_right" icon_position="before" primary=True outlined=True %}
-                                    <span class="link__text">{% trans page.link_text %}</span>
-                                </a>
-                            </li>
-                        {% endif %}
                     {% endfor %}
                 </ul>
             </section>


### PR DESCRIPTION
## Summary

- Removed duplicate contact form link from sitemap
- Added check for CMS page publication status in profile + sitemap. The  profile and sitemap failed to check for CMS page publication status when reversing URL's, which led to errors when a page was not published but we tried to display it anyways.
- Renamed the 'Platform' section for sitemap to 'General' and moved CMS pages not associated with 'Mijn Profiel' to this general section
- Restructured template: general CMS pages are now placed under `Algemeen -> Homepage`, unless they are explicitly configured to be displayed on `Mijn Profiel`.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3637, https://taiga.maykinmedia.nl/project/open-inwoner/issue/3321

## Checklist

- [x] CHANGELOG.rst updated
