### PR TITLE
[#2111] Implement afval filters web components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Nieuwe features
 * [:gh:`2113`]: Diagram (chart.js) toegevoegd ten behoeve van de 'Mijn Afval' app.
 * [:gh:`2119`, :gh:`2182`, :pr:`2151`]: API-client en configuratie voor 'Mijn Afval' aangemaakt.
 * [:gh:`2157`, :gh:`2205`]: Toon het nieuwste antwoord op OpenKlant-vragen.
-* [:gh:`2192`, :pr:`2195`]: Filters voor 'Mijn Afval' geïmplementeerd.
+* [:gh:`2192`, :pr:`2195`, :pr:`2200`]: Filters voor 'Mijn Afval' geïmplementeerd.
 
 Bugfixes
 --------

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@gemeente-denhaag/action": "^4.0.1",
         "@gemeente-denhaag/side-navigation": "^4.0.2",
-        "@open-inwoner/design-tokens": "^0.0.25",
+        "@open-inwoner/design-tokens": "^0.0.27",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "@utrecht/button-css": "^2.3.1",
         "@utrecht/document-css": "^1.5.1",
@@ -1355,9 +1355,9 @@
       "license": "MIT"
     },
     "node_modules/@open-inwoner/design-tokens": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.25.tgz",
-      "integrity": "sha512-aQCO0pB1UlzQ8/3zTmbzKYPSKFUgdnaYlTKxI+Oq8tuMjhgfuqVIMifFHi5AGQ5mYgKsptOVlDNOzt2BdcfdKQ==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@open-inwoner/design-tokens/-/design-tokens-0.0.27.tgz",
+      "integrity": "sha512-QLPupglyPEPvKP4hGNahyldGNvsh39QwwIsduzk3hrbVxOzxQ7wdFVKCJsXRGYxj+GxhM+IHEaNQ3qT0Ziw9PQ==",
       "license": "EUPL-1.2"
     },
     "node_modules/@parcel/watcher": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:ui": "vitest --ui",
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
-    "watch": "vite build --watch --mode development"
+    "watch": "vite build --watch --mode development --debug"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@gemeente-denhaag/action": "^4.0.1",
     "@gemeente-denhaag/side-navigation": "^4.0.2",
-    "@open-inwoner/design-tokens": "^0.0.25",
+    "@open-inwoner/design-tokens": "^0.0.27",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "@utrecht/button-css": "^2.3.1",
     "@utrecht/document-css": "^1.5.1",

--- a/src/open_inwoner/mijn_afval/tests/test_views.py
+++ b/src/open_inwoner/mijn_afval/tests/test_views.py
@@ -74,8 +74,7 @@ class ExtractFilterOptionsTest(TestCase):
         self.assertEqual(options["afval_types"][1]["value"], "restafval")
 
         # Verify year range calculated from ledigingen
