### PR TITLE
[#2091] Allow OIDC logout via GET request for staff users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:gh-issue:`2091`]: Beheerders toestaan om uit te loggen via frontend.
+
 Onderhoud
 ---------
 

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -3166,3 +3166,106 @@ class EIDASOIDCFlowTests(WebTest):
             "duplicate-pseudo-id",
             msg="User's eIDAS pseudo_id must remain unchanged",
         )
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class GenericOIDCLogoutViewTests(WebTest):
+    """Tests for the generic OIDC logout view (for staff/admin users)."""
+
+    def test_generic_oidc_logout_accepts_get_request_for_oidc_users(self):
+        """
+        Test that the generic OIDC logout view accepts GET requests for users
+        with login_type=oidc.
+
+        Needed because staff users who log in via OIDC need to be able to log
+        out using a simple link (GET request), not a form POST.
+        """
+        user = UserFactory.create(login_type=LoginTypeChoices.oidc)
+        self.client.force_login(user)
+
+        logout_url = reverse("oidc_logout")
+
+        # Verify user is logged in
+        self.assertTrue(self.client.session.get("_auth_user_id"))
+
+        # Perform logout via GET request
+        response = self.client.get(logout_url)
+
+        # Should redirect to logout redirect URL
+        self.assertRedirects(
+            response,
+            settings.LOGOUT_REDIRECT_URL,
+            fetch_redirect_response=False,
+        )
+
+        # User should be logged out
+        self.assertFalse(response.wsgi_request.user.is_authenticated)
+        self.assertNotIn("_auth_user_id", self.client.session)
+
+    def test_generic_oidc_logout_redirects_non_oidc_users_to_correct_endpoint(self):
+        """
+        Test that users with non-OIDC login types who manually navigate to
+        /oidc/logout/ are redirected to their proper logout endpoint which
+        handles SSO logout.
+        """
+        # Map login types to appropriate factory and any required fields
+        login_type_configs = {
+            LoginTypeChoices.default: {
+                "factory": UserFactory,
+                "kwargs": {},
+            },
+            LoginTypeChoices.digid: {
+                "factory": DigidUserFactory,
+                "kwargs": {},
+            },
+            LoginTypeChoices.eherkenning: {
+                "factory": eHerkenningUserFactory,
+                "kwargs": {},
+            },
+            LoginTypeChoices.eidas_person_bsn: {
+                "factory": UserFactory,
+                "kwargs": {
+                    "login_type": LoginTypeChoices.eidas_person_bsn,
+                    "bsn": "123456782",
+                    "eidas_pseudo_id": "eidas-bsn-pseudo-123",
+                },
+            },
+            LoginTypeChoices.eidas_person_pseudo_id: {
+                "factory": UserFactory,
+                "kwargs": {
+                    "login_type": LoginTypeChoices.eidas_person_pseudo_id,
+                    "eidas_pseudo_id": "eidas-person-pseudo-456",
+                },
+            },
+            LoginTypeChoices.eidas_company: {
+                "factory": UserFactory,
+                "kwargs": {
+                    "login_type": LoginTypeChoices.eidas_company,
+                    "kvk": "12345678",
+                    "eidas_pseudo_id": "eidas-bsn-pseudo-789",
+                },
+            },
+        }
+
+        for login_type, config in login_type_configs.items():
+            with self.subTest(login_type=login_type):
+                factory = config["factory"]
+                kwargs = config["kwargs"]
+                user = factory.create(**kwargs)
+
+                self.client.force_login(user)
+
+                # User with non-OIDC login_type tries to use generic OIDC logout
+                response = self.client.get(reverse("oidc_logout"))
+
+                # Should redirect to the correct logout URL for their login type
+                expected_logout_url = user.get_logout_url()
+                self.assertRedirects(
+                    response, expected_logout_url, fetch_redirect_response=False
+                )
+
+                # User should still be logged in (redirect happened before logout)
+                self.assertTrue(self.client.session.get("_auth_user_id"))
+
+                # Clean up for next iteration
+                self.client.logout()

