### PR TITLE
[#3642] Remove 'Zaaknummer' text for Formulieren on Home

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -106,8 +106,9 @@ Nieuwe features
   vlag zodat verweesde configuratie makkelijk kan worden geïdentificeerd.
 * [:taiga-us:`3578`, :pr:`2043`]: Nieuw Front-end ontwerp voor CMS plug-in 'Balie Afspraken' gebouwd met
   design-tokens volgens het NLDS principe.
-* [:taiga-us:`3606`, :pr:`2051`]: Zaken en open formulieren hebben nu verschillende teksten voor de status
-  en actieknop/link.
+* [:taiga-us:`3615`, :pr:`2051`, :pr:`2065`]: Zaken en open formulieren hebben nu
+  verschillende teksten voor de status en actieknop/link en op de Home pagina. Het
+  zaaknummer wordt alleen getoond voor reguliere zaken, niet voor formulieren.
 * [:taiga-us:`3606`]: Experimentele client geïmplementeerd met mock data ter ondersteuning van het ontwikkelen
   van de 'Mijn Afval' module.
 * [:taiga-us:`3607`, :pr:`2075`]: Basisapp ‘Mijn Afval’ geïmplementeerd en geïntegreerd met Django CMS.

--- a/src/open_inwoner/cms/plugins/tests/test_zaken.py
+++ b/src/open_inwoner/cms/plugins/tests/test_zaken.py
@@ -201,7 +201,8 @@ class CMSZakenPluginTest(TestCase):
         # Check attributes (note: template uses 'identificatie' not 'identification')
         zaak_item = zaak_items.eq(0)
         self.assertEqual(zaak_item.attr("identificatie"), "ZAAK-001")
-        self.assertEqual(zaak_item.attr("description"), "Zaaknummer: ZAAK-001")
+        self.assertIn("Zaaknummer:", zaak_item.attr("description"))
+        self.assertIn("ZAAK-001", zaak_item.attr("description"))
         self.assertIn("test-uuid-123", zaak_item.attr("detail-url"))
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
@@ -457,8 +458,9 @@ class CMSZakenPluginTest(TestCase):
         pyquery = PyQuery(response.content.decode("utf-8"))
         zaak_item = pyquery.find("oip-home-plugin-card")
 
-        # Verify naam is mapped to description attribute
-        self.assertEqual(zaak_item.attr("description"), "Zaaknummer: ZAAK-001")
+        # Verify naam is mapped to description attribute with Zaaknummer label
+        self.assertIn("Zaaknummer:", zaak_item.attr("description"))
+        self.assertIn("ZAAK-001", zaak_item.attr("description"))
 
     @patch("open_inwoner.cms.plugins.views.CaseListService.get_cases")
     @patch(
@@ -506,6 +508,7 @@ class CMSZakenPluginTest(TestCase):
         """
         Test that both 'naam' field (from formulieren) and 'description' field
         (from regular zaken) are correctly mapped to 'description' in the component output.
+        Formulieren should have empty description, cases should show "Zaaknummer: " label.
         """
         api_group = ZGWApiGroupConfigFactory()
 
@@ -549,14 +552,13 @@ class CMSZakenPluginTest(TestCase):
         # Should have both items
         self.assertEqual(len(zaak_items), 2)
 
-        # First item should be the formulier with "naam" field
+        # First item should be the formulier with empty description
         submission_item = zaak_items.eq(0)
         self.assertEqual(submission_item.attr("identificatie"), "SUBMISSION-001")
-        self.assertEqual(
-            submission_item.attr("description"), "Zaaknummer: SUBMISSION-001"
-        )
+        self.assertEqual(submission_item.attr("description"), "")
 
-        # Second item should be the case with "description" field
+        # Second item should be the case with "Zaaknummer: " label
         case_item = zaak_items.eq(1)
         self.assertEqual(case_item.attr("identificatie"), "ZAAK-001")
-        self.assertEqual(case_item.attr("description"), "Zaaknummer: ZAAK-001")
+        self.assertIn("Zaaknummer:", case_item.attr("description"))
+        self.assertIn("ZAAK-001", case_item.attr("description"))

--- a/src/open_inwoner/cms/plugins/views.py
+++ b/src/open_inwoner/cms/plugins/views.py
@@ -15,6 +15,7 @@ from open_inwoner.cms.cases.views.services import CaseListService
 from open_inwoner.cms.plugins.models import CMSZakenPluginConfig
 from open_inwoner.cms.plugins.models.zaken import MAX_CASES_DEFAULT, MIN_CASES
 from open_inwoner.htmx.mixins import RequiresHtmxMixin
+from open_inwoner.openzaak.constants import TypeAanvraag
 from open_inwoner.openzaak.types import UniformCase
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -24,6 +25,19 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
     """
     HTMX endpoint that fetches and returns content for the `CMSZakenPlugin`.
     """
+
+    def _get_detail_label(self, zaak: dict) -> str:
+        """
+        Generate the detail label to display under the card title.
+        """
+
+        is_formulier = zaak.get("type_aanvraag") == TypeAanvraag.FORMULIER.value
+        identification = zaak.get("identification", "")
+
+        if is_formulier or not identification:
+            return ""
+
+        return _("Zaaknummer: %(identification)s") % {"identification": identification}
 
     def get(self, request: HttpRequest, plugin_id: int) -> HttpResponse:
         case_service = CaseListService(request)
@@ -111,7 +125,8 @@ class ZakenPluginContentView(RequiresHtmxMixin, CaseLogMixin, View):
                     "identification": zaak.get("identification", ""),
                     # for 'formulieren':
                     # "naam" from API -> "description" for web component
-                    "description": zaak.get("naam", zaak.get("description", "")),
+                    "title": zaak.get("naam", zaak.get("description", "")),
+                    "detail_label": self._get_detail_label(zaak),
                 }
             except (AttributeError, KeyError):
                 logger.error(

--- a/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.scss
+++ b/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.scss
@@ -52,6 +52,10 @@
       var(--oip-plugin-card-content-padding-block-end);
     width: 100%;
     align-items: flex-end;
+    // Give minimal spacing on desktop for Openstaande Formulieren
+    @media (min-width: 768px) {
+      min-height: 70px;
+    }
   }
 
   &__body {

--- a/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
+++ b/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
@@ -12,11 +12,11 @@
             {% if error_message %}<div slot="error">{{ error_message }}</div> {% endif %}
             {% for zaak in zaken %}
                 <oip-home-plugin-card
-                    title="{{ zaak.description }}"
-                    description="{% if zaak.identification %}{% trans "Zaaknummer: " %}{{zaak.identification}}{% endif %}"
+                    title="{{ zaak.title }}"
+                    description="{{ zaak.detail_label }}"
                     identificatie="{{ zaak.identification }}"
                     detail-url="{{ zaak.url }}"
-                    >
+                >
                 </oip-home-plugin-card>
             {% endfor %}
         </oip-home-plugin-section>


### PR DESCRIPTION
## Summary

'Zaaknummer' does not apply well to Openstaande Formulieren, 
where the 'identificatie' is both the name as well as a number.
So we will keep that empty but keep the stylistic spacing.

## Issue References

- Taiga Issue: https://taiga.maykinmedia.nl/project/open-inwoner/task/3642

## Checklist

- [x] CHANGELOG.rst updated

