### PR TITLE
:sparkles: Fix a issue where the fonts are not loaded in sb.

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,13 @@ const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
   addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
   staticDirs: [{ from: '../src/open_inwoner/static', to: '/static' }],
+  viteFinal: async (config) => {
+    // Set base path for GitHub Pages deployment at /open-inwoner/
+    if (process.env.NODE_ENV === 'production') {
+      config.base = '/open-inwoner/';
+    }
+    return config;
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Resolve a issue where the fonts could not be loaded, because we the build base is not set properly in sb github pages env.

## Issue References

- Github Issue: #2099 

## Checklist

- [x] CHANGELOG.rst updated