### PR TITLE
[#2198] Bump Django to 4.2.28

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Onderhoud
 * [:gh:`2166`]:  ``weasyprint`` bijgewerkt naar versie ``0.68``.
 * [:gh:`2179`, :cve:`CVE-2025-13465`]: ``@utrecht/component-library-react`` bijgewerkt naar versie ``12.0.0``
   en ``loadash-es`` override bijgewerkt naar versie ``4.17.23`` om :cve:`CVE-2025-13465` te mitigeren.
+* [:gh:`2198`, :pr:`2197`]: Django bijgewerkt naar versie ``4.2.28``.
 
 2.0.1 (2026-01-26)
 ==================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,7 +97,7 @@ defusedxml==0.7.1
     # via odfpy
 diff-match-patch==20200713
     # via django-import-export
-django==4.2.27
+django==4.2.28
     # via
     #   -r requirements/base.in
     #   django-admin-index

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -177,7 +177,7 @@ diff-match-patch==20200713
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-import-export
-django==4.2.27
+django==4.2.28
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -208,7 +208,7 @@ diff-match-patch==20200713
     #   django-import-export
 distlib==0.3.9
     # via virtualenv
-django==4.2.27
+django==4.2.28
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Upgraded Django to 4.2.28 with security patches.

https://docs.djangoproject.com/en/6.0/releases/4.2.28/

Closes #2198 


## Checklist

- [x] CHANGELOG.rst updated