-        self.assertEqual(options["earliest_year"], 2023)
-        self.assertEqual(options["latest_year"], 2025)
+        self.assertListEqual(options["period"], [2025, 2023])
 
     def test_extract_filter_options_no_ledigingen(self):
         profiel = AfvalProfiel(
@@ -93,9 +92,8 @@ class ExtractFilterOptionsTest(TestCase):
 
         options = _extract_filter_options(profiel)
 
-        # Verify year range is None when no ledigingen
-        self.assertIsNone(options["earliest_year"])
-        self.assertIsNone(options["latest_year"])
+        # Verify emptry period options when no ledigingen
+        self.assertListEqual(options["period"], [])
 
     def test_extract_filter_options_same_year(self):
         profiel = AfvalProfiel(
@@ -124,9 +122,8 @@ class ExtractFilterOptionsTest(TestCase):
 
         options = _extract_filter_options(profiel)
 
-        # Verify same year for both earliest and latest
-        self.assertEqual(options["earliest_year"], 2024)
-        self.assertEqual(options["latest_year"], 2024)
+        # Verify single period options
+        self.assertListEqual(options["period"], [2024])
 
 
 class ConvertPeriodToDatesTest(TestCase):

--- a/src/open_inwoner/mijn_afval/views.py
+++ b/src/open_inwoner/mijn_afval/views.py
@@ -128,8 +128,7 @@ class AfvalProfielView(
             filter_options = {
                 "addresses": [],
                 "afval_types": [],
-                "earliest_year": None,
-                "latest_year": None,
+                "periode": [],
             }
 
         context["afval_data"] = afval_data
@@ -331,18 +330,12 @@ def _extract_filter_options(profiel: AfvalProfiel) -> dict:
     ]
 
     # Calculate year range from ledigingen
-    earliest_year = None
-    latest_year = None
-    if profiel.ledigingen:
-        dates = [lediging.geleegd_op for lediging in profiel.ledigingen]
-        earliest_year = min(dates).year
-        latest_year = max(dates).year
+    dates = {lediging.geleegd_op.year for lediging in profiel.ledigingen}
 
     return {
         "addresses": formatted_addresses,
         "afval_types": afval_types,
-        "earliest_year": earliest_year,
-        "latest_year": latest_year,
+        "periode": list(dates),
     }
 
 

--- a/src/open_inwoner/react/components/AfvalFilter/AfvalFilter.stories.tsx
+++ b/src/open_inwoner/react/components/AfvalFilter/AfvalFilter.stories.tsx
@@ -1,0 +1,135 @@
+import { withIntl, withLoader } from '@react/lib/decorators/storybook';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import {
+  AFVAL_FILTERS_DEFINITION,
+  AfvalFilter,
+  type AfvalFilterConfig,
+} from '.';
+
+type IAfvalFilterProps = {
+  dataId?: string;
+  data?: AfvalFilterConfig;
+};
+
+type Story = StoryObj<IAfvalFilterProps>;
+
+const sampleConfig: AfvalFilterConfig = {
+  addresses: [
+    'Lindelaan 156 A, 3456 GH, Den Haag',
+    'Kerkstraat 42, 2511 AB, Den Haag',
+    'Binnenhof 1, 2513 AA, Den Haag',
+  ],
+  afval_types: [
+    { label: 'Restafval', value: 'restafval' },
+    { label: 'GFT', value: 'gft' },
+    { label: 'Papier', value: 'papier' },
+    { label: 'PMD', value: 'pmd' },
+  ],
+  periode: [2025, 2024, 2023],
+};
+
+const meta: Meta<typeof AfvalFilter> = {
+  title: 'Components/AfvalFilter',
+  component: AfvalFilter,
+  decorators: [withIntl],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+The AfvalFilter component is a specialized filter bar for the "Mijn Afval" page.
+
+It wraps the generic Filters component and automatically creates filter groups
+from an \`AfvalFilterConfig\` containing addresses, waste types, and periods.
+
+**Features:**
+- Automatically builds filter groups from afval-specific configuration
+- Reads initial filter state from URL query parameters
+- Supports addresses, afval types, and period (year) filters
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+
+/**
+ * Default state with all filter groups and no pre-selected filters.
+ */
+export const Default: Story = {
+  args: {
+    data: sampleConfig,
+  },
+};
+
+/**
+ * Only period filters available.
+ */
+export const PeriodOnly: Story = {
+  args: {
+    data: {
+      ...sampleConfig,
+      addresses: [],
+      afval_types: [],
+    },
+  },
+};
+
+/**
+ * Only afval type filters available.
+ */
+export const AfvalTypesOnly: Story = {
+  args: {
+    data: {
+      ...sampleConfig,
+      addresses: [],
+      periode: [],
+    },
+  },
+};
+
+/**
+ * Single address, useful for users with one registered address.
+ */
+export const SingleAddress: Story = {
+  args: {
+    data: {
+      ...sampleConfig,
+      addresses: ['Kerkstraat 42, 2511 AB, Den Haag'],
+      periode: [2025],
+    },
+  },
+};
+
+/**
+ * Many addresses for users with multiple registered locations.
+ */
+export const ManyAddresses: Story = {
+  args: {
+    data: {
+      ...sampleConfig,
+      addresses: Array.from(
+        { length: 8 },
+        (_, i) => `Straatnaam ${i + 1}, ${1000 + i} AB, Den Haag`
+      ),
+    },
+  },
+};
+
+/**
+ * Rendered as a web component via oip-afval-filters.
+ */
+export const AsWebComponent: Story = {
+  decorators: [withLoader(AFVAL_FILTERS_DEFINITION.tagName)],
+  render: () => {
+    return (
+      <>
+        <script type="application/json" id="storybook-afval-filter-config">
+          {JSON.stringify(sampleConfig)}
+        </script>
+        <oip-afval-filters data-id="storybook-afval-filter-config" />
+      </>
+    );
+  },
+};

--- a/src/open_inwoner/react/components/AfvalFilter/AfvalFilter.tsx
+++ b/src/open_inwoner/react/components/AfvalFilter/AfvalFilter.tsx
@@ -1,0 +1,50 @@
+import { Filters, IFilterChoice } from '@react/components/Filters';
+import { usePropsOrScriptData } from '@react/lib/json';
+import { AnyComponent as AC } from 'preact';
+import { useAfvalFilter } from '.';
+
+/**
+ * Type of the data.
+ * The actual format is defined in the backend.
+ */
+export interface AfvalFilterConfig {
+  addresses: string[];
+  afval_types: IFilterChoice[];
+  periode: number[];
+}
+
+/**
+ * The names of the filters.
+ * The name will be used in the GET query string.
+ */
+export type AfvalFilterTypes = 'periode' | 'adres' | 'afval-type';
+
+/**
+ * The AfvalFilter component props.
+ * @param
+ * @param
+ */
+export type IAfvalFilterProps = {
+  /**
+   * `dataId` is used by web-components.
+   * Only works in combination with a json script.
+   * The json script should contain data conform the `AfvalFilterConfig` type.
+   */
+  dataId?: string;
+  /**
+   * `data` is used by Preact components to pass data as an object.
+   */
+  data?: AfvalFilterConfig;
+};
+
+const AfvalFilter: AC<IAfvalFilterProps> = ({ data, dataId }) => {
+  const config = usePropsOrScriptData<AfvalFilterConfig>(data, dataId);
+  if (!config) return <></>;
+
+  const afvalFilter = useAfvalFilter(config);
+  if (!afvalFilter) return <></>;
+
+  return <Filters data={afvalFilter} />;
+};
+
+export default AfvalFilter;

--- a/src/open_inwoner/react/components/AfvalFilter/constants.ts
+++ b/src/open_inwoner/react/components/AfvalFilter/constants.ts
@@ -1,0 +1,12 @@
+import { WebComponentDefinition } from '@react/lib/web-component';
+import { IAfvalFilterProps } from '.';
+
+export const AFVAL_FILTERS_DEFINITION: WebComponentDefinition<
+  'oip-afval-filters',
+  IAfvalFilterProps
+> = {
+  tagName: 'oip-afval-filters',
+  propNames: ['dataId', 'data'],
+  options: { shadow: false, i18n: true },
+  importer: () => import('./AfvalFilter'),
+};

--- a/src/open_inwoner/react/components/AfvalFilter/hooks/useAfvalFilter.spec.ts
+++ b/src/open_inwoner/react/components/AfvalFilter/hooks/useAfvalFilter.spec.ts
@@ -1,0 +1,196 @@
+import { renderHook } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AfvalFilterConfig, AfvalFilterTypes, useAfvalFilter } from '..';
+
+// Mock react-intl – formatMessage returns the defaultMessage as a plain string
+vi.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: (descriptor: { defaultMessage: string }) =>
+      // @ts-expect-error this is valid
+      descriptor.defaultMessage[0].value,
+  }),
+}));
+
+const fullConfig: AfvalFilterConfig = {
+  periode: [2024, 2025],
+  afval_types: [
+    { value: 'rest', label: 'Restafval' },
+    { value: 'gft', label: 'GFT' },
+  ],
+  addresses: ['Kerkstraat 12', 'Dorpslaan 5'],
+};
+
+describe('useAfvalFilter', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    // Save and mock window.location.search
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, search: '' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  describe('filterGroups', () => {
+    it('creates a period group from config.period', () => {
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+      const periodGroup = result.current.filterGroups.find(
+        (g) => g.name === 'periode'
+      );
+
+      expect(periodGroup).toBeDefined();
+      expect(periodGroup!.label).toBe('Periode');
+      expect(periodGroup!.choices).toEqual([
+        { label: 'Jaar 2024', value: '2024' },
+        { label: 'Jaar 2025', value: '2025' },
+      ]);
+    });
+
+    it('creates an afval-type group from config.afval_types', () => {
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+      const typeGroup = result.current.filterGroups.find(
+        (g) => g.name === 'afval-type'
+      );
+
+      expect(typeGroup).toBeDefined();
+      expect(typeGroup!.label).toBe('Type container');
+      expect(typeGroup!.choices).toEqual([
+        { value: 'rest', label: 'Restafval' },
+        { value: 'gft', label: 'GFT' },
+      ]);
+    });
+
+    it('creates an adres group from config.addresses', () => {
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+      const adresGroup = result.current.filterGroups.find(
+        (g) => g.name === 'adres'
+      );
+
+      expect(adresGroup).toBeDefined();
+      expect(adresGroup!.label).toBe('Adres');
+      expect(adresGroup!.choices).toEqual([
+        { label: 'Kerkstraat 12', value: 'Kerkstraat 12' },
+        { label: 'Dorpslaan 5', value: 'Dorpslaan 5' },
+      ]);
+    });
+
+    it('omits period group when config.period is undefined', () => {
+      const config: AfvalFilterConfig = {
+        ...fullConfig,
+        periode: undefined as any,
+      };
+      const { result } = renderHook(() => useAfvalFilter(config));
+
+      expect(
+        result.current.filterGroups.find((g) => g.name === 'periode')
+      ).toBeUndefined();
+    });
+
+    it('omits afval-type group when config.afval_types is undefined', () => {
+      const config: AfvalFilterConfig = {
+        ...fullConfig,
+        afval_types: undefined as any,
+      };
+      const { result } = renderHook(() => useAfvalFilter(config));
+
+      expect(
+        result.current.filterGroups.find((g) => g.name === 'afval-type')
+      ).toBeUndefined();
+    });
+
+    it('omits adres group when config.addresses is undefined', () => {
+      const config: AfvalFilterConfig = {
+        ...fullConfig,
+        addresses: undefined as any,
+      };
+      const { result } = renderHook(() => useAfvalFilter(config));
+
+      expect(
+        result.current.filterGroups.find((g) => g.name === 'adres')
+      ).toBeUndefined();
+    });
+
+    it('returns empty filterGroups when all config fields are undefined', () => {
+      const config = {} as AfvalFilterConfig;
+      const { result } = renderHook(() => useAfvalFilter(config));
+
+      expect(result.current.filterGroups).toEqual(
+        [] satisfies typeof result.current.filterGroups
+      );
+    });
+
+    it('preserves group order: period, afval-type, adres', () => {
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+      const names = result.current.filterGroups.map((g) => g.name);
+
+      expect(names).toEqual([
+        'periode',
+        'afval-type',
+        'adres',
+      ] satisfies AfvalFilterTypes[]);
+    });
+  });
+
+  describe('initialFilterState', () => {
+    it('returns empty arrays when no URL params are present', () => {
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+
+      expect(result.current.initialFilterState).toEqual({
+        periode: [],
+        adres: [],
+        'afval-type': [],
+      } satisfies typeof result.current.initialFilterState);
+    });
+
+    it('reads period values from URL search params', () => {
+      window.location.search = '?periode=2024';
+
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+
+      expect(result.current.initialFilterState.periode).toEqual([
+        '2024',
+      ] satisfies typeof result.current.initialFilterState.periode);
+    });
+
+    it('reads adres values from URL search params', () => {
+      window.location.search = '?adres=Kerkstraat+12';
+
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+
+      expect(result.current.initialFilterState.adres).toEqual([
+        'Kerkstraat 12',
+      ] satisfies typeof result.current.initialFilterState.adres);
+    });
+
+    it('reads afval-type values from URL search params', () => {
+      window.location.search = '?afval-type=rest&afval-type=gft';
+
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+
+      expect(result.current.initialFilterState['afval-type']).toEqual([
+        'rest',
+        'gft',
+      ] satisfies (typeof result.current.initialFilterState)['afval-type']);
+    });
+
+    it('reads multiple filter types from URL simultaneously', () => {
+      window.location.search = '?periode=2025&adres=Dorpslaan+5&afval-type=gft';
+
+      const { result } = renderHook(() => useAfvalFilter(fullConfig));
+
+      expect(result.current.initialFilterState).toEqual({
+        periode: ['2025'],
+        adres: ['Dorpslaan 5'],
+        'afval-type': ['gft'],
+      } satisfies typeof result.current.initialFilterState);
+    });
+  });
+});

--- a/src/open_inwoner/react/components/AfvalFilter/hooks/useAfvalFilters.ts
+++ b/src/open_inwoner/react/components/AfvalFilter/hooks/useAfvalFilters.ts
@@ -1,0 +1,82 @@
+import {
+  FilterState,
+  IFilterGroup,
+  IFiltersConfig,
+} from '@react/components/Filters';
+import { useMemo } from 'preact/hooks';
+import { useIntl } from 'react-intl';
+import { AfvalFilterConfig, AfvalFilterTypes } from '..';
+
+/**
+ * Hook tailor made for Mijn Afval filters.
+ * Creates both the filterGroups and initialFilterState.
+ * @param config
+ */
+export const useAfvalFilter = (
+  config: AfvalFilterConfig
+): IFiltersConfig<AfvalFilterTypes> => {
+  const intl = useIntl();
+
+  const filterGroups = useMemo(() => {
+    const groups: IFilterGroup<AfvalFilterTypes>[] = [];
+
+    if (config.periode) {
+      groups.push({
+        name: 'periode',
+        label: intl.formatMessage({
+          id: 'filter.period_filter',
+          description: 'The label for the filter period',
+          defaultMessage: 'Periode',
+        }),
+        choices: config.periode.map((choice) => ({
+          label: `${intl.formatMessage({
+            id: 'filter.period_filter_year_prefix',
+            description: 'The prefix for the options of type period',
+            defaultMessage: 'Jaar',
+          })} ${choice}`,
+          value: String(choice),
+        })),
+        multiple: false,
+      });
+    }
+
+    if (config.afval_types) {
+      groups.push({
+        name: 'afval-type',
+        label: intl.formatMessage({
+          id: 'filter.container_type_filter',
+          description: 'The label for the filter container type',
+          defaultMessage: 'Type container',
+        }),
+        choices: config.afval_types,
+      });
+    }
+
+    if (config.addresses) {
+      groups.push({
+        name: 'adres',
+        label: intl.formatMessage({
+          id: 'filter.adres_filter',
+          description: 'The label for the filter adres',
+          defaultMessage: 'Adres',
+        }),
+        choices: config.addresses.map((choice) => ({
+          label: choice,
+          value: choice,
+        })),
+      });
+    }
+
+    return groups;
+  }, [config]);
+
+  const defaultValues = new URLSearchParams(window.location.search);
+
+  const initialFilterState: FilterState<AfvalFilterTypes> = {
+    periode: defaultValues.getAll('periode'),
+    adres: defaultValues.getAll('adres'),
+    'afval-type': defaultValues.getAll('afval-type'),
+  };
+
+  return { initialFilterState, filterGroups };
+};

--- a/src/open_inwoner/react/components/AfvalFilter/index.ts
+++ b/src/open_inwoner/react/components/AfvalFilter/index.ts
@@ -1,0 +1,15 @@
+// Preact Component
+export { default as AfvalFilter } from './AfvalFilter';
+
+// Types
+export type {
+  AfvalFilterConfig,
+  AfvalFilterTypes,
+  IAfvalFilterProps,
+} from './AfvalFilter';
+
+// Constants
+export * from './constants';
+
+// Hooks
+export * from './hooks/useAfvalFilters';

--- a/src/open_inwoner/react/components/Button/Button.scss
+++ b/src/open_inwoner/react/components/Button/Button.scss
@@ -1,0 +1,24 @@
+// This file is an addition/overwrite on the legacy scss/**/Button.scss styling.
+.button {
+  &--icon-lg {
+    [class*='icons'],
+    [class*='Icons'] {
+      font-size: 24px;
+      max-width: 24px;
+    }
+  }
+
+  &--no-underline {
+    text-decoration: none !important;
+  }
+
+  // Overwrites scss/**/Button.scss disabled styling.
+  &:disabled,
+  &--disabled {
+    background-color: var(--color-gray) !important;
+    border-color: var(--color-gray) !important;
+    color: var(--color-white);
+    cursor: default;
+    pointer-events: none;
+  }
+}

--- a/src/open_inwoner/react/components/Button/Button.stories.tsx
+++ b/src/open_inwoner/react/components/Button/Button.stories.tsx
@@ -1,0 +1,2 @@
+// TODO write button stories.
+export default {};

--- a/src/open_inwoner/react/components/Button/Button.tsx
+++ b/src/open_inwoner/react/components/Button/Button.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx';
+import {
+  AnyComponent as AC,
+  ButtonHTMLAttributes,
+  MouseEventHandler,
+} from 'preact';
+import './Button.scss';
+
+export type ButtonProps = {
+  text?: string;
+  handleClick: MouseEventHandler<HTMLButtonElement>;
+  variant: 'primary' | 'secondary';
+  transparent?: boolean;
+  className?: string;
+  iconSize?: 'md' | 'lg';
+  underline?: 'none' | 'hover';
+  fullWidth?: boolean;
+} & ButtonHTMLAttributes;
+
+const Button: AC<ButtonProps> = ({
+  text,
+  handleClick,
+  title,
+  variant = 'primary',
+  children,
+  transparent,
+  type = 'button',
+  className,
+  iconSize,
+  underline = 'none',
+  disabled,
+  fullWidth = false,
+  ...props
+}) => {
+  return (
+    <button
+      {...props}
+      type={type}
+      className={clsx(
+        'button',
+        `button--${variant}`,
+        {
+          ['button--transparent']: transparent,
+          ['button--fullwidth']: fullWidth,
+          ['button--disabled']: disabled,
+          ['button--textless']: !text,
+          ['button--icon']: !text,
+          ['button--icon-lg']: iconSize == 'lg',
+          ['button--no-underline']: underline === 'none',
+        },
+        className
+      )}
+      onClick={handleClick}
+      title={title || text}
+      aria-label={text || title}
+      disabled={disabled}
+    >
+      {text ? <span class="button__inner-text">{text}</span> : children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/open_inwoner/react/components/Button/constants.ts
+++ b/src/open_inwoner/react/components/Button/constants.ts
@@ -1,0 +1,12 @@
+import { WebComponentDefinition } from '@react/lib/web-component';
+import type { ButtonProps } from './Button';
+
+export const BUTTON_DEFINITION: WebComponentDefinition<
+  'oip-button',
+  ButtonProps
+> = {
+  tagName: 'oip-button',
+  propNames: [],
+  options: { shadow: false },
+  importer: () => import('./Button'),
+};

--- a/src/open_inwoner/react/components/Button/index.ts
+++ b/src/open_inwoner/react/components/Button/index.ts
@@ -1,0 +1,8 @@
+// Preact Component
+export { default as Button } from './Button';
+
+// Types
+export type { ButtonProps } from './Button';
+
+// Constants
+export * from './constants';

--- a/src/open_inwoner/react/components/Filters/Filters.scss
+++ b/src/open_inwoner/react/components/Filters/Filters.scss
@@ -1,0 +1,7 @@
+.oip-filter__wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--oip-filter-wrapper-gap);
+  font-family: var(--oip-filter-wrapper-font-family);
+  margin-block-end: 1rem;
+}

--- a/src/open_inwoner/react/components/Filters/Filters.spec.tsx
+++ b/src/open_inwoner/react/components/Filters/Filters.spec.tsx
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/preact';
+import { describe, expect, it, vi } from 'vitest';
+import { type IFiltersConfig, Filters } from '.';
+
+// Mock react-intl
+vi.mock('react-intl', () => ({
+  FormattedMessage: ({ children, defaultMessage }: any) => {
+    if (typeof children === 'function') {
+      return children(defaultMessage[0].value);
+    }
+    return defaultMessage[0].value || '';
+  },
+  IntlProvider: ({ children }: any) => children,
+}));
+
+const mockConfig: IFiltersConfig = {
+  filterGroups: [
+    {
+      name: 'status',
+      label: 'Status',
+      choices: [
+        { value: 'active', label: 'Active' },
+        { value: 'inactive', label: 'Inactive' },
+      ],
+    },
+    {
+      name: 'category',
+      label: 'Category',
+      choices: [
+        { value: 'type1', label: 'Type 1' },
+        { value: 'type2', label: 'Type 2' },
+      ],
+    },
+  ],
+  initialFilterState: {},
+};
+
+describe('FiltersBar', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+
+    expect(
+      container.querySelector('.oip-filter-bar--desktop')
+    ).toBeInTheDocument();
+  });
+
+  it('renders desktop and mobile layouts', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+
+    const desktopBar = container.querySelector('.oip-filter-bar--desktop');
+    const filterBarLabel = container.querySelector('.oip-filter-bar__label');
+    const filters = container.querySelector('.oip-filter-bar__filters');
+
+    expect(desktopBar).toBeInTheDocument();
+    expect(filterBarLabel).toBeInTheDocument();
+    expect(filters).toBeInTheDocument();
+  });
+
+  it('renders desktop filter bar in desktop mode', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+
+    // matchMedia mock returns false, so we're in desktop mode
+    const desktopBar = container.querySelector('.oip-filter-bar--desktop');
+    expect(desktopBar).toBeInTheDocument();
+
+    // Mobile bar should not be present in desktop mode
+    const mobileBar = container.querySelector('.oip-filter-bar--mobile');
+    expect(mobileBar).not.toBeInTheDocument();
+  });
+
+  it('applies correct CSS classes for layout', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+
+    const desktopBar = container.querySelector('.oip-filter-bar--desktop');
+    const filterBarLabel = container.querySelector('.oip-filter-bar__label');
+    const filters = container.querySelector('.oip-filter-bar__filters');
+
+    expect(desktopBar).toHaveClass('oip-filter-bar--desktop');
+    expect(filterBarLabel).toHaveClass('oip-filter-bar__label');
+    expect(filters).toHaveClass('oip-filter-bar__filters');
+  });
+
+  it('renders filter label text', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+    const label = container.querySelector('.oip-filter-bar__label');
+    expect(label).toHaveTextContent('Filter op:');
+  });
+
+  it('renders filters from config', () => {
+    const { container } = render(<Filters data={mockConfig} />);
+
+    // Component should render successfully with config data
+    expect(
+      container.querySelector('.oip-filter-bar--desktop')
+    ).toBeInTheDocument();
+
+    // Check that filters are rendered
+    const filters = container.querySelectorAll('.oip-filter');
+    expect(filters.length).toBe(2); // We have 2 filter groups in mockConfig
+  });
+});

--- a/src/open_inwoner/react/components/Filters/Filters.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/Filters.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { Filters, type IFiltersProps } from '.';
+
+type Story = StoryObj<IFiltersProps>;
+
+const sampleFilterGroups = [
+  {
+    name: 'status',
+    label: 'Status',
+    choices: [
+      { label: 'Open', value: 'open' },
+      { label: 'In behandeling', value: 'in-behandeling' },
+      { label: 'Afgerond', value: 'afgerond' },
+      { label: 'Geannuleerd', value: 'geannuleerd' },
+    ],
+  },
+  {
+    name: 'categorie',
+    label: 'Categorie',
+    choices: [
+      { label: 'Vraag', value: 'vraag' },
+      { label: 'Melding', value: 'melding' },
+      { label: 'Klacht', value: 'klacht' },
+    ],
+  },
+  {
+    name: 'datum',
+    label: 'Datum',
+    choices: [
+      { label: 'Afgelopen week', value: 'week' },
+      { label: 'Afgelopen maand', value: 'maand' },
+      { label: 'Afgelopen jaar', value: 'jaar' },
+    ],
+  },
+];
+
+const meta: Meta<typeof Filters> = {
+  title: 'Components/Filters',
+  component: Filters,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+The FiltersBar component renders a responsive filter interface for filtering data.
+
+**Features:**
+- Multiple filter groups rendered as dropdown selects
+- Cumulative filtering (multiple selections per category)
+- Active filter chips display below the bar
+- "Toon resultaten" button activates when filters change
+- Reset functionality via "Filters wissen" button
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+
+/**
+ * Default state with no filters selected.
+ * Shows the filter bar with three filter groups.
+ */
+export const Default: Story = {
+  args: {
+    data: {
+      filterGroups: sampleFilterGroups,
+      initialFilterState: {
+        status: [],
+        categorie: [],
+        datum: [],
+      },
+    },
+  },
+};
+
+/**
+ * Filters pre-selected on page load (e.g. from URL query params).
+ * Shows filter chips below the bar.
+ */
+export const WithActiveFilters: Story = {
+  args: {
+    data: {
+      filterGroups: sampleFilterGroups,
+      initialFilterState: {
+        status: ['open', 'in-behandeling'],
+        categorie: ['melding'],
+        datum: [],
+      },
+    },
+  },
+};
+
+/**
+ * A single filter group, for simpler use cases.
+ */
+export const SingleFilterGroup: Story = {
+  args: {
+    data: {
+      filterGroups: [
+        {
+          name: 'categorie',
+          label: 'Categorie',
+          choices: [
+            { label: 'Vraag', value: 'vraag' },
+            { label: 'Melding', value: 'melding' },
+            { label: 'Klacht', value: 'klacht' },
+          ],
+        },
+      ],
+      initialFilterState: {
+        categorie: [],
+      },
+    },
+  },
+};
+
+/**
+ * A filter group with many choices.
+ */
+export const ManyChoices: Story = {
+  args: {
+    data: {
+      filterGroups: [
+        {
+          name: 'onderwerp',
+          label: 'Onderwerp',
+          choices: Array.from({ length: 12 }, (_, i) => ({
+            label: `Onderwerp ${i + 1}`,
+            value: `onderwerp-${i + 1}`,
+          })),
+        },
+        ...sampleFilterGroups.slice(1),
+      ],
+      initialFilterState: {
+        onderwerp: [],
+        categorie: [],
+        datum: [],
+      },
+    },
+  },
+};
+
+/**
+ * Filter chips can be hidden by setting showChips to "false".
+ */
+export const WithoutChips: Story = {
+  args: {
+    data: {
+      filterGroups: sampleFilterGroups,
+      initialFilterState: {
+        status: ['afgerond'],
+        categorie: [],
+        datum: ['maand', 'jaar'],
+      },
+    },
+    showChips: false,
+  },
+};
+
+/**
+ * All filters in every group are selected.
+ */
+export const AllFiltersSelected: Story = {
+  args: {
+    data: {
+      filterGroups: sampleFilterGroups,
+      initialFilterState: {
+        status: sampleFilterGroups[0].choices.map((c) => c.value),
+        categorie: sampleFilterGroups[1].choices.map((c) => c.value),
+        datum: sampleFilterGroups[2].choices.map((c) => c.value),
+      },
+    },
+  },
+};

--- a/src/open_inwoner/react/components/Filters/Filters.tsx
+++ b/src/open_inwoner/react/components/Filters/Filters.tsx
@@ -1,0 +1,37 @@
+import { usePropsOrScriptData } from '@react/lib/json/json';
+import { AnyComponent as AC } from 'preact';
+import Filter from './components/Filter/Filter';
+import FilterBar from './components/FilterBar/FilterBar';
+import FilterChips from './components/FilterChips/FilterChips';
+import { FiltersProvider } from './context/FiltersContext';
+import './Filters.scss';
+import { IFiltersConfig, IFiltersProps } from '.';
+
+const Filters: AC<IFiltersProps> = ({ data, dataId, showChips = true }) => {
+  const config = usePropsOrScriptData<IFiltersConfig>(data, dataId);
+
+  // Fail silently
+  if (!config || !config.filterGroups.length) return <></>;
+
+  return (
+    <FiltersProvider {...config}>
+      <FilterBar>
+        {config.filterGroups.map((group) => {
+          if (!group.choices.length) return;
+          return (
+            <Filter
+              key={group.name}
+              name={group.name}
+              label={group.label}
+              choices={group.choices}
+              multiple={group.multiple}
+            />
+          );
+        })}
+      </FilterBar>
+      {showChips && <FilterChips />}
+    </FiltersProvider>
+  );
+};
+
+export default Filters;

--- a/src/open_inwoner/react/components/Filters/components/Filter/Filter.scss
+++ b/src/open_inwoner/react/components/Filters/components/Filter/Filter.scss
@@ -1,0 +1,210 @@
+.oip-filter {
+  &:is(fieldset) {
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  // Desktop variant
+  &--dropdown {
+    position: relative;
+    min-width: var(--oip-filter-dropdown-min-width);
+  }
+
+  // Mobile variant
+  &--mobile {
+    display: flex;
+    flex-direction: column;
+    gap: var(--oip-filter-mobile-gap);
+  }
+
+  &__button {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--oip-filter-button-gap);
+
+    width: 100%;
+    min-width: var(--oip-filter-button-min-width);
+    max-width: var(--oip-filter-button-max-width);
+
+    padding: var(--oip-filter-button-padding);
+    border: 1px solid var(--oip-filter-button-border-color);
+    border-radius: var(--oip-filter-button-border-radius);
+    background-color: var(--oip-filter-button-background-color);
+    color: var(--oip-filter-button-color);
+    font-family: var(--oip-filter-button-font-family);
+    font-size: var(--oip-filter-button-font-size);
+    font-weight: var(--oip-filter-button-font-weight);
+    cursor: pointer;
+    transition: 0.2s ease;
+    transition-property: background-color, border-color, color;
+
+    &:hover {
+      background-color: var(--oip-filter-button-hover-background-color);
+    }
+
+    &--active {
+      color: var(--oip-filter-button-active-color);
+      border-color: var(--oip-filter-button-active-border-color);
+      font-weight: var(--oip-filter-button-active-font-weight);
+    }
+
+    &--open {
+      border-radius: var(--oip-filter-button-border-radius)
+        var(--oip-filter-button-border-radius) 0 0;
+
+      span[class*='icon'] {
+        transform: rotate(180deg);
+      }
+    }
+
+    span[class*='icon'] {
+      font-size: var(--oip-filter-button-icon-size);
+      width: var(--oip-filter-button-icon-size);
+      flex-shrink: 0;
+      transition: 0.2s ease;
+      transition-property: transform;
+    }
+  }
+
+  &__label {
+    flex: 1;
+    font-family: var(--oip-filter-button-font-family);
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__title {
+    font-size: var(--oip-filter-title-font-size);
+    font-weight: var(--oip-filter-title-font-weight);
+    color: var(--oip-filter-title-color);
+    margin: 0;
+    padding: 0;
+  }
+
+  &--mobile &__title {
+    margin-bottom: var(--oip-filter-mobile-gap);
+  }
+
+  &__choices {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &--dropdown &__choices {
+    position: absolute;
+    top: calc(100% - 1px);
+    left: 0;
+    right: 0;
+    background-color: var(--oip-filter-choices-background-color);
+    color: var(--oip-filter-choices-color);
+    border: 1px solid var(--oip-filter-choices-border-color);
+    border-radius: 0 0 var(--oip-filter-choices-border-radius)
+      var(--oip-filter-choices-border-radius);
+    box-shadow: var(--oip-filter-choices-box-shadow);
+    z-index: 1100;
+    max-height: 300px;
+    max-width: calc(var(--oip-filter-button-max-width) - 2px);
+    overflow-y: auto;
+  }
+
+  &--mobile &__choices {
+    gap: var(--oip-filter-choices-gap);
+  }
+
+  &__option {
+    background-color: var(--oip-filter-option-background-color);
+    border-radius: var(--oip-filter-option-border-radius);
+    border-top: none;
+    color: var(--oip-filter-option-color);
+    display: flex;
+
+    border-top: 1px solid var(--oip-filter-option-border-color);
+    border-right: 1px solid var(--oip-filter-option-border-color);
+    border-bottom: 1px solid var(--oip-filter-option-border-color);
+    border-left: 4px solid var(--oip-filter-option-border-color);
+
+    &:hover,
+    &--active {
+      background-color: var(--oip-filter-option-hover-background-color);
+    }
+
+    .oip-filter__option-input {
+      opacity: 0;
+      width: 0;
+      margin: 0;
+      border: 0;
+      appearance: none;
+
+      &:checked ~ .oip-filter__option-label:before {
+        color: var(--oip-filter-option-checked-icon-color);
+        font-family: 'Material Icons Outlined';
+      }
+
+      &:checked[type='radio'] ~ .oip-filter__option-label:before {
+        content: 'radio_button_checked';
+      }
+
+      &:checked[type='checkbox'] ~ .oip-filter__option-label:before {
+        content: 'check_box';
+      }
+
+      &:focus-visible ~ .oip-filter__option-label span {
+        text-decoration: underline;
+      }
+    }
+
+    &-input[type='radio'] ~ &-label:before {
+      content: 'radio_button_unchecked';
+    }
+
+    &-input[type='checkbox'] ~ &-label:before {
+      content: 'check_box_outline_blank';
+    }
+
+    &-label {
+      color: var(--oip-filter-option-label-color);
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: var(--oip-filter-option-label-gap);
+      text-decoration: none;
+      width: 100%;
+      line-height: 24px;
+      padding: var(--oip-filter-option-padding-block)
+        var(--oip-filter-option-padding-inline);
+
+      &:before {
+        flex-shrink: 0;
+        color: var(--oip-filter-option-icon-color);
+        width: var(--oip-filter-option-icon-size);
+        height: var(--oip-filter-option-icon-size);
+        font-family: 'Material Icons Outlined';
+        font-size: var(--oip-filter-option-icon-size);
+      }
+    }
+
+    &:has(.oip-filter__option-input:checked) {
+      border-top: 1px solid var(--oip-filter-option-checked-border-color);
+      border-right: 1px solid var(--oip-filter-option-checked-border-color);
+      border-bottom: 1px solid var(--oip-filter-option-checked-border-color);
+      border-left: 4px solid var(--oip-filter-option-checked-border-color);
+    }
+  }
+
+  &--dropdown .oip-filter__option {
+    border-radius: 0;
+
+    &:last-of-type {
+      --options-border-radius: var(--oip-filter-choices-border-radius);
+      --options-border-width: 1px;
+      --option-radius: calc(
+        var(--options-border-radius) - var(--options-border-width)
+      );
+      border-radius: 0 0 var(--option-radius) var(--option-radius);
+    }
+  }
+}

--- a/src/open_inwoner/react/components/Filters/components/Filter/Filter.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/components/Filter/Filter.stories.tsx
@@ -1,0 +1,96 @@
+import { withFilterProvider } from '@react/lib/decorators/storybook';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { Filter, type IFilterGroup } from '../..';
+
+type Story = StoryObj<IFilterGroup>;
+
+const group = {
+  name: 'type-container',
+  label: 'Type container',
+  choices: [
+    { label: 'Restafval', value: 'restafval' },
+    { label: 'GFT', value: 'gft' },
+    { label: 'Papier', value: 'papier' },
+    { label: 'PMD', value: 'pmd' },
+  ],
+};
+
+const meta: Meta<IFilterGroup> = {
+  title: 'Components/Filters/Filter',
+  component: Filter,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+Individual filter dropdown component. Renders a button that opens a multi-select dropdown with checkbox options.
+
+Must be used within a FilterProvider context.
+
+**Desktop:** Dropdown button with click-outside-to-close behavior.
+**Mobile:** Section with title and inline checkbox list.
+        `,
+      },
+    },
+  },
+  args: group,
+  decorators: [withFilterProvider([group])],
+};
+
+export default meta;
+
+/**
+ * Default closed dropdown with no selections.
+ */
+export const Default: Story = {
+  args: group,
+};
+
+/**
+ * Filter with pre-selected values. The button label shows the count.
+ */
+export const WithSelectedValues: Story = {
+  decorators: [
+    withFilterProvider([group], { 'type-container': ['restafval', 'gft'] }),
+  ],
+};
+
+/**
+ * Filter with many choices to verify scrolling behavior.
+ */
+export const ManyChoices: Story = {
+  args: {
+    name: 'adres',
+    label: 'Adres',
+    choices: Array.from({ length: 10 }, (_, i) => ({
+      label: `Straatnaam ${i + 1}, ${1000 + i} AB, Den Haag`,
+      value: `straat-${i + 1}`,
+    })),
+  },
+};
+
+/**
+ * Filter with only a single choice.
+ */
+export const SingleChoice: Story = {
+  args: {
+    name: 'periode',
+    label: 'Periode',
+    choices: [{ label: 'Jaar 2024', value: '2024' }],
+  },
+};
+
+/**
+ * Filter with only a single choice.
+ */
+export const SingleValueChoice: Story = {
+  args: {
+    name: 'periode',
+    label: 'Periode',
+    choices: [
+      { label: 'Jaar 2024', value: '2024' },
+      { label: 'Jaar 2025', value: '2025' },
+    ],
+    multiple: false,
+  },
+};

