### PR TITLE
fix: [#2125] use custom build of django-digid-eherkenning

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -44,7 +44,6 @@ fontawesomefree
 django-timeline-logger
 django-csp
 django-csp-reports
-mozilla-django-oidc-db[setup-configuration]
 django-open-forms-client
 django-htmx
 playwright
@@ -82,7 +81,11 @@ elastic-apm  # Elastic APM integration
 beautifulsoup4
 
 # DigidLocal
-django-digid-eherkenning[oidc]
+
+# Pinned to fix #2125 -- we can't upgrade to the latest django-digid-eherkenning due
+# to it being dependent on the newest version of django-mozilla-django-oidcdb
+git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning[oidc]
+mozilla-django-oidc-db[setup-configuration]
 maykin-python3-saml
 pyopenssl
 django-sessionprofile

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -200,7 +200,7 @@ django-csp==3.7
     # via -r requirements/base.in
 django-csp-reports==1.9.1
     # via -r requirements/base.in
-django-digid-eherkenning[oidc]==0.19.2
+django-digid-eherkenning[oidc] @ git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning
     # via -r requirements/base.in
 django-elasticsearch-dsl==8.2
     # via -r requirements/base.in
@@ -441,7 +441,9 @@ mdurl==0.1.2
 messagebird==2.1.0
     # via -r requirements/base.in
 mozilla-django-oidc==4.0.1
-    # via mozilla-django-oidc-db
+    # via
+    #   django-digid-eherkenning
+    #   mozilla-django-oidc-db
 mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -314,7 +314,7 @@ django-csp-reports==1.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning[oidc]==0.19.2
+django-digid-eherkenning[oidc] @ git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -784,6 +784,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   mozilla-django-oidc-db
 mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -349,7 +349,7 @@ django-csp-reports==1.9.1
     #   -r requirements/ci.txt
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-digid-eherkenning[oidc]==0.19.2
+django-digid-eherkenning[oidc] @ git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -868,6 +868,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   mozilla-django-oidc-db
 mozilla-django-oidc-db[setup-configuration]==0.23.0
     # via


### PR DESCRIPTION
Our django-digid-eherkenning version has an incorrect translation for DigiD saml error messages. This is fixed in newer versions, which we cannot upgrade to because it requires first doing the (non-trivial) upgrade of mozilla-django-oidc-db.

Once we update the latter, we can bump our dependency back to latest.

Fixes: #2125 