### PR TITLE
[#2209] Add ckeditor back to INSTALLED_APPS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Bugfixes
   juiste DigiD SAML Foutmeldingen worden gebruikt.
 * [:gh:`2191`]: Foutmnelding opgelost in Afval Profiel pagina waar `messages.error()` en `messages.info()`
   zonder verplicht `request` argument werden aangeroepn.
+* [:gh:`2209`, :pr:`2213`]: Ckeditor opnieuw toegevoegd aan INSTALLED_APPS voor compatibiliteit met
+  mail-editor.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -175,6 +175,7 @@ INSTALLED_APPS = [
     # 'django.contrib.sitemaps',
     # External applications.
     "corsheaders",
+    "ckeditor",
     "rest_framework",
     "rest_framework.authtoken",
     "drf_spectacular",


### PR DESCRIPTION
## Summary

Our mail editor (https://github.com/maykinmedia/mail-editor) still uses the old CKEditorWidget for editing mail templates. As ckeditor is no longer in INSTALLED_APPS, the templates are no longer found. The commit adds 'ckeditor' back until we have a proper solution in our mail-editor.

Fixes #2209 

This is a temporary fix until the mail editor is updated

## Issue References

- [x] CHANGELOG.rst updated