--- a/src/open_inwoner/react/components/Filters/components/Filter/Filter.tsx
+++ b/src/open_inwoner/react/components/Filters/components/Filter/Filter.tsx
@@ -1,0 +1,143 @@
+import { MaterialIcon } from '@react/components/MaterialIcon';
+import { useIsMobile, useOnClickOutside } from '@react/lib/hooks';
+import clsx from 'clsx';
+import { AnyComponent as AC } from 'preact';
+import { type IFilterGroup, useFilterContext } from '../..';
+import { useSelect } from '../../hooks/useSelect';
+import './Filter.scss';
+
+/**
+ * Filter - Individual filter component
+ *
+ * Renders differently based on isMobile prop:
+ * - Desktop: multi-select dropdown with local open/close state
+ * - Mobile: section with title and checkbox list
+ *
+ * Must be used within a FilterWrapper.
+ *
+ * @example
+ * ```tsx
+ * <Filter
+ *   name="category"
+ *   label="Category"
+ *   choices={[
+ *     { value: 'a', label: 'Option A' },
+ *     { value: 'b', label: 'Option B' },
+ *   ]}
+ * />
+ * ```
+ */
+const Filter: AC<IFilterGroup> = ({
+  name,
+  label,
+  choices,
+  multiple = true,
+}) => {
+  const { selectedFilters, toggleValue, toggleValueRadio } = useFilterContext();
+
+  const isMobile = useIsMobile();
+  const Wrapper = isMobile ? 'fieldset' : 'div';
+  const selectedValues = selectedFilters[name] || [];
+  const selectedCount = selectedValues.length;
+
+  const {
+    containerRef,
+    isOpen,
+    activeIndex,
+    handleKeyDown,
+    closeDropdown,
+    toggleDropdown,
+  } = useSelect({ choices, multiple, name, toggleValue, toggleValueRadio });
+
+  const showChoices = isMobile || isOpen;
+
+  // Close dropdown when clicking outside (desktop only)
+  useOnClickOutside(containerRef, closeDropdown, isMobile || !isOpen);
+
+  return (
+    <Wrapper
+      class={clsx(
+        'oip-filter',
+        isMobile ? 'oip-filter--mobile' : 'oip-filter--dropdown'
+      )}
+      ref={containerRef as any}
+      onKeyDown={isMobile ? undefined : handleKeyDown}
+    >
+      {isMobile ? (
+        <legend className="oip-filter__title" id={`filter-${name}`}>
+          {label}
+        </legend>
+      ) : (
+        <button
+          type="button"
+          className={clsx('oip-filter__button', {
+            ['oip-filter__button--open']: showChoices,
+          })}
+          onClick={toggleDropdown}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          title={label}
+          id={`filter-${name}`}
+        >
+          <span class="oip-filter__label">
+            {selectedCount > 0 ? `${label} (${selectedCount})` : label}
+          </span>
+          <MaterialIcon name="expand_more" />
+        </button>
+      )}
+
+      {/* DROPDOWN LIST */}
+      {showChoices && (
+        <div
+          className={'oip-filter__choices'}
+          role="listbox"
+          aria-labelledby={`filter-${name}`}
+          aria-expanded={showChoices}
+          aria-activedescendant={
+            activeIndex >= 0
+              ? `option-${name}-${choices[activeIndex].value}`
+              : undefined
+          }
+        >
+          {choices.map((choice, index) => {
+            const isChecked = selectedValues.includes(choice.value);
+
+            return (
+              <div
+                className={clsx('oip-filter__option', {
+                  'oip-filter__option--active': index === activeIndex,
+                })}
+                role="option"
+                aria-selected={isChecked}
+                key={`${name}.${choice.value}`}
+                id={`option-${name}-${choice.value}`}
+              >
+                <input
+                  type={multiple ? 'checkbox' : 'radio'}
+                  name={name}
+                  class="oip-filter__option-input"
+                  id={`${name}.${choice.value}`}
+                  value={choice.value}
+                  checked={isChecked}
+                  tabIndex={isMobile ? undefined : -1}
+                  onChange={() => {
+                    if (multiple) toggleValue(name, choice.value);
+                    else toggleValueRadio(name, choice.value);
+                  }}
+                />
+                <label
+                  class="oip-filter__option-label"
+                  htmlFor={`${name}.${choice.value}`}
+                >
+                  <span>{choice.label}</span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Wrapper>
+  );
+};
+
+export default Filter;

--- a/src/open_inwoner/react/components/Filters/components/Filter/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/Filter/index.ts
@@ -1,0 +1,2 @@
+// Preact Component
+export { default as Filter } from './Filter';

--- a/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.scss
+++ b/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.scss
@@ -1,0 +1,45 @@
+.oip-filter-bar {
+  &--mobile {
+    display: flex;
+    align-items: center;
+
+    @media (min-width: 768px) {
+      display: none;
+    }
+  }
+
+  // DESKTOP: Inline filter bar
+  &--desktop {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--oip-filter-bar-gap);
+    padding-block-start: var(--oip-filter-bar-padding-block-start);
+    padding-block-end: var(--oip-filter-bar-padding-block-end);
+    padding-inline-start: var(--oip-filter-bar-padding-inline-start);
+    padding-inline-end: var(--oip-filter-bar-padding-inline-end);
+    background-color: var(--oip-filter-bar-background-color);
+    border-radius: var(--oip-filter-bar-border-radius);
+
+    @media (max-width: 767px) {
+      display: none;
+    }
+  }
+
+  &__label {
+    flex: 0 0 auto;
+    font-family: var(--oip-filter-bar-label-font-family);
+    font-weight: var(--oip-filter-bar-label-font-weight);
+    white-space: nowrap;
+    color: var(--oip-filter-bar-label-color);
+  }
+
+  &__filters {
+    display: flex;
+    font-family: var(--font-family-body);
+    gap: var(--oip-filter-bar-gap);
+    flex-wrap: wrap;
+    align-items: center;
+    flex: 1 1 auto;
+  }
+}

--- a/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.stories.tsx
@@ -1,0 +1,106 @@
+import { withFilterProvider } from '@react/lib/decorators/storybook';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { Filter, FilterBar, type IFilterBarProps } from '..';
+
+type Story = StoryObj<IFilterBarProps>;
+
+const filterGroups = [
+  {
+    name: 'adres',
+    label: 'Adres',
+    choices: [
+      {
+        label: 'Lindelaan 156 A, 3456 GH, Den Haag',
+        value: 'Lindelaan 156 A, 3456 GH, Den Haag',
+      },
+      {
+        label: 'Kerkstraat 42, 2511 AB, Den Haag',
+        value: 'Kerkstraat 42, 2511 AB, Den Haag',
+      },
+    ],
+  },
+  {
+    name: 'type-container',
+    label: 'Type container',
+    choices: [
+      { label: 'Restafval', value: 'restafval' },
+      { label: 'GFT', value: 'gft' },
+      { label: 'Papier', value: 'papier' },
+      { label: 'PMD', value: 'pmd' },
+    ],
+  },
+  {
+    name: 'periode',
+    label: 'Periode',
+    choices: [
+      { label: 'Jaar 2025', value: '2025' },
+      { label: 'Jaar 2024', value: '2024' },
+      { label: 'Jaar 2023', value: '2023' },
+    ],
+  },
+];
+
+const FilterChildren = () => (
+  <>
+    {filterGroups.map((group) => (
+      <Filter
+        key={group.name}
+        name={group.name}
+        label={group.label}
+        choices={group.choices}
+      />
+    ))}
+  </>
+);
+
+const meta: Meta<IFilterBarProps> = {
+  title: 'Components/Filters/FilterBar',
+  component: FilterBar,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+Container for Filter components. Renders differently per breakpoint:
+
+**Desktop:** Horizontal bar with "Filter op:" label, filter dropdowns, and "Toon resultaten" button.
+**Mobile:** A "Filters" button that opens a full-screen modal.
+
+Must be used within a FilterProvider context.
+        `,
+      },
+    },
+  },
+  decorators: [withFilterProvider(filterGroups)],
+};
+
+export default meta;
+
+/**
+ * Desktop filter bar with no selections. "Toon resultaten" button is disabled.
+ */
+export const Default: Story = {
+  render: () => (
+    <FilterBar>
+      <FilterChildren />
+    </FilterBar>
+  ),
+};
+
+/**
+ * Filter bar with pre-selected filters. "Toon resultaten" button remains
+ * disabled until the user changes a selection.
+ */
+export const WithActiveFilters: Story = {
+  decorators: [
+    withFilterProvider(filterGroups, {
+      'type-container': ['restafval', 'gft'],
+      periode: ['2024'],
+    }),
+  ],
+  render: () => (
+    <FilterBar>
+      <FilterChildren />
+    </FilterBar>
+  ),
+};

--- a/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterBar/FilterBar.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@react/components/Button';
+import { MaterialIcon } from '@react/components/MaterialIcon';
+import { useIsMobile } from '@react/lib/hooks/useIsMobile';
+import clsx from 'clsx';
+import type { AnyComponent as AC } from 'preact';
+import { useState } from 'preact/hooks';
+import { FormattedMessage } from 'react-intl';
+import { FilterModal, useFilterContext } from '../..';
+import './FilterBar.scss';
+
+export interface IFilterBarProps {}
+
+const FilterBar: AC<IFilterBarProps> = ({ children }) => {
+  const { isFiltered, isDirty, applyFilters } = useFilterContext();
+
+  const isMobile = useIsMobile();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  return (
+    <>
+      {/* MOBILE: Filter button to open modal */}
+      {isMobile && (
+        <div className={clsx('oip-filter-bar', 'oip-filter-bar--mobile')}>
+          <Button
+            variant="primary"
+            handleClick={openModal}
+            transparent
+            iconSize="lg"
+            underline="none"
+          >
+            <MaterialIcon name="filter_alt" />
+            <span class="button__inner-text">
+              <FormattedMessage
+                id="filter.mobile_heading"
+                description="The title of the mobile dialog filters"
+                defaultMessage="Filters"
+              />
+            </span>
+            {isFiltered && <MaterialIcon name="check" />}
+          </Button>
+        </div>
+      )}
+
+      {/* DESKTOP: Inline filter bar */}
+      {!isMobile && (
+        <div className={clsx('oip-filter-bar', 'oip-filter-bar--desktop')}>
+          <span class="oip-filter-bar__label">
+            <FormattedMessage
+              id="filter.heading"
+              description="The title of the filters"
+              defaultMessage="Filter op:"
+            />
+          </span>
+
+          {/* FILTERS */}
+          <div class="oip-filter-bar__filters">
+            {children}
+            <Button
+              variant="primary"
+              handleClick={applyFilters}
+              iconSize="lg"
+              underline="none"
+              disabled={!isDirty}
+            >
+              <span class="button__inner-text">
+                <FormattedMessage
+                  id="filter.show_results"
+                  description="Show results text"
+                  defaultMessage="Toon resultaten"
+                />
+              </span>
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* MOBILE: Modal */}
+      {isMobile && isModalOpen && (
+        <FilterModal onClose={closeModal}>{children}</FilterModal>
+      )}
+    </>
+  );
+};
+
+export default FilterBar;

--- a/src/open_inwoner/react/components/Filters/components/FilterBar/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/FilterBar/index.ts
@@ -1,0 +1,5 @@
+// Preact Component
+export { default as FilterBar } from './FilterBar';
+
+// Types
+export type { IFilterBarProps } from './FilterBar';

--- a/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.scss
+++ b/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.scss
@@ -1,0 +1,55 @@
+.oip-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--oip-filter-chip-gap);
+  padding-block-start: var(--oip-filter-chip-padding-block-start);
+  padding-block-end: var(--oip-filter-chip-padding-block-end);
+  padding-inline-start: var(--oip-filter-chip-padding-inline-start);
+  padding-inline-end: var(--oip-filter-chip-padding-inline-end);
+  background-color: var(--oip-filter-chip-background-color);
+  border: 1px solid var(--oip-filter-chip-border-color);
+  border-radius: var(--oip-filter-chip-border-radius);
+  font-size: var(--oip-filter-chip-font-size);
+  line-height: var(--oip-filter-chip-line-height);
+  color: var(--oip-filter-chip-color);
+  height: fit-content;
+
+  @media (min-width: 768px) {
+    font-size: var(--oip-filter-chip-desktop-font-size);
+    line-height: var(--oip-filter-chip-desktop-line-height);
+    padding-block-start: var(--oip-filter-chip-desktop-padding-block-start);
+    padding-block-end: var(--oip-filter-chip-desktop-padding-block-end);
+    padding-inline-start: var(--oip-filter-chip-desktop-padding-inline-start);
+    padding-inline-end: var(--oip-filter-chip-desktop-padding-inline-end);
+  }
+
+  &__group {
+    font-weight: var(--oip-filter-chip-group-font-weight);
+  }
+
+  &__label {
+    font-weight: var(--oip-filter-chip-label-font-weight);
+  }
+
+  // Filter chip remove cross (inside chip)
+  &__remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    span[class*='icon'] {
+      font-size: var(--oip-filter-chip-remove-icon-size);
+    }
+  }
+}

--- a/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { FilterChip, FilterChipProps } from '.';
+
+type Story = StoryObj<FilterChipProps>;
+
+const meta: Meta<FilterChipProps> = {
+  title: 'Components/Filters/FilterChip',
+  component: FilterChip,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A removable chip that displays a single selected filter value. Shows the label and a close button to remove it.',
+      },
+    },
+  },
+  args: {
+    onRemove: () => {},
+  },
+};
+
+export default meta;
+
+/**
+ * Default chip showing a selected filter value.
+ */
+export const Default: Story = {
+  args: {
+    groupName: 'type-container',
+    groupLabel: 'Type container',
+    value: 'restafval',
+    label: 'Restafval',
+  },
+};
+
+/**
+ * Chip with a long label to verify truncation / wrapping.
+ */
+export const LongLabel: Story = {
+  args: {
+    groupName: 'adres',
+    groupLabel: 'Adres',
+    value: 'Lindelaan 156 A, 3456 GH, Den Haag',
+    label: 'Lindelaan 156 A, 3456 GH, Den Haag',
+  },
+};
+
+/**
+ * Multiple chips displayed side by side.
+ */
+export const MultipleChips: Story = {
+  render: () => {
+    const noop = () => {};
+    return (
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+        <FilterChip
+          groupName="type-container"
+          groupLabel="Type container"
+          value="restafval"
+          label="Restafval"
+          onRemove={noop}
+        />
+        <FilterChip
+          groupName="type-container"
+          groupLabel="Type container"
+          value="gft"
+          label="GFT"
+          onRemove={noop}
+        />
+        <FilterChip
+          groupName="periode"
+          groupLabel="Periode"
+          value="2024"
+          label="Jaar 2024"
+          onRemove={noop}
+        />
+      </div>
+    );
+  },
+};

--- a/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterChip/FilterChip.tsx
@@ -1,0 +1,58 @@
+import { MaterialIcon } from '@react/components/MaterialIcon';
+import { AnyComponent as AC } from 'preact';
+import { useIntl } from 'react-intl';
+import './FilterChip.scss';
+
+export interface FilterChipProps {
+  groupName: string;
+  groupLabel: string;
+  value: string;
+  label: string;
+  onRemove: (groupName: string, value: string) => void;
+}
+
+/**
+ * FilterChip - Displays a single selected filter value as a removable chip
+ */
+const FilterChip: AC<FilterChipProps> = ({
+  groupName,
+  groupLabel,
+  value,
+  label,
+  onRemove,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <div class="oip-filter-chip">
+      <span class="oip-filter-chip__label">{label}</span>
+      <button
+        type="button"
+        class="oip-filter-chip__remove"
+        onClick={() => onRemove(groupName, value)}
+        aria-label={intl.formatMessage(
+          {
+            id: 'filter.chip.remove_aria_label',
+            description:
+              'Accessible label for the button that removes a selected filter chip',
+            defaultMessage: 'Verwijder filter {groupLabel}: {label}',
+          },
+          { groupLabel, label }
+        )}
+        title={intl.formatMessage(
+          {
+            id: 'filter.chip.remove_title',
+            description:
+              'Tooltip for the button that removes a selected filter chip',
+            defaultMessage: 'Verwijder filter {label}',
+          },
+          { label }
+        )}
+      >
+        <MaterialIcon name="close" />
+      </button>
+    </div>
+  );
+};
+
+export default FilterChip;

--- a/src/open_inwoner/react/components/Filters/components/FilterChip/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/FilterChip/index.ts
@@ -1,0 +1,5 @@
+// Preact Component
+export { default as FilterChip } from './FilterChip';
+
+// Types
+export type { FilterChipProps } from './FilterChip';

--- a/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.scss
+++ b/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.scss
@@ -1,0 +1,14 @@
+.oip-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--oip-filter-chips-gap);
+
+  &__clear-button {
+    font-weight: var(--oip-filter-chips-clear-button-font-weight);
+
+    @media (max-width: 767px) {
+      padding: 0;
+    }
+  }
+}

--- a/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.stories.tsx
@@ -1,0 +1,85 @@
+import { withFilterProvider } from '@react/lib/decorators/storybook';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { FilterChips, FilterChipsProps } from '.';
+
+type Story = StoryObj<FilterChipsProps>;
+
+const filterGroups = [
+  {
+    name: 'type-container',
+    label: 'Type container',
+    choices: [
+      { label: 'Restafval', value: 'restafval' },
+      { label: 'GFT', value: 'gft' },
+      { label: 'Papier', value: 'papier' },
+    ],
+  },
+  {
+    name: 'periode',
+    label: 'Periode',
+    choices: [
+      { label: 'Jaar 2025', value: '2025' },
+      { label: 'Jaar 2024', value: '2024' },
+    ],
+  },
+];
+
+const meta: Meta<FilterChipsProps> = {
+  title: 'Components/Filters/FilterChips',
+  component: FilterChips,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Displays all currently selected filters as removable chips with an optional "Filters wissen" (clear all) button. Must be used within a FilterProvider context.',
+      },
+    },
+  },
+  decorators: [
+    withFilterProvider(filterGroups, {
+      'type-container': ['restafval', 'gft'],
+      periode: ['2024'],
+    }),
+  ],
+};
+
+export default meta;
+
+/**
+ * Active filter chips with "Filters wissen" button.
+ */
+export const Default: Story = {};
+
+/**
+ * Chips without the "Filters wissen" button.
+ */
+export const WithoutClearAll: Story = {
+  args: {
+    showClearAll: false,
+  },
+};
+
+/**
+ * Single selected filter chip.
+ */
+export const SingleFilter: Story = {
+  decorators: [
+    withFilterProvider(filterGroups, {
+      'type-container': ['restafval'],
+      periode: [],
+    }),
+  ],
+};
+
+/**
+ * When no filters are selected, nothing is rendered.
+ */
+export const NoFilters: Story = {
+  decorators: [
+    withFilterProvider(filterGroups, {
+      'type-container': [],
+      periode: [],
+    }),
+  ],
+};

--- a/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterChips/FilterChips.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@react/components/Button';
+import { AnyComponent as AC } from 'preact';
+import { FormattedMessage } from 'react-intl';
+import { FilterChip, useFilterContext } from '../..';
+import './FilterChips.scss';
+
+export interface FilterChipsProps {
+  showClearAll?: boolean;
+}
+
+const FilterChips: AC<FilterChipsProps> = ({ showClearAll = true }) => {
+  const {
+    filterGroups,
+    selectedFilters,
+    isFiltered,
+    toggleValue,
+    clearAllFilters,
+  } = useFilterContext();
+
+  // Don't render if no filters are selected
+  if (!isFiltered) return null;
+
+  return (
+    <div className="oip-filter-chips">
+      {filterGroups.map((group) =>
+        selectedFilters[group.name].map((value) => {
+          const choice = group.choices.find((c) => c.value === value);
+          if (!choice) return null;
+          return (
+            <FilterChip
+              key={`${group.name}-${value}`}
+              groupName={group.name}
+              groupLabel={group.label}
+              value={choice.value}
+              label={choice.label}
+              onRemove={toggleValue}
+            />
+          );
+        })
+      )}
+      {showClearAll && isFiltered && (
+        <Button
+          handleClick={clearAllFilters}
+          className="oip-filter-chips__clear-button"
+          variant="primary"
+          transparent
+        >
+          <FormattedMessage
+            id="filter.clear_all"
+            description="The label of the 'clear all' button."
+            defaultMessage="Filters wissen"
+          >
+            {(text) => <span class="button__inner-text">{text}</span>}
+          </FormattedMessage>
+        </Button>
+      )}
+    </div>
+  );
+};
+export default FilterChips;

--- a/src/open_inwoner/react/components/Filters/components/FilterChips/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/FilterChips/index.ts
@@ -1,0 +1,5 @@
+// Preact Component
+export { default as FilterChips } from './FilterChips';
+
+// Types
+export type { FilterChipsProps } from './FilterChips';

--- a/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.scss
+++ b/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.scss
@@ -1,0 +1,79 @@
+.oip-filter-modal {
+  // Fix for modal story to make sure it has an intrinsic size.
+  .docs-story .oip-filter__wrapper:has(&) {
+    min-height: 600px;
+  }
+
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100% - 1rem);
+  margin-top: 1rem;
+  overflow-y: auto;
+  background-color: var(--oip-filter-modal-background-color);
+  border-radius: var(--oip-filter-modal-border-radius)
+    var(--oip-filter-modal-border-radius) 0 0;
+  padding: var(--oip-filter-modal-padding);
+  gap: var(--oip-filter-modal-gap);
+
+  &__backdrop {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: fixed;
+    inset: 0;
+    background-color: var(--oip-filter-modal-backdrop-background-color);
+    z-index: 1050; // Just a big number
+
+    @media (min-width: 768px) {
+      display: none;
+    }
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex-shrink: 0;
+    gap: var(--oip-filter-modal-header-gap);
+  }
+
+  &__header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--oip-filter-modal-header-gap);
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  &__heading {
+    font-size: var(--oip-filter-modal-heading-font-size);
+    font-weight: var(--oip-filter-modal-heading-font-weight);
+    color: var(--oip-filter-modal-heading-color);
+    font-family: var(--font-family-heading);
+    margin: 0;
+  }
+
+  &__close {
+    padding: 0;
+    height: fit-content;
+    width: var(--oip-filter-modal-close-button-size);
+
+    span[class*='icon'] {
+      width: var(--oip-filter-modal-close-button-size);
+      font-size: var(--oip-filter-modal-close-button-size);
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-family-body);
+    overflow-y: auto;
+    gap: var(--oip-filter-modal-content-gap);
+  }
+
+  &__footer {
+    padding-bottom: var(--oip-filter-modal-footer-padding-bottom);
+    flex-shrink: 0;
+  }
+}

--- a/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.stories.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.stories.tsx
@@ -1,0 +1,107 @@
+import { withFilterProvider } from '@react/lib/decorators/storybook';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+import { Filter, FilterModal, IFilterModalProps } from '..';
+
+type Story = StoryObj<IFilterModalProps>;
+
+const filterGroups = [
+  {
+    name: 'type-container',
+    label: 'Type container',
+    choices: [
+      { label: 'Restafval', value: 'restafval' },
+      { label: 'GFT', value: 'gft' },
+      { label: 'Papier', value: 'papier' },
+      { label: 'PMD', value: 'pmd' },
+    ],
+  },
+  {
+    name: 'periode',
+    label: 'Periode',
+    choices: [
+      { label: 'Jaar 2025', value: '2025' },
+      { label: 'Jaar 2024', value: '2024' },
+      { label: 'Jaar 2023', value: '2023' },
+    ],
+  },
+];
+
+const FilterChildren = () => (
+  <>
+    {filterGroups.map((group) => (
+      <Filter
+        key={group.name}
+        name={group.name}
+        label={group.label}
+        choices={group.choices}
+      />
+    ))}
+  </>
+);
+
+const meta: Meta<IFilterModalProps> = {
+  title: 'Components/Filters/FilterModal',
+  component: FilterModal,
+  globals: {
+    viewport: { value: 'phone', isRotated: false },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+Full-screen modal for mobile filter selection. Shows filter sections with checkboxes, a "Wis alle filters" button, and a "Toon resultaten" submit button.
+
+
+**Key Features:**
+- Click-outside to close modal.
+- Reset button.
+- Multiple filters.
+- Submit button that is only active if there is a state change
+
+**Filter Integration:**
+- Uses the context to update the filter state.
+
+
+**FYI**
+- **Must be used within a FilterProvider context.**
+- **This component is only visible on small screen sizes (< 768px)**
+          `,
+      },
+    },
+  },
+  decorators: [withFilterProvider(filterGroups)],
+  args: {
+    onClose: () => {},
+  },
+};
+
+export default meta;
+
+/**
+ * Modal with no filters selected. "Toon resultaten" button is disabled.
+ */
+export const Default: Story = {
+  render: (args) => (
+    <FilterModal onClose={args.onClose}>
+      <FilterChildren />
+    </FilterModal>
+  ),
+};
+
+/**
+ * Modal with pre-selected filters.
+ */
+export const WithActiveFilters: Story = {
+  decorators: [
+    withFilterProvider(filterGroups, {
+      'type-container': ['restafval', 'gft'],
+      periode: ['2024'],
+    }),
+  ],
+  render: (args) => (
+    <FilterModal onClose={args.onClose}>
+      <FilterChildren />
+    </FilterModal>
+  ),
+};

--- a/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.tsx
+++ b/src/open_inwoner/react/components/Filters/components/FilterModal/FilterModal.tsx
@@ -1,0 +1,87 @@
+import { Button } from '@react/components/Button';
+import { MaterialIcon } from '@react/components/MaterialIcon';
+import type { AnyComponent } from 'preact';
+import { FormattedMessage } from 'react-intl';
+import { useFilterContext } from '../..';
+import './FilterModal.scss';
+
+export interface IFilterModalProps {
+  onClose: () => void;
+}
+
+/**
+ * FilterModal - Full-screen modal for mobile filter selection
+ *
+ * Must be used within a FilterWrapper.
+ */
+const FilterModal: AnyComponent<IFilterModalProps> = ({
+  onClose,
+  children,
+}) => {
+  const { clearAllFilters, applyFilters, isDirty } = useFilterContext();
+
+  const handleApply = () => {
+    applyFilters();
+    onClose();
+  };
+
+  return (
+    <div
+      class="oip-filter-modal__backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div class="oip-filter-modal">
+        <header class="oip-filter-modal__header">
+          <div class="oip-filter-modal__header-actions">
+            <Button
+              title="Sluiten"
+              variant="primary"
+              handleClick={onClose}
+              transparent
+              className={'oip-filter-modal__close'}
+            >
+              <MaterialIcon name="close" />
+            </Button>
+            <Button
+              text="Wis alle filters"
+              variant="primary"
+              handleClick={clearAllFilters}
+              transparent
+            />
+          </div>
+          <h2 class="oip-filter-modal__heading">
+            <FormattedMessage
+              id="filter.mobile_title"
+              description="The title of the mobile dialog filters"
+              defaultMessage="Filters"
+            />
+          </h2>
+        </header>
+
+        {/* FILTERS */}
+        <div class="oip-filter-modal__content">{children}</div>
+
+        <div class="oip-filter-modal__footer">
+          <Button
+            variant="primary"
+            handleClick={handleApply}
+            disabled={!isDirty}
+            fullWidth
+          >
+            <span class="button__inner-text">
+              <FormattedMessage
+                id="filter.show_results"
+                description="Show results text"
+                defaultMessage="Toon resultaten"
+              />
+            </span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FilterModal;

--- a/src/open_inwoner/react/components/Filters/components/FilterModal/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/FilterModal/index.ts
@@ -1,0 +1,5 @@
+// Preact Component
+export { default as FilterModal } from './FilterModal';
+
+// Types
+export type { IFilterModalProps } from './FilterModal';

--- a/src/open_inwoner/react/components/Filters/components/index.ts
+++ b/src/open_inwoner/react/components/Filters/components/index.ts
@@ -1,0 +1,5 @@
+export * from './Filter';
+export * from './FilterBar';
+export * from './FilterModal';
+export * from './FilterChip';
+export * from './FilterChips';

--- a/src/open_inwoner/react/components/Filters/context/FiltersContext.tsx
+++ b/src/open_inwoner/react/components/Filters/context/FiltersContext.tsx
@@ -1,0 +1,106 @@
+import { serializeParams } from '@react/lib/url/url';
+import some from 'lodash/some';
+import { type AnyComponent as AC, createContext } from 'preact';
+import { useCallback, useContext, useMemo } from 'preact/hooks';
+import { type IFilterGroup, type IFiltersConfig, useFilterState } from '..';
+
+export interface FiltersContextValue {
+  // State
+  filterGroups: IFilterGroup[];
+  selectedFilters: Record<string, string[]>;
+  isDirty: boolean;
+
+  // Computed
+  isFiltered: boolean;
+
+  // Actions
+  toggleValue: (groupName: string, value: string) => void;
+  toggleValueRadio: (groupName: string, value: string) => void;
+  clearAllFilters: () => void;
+  applyFilters: () => void;
+}
+
+const FiltersContext = createContext<FiltersContextValue | null>(null);
+
+/**
+ * Provider provides all business logic for the filter.
+ * Now we do not have to pass all filter methods down to all sub-components.
+ */
+export const FiltersProvider: AC<IFiltersConfig> = ({
+  initialFilterState = {},
+  filterGroups = [],
+  children,
+}) => {
+  const {
+    // Current state
+    selectedFilters,
+    isDirty,
+    // Selected filters control.
+    toggleValue,
+    toggleValueRadio,
+    clearAllFilters,
+  } = useFilterState(initialFilterState);
+
+  // Apply filters (navigates to URL with query params)
+  const applyFilters = useCallback(() => {
+    const baseUrl = location.origin + location.pathname;
+    const params = serializeParams(selectedFilters);
+    const queryString = params.toString();
+    const targetUrl = queryString ? `${baseUrl}?${queryString}` : baseUrl;
+    window.location.assign(targetUrl);
+  }, [selectedFilters]);
+
+  // Computed values
+  const isFiltered = useMemo(
+    () => some(selectedFilters, (values) => values.length > 0),
+    [selectedFilters]
+  );
+
+  const value: FiltersContextValue = useMemo(
+    () => ({
+      filterGroups,
+      selectedFilters,
+      isFiltered,
+      isDirty,
+      toggleValue,
+      toggleValueRadio,
+      clearAllFilters,
+      applyFilters,
+    }),
+    [
+      filterGroups,
+      selectedFilters,
+      isFiltered,
+      isDirty,
+      toggleValue,
+      toggleValueRadio,
+      clearAllFilters,
+      applyFilters,
+    ]
+  );
+
+  return (
+    <div className="oip-filter__wrapper">
+      <FiltersContext.Provider value={value}>
+        {children}
+      </FiltersContext.Provider>
+    </div>
+  );
+};
+
+/**
+ * Hook to access filter context
+ * Throws error if used outside FilterProvider
+ */
+export const useFilterContext = (): FiltersContextValue => {
+  const context = useContext(FiltersContext);
+
+  if (!context) {
+    throw new Error(
+      'useFilterContext must be used within a FilterProvider. ' +
+        'Wrap your component tree with <FilterProvider>.'
+    );
+  }
+
+  return context;
+};

--- a/src/open_inwoner/react/components/Filters/hooks/useFilterState.spec.ts
+++ b/src/open_inwoner/react/components/Filters/hooks/useFilterState.spec.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/preact';
+import { describe, expect, it } from 'vitest';
+import { FilterState, useFilterState } from '..';
+
+const emptyState: FilterState = {
+  color: [],
+  size: [],
+};
+
+const prefilledState: FilterState = {
+  color: ['red'],
+  size: ['small', 'large'],
+};
+
+describe('useFilterState', () => {
+  describe('initial state', () => {
+    it('returns the initial filter state as selectedFilters', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      expect(result.current.selectedFilters).toEqual(emptyState);
+    });
+
+    it('returns pre-filled initial state correctly', () => {
+      const { result } = renderHook(() => useFilterState(prefilledState));
+
+      expect(result.current.selectedFilters).toEqual(prefilledState);
+    });
+
+    it('is not dirty when no changes have been made', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      expect(result.current.isDirty).toBe(false);
+    });
+  });
+
+  describe('toggleValue', () => {
+    it('adds a value to an empty group', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+
+      expect(result.current.selectedFilters.color).toEqual(['red']);
+    });
+
+    it('removes a value that is already selected (toggle off)', () => {
+      const { result } = renderHook(() => useFilterState(prefilledState));
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+
+      expect(result.current.selectedFilters.color).toEqual([]);
+    });
+
+    it('adds a second value to a group with an existing selection', () => {
+      const { result } = renderHook(() =>
+        useFilterState({ ...emptyState, color: ['red'] })
+      );
+
+      act(() => {
+        result.current.toggleValue('color', 'blue');
+      });
+
+      expect(result.current.selectedFilters.color).toEqual(['red', 'blue']);
+    });
+
+    it('does not affect other groups', () => {
+      const { result } = renderHook(() => useFilterState(prefilledState));
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+
+      expect(result.current.selectedFilters.size).toEqual(['small', 'large']);
+    });
+
+    it('handles toggling a value for a non-existent group', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.toggleValue('unknown', 'value');
+      });
+
+      expect(result.current.selectedFilters.unknown).toEqual(['value']);
+    });
+  });
+
+  describe('clearAllFilters', () => {
+    it('clears all selected filters', () => {
+      const { result } = renderHook(() => useFilterState(prefilledState));
+
+      act(() => {
+        result.current.clearAllFilters();
+      });
+
+      expect(result.current.selectedFilters).toEqual({
+        color: [],
+        size: [],
+      });
+    });
+
+    it('is a no-op when all filters are already empty', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.clearAllFilters();
+      });
+
+      expect(result.current.selectedFilters).toEqual(emptyState);
+    });
+  });
+
+  describe('isDirty', () => {
+    it('becomes true after toggling a value', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('becomes false when toggled back to initial state', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+      expect(result.current.isDirty).toBe(true);
+
+      act(() => {
+        result.current.toggleValue('color', 'red');
+      });
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('becomes true after clearing pre-filled filters', () => {
+      const { result } = renderHook(() => useFilterState(prefilledState));
+
+      act(() => {
+        result.current.clearAllFilters();
+      });
+
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('is not dirty when clearing already-empty filters', () => {
+      const { result } = renderHook(() => useFilterState(emptyState));
+
+      act(() => {
+        result.current.clearAllFilters();
+      });
+
+      expect(result.current.isDirty).toBe(false);
+    });
+  });
+});

--- a/src/open_inwoner/react/components/Filters/hooks/useFilterState.ts
+++ b/src/open_inwoner/react/components/Filters/hooks/useFilterState.ts
@@ -1,0 +1,51 @@
+import isEqual from 'lodash/isEqual';
+import mapValues from 'lodash/mapValues';
+import xor from 'lodash/xor';
+import { useCallback, useMemo, useState } from 'preact/hooks';
+import { FilterState } from '..';
+
+export const useFilterState = (initialFilterState: FilterState) => {
+  const [selectedFilters, setSelectedFilters] =
+    useState<FilterState>(initialFilterState);
+
+  // Toggle a single value (multiple: checkbox)
+  const toggleValue = useCallback((groupName: string, value: string) => {
+    setSelectedFilters((prev) => {
+      const groupValue = prev[groupName] || [];
+      return {
+        ...prev,
+        [groupName]: xor(groupValue, [value]),
+      };
+    });
+  }, []);
+
+  // Toggle a single value (single: radio)
+  const toggleValueRadio = useCallback((groupName: string, value: string) => {
+    setSelectedFilters((prev) => {
+      return {
+        ...prev,
+        [groupName]: [value],
+      };
+    });
+  }, []);
+
+  // Clear all filters
+  const clearAllFilters = useCallback(() => {
+    setSelectedFilters((prev) => mapValues(prev, () => []));
+  }, []);
+
+  // True when values have changed since last GET.
+  const isDirty = useMemo(() => {
+    return !isEqual(initialFilterState, selectedFilters);
+  }, [initialFilterState, selectedFilters]);
+
+  return {
+    // Current state
+    selectedFilters,
+    isDirty,
+    // Selected filters control.
+    toggleValue,
+    toggleValueRadio,
+    clearAllFilters,
+  };
+};

--- a/src/open_inwoner/react/components/Filters/hooks/useSelect.spec.ts
+++ b/src/open_inwoner/react/components/Filters/hooks/useSelect.spec.ts
@@ -1,0 +1,270 @@
+import { act, renderHook } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSelect } from './useSelect';
+
+const choices = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'blueberry', label: 'Blueberry' },
+  { value: 'cherry', label: 'Cherry' },
+];
+
+const key = (k: string, extra?: KeyboardEventInit) =>
+  new KeyboardEvent('keydown', {
+    key: k,
+    bubbles: true,
+    cancelable: true,
+    ...extra,
+  });
+
+describe('useSelect', () => {
+  let toggleValue: ReturnType<typeof vi.fn>;
+  let toggleValueRadio: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toggleValue = vi.fn();
+    toggleValueRadio = vi.fn();
+  });
+
+  const render = (multiple = true) =>
+    renderHook(() =>
+      useSelect({
+        choices,
+        multiple,
+        name: 'fruit',
+        toggleValue,
+        toggleValueRadio,
+      })
+    );
+
+  describe('initial state', () => {
+    it('starts closed with no active index', () => {
+      const { result } = render();
+      expect(result.current.isOpen).toBe(false);
+      expect(result.current.activeIndex).toBe(-1);
+    });
+  });
+
+  describe('toggleDropdown', () => {
+    it('opens the dropdown', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      expect(result.current.isOpen).toBe(true);
+    });
+
+    it('closes the dropdown when already open', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.toggleDropdown());
+      expect(result.current.isOpen).toBe(false);
+    });
+  });
+
+  describe('closeDropdown', () => {
+    it('closes the dropdown and resets activeIndex', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.closeDropdown());
+      expect(result.current.isOpen).toBe(false);
+      expect(result.current.activeIndex).toBe(-1);
+    });
+  });
+
+  describe('ArrowDown', () => {
+    it('opens the dropdown when closed', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      expect(result.current.isOpen).toBe(true);
+    });
+
+    it('increments activeIndex from -1 to 0', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('increments activeIndex on each press', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      expect(result.current.activeIndex).toBe(1);
+    });
+
+    it('clamps at the last option', () => {
+      const { result } = render();
+      choices.forEach(() =>
+        act(() => result.current.handleKeyDown(key('ArrowDown')))
+      );
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      expect(result.current.activeIndex).toBe(choices.length - 1);
+    });
+  });
+
+  describe('ArrowUp', () => {
+    it('opens the dropdown when closed', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowUp')));
+      expect(result.current.isOpen).toBe(true);
+    });
+
+    it('clamps at 0 when already at the top', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowUp')));
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('decrements activeIndex', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key('ArrowUp')));
+      expect(result.current.activeIndex).toBe(0);
+    });
+  });
+
+  describe('Escape', () => {
+    it('closes the dropdown and resets activeIndex', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key('Escape')));
+      expect(result.current.isOpen).toBe(false);
+      expect(result.current.activeIndex).toBe(-1);
+    });
+
+    it('does nothing when the dropdown is already closed', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('Escape')));
+      expect(result.current.isOpen).toBe(false);
+    });
+  });
+
+  describe('Tab', () => {
+    it('closes the dropdown', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('Tab')));
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('resets activeIndex', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key('Tab')));
+      expect(result.current.activeIndex).toBe(-1);
+    });
+  });
+
+  describe('Enter / Space', () => {
+    it('calls toggleValue with the active choice (multiple)', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('ArrowDown'))); // index 0 = apple
+      act(() => result.current.handleKeyDown(key('Enter')));
+      expect(toggleValue).toHaveBeenCalledWith('fruit', 'apple');
+    });
+
+    it('calls toggleValueRadio with the active choice (single)', () => {
+      const { result } = render(false);
+      act(() => result.current.handleKeyDown(key('ArrowDown')));
+      act(() => result.current.handleKeyDown(key(' ')));
+      expect(toggleValueRadio).toHaveBeenCalledWith('fruit', 'apple');
+    });
+
+    it('does nothing when no option is active', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('Enter')));
+      expect(toggleValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('typeahead', () => {
+    it('opens the dropdown if closed when typing', () => {
+      const { result } = render();
+      act(() => result.current.handleKeyDown(key('a')));
+      expect(result.current.isOpen).toBe(true);
+    });
+
+    it('jumps to the first option whose label starts with the typed letter', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('c')));
+      expect(result.current.activeIndex).toBe(3); // Cherry
+    });
+
+    it('is case-insensitive', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('C')));
+      expect(result.current.activeIndex).toBe(3); // Cherry
+    });
+
+    it('accumulates characters to narrow the match', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('b')));
+      expect(result.current.activeIndex).toBe(1); // Banana
+      act(() => result.current.handleKeyDown(key('l'))); // buffer = 'bl'
+      expect(result.current.activeIndex).toBe(2); // Blueberry
+    });
+
+    it('also matches if the label contains (but does not start with) the query', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('a')));
+      act(() => result.current.handleKeyDown(key('n'))); // buffer = 'an' → 'banana'.includes('an')
+      expect(result.current.activeIndex).toBe(1); // Banana
+    });
+
+    it('searches from activeIndex + 1 to cycle through matches', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('b'))); // → Banana (index 1)
+      expect(result.current.activeIndex).toBe(1);
+
+      // Reset buffer via fake timer, then press 'b' again from index 1
+    });
+
+    it('does not change activeIndex when no match is found', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('ArrowDown'))); // index 0
+      act(() => result.current.handleKeyDown(key('z')));
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('ignores keys with modifier keys', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('a', { ctrlKey: true })));
+      expect(result.current.activeIndex).toBe(-1);
+    });
+
+    it('ignores keys while IME is composing', () => {
+      const { result } = render();
+      act(() => result.current.toggleDropdown());
+      act(() => result.current.handleKeyDown(key('a', { isComposing: true })));
+      expect(result.current.activeIndex).toBe(-1);
+    });
+
+    describe('buffer reset', () => {
+      beforeEach(() => vi.useFakeTimers());
+      afterEach(() => vi.useRealTimers());
+
+      it('resets the buffer after 500 ms so the next keypress starts fresh', () => {
+        const { result } = render();
+        act(() => result.current.toggleDropdown());
+        act(() => result.current.handleKeyDown(key('b'))); // → Banana (index 1)
+        expect(result.current.activeIndex).toBe(1);
+
+        act(() => {
+          vi.advanceTimersByTime(500);
+        }); // buffer resets
+
+        act(() => result.current.handleKeyDown(key('b'))); // fresh 'b', starts from index 2 → Blueberry
+        expect(result.current.activeIndex).toBe(2);
+      });
+    });
+  });
+});

