### PR TITLE
Update link to libxml2 in installation docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Onderhoud
 * [:gh:`2166`]:  ``weasyprint`` bijgewerkt naar versie ``0.68``.
 * [:gh:`2179`, :cve:`CVE-2025-13465`]: ``@utrecht/component-library-react`` bijgewerkt naar versie ``12.0.0``
   en ``loadash-es`` override bijgewerkt naar versie ``4.17.23`` om :cve:`CVE-2025-13465` te mitigeren.
+* [:gh:`2189` :pr:`2188`]: Gebroken link naar libxml2 in documentatie gerepareerd.
 
 2.0.1 (2026-01-26)
 ==================

--- a/docs/installation/development.rst
+++ b/docs/installation/development.rst
@@ -32,7 +32,7 @@ For Linux (Debian) they are following:
 .. _Node.js: http://nodejs.org/
 .. _npm: https://www.npmjs.com/
 .. _Elastic Search: https://www.elastic.co/
-.. _Libxml2: https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home
+.. _Libxml2: https://gitlab.gnome.org/GNOME/libxml2
 .. _GDAL: https://gdal.org/
 
 


### PR DESCRIPTION
## Summary

The link to libxml2 was broken, causing the docs build to fail.

Fixes #2189 

## Checklist

- [x] CHANGELOG.rst updated



<!-- readthedocs-preview open-inwoner start -->
----
📚 Documentation preview 📚: https://open-inwoner--2188.org.readthedocs.build/en/2188/

<!-- readthedocs-preview open-inwoner end -->