### PR TITLE
[#2190] Set up commitizen

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -106,6 +106,24 @@ jobs:
             echo "✅ SUCCESS: Ruff versions match ($CI_VERSION)"
           fi
 
+  commit-message-check:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: 'pyproject.toml'
+      - name: Install commitizen
+        run: pip install commitizen==4.16.3
+      - name: Check commit messages
+        run: |
+          cz check --rev-range origin/${GITHUB_BASE_REF}..${{ github.sha }}
+
   zizmor:
     name: GitHub Actions Security Analysis with zizmor 🌈
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
         entry: npx prettier --write --ignore-unknown
         language: system
         types_or: [javascript, jsx, ts, tsx, css, scss, json, yaml, markdown]
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -25,3 +26,18 @@ repos:
     rev: v1.22.0
     hooks:
       - id: zizmor
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.16.3
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
+        args:
+          - --allow-abort
+          - --allowed-prefixes
+          - Merge
+          - Revert
+          - Pull request
+          - fixup!
+          - squash!
+          - amend!
+          - --commit-msg-file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,16 +57,52 @@ repository is forked, you can clone it to your local machine.
 On your local machine, create a new branch, and name it like:
 
 - `feature/some-new-feature`, if the changes implement a new feature
-- `issue/some-issue`, if the changes fix an issue
+- `fix/some-bug`, if the changes fix a bug
+- `issue/some-issue`, for all other code changes
 
 Once you have made changes or additions to the code, you can commit them (try to
-keep the commit message descriptive but short). If an issue already exists in
-the list of existing [issues][issues] for the changes you made, be sure to
-format your commit message like
-`:gitmoji: Fixes #<issue_id> -- description of changes made`, where `<issue_id>`
-corresponds to the number of the issue on GitHub. To demonstrate that the
-changes implement the new feature/fix the issue, make sure to also add tests to
-the existing Django testsuite.
+keep the commit message descriptive but short). Commits should follow the
+[Conventional Commits](https://www.conventionalcommits.org/) pattern:
+
+```
+<type>: [#issue-reference] <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types include `feat`, `fix`, `docs`, `style`, `refactor`, `test`, and
+`chore`. If an issue already exists in the list of existing [issues][issues] for
+the changes you made, be sure to reference it in the commit message, e.g.
+`feat: [#1234] add new feature`, and optionally in the footer. Use imperative
+mood to describe the change. It can help to think of your messages as starting
+with "If applied, this commit will.." (`add new feature` instead of
+`added new feature`).
+
+#### Using Commitizen
+
+To facilitate creating commits that comply with the conventional commit format,
+you can use the [Commitizen](https://github.com/commitizen-tools/commitizen) CLI
+tool. This interactive tool will guide you through creating properly formatted
+commit messages.
+
+To install Commitizen:
+
+- **Linux**: `pip install --user commitizen` or `pipx install commitizen`
+- **macOS**: `brew install commitizen` or `pip install --user commitizen`
+
+Once installed, instead of `git commit`, use:
+
+```
+$ cz commit
+```
+
+This will interactively prompt you for the commit type, description, and other
+fields to build a compliant commit message.
+
+To demonstrate that the changes implement the new feature/fix the issue, make
+sure to also add tests to the existing Django testsuite.
 
 ### Making a pull request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ update_changelog_on_bump = true
 [tool.commitizen.customize]
 commit_parser = "^(?P<change_type>feat|fix|docs|style|refactor|test|build|ci|chore|revert)(?:\\((?P<scope>[^)]+)\\))?!?:\\s(?P<message>.+)"
 changelog_pattern = "^(feat|fix|docs|style|refactor|test|build|ci|chore|revert)(\\(.+\\))?(!)?:"
+schema_pattern = "^(feat|fix|docs|style|refactor|test|build|ci|chore|revert)(\\([a-z0-9_-]+\\))?!?:\\s(\\[#\\d+\\]\\s)?.+"
 message_template = "{{change_type}}:{% if issue %} [#{{ issue }}]{% endif %} {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
 
 [[tool.commitizen.customize.questions]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,17 @@ tag_format = "v$version"
 version_scheme = "semver2"
 version_provider = "pep621"
 update_changelog_on_bump = true
+pre_bump_hooks = [
+    "sed -i \"s/releaseDate: '.*'/releaseDate: '$(date +%Y-%m-%d)'/\" publiccode.yaml",
+    "uv lock",
+    "pre-commit run --files pyproject.toml README.rst publiccode.yaml src/open_inwoner/conf/base.py $CZ_PRE_CHANGELOG_FILE_NAME uv.lock || true",
+    "git add -u",
+]
+version_files = [
+    "README.rst::Version: ",
+    "publiccode.yaml:softwareVersion: ",
+    'src/open_inwoner/conf/base.py:RELEASE = "v',
+]
 
 [tool.commitizen.customize]
 commit_parser = "^(?P<change_type>feat|fix|docs|style|refactor|test|build|ci|chore|revert)(?:\\((?P<scope>[^)]+)\\))?!?:\\s(?P<message>.+)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,3 +177,52 @@ line-ending = "lf"
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "logging".msg = "Use `structlog.get_logger(__name__)` instead of the stdlib logging module."
 "open_inwoner.openzaak.clients.MultiZgwClientProxy".msg = "Use ZGWService instead of MultiZgwClientProxy directly."
+
+[tool.commitizen]
+name = "cz_customize"
+tag_format = "v$version"
+version_scheme = "semver2"
+version_provider = "pep621"
+update_changelog_on_bump = true
+
+[tool.commitizen.customize]
+commit_parser = "^(?P<change_type>feat|fix|docs|style|refactor|test|build|ci|chore|revert)(?:\\((?P<scope>[^)]+)\\))?!?:\\s(?P<message>.+)"
+changelog_pattern = "^(feat|fix|docs|style|refactor|test|build|ci|chore|revert)(\\(.+\\))?(!)?:"
+message_template = "{{change_type}}:{% if issue %} [#{{ issue }}]{% endif %} {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
+
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "change_type"
+message = "Select the type of change you are committing"
+choices = [
+    {value = "feat", name = "feat: A new feature. Correlates with MINOR in SemVer"},
+    {value = "fix", name = "fix: A bug fix. Correlates with PATCH in SemVer"},
+    {value = "docs", name = "docs: Documentation only changes"},
+    {value = "style", name = "style: Changes that do not affect the meaning of the code"},
+    {value = "refactor", name = "refactor: A code change that neither fixes a bug nor adds a feature"},
+    {value = "test", name = "test: Adding missing tests or correcting existing tests"},
+    {value = "build", name = "build: Changes that affect the build system or external dependencies"},
+    {value = "ci", name = "ci: Changes to CI configuration files and scripts"},
+    {value = "chore", name = "chore: Other changes that don't modify src or test files"},
+    {value = "revert", name = "revert: Reverts a previous commit"},
+]
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "issue"
+message = "Provide the issue number: (press [enter] to skip)"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "subject"
+message = "Write a short and imperative summary of the code changes: (lower case and no period)"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "body"
+message = "Provide additional contextual information about the code changes: (press [enter] to skip)"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "footer"
+message = "Information about Breaking Changes and reference issues that this commit closes: (press [enter] to skip)"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ cffi==2.0.0
     # via
     #   cryptography
     #   weasyprint
-charset-normalizer==2.0.6
+charset-normalizer==3.4.4
     # via
     #   reportlab
     #   requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -524,7 +524,7 @@ opentelemetry-util-http==0.58b0
     #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1
     # via furl
-packaging==23.0
+packaging==26.0
     # via
     #   django-cms
     #   djangocms-versioning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -930,7 +930,7 @@ orderedmultidict==1.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   furl
-packaging==23.0
+packaging==26.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -96,7 +96,7 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   cryptography
     #   weasyprint
-charset-normalizer==2.0.6
+charset-normalizer==3.4.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,3 +14,5 @@ django-silk
 # VCR
 pytest-recording
 vcrpy
+
+commitizen

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,6 +26,8 @@ ape-pie==0.2.0
     #   objects-api-client-django
     #   open-klant-client
     #   zgw-consumers
+argcomplete==3.6.3
+    # via commitizen
 asgiref==3.11.1
     # via
     #   -c requirements/ci.txt
@@ -116,6 +118,7 @@ charset-normalizer==3.4.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   commitizen
     #   reportlab
     #   requests
 clamd==1.0.2
@@ -148,6 +151,10 @@ click-repl==0.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
+colorama==0.4.6
+    # via commitizen
+commitizen==4.16.3
+    # via -r requirements/dev.in
 commonmark==0.9.1
     # via
     #   -c requirements/ci.txt
@@ -199,11 +206,15 @@ cssselect2==0.8.0
     #   -r requirements/ci.txt
     #   svglib
     #   weasyprint
+decli==0.6.3
+    # via commitizen
 defusedxml==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   odfpy
+deprecated==1.3.1
+    # via commitizen
 diff-match-patch==20200713
     # via
     #   -c requirements/ci.txt
@@ -797,6 +808,7 @@ jinja2==3.1.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   commitizen
     #   flask
     #   sphinx
 josepy==1.13.0
@@ -1029,6 +1041,7 @@ packaging==26.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   build
+    #   commitizen
     #   django-cms
     #   djangocms-versioning
     #   kombu
@@ -1080,6 +1093,8 @@ prompt-toolkit==3.0.36
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   click-repl
+    #   commitizen
+    #   questionary
 propcache==0.3.2
     # via
     #   -c requirements/ci.txt
@@ -1230,6 +1245,7 @@ pyyaml==6.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   commitizen
     #   drf-spectacular
     #   gemma-zds-client
     #   pre-commit
@@ -1244,6 +1260,8 @@ qrcode==6.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
+questionary==2.1.1
+    # via commitizen
 recommonmark==0.7.1
     # via
     #   -c requirements/ci.txt
@@ -1427,6 +1445,8 @@ tblib==1.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+termcolor==3.3.0
+    # via commitizen
 tinycss2==1.5.1
     # via
     #   -c requirements/ci.txt
@@ -1441,6 +1461,8 @@ tinyhtml5==2.0.0
     #   weasyprint
 tomli==1.2.1
     # via pep517
+tomlkit==0.15.0
+    # via commitizen
 typer==0.21.1
     # via
     #   -c requirements/ci.txt
@@ -1557,6 +1579,7 @@ wrapt==1.14.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   deprecated
     #   elastic-apm
     #   opentelemetry-instrumentation
     #   vcrpy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1024,7 +1024,7 @@ orderedmultidict==1.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   furl
-packaging==23.0
+packaging==26.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -112,7 +112,7 @@ cffi==2.0.0
     #   weasyprint
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==2.0.6
+charset-normalizer==3.4.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

Added and configured commitizen to enforce conventional commit style:

- custom commit types: all of classic conventional commits except `perf`
- commit format (example) `feat: [#1234] add new feature`
- issue reference is optional
- commit message format is validated in CI for the commits in the PR
- pre-commit hook validation for early feedback

`CONTRIBUTING.md` updated with instructions about commit message format.

Closes #2190

## To be discussed 

- Merge commits: my suggestion is to switch to rebase-only workflow without merge commits. A clean commit tree is worth the loss of contextual info in my view.
- issue references: we could enforce issue references for `feat` commits but leave them optional for other type of commits. The rationale is that, first, features are exclusively driven by clients, whereas other types of code changes could also be motivated by us, and secondly, issues often add useful context for feature commits, not so much for other types (small bug fixes, updates to the docs etc; it would be annoying to have to create an issue for everything just to comply with a commit message format).

## Checklist

- [ ] CHANGELOG.rst updated
