### PR TITLE
fix: [#2116] bump maykin-django-prosemirror to 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Bugfixes
 --------
 
 * [:gh-issue:`2091`]: Beheerders toestaan om uit te loggen via frontend.
+* [:gh-issue:`2116`]: Naamgeving conflict tussen Prosemirror en Leaflet opgelost,
+  waardoor de Prosemirror editor op alle pagina's naar verwachting werkt.
 
 Onderhoud
 ---------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -424,7 +424,7 @@ maykin-2fa==1.0.2
     # via -r requirements/base.in
 maykin-common[otel]==0.10.0
     # via -r requirements/base.in
-maykin-django-prosemirror[images]==0.3.0
+maykin-django-prosemirror[images]==0.4.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -750,7 +750,7 @@ maykin-common[otel]==0.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-django-prosemirror[images]==0.3.0
+maykin-django-prosemirror[images]==0.4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -834,7 +834,7 @@ maykin-common[otel]==0.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-django-prosemirror[images]==0.3.0
+maykin-django-prosemirror[images]==0.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #2116.