--- a/src/open_inwoner/react/components/Filters/hooks/useSelect.ts
+++ b/src/open_inwoner/react/components/Filters/hooks/useSelect.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { type IFilterChoice } from '..';
+
+interface UseSelectOptions {
+  choices: IFilterChoice[];
+  multiple: boolean;
+  name: string;
+  toggleValue: (name: string, value: string) => void;
+  toggleValueRadio: (name: string, value: string) => void;
+}
+
+export const useSelect = ({
+  choices,
+  multiple,
+  name,
+  toggleValue,
+  toggleValueRadio,
+}: UseSelectOptions) => {
+  const containerRef = useRef<HTMLElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const typeaheadBuffer = useRef('');
+  const typeaheadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openDropdown = () => {
+    setIsOpen(true);
+    setActiveIndex(0);
+  };
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+  };
+
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape':
+        if (!isOpen) break;
+        e.preventDefault();
+        closeDropdown();
+        break;
+
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!isOpen) openDropdown();
+        else
+          setActiveIndex((prev) =>
+            prev < choices.length - 1 ? prev + 1 : prev
+          );
+        break;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!isOpen) openDropdown();
+        else setActiveIndex((prev) => (prev >= 0 ? prev - 1 : prev));
+        break;
+
+      case 'Tab':
+        closeDropdown();
+        break;
+
+      case 'Enter':
+      case ' ':
+        if (activeIndex >= 0) {
+          e.preventDefault();
+          const choice = choices[activeIndex];
+          if (multiple) toggleValue(name, choice.value);
+          else toggleValueRadio(name, choice.value);
+        }
+        break;
+
+      default:
+        if (
+          e.key.length === 1 &&
+          !e.ctrlKey &&
+          !e.metaKey &&
+          !e.altKey &&
+          !e.isComposing
+        ) {
+          if (!isOpen) setIsOpen(true);
+
+          typeaheadBuffer.current += e.key.toLowerCase();
+          if (typeaheadTimer.current) clearTimeout(typeaheadTimer.current);
+          typeaheadTimer.current = setTimeout(() => {
+            typeaheadBuffer.current = '';
+          }, 500);
+
+          const query = typeaheadBuffer.current;
+          const startIndex = activeIndex >= 0 ? activeIndex + 1 : 0;
+          for (let i = 0; i < choices.length; i++) {
+            const index = (startIndex + i) % choices.length;
+            const label = choices[index].label.toLowerCase();
+            if (label.startsWith(query) || label.includes(query)) {
+              setActiveIndex(index);
+              break;
+            }
+          }
+        }
+        break;
+    }
+  };
+
+  // Scroll active option into view when navigating with keyboard
+  useEffect(() => {
+    if (activeIndex < 0) return;
+    const id = `option-${name}-${choices[activeIndex].value}`;
+    document.getElementById(id)?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  // Cleanup typeahead timer on unmount
+  useEffect(() => {
+    return () => {
+      if (typeaheadTimer.current) clearTimeout(typeaheadTimer.current);
+    };
+  }, []);
+
+  return {
+    containerRef,
+    isOpen,
+    activeIndex,
+    handleKeyDown,
+    closeDropdown,
+    toggleDropdown,
+  };
+};

--- a/src/open_inwoner/react/components/Filters/index.ts
+++ b/src/open_inwoner/react/components/Filters/index.ts
@@ -1,0 +1,14 @@
+// Preact Component
+export { default as Filters } from './Filters';
+
+// Sub Preact Components
+export * from './components';
+
+// Types
+export type * from './types';
+
+// Context
+export * from './context/FiltersContext';
+
+// Hooks
+export { useFilterState } from './hooks/useFilterState';

--- a/src/open_inwoner/react/components/Filters/types.ts
+++ b/src/open_inwoner/react/components/Filters/types.ts
@@ -1,0 +1,77 @@
+/**
+ * The filter group frontend type.
+ * @template T define which name the IFilterGroup can have.
+ * @example IFilterGroup<"date" | "sort">
+ */
+export interface IFilterGroup<T extends string = string> {
+  /**
+   * Name of the filter group.
+   * This is used to build the GET query string.
+   */
+  name: T;
+  /**
+   * Visible label used of the filter.
+   */
+  label: string;
+  /**
+   * Array of choices used to render the filter options.
+   */
+  choices: IFilterChoice[];
+  /**
+   * Render the filter options as radio's (false) or checkboxes (true)
+   * @default true // renders with checkboxes
+   */
+  multiple?: boolean;
+}
+
+/**
+ * Interface for the filter choice.
+ * Used in the filter options.
+ */
+export interface IFilterChoice {
+  label: string;
+  value: string;
+}
+
+/**
+ * The initial/current state of the filters
+ * @template T define which names the FilterState have.
+ * @example
+ * ```
+ * const filterState: FilterState<"date", "sort"> = {
+ *   date: ['2024']
+ *   sort: []
+ * }
+ * ```
+ */
+export type FilterState<T extends string = string> = Record<T, string[]>;
+
+/**
+ * The config for the filters.
+ * This config is used to build the actual filters.
+ */
+export interface IFiltersConfig<T extends string = string> {
+  filterGroups: IFilterGroup<T>[];
+  initialFilterState: FilterState<T>;
+}
+
+/**
+ * Type of component props the filters component.
+ */
+export interface IFiltersProps {
+  /**
+   * `dataId` is used by web-components.
+   * Only works in combination with a json script.
+   * The json script should contain data conform the `IFiltersConfig` type.
+   */
+  dataId?: string;
+  /**
+   * `data` is used by Preact components to pass data as an object.
+   */
+  data?: IFiltersConfig;
+  /**
+   * Define if the filters show chips and a clear all button.
+   * @default true // Show chips on default
+   */
+  showChips?: boolean;
+}

--- a/src/open_inwoner/react/i18n/compiled/en.json
+++ b/src/open_inwoner/react/i18n/compiled/en.json
@@ -5,6 +5,88 @@
       "value": "The chart is not created. See tables below for the data."
     }
   ],
