### PR TITLE
[#2082] clear elasticsearch connection cache in tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,7 @@ Onderhoud
 * [:pr:`2226`]: Verwijderde dubbele vermeldingen uit changelog.
 * [:gh:`2228`]: ``vite`` configuratie verbeterd.
 * [:gh:`2232`]: Bijgewerkte admin index-fixture.
+* [:gh:`2082`]: Elasticsearch-verbindingscache gewist in tests.
 
 2.0.2 (2026-01-27)
 ==================

--- a/src/open_inwoner/plans/tests/test_htmx.py
+++ b/src/open_inwoner/plans/tests/test_htmx.py
@@ -11,7 +11,7 @@ from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
 
 
 @tag("e2e")
-@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls", DEBUG=True)
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class PlansHTMXTest(PlaywrightSyncLiveServerTestCase):
     uploaded_bytes = b"fake pdf"
     uploaded_filename = "upload_test.pdf"

--- a/src/open_inwoner/search/tests/test_config.py
+++ b/src/open_inwoner/search/tests/test_config.py
@@ -1,10 +1,26 @@
+import contextlib
+
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
+
+from elasticsearch.dsl.connections import connections
 
 from open_inwoner.search.apps import SearchAppConfig
 
 
 class ElasticsearchConfigTest(TestCase):
+    def tearDown(self):
+        # Clear elasticsearch-dsl connections cache to prevent test interference
+        # These tests configure ES with invalid settings, which affects subsequent tests
+        with contextlib.suppress(KeyError):
+            connections.remove_connection("default")
+
+        # Reconfigure with the correct settings from Django settings
+        if hasattr(settings, "ELASTICSEARCH_DSL"):
+            connections.configure(**settings.ELASTICSEARCH_DSL)
+        super().tearDown()
+
     @override_settings(ELASTICSEARCH_DSL={"default": {"hosts": "localhost"}})
     def test_search_app_ready_hook_raises_error_with_unqualified_host(self):
         app_config = SearchAppConfig.create("open_inwoner.search")


### PR DESCRIPTION
## Summary

The ElasticsearchConfigTest overwrites the settings with an invalid host for testing purposes. The settings are cached and affect subsequent tests (depending on the order in which they are run).

## Issue References

Closes #2082

## Checklist

- [x] CHANGELOG.rst updated
