### PR TITLE
fix: specify target languages for prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         name: prettier
         entry: npx prettier --write --ignore-unknown
         language: system
+        types_or: [javascript, jsx, ts, tsx, css, scss, json, yaml, markdown]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:


### PR DESCRIPTION
Without target languages specified, the prettier hook failed with: `'[error] No matching files. Patterns: .git/COMMIT_EDITMSG'`.


## Checklist

- [ ] CHANGELOG.rst updated