+  "filter.adres_filter": [
+    {
+      "type": 0,
+      "value": "Address"
+    }
+  ],
+  "filter.chip.remove_aria_label": [
+    {
+      "type": 0,
+      "value": "Remove filter "
+    },
+    {
+      "type": 1,
+      "value": "groupLabel"
+    },
+    {
+      "type": 0,
+      "value": ": "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    }
+  ],
+  "filter.chip.remove_title": [
+    {
+      "type": 0,
+      "value": "Remove filter "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    }
+  ],
+  "filter.clear_all": [
+    {
+      "type": 0,
+      "value": "Clear filters"
+    }
+  ],
+  "filter.container_type_filter": [
+    {
+      "type": 0,
+      "value": "Type container"
+    }
+  ],
+  "filter.heading": [
+    {
+      "type": 0,
+      "value": "Filter:"
+    }
+  ],
+  "filter.mobile_heading": [
+    {
+      "type": 0,
+      "value": "Filters"
+    }
+  ],
+  "filter.mobile_title": [
+    {
+      "type": 0,
+      "value": "Filters"
+    }
+  ],
+  "filter.period_filter": [
+    {
+      "type": 0,
+      "value": "Period"
+    }
+  ],
+  "filter.period_filter_year_prefix": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "filter.show_results": [
+    {
+      "type": 0,
+      "value": "Show results"
+    }
+  ],
   "kvkbranchselector.clear": [
     {
       "type": 0,

--- a/src/open_inwoner/react/i18n/compiled/nl.json
+++ b/src/open_inwoner/react/i18n/compiled/nl.json
@@ -5,6 +5,88 @@
       "value": "De grafiek kan niet worden weergegeven. Zie de tabellen hieronder voor de gegevens."
     }
   ],
