### PR TITLE
✨ [3636] Set limit to 0 on product question inline to prevent error on save

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -178,6 +178,8 @@ Bugfixes
   toegoevegd, en de logica voor alle login types is opgeschoond.
 * [:taiga-is:`3599`, :pr:`2045`]: Bij het bekijken van de bron code van componenten in Storybook
   wordt nu de correcte styling getoond.
+* [:taiga-ta:`3636`, :pr:`2068`]: Automatisch toegevoegen van een extra veelgestelde vraag in
+  product admin is uitgezet.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/pdc/admin/faq.py
+++ b/src/open_inwoner/pdc/admin/faq.py
@@ -19,7 +19,7 @@ class QuestionAdmin(OrderedModelAdmin):
 
 class QuestionInline(admin.TabularInline):
     model = Question
-    extra = 1
+    extra = 0
 
     fields = [
         "question",


### PR DESCRIPTION
## Summary

When editing a Product, it creates an empty "Veelgestelde vraag" with a required label

## Issue References

- Taiga Task: https://taiga.maykinmedia.nl/project/open-inwoner/task/3636

## Checklist

- [x] CHANGELOG.rst updated