### PR TITLE
[#3640] Update admin index fixture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -214,7 +214,8 @@ Onderhoud
 * [:pr:`2031`] Verouderde ``mozilla-django-oidc-db`` cache-instellingen verwijderd.
 * [:pr:`2041`]: ``certifi`` bijgewerkt naar versie ``2025.11.12``.
 * [:taiga-us:`3581`, :pr:`2050`]: Vertalingen bijgewerkt.
-* [:pr:`2018`] ``objects-api-client-django`` bijgewerkt naar nieuwste versie ``0.5.0``.
+* [:pr:`2018`, :pr:`2063`] ``objects-api-client-django`` bijgewerkt naar nieuwste
+  versie ``0.5.0``.
 
 1.35.2 (2025-11-13)
 ===================

--- a/src/open_inwoner/conf/fixtures/django-admin-index.json
+++ b/src/open_inwoner/conf/fixtures/django-admin-index.json
@@ -140,7 +140,7 @@
         ["laposta", "lapostaconfig"],
         ["notifications", "notificationsapiconfig"],
         ["notifications", "subscription"],
-        ["objectsapiclient", "objectsclientconfiguration"],
+        ["objectsapiclient", "objectsapiserviceconfiguration"],
         ["openformsclient", "configuration"],
         ["openklant", "klantcontactmomentanswer"],
         ["openklant", "klantensysteemconfig"],


### PR DESCRIPTION
## Summary

The admin index had to be updated for the new version of objects-api-client-django

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3640

## Checklist

- [x] CHANGELOG.rst updated
