### PR TITLE
Remove hardcoded test value from OpenAfvalAPIClient

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Deployment aandachtspunten
 Nieuwe features
 ---------------
 
-* [:taiga-us:`3607`, :pr:`2075`, :pr:`2079`]: Basisapp ‘Mijn Afval’ geïmplementeerd en
+* [:taiga-us:`3607`, :pr:`2075`, :pr:`2079`, :pr:`2193`]: Basisapp ‘Mijn Afval’ geïmplementeerd en
   geïntegreerd met Django CMS.
 * [:gh:`2101`, :oip-nlds:`30`, :oip-nlds:`34`]: Styling van tegels op de Home pagina en van externe-links plugin
   op de Home pagina overgezet naar design-tokens zodat deze volgens de NLDS principes gebruikt kunnen worden.

--- a/src/open_inwoner/mijn_afval/clients.py
+++ b/src/open_inwoner/mijn_afval/clients.py
@@ -12,7 +12,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class OpenAfvalAPIClient(APIClient):
     def get_afval_profiel(self, bsn: str) -> AfvalProfiel:
         try:
-            response = self.get("afval-profiel/987654321")
+            response = self.get(f"afval-profiel/{bsn}")
             response.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             status_code = exc.response.status_code

--- a/src/open_inwoner/mijn_afval/tests/test_client.py
+++ b/src/open_inwoner/mijn_afval/tests/test_client.py
@@ -2,6 +2,8 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
+import requests
+
 from open_inwoner.mijn_afval.clients import OpenAfvalAPIClient
 from open_inwoner.mijn_afval.exceptions import MijnAfvalException
 
@@ -67,9 +69,6 @@ class OpenAfvalClientTest(TestCase):
         self.assertEqual(len(profiel.ledigingen), 1)
 
     def test_get_afval_profiel_http_error(self):
-        """Test HTTP error raises MijnAfvalException"""
-        import requests
-
         client = OpenAfvalAPIClient(base_url="https://api.example.com")
 
         mock_response = Mock()
@@ -81,3 +80,75 @@ class OpenAfvalClientTest(TestCase):
         with patch.object(client, "get", return_value=mock_response):
             with self.assertRaises(MijnAfvalException):
                 client.get_afval_profiel(bsn="123456789")
+
+    def test_get_afval_profiel_uses_correct_bsn_in_url(self):
+        """
+        Regression test: verify the BSN parameter is used in the API endpoint URL
+        """
+        client = OpenAfvalAPIClient(base_url="https://api.example.com")
+
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "klant": {"id": "klant-456", "bsn": "987654321", "naam": "Jane Doe"},
+            "summary": {
+                "totaalGewicht": 500.0,
+                "totaalGewichtPerAfvalType": {"restafval": 500.0},
+                "aantalLedigingen": 5,
+                "aantalContainers": 1,
+                "aantalContainerLocaties": 1,
+                "periode": {
+                    "eersteLediging": "2024-01-01T10:00:00+01:00",
+                    "laatsteLediging": "2024-06-30T10:00:00+01:00",
+                },
+            },
+            "containers": [],
+            "containerLocaties": [],
+            "ledigingen": [],
+        }
+        mock_response.status_code = 200
+
+        with patch.object(client, "get", return_value=mock_response) as mock_get:
+            client.get_afval_profiel(bsn="987654321")
+
+            # Verify the correct endpoint was called with the provided BSN
+            mock_get.assert_called_once_with("afval-profiel/987654321")
+
+    def test_get_afval_profiel_different_bsns_call_different_endpoints(self):
+        """
+        Regression test: verify different BSN values result in different API calls
+        """
+        client = OpenAfvalAPIClient(base_url="https://api.example.com")
+
+        mock_response_template = {
+            "klant": {"id": "klant-id", "bsn": "000000000", "naam": "Test User"},
+            "summary": {
+                "totaalGewicht": 100.0,
+                "totaalGewichtPerAfvalType": {},
+                "aantalLedigingen": 1,
+                "aantalContainers": 1,
+                "aantalContainerLocaties": 1,
+                "periode": {
+                    "eersteLediging": "2024-01-01T10:00:00+01:00",
+                    "laatsteLediging": "2024-01-31T10:00:00+01:00",
+                },
+            },
+            "containers": [],
+            "containerLocaties": [],
+            "ledigingen": [],
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = mock_response_template
+        mock_response.status_code = 200
+
+        test_bsns = ["111111111", "222222222", "333333333"]
+
+        with patch.object(client, "get", return_value=mock_response) as mock_get:
+            for bsn in test_bsns:
+                client.get_afval_profiel(bsn=bsn)
+
+            # Verify each BSN was used in its API call
+            self.assertEqual(mock_get.call_count, 3)
+            mock_get.assert_any_call("afval-profiel/111111111")
+            mock_get.assert_any_call("afval-profiel/222222222")
+            mock_get.assert_any_call("afval-profiel/333333333")


### PR DESCRIPTION
## Summary

The `OpenAfvalAPIClient` had a hard-coded parameter from development/testing

## Checklist

- [x] CHANGELOG.rst updated
