### PR TITLE
Upgrade preact to 10.27.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Onderhoud
   termen te gebruiken
 * [:gh-issue:`2126`]: ``storybook`` en storybook plugins bijgewerkt naar versie ``10.1.11``.
 * [:gh-issue:`2112`] ``README.rst`` bijgewerkt met Storybook link en correctie in badges en copyright.
+* [:cve:`CVE-2026-22028`, :gh-issue:`2164`] ``preact`` bijgewerkt naar versie ``10.27.3``.
 
 2.0.0 (2026-01-05)
 ==================

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "leaflet": "^1.7.1",
         "material-icons": "^1.13.12",
         "microscope-sass": "latest",
-        "preact": "^10.27.2",
+        "preact": "^10.27.3",
         "preact-custom-element": "^4.6.0",
         "proj4leaflet": "^1.0.2",
         "react": "^18.3.1",
@@ -17130,7 +17130,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.27.2",
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "leaflet": "^1.7.1",
     "material-icons": "^1.13.12",
     "microscope-sass": "latest",
-    "preact": "^10.27.2",
+    "preact": "^10.27.3",
     "preact-custom-element": "^4.6.0",
     "proj4leaflet": "^1.0.2",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

UPGRADE preact to secure version - v10.27.3

## Issue References

- Github Issue: #2164 

## Checklist

- [x] CHANGELOG.rst updated