### PR TITLE
Missing request argument to messages.error() and messages.info()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,8 @@ Bugfixes
   weer correct wordt geladen.
 * [:gh:`2125`]: ``django-digid-eherkenning`` bijgewerkt naar custom release zodat de
   juiste DigiD SAML Foutmeldingen worden gebruikt.
+* [:gh:`2191`]: Foutmnelding opgelost in Afval Profiel pagina waar `messages.error()` en `messages.info()`
+  zonder verplicht `request` argument werden aangeroepn.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/mijn_afval/views.py
+++ b/src/open_inwoner/mijn_afval/views.py
@@ -298,14 +298,16 @@ class AfvalProfielView(
             }
         )
         if not self.request.user.bsn:
-            messages.info(_("Gegevens alleen beschikbaar voor gebruikers met BSN."))
+            messages.info(
+                self.request, _("Gegevens alleen beschikbaar voor gebruikers met BSN.")
+            )
             return context
 
         # fetch data from API
         afval_config = MijnAfvalConfig.get_solo()
 
         if not (openafval_service := afval_config.openafval_service):
-            messages.error(_("This module is not yet configured"))
+            messages.error(self.request, _("This module is not yet configured"))
             return context
 
         api_client = build_zgw_client(


### PR DESCRIPTION
## Summary

Errror when viewing afval-profiel: "TypeError at /mijn-afval/ error() missing 1 required positional argument: 'message'"
Possibly a requirement since Django 4.2.

## Checklist

- [x] CHANGELOG.rst updated