--- a/src/open_inwoner/accounts/views/__init__.py
+++ b/src/open_inwoner/accounts/views/__init__.py
@@ -28,6 +28,7 @@ from .auth_oidc import (
     eidas_callback,
     eidas_init,
     eidas_logout,
+    generic_oidc_logout,
 )
 from .contacts import (
     ContactApprovalView,
@@ -104,4 +105,5 @@ __all__ = [
     "eidas_init",
     "eidas_callback",
     "eidas_logout",
+    "generic_oidc_logout",
 ]

--- a/src/open_inwoner/accounts/views/auth_oidc.py
+++ b/src/open_inwoner/accounts/views/auth_oidc.py
@@ -19,6 +19,7 @@ from mozilla_django_oidc_db.views import (
     OIDCInit,
 )
 
+from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.models import (
     OpenIDDigiDConfig,
     OpenIDEHerkenningConfig,
@@ -140,6 +141,43 @@ class OIDCLogoutView(View):
 
         logger.warning("No OIDC logout endpoint defined")
         return HttpResponseRedirect(self.get_success_url())
+
+
+class GenericOIDCLogoutView(OIDCLogoutView):
+    """
+    Generic OIDC logout view that doesn't require a specific config class.
+    This is used for the generic admin OIDC logout endpoint.
+
+    Note: This view should only be used for users with login_type=oidc.
+    DigiD/eHerkenning/eIDAS users should use their respective logout endpoints
+    which handle SSO logout at the identity provider.
+    """
+
+    config_class = None
+
+    def get(self, request):
+        if request.user.is_authenticated and hasattr(request.user, "login_type"):
+            if request.user.login_type != LoginTypeChoices.oidc:
+                correct_logout_url = request.user.get_logout_url()
+                logger.warning(
+                    "User with non-generic OIDC login_type attempted to use generic "
+                    "OIDC logout endpoint, redirecting to correct logout URL",
+                    user_id=request.user.id,
+                    login_type=request.user.login_type,
+                    redirect_to=correct_logout_url,
+                )
+                return HttpResponseRedirect(correct_logout_url)
+
+        # For generic OIDC logout, we don't have a specific config to check
+        # Just log out the user and redirect
+        if "oidc_login_next" in request.session:
+            del request.session["oidc_login_next"]
+
+        auth.logout(request)
+        return HttpResponseRedirect(self.get_success_url())
+
+
+generic_oidc_logout = GenericOIDCLogoutView.as_view()
 
 
 class DigiDOIDCAuthenticationCallbackView(CallbackView):

--- a/src/open_inwoner/urls.py
+++ b/src/open_inwoner/urls.py
@@ -27,6 +27,7 @@ from open_inwoner.accounts.views import (
     PasswordResetView,
     ResendTokenView,
     VerifyTokenView,
+    generic_oidc_logout,
 )
 from open_inwoner.configurations import views
 from open_inwoner.core.views import sitemap
@@ -118,6 +119,7 @@ urlpatterns = [
         "sessions/",
         include("open_inwoner.extended_sessions.urls", namespace="sessions"),
     ),
+    path("oidc/logout/", generic_oidc_logout, name="oidc_logout"),
     path("oidc/", include("mozilla_django_oidc.urls")),
     path("digid-oidc/", include("open_inwoner.accounts.digid_urls")),
     path("eherkenning-oidc/", include("open_inwoner.accounts.eherkenning_urls")),


### PR DESCRIPTION
## Summary

Whenn staff users log in via OIDC (eIDAS), they get `login_type=LoginTypeChoices.oidc`. The `get_logout_url()` method returns `reverse("oidc_logout")` which mapped to mozilla_django_oidc's `OIDCLogoutView`. This view only accepts POST requests by default. A `GenericOIDCLogoutView` is added to allow OIDC users to log out by following a link (GET request).

## Issue References

Closes #2091 

## Checklist

- [x] CHANGELOG.rst updated
