### PR TITLE
build: [#2206] pin setuptools to <81

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Onderhoud
 * [:gh:`2179`, :cve:`CVE-2025-13465`]: ``@utrecht/component-library-react`` bijgewerkt naar versie ``12.0.0``
   en ``loadash-es`` override bijgewerkt naar versie ``4.17.23`` om :cve:`CVE-2025-13465` te mitigeren.
 * [:gh:`2198`, :pr:`2197`]: Django bijgewerkt naar versie ``4.2.28``.
+* [:gh:`2206`, :pr:`2207`]: `setuptools` bijgewerkt naar versie ``<81``.
 
 2.0.1 (2026-01-26)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,11 @@ version = "2.0.0-dev"
 requires-python = "== 3.12"
 
 [tool.uv.pip]
+# Note: setuptools is NOT excluded because it must be explicitly installed
+# to ensure pkg_resources is available for legacy dependencies (django-axes,
+# django-formtools). See requirements/base.in for setuptools<81 pin.
 no-emit-package = [
   "pip",
-  "setuptools",
 ]
 
 [tool.ruff]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
 # Core python libraries
+setuptools<81  # pin for pkg_resources compatibility (django-axes, django-formtools)
 Pillow>=9.0.0 # handle images
 psycopg2  # database driver
 pytz  # handle timezones

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -630,6 +630,10 @@ ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 sentry-sdk[django]==2.19.2
     # via -r requirements/base.in
+setuptools==80.10.2
+    # via
+    #   -r requirements/base.in
+    #   josepy
 shellingham==1.5.4
     # via typer
 simplejson==3.19.2
@@ -736,6 +740,3 @@ zipp==3.23.0
     # via importlib-metadata
 zopfli==0.1.9
     # via fonttools
-
-# The following packages were excluded from the output:
-# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1129,6 +1129,11 @@ sentry-sdk[django]==2.19.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+setuptools==80.10.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   josepy
 shellingham==1.5.4
     # via
     #   -c requirements/base.txt
@@ -1355,6 +1360,3 @@ zopfli==0.1.9
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   fonttools
-
-# The following packages were excluded from the output:
-# setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1268,6 +1268,15 @@ sentry-sdk[django]==2.19.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+setuptools==80.10.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   josepy
+    #   locust
+    #   pip-tools
+    #   zope-event
+    #   zope-interface
 shellingham==1.5.4
     # via
     #   -c requirements/ci.txt
@@ -1571,4 +1580,3 @@ zopfli==0.1.9
 
 # The following packages were excluded from the output:
 # pip
-# setuptools


### PR DESCRIPTION
## Summary

`setuptools` 82.0+ removed the deprecated `pkg_resources` module, but several dependencies still rely on it:
- django-axes 8.3.0
- django-formtools 2.3 (transitive via django-cms)

This pins setuptools to <81 to restore `pkg_resources` until affected packages are upgraded or replaced.

Note: the latest version of `django-formtools` still imports from `pkg_resources`.

Closes #2206 

## Checklist

- [x] CHANGELOG.rst updated