+  "filter.adres_filter": [
+    {
+      "type": 0,
+      "value": "Adres"
+    }
+  ],
+  "filter.chip.remove_aria_label": [
+    {
+      "type": 0,
+      "value": "Verwijder filter "
+    },
+    {
+      "type": 1,
+      "value": "groupLabel"
+    },
+    {
+      "type": 0,
+      "value": ": "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    }
+  ],
+  "filter.chip.remove_title": [
+    {
+      "type": 0,
+      "value": "Verwijder filter "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    }
+  ],
+  "filter.clear_all": [
+    {
+      "type": 0,
+      "value": "Filters wissen"
+    }
+  ],
+  "filter.container_type_filter": [
+    {
+      "type": 0,
+      "value": "Type container"
+    }
+  ],
+  "filter.heading": [
+    {
+      "type": 0,
+      "value": "Filter op:"
+    }
+  ],
+  "filter.mobile_heading": [
+    {
+      "type": 0,
+      "value": "Filters"
+    }
+  ],
+  "filter.mobile_title": [
+    {
+      "type": 0,
+      "value": "Filters"
+    }
+  ],
+  "filter.period_filter": [
+    {
+      "type": 0,
+      "value": "Periode"
+    }
+  ],
+  "filter.period_filter_year_prefix": [
+    {
+      "type": 0,
+      "value": "Jaar"
+    }
+  ],
+  "filter.show_results": [
+    {
+      "type": 0,
+      "value": "Toon resultaten"
+    }
+  ],
   "kvkbranchselector.clear": [
     {
       "type": 0,

--- a/src/open_inwoner/react/i18n/locales/en.json
+++ b/src/open_inwoner/react/i18n/locales/en.json
@@ -4,6 +4,61 @@
     "description": "The default message of the chart.",
     "originalDefault": "De grafiek kan niet worden weergegeven. Zie de tabellen hieronder voor de gegevens."
   },
+  "filter.adres_filter": {
+    "defaultMessage": "Address",
+    "description": "The label for the filter adres",
+    "originalDefault": "Adres"
+  },
+  "filter.chip.remove_aria_label": {
+    "defaultMessage": "Remove filter {groupLabel}: {label}",
+    "description": "Accessible label for the button that removes a selected filter chip",
+    "originalDefault": "Verwijder filter {groupLabel}: {label}"
+  },
+  "filter.chip.remove_title": {
+    "defaultMessage": "Remove filter {label}",
+    "description": "Tooltip for the button that removes a selected filter chip",
+    "originalDefault": "Verwijder filter {label}"
+  },
+  "filter.clear_all": {
+    "defaultMessage": "Clear filters",
+    "description": "The label of the 'clear all' button.",
+    "originalDefault": "Filters wissen"
+  },
+  "filter.container_type_filter": {
+    "defaultMessage": "Type container",
+    "description": "The label for the filter container type",
+    "originalDefault": "Type container"
+  },
+  "filter.heading": {
+    "defaultMessage": "Filter:",
+    "description": "The title of the filters",
+    "originalDefault": "Filter op:"
+  },
+  "filter.mobile_heading": {
+    "defaultMessage": "Filters",
+    "description": "The title of the mobile dialog filters",
+    "originalDefault": "Filters"
+  },
+  "filter.mobile_title": {
+    "defaultMessage": "Filters",
+    "description": "The title of the mobile dialog filters",
+    "originalDefault": "Filters"
+  },
+  "filter.period_filter": {
+    "defaultMessage": "Period",
+    "description": "The label for the filter period",
+    "originalDefault": "Periode"
+  },
+  "filter.period_filter_year_prefix": {
+    "defaultMessage": "Year",
+    "description": "The prefix for the options of type period",
+    "originalDefault": "Jaar"
+  },
+  "filter.show_results": {
+    "defaultMessage": "Show results",
+    "description": "Show results text",
+    "originalDefault": "Toon resultaten"
+  },
   "kvkbranchselector.clear": {
     "defaultMessage": "Clear",
     "description": "Clear search button label",

--- a/src/open_inwoner/react/i18n/locales/nl.json
+++ b/src/open_inwoner/react/i18n/locales/nl.json
@@ -4,6 +4,61 @@
     "description": "The default message of the chart.",
     "originalDefault": "De grafiek kan niet worden weergegeven. Zie de tabellen hieronder voor de gegevens."
   },
+  "filter.adres_filter": {
+    "defaultMessage": "Adres",
+    "description": "The label for the filter adres",
+    "originalDefault": "Adres"
+  },
+  "filter.chip.remove_aria_label": {
+    "defaultMessage": "Verwijder filter {groupLabel}: {label}",
+    "description": "Accessible label for the button that removes a selected filter chip",
+    "originalDefault": "Verwijder filter {groupLabel}: {label}"
+  },
+  "filter.chip.remove_title": {
+    "defaultMessage": "Verwijder filter {label}",
+    "description": "Tooltip for the button that removes a selected filter chip",
+    "originalDefault": "Verwijder filter {label}"
+  },
+  "filter.clear_all": {
+    "defaultMessage": "Filters wissen",
+    "description": "The label of the 'clear all' button.",
+    "originalDefault": "Filters wissen"
+  },
+  "filter.container_type_filter": {
+    "defaultMessage": "Type container",
+    "description": "The label for the filter container type",
+    "originalDefault": "Type container"
+  },
+  "filter.heading": {
+    "defaultMessage": "Filter op:",
+    "description": "The title of the filters",
+    "originalDefault": "Filter op:"
+  },
+  "filter.mobile_heading": {
+    "defaultMessage": "Filters",
+    "description": "The title of the mobile dialog filters",
+    "originalDefault": "Filters"
+  },
+  "filter.mobile_title": {
+    "defaultMessage": "Filters",
+    "description": "The title of the mobile dialog filters",
+    "originalDefault": "Filters"
+  },
+  "filter.period_filter": {
+    "defaultMessage": "Periode",
+    "description": "The label for the filter period",
+    "originalDefault": "Periode"
+  },
+  "filter.period_filter_year_prefix": {
+    "defaultMessage": "Jaar",
+    "description": "The prefix for the options of type period",
+    "originalDefault": "Jaar"
+  },
+  "filter.show_results": {
+    "defaultMessage": "Toon resultaten",
+    "description": "Show results text",
+    "originalDefault": "Toon resultaten"
+  },
   "kvkbranchselector.clear": {
     "defaultMessage": "Wissen",
     "description": "Clear search button label",

--- a/src/open_inwoner/react/lib/decorators/storybook.tsx
+++ b/src/open_inwoner/react/lib/decorators/storybook.tsx
@@ -1,10 +1,14 @@
 import { I18nProvider } from '@react/i18n';
 import type { StoryFn } from '@storybook/preact-vite';
 import { WebComponentLoader, WebComponentTagName } from '../web-component';
+import { FiltersProvider } from '@react/components/Filters/context/FiltersContext';
+import { IFilterGroup } from '@react/components/Filters';
 /**
  * Decorator that adds the openinwoner-theme class to the body
  */
 export const withThemeClass = (Story: StoryFn) => {
+  // Make sure each design token is available.
+  document.documentElement.classList.add('openinwoner-theme');
   document.body.classList.add('openinwoner-theme');
   return <Story />;
 };
@@ -32,3 +36,33 @@ export const withLoader =
     WebComponentLoader.importWebComponent(tagName);
     return <Story />;
   };
+
+/**
+ * Decorator to make allow sub filter to render with a valid filter context.
+ */
+export const withFilterProvider =
+  (
+    filterGroups: IFilterGroup[],
+    initialFilterState: Record<string, string[]> = {}
+  ) =>
+  (Story: StoryFn) => (
+    <FiltersProvider
+      initialFilterState={initialFilterState}
+      filterGroups={
+        filterGroups || [
+          {
+            name: 'type-container',
+            label: 'Type container',
+            choices: [
+              { label: 'Restafval', value: 'restafval' },
+              { label: 'GFT', value: 'gft' },
+              { label: 'Papier', value: 'papier' },
+              { label: 'PMD', value: 'pmd' },
+            ],
+          },
+        ]
+      }
+    >
+      <Story />
+    </FiltersProvider>
+  );

--- a/src/open_inwoner/react/lib/hooks/index.ts
+++ b/src/open_inwoner/react/lib/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useDebounce } from './useDebounce';
+export { useIsMobile } from './useIsMobile';
+export { useOnClickOutside } from './useOnClickOutside';

