### PR TITLE
fix: [#2099] concurrency control for Storybook should only be on deploy

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,11 +15,6 @@ on:
       - ready_for_review
   workflow_dispatch:
 
-# Allow one concurrent deployment
-concurrency:
-  group: 'pages-${{ github.ref_name }}' # unique builds for branch/tag name
-  cancel-in-progress: true
-
 jobs:
   storybook:
     name: Create storybook build
@@ -47,6 +42,11 @@ jobs:
       contents: read
       pages: write
       id-token: write
+
+    # Allow one concurrent deployment
+    concurrency:
+      group: 'pages-${{ github.ref_name }}' # unique builds for branch/tag name
+      cancel-in-progress: true
 
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' && github.event_name == 'push' # Exclude PRs


### PR DESCRIPTION
The concurrency constraint applied to all Storybook builds, not just
deploys, which meant that you would sometimes get failing storybook
CI on feature branches, where the build step is required to succeed.