--- a/src/open_inwoner/react/lib/hooks/useIsMobile.ts
+++ b/src/open_inwoner/react/lib/hooks/useIsMobile.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'preact/hooks';
+
+const MOBILE_BREAKPOINT = '(max-width: 767px)';
+
+/**
+ * Hook to detect mobile viewport using media query.
+ * Returns true when viewport width is <= 767px.
+ */
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(MOBILE_BREAKPOINT).matches;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(MOBILE_BREAKPOINT);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return isMobile;
+};

--- a/src/open_inwoner/react/lib/hooks/useOnClickOutside.ts
+++ b/src/open_inwoner/react/lib/hooks/useOnClickOutside.ts
@@ -1,0 +1,35 @@
+import type { RefObject } from 'preact';
+import { useEffect } from 'preact/hooks';
+
+/**
+ * Hook that triggers callback when clicking outside the referenced element
+ *
+ * @example
+ * ```tsx
+ * const ref = useRef<HTMLDivElement>(null);
+ * useOnClickOutside(ref, () => setOpen(false), !isOpen);
+ *
+ * return <div ref={ref}>...</div>;
+ * ```
+ */
+export const useOnClickOutside = (
+  ref: RefObject<HTMLElement>,
+  onClickOutside: () => void,
+  disabled = false
+) => {
+  useEffect(() => {
+    if (disabled) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [ref, disabled, onClickOutside]);
+};

--- a/src/open_inwoner/react/lib/url/url.ts
+++ b/src/open_inwoner/react/lib/url/url.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a query string based on params.
+ * @param params Params (parameters) object.
+ * @return query A (serialized) query string.
+ */
+export const serializeParams = (params: Record<string, string | string[]>) => {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, values]) => {
+    if (values && Array.isArray(values))
+      values.forEach((value) => searchParams.append(key, value));
+    else searchParams.append(key, values);
+  });
+
+  return searchParams;
+};

--- a/src/open_inwoner/react/lib/web-component/registry.ts
+++ b/src/open_inwoner/react/lib/web-component/registry.ts
@@ -8,6 +8,7 @@ import { HOME_PLUGIN_CARD_ITEM_DEFINITION } from '@react/components/HomePluginCa
 import { ACCORDION_DEFINITION } from '@react/components/Accordion/constants';
 import { TABLE_DEFINITION } from '@react/components/Table/constants';
 import { CHART_DEFINITION } from '@react/components/Chart/constants';
+import { AFVAL_FILTERS_DEFINITION } from '@react/components/AfvalFilter/constants';
 
 /**
  * Web component registry
@@ -31,4 +32,5 @@ export const WEB_COMPONENT_REGISTRY = {
   [ACCORDION_DEFINITION.tagName]: ACCORDION_DEFINITION,
   [TABLE_DEFINITION.tagName]: TABLE_DEFINITION,
   [CHART_DEFINITION.tagName]: CHART_DEFINITION,
+  [AFVAL_FILTERS_DEFINITION.tagName]: AFVAL_FILTERS_DEFINITION,
 } as const;

--- a/src/open_inwoner/react/test/test-setup.ts
+++ b/src/open_inwoner/react/test/test-setup.ts
@@ -1,0 +1,16 @@
+// Global test setup for vitest
+
+// Mock window.matchMedia for mobile detection tests
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  }),
+});

--- a/src/open_inwoner/templates/master.html
+++ b/src/open_inwoner/templates/master.html
@@ -36,6 +36,7 @@
         <link rel="apple-touch-icon" href="{{ favicon }}">{% endif %}
 
         <link nonce="{{ request.csp_nonce }}" href="{% static 'bundles/open_inwoner-css.css' %}" media="all" rel="stylesheet" />
+        <link nonce="{{ request.csp_nonce }}" href="{% static 'bundles/open_inwoner-frontend.css' %}" media="all" rel="stylesheet" />
 
         <style nonce="{{ request.csp_nonce }}">
             :root {
@@ -77,8 +78,7 @@
     </head>
 
     <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="utrecht-page">
-
-    {% get_solo 'configurations.SiteConfiguration' as config %}
+        {% get_solo 'configurations.SiteConfiguration' as config %}
 
         {% if cookiebanner_enabled %}
         {# render cookiebanner first #}

--- a/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
+++ b/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
@@ -14,9 +14,13 @@
             {% if page_description %}
                 <p class="utrecht-paragraph utrecht-paragraph--lead">{{ page_description }}</p>
             {% endif %}
-            {{ filter_options|json_script:"filter-options" }}
-            {{ afval_data|json_script:"afval-data" }}
-            <oip-chart data-id="afval-data"></oip-chart>
+            {# Filter Component #}
+            {{ filter_options|json_script:"filter_options" }}
+            <oip-afval-filters data-id="filter_options"></oip-afval-filters>
+            {# chart #}
+            {{afval_data|json_script:"afval_data"}}
+            <oip-chart data-id="afval_data"></oip-chart>
+            {# Afval Data Display #}
             {% for afval_obj in afval_data %}
                 <article class="afval-object">
                     {# Accordion wrapping address and all containers #}

--- a/vite.config.js
+++ b/vite.config.js
@@ -85,8 +85,7 @@ export default defineConfig(({ mode }) => {
         // Bundle file name manager.
         output: {
           entryFileNames: '[name].js',
-          chunkFileNames: '[name]-[hash].bundle.js',
-          // Remove hash from asset file name.
+          chunkFileNames: '[name].bundle.js',
           assetFileNames: '[name].[ext]',
         },
       },
@@ -101,6 +100,11 @@ export default defineConfig(({ mode }) => {
         '@react': path.resolve(__dirname, 'src/open_inwoner/react'),
       },
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/open_inwoner/react/test/test-setup.ts'],
     },
   };
 });


### PR DESCRIPTION
## Summary

Implement multiple web components for the afval filters

### Styling issue

> [!NOTE]
> As long as https://github.com/maykinmedia/open-inwoner-design-tokens/pull/39 is not merged we need to have a small configuration to install the design tokens.

**UPDATE**
https://github.com/maykinmedia/open-inwoner-design-tokens/pull/39 has been merged and published as `v0.0.27` to [NPM](https://www.npmjs.com/package/@open-inwoner/design-tokens).

#### Requirements
- Local version of https://github.com/maykinmedia/open-inwoner-design-tokens - checked-out on branch `issue/afval-filter-tokens`. (with installed packages `npm install`)

#### Steps
1. Build design tokens `npm run build` in open-inwoner-design-tokens.
2. Install design tokens in this repo -> `npm install ~/path/to/open-inwoner-design-tokens`.
3. Build the open-inwoner frontend `npm run build`.

## Issue References

- Github Issue: #2111 
- Design tokens PR: https://github.com/maykinmedia/open-inwoner-design-tokens/pull/39

## Checklist

- [x] CHANGELOG.rst updated
- [x] Storybook component updated/created
- [x] Vitest tests added/updated <!-- If the PR has typescript changes -->
