### PR TITLE
[#2212] Youtube video iframe refferer policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Bugfixes
 * [:gh:`2210`]: Exports en imports van de ZGW catalogi via bestanden gaat nu correct om
   met prosemirror velden. Tevens zullen via een datamigratie de bestaande velden in de
   ZGW catalogus gechecked worden op valide waarden voor de prosemirror velden.
+* [:gh:`2212`]: ``referrerpolicy="strict-origin-when-cross-origin"`` toegevoegd aan de video
+  iframe om het site-brede referrerbeleid te overschrijven voor dit specifieke element.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/templates/cms/plugins/videoplayer/videoplayer.html
+++ b/src/open_inwoner/templates/cms/plugins/videoplayer/videoplayer.html
@@ -1,7 +1,7 @@
 <section class="plugin video{% if instance.full_width %} video--full-width{% endif %} video--{{ instance.video.player_type }}">
     <div class="video__container">
         <div class="video__player">
-            <iframe class="video__iframe video__iframe--{{ instance.video.player_type }}" id="video-{{ instance.pk }}-{{ instance.video.pk }}" src="{{ instance.video.player_url }}" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; fullscreen"></iframe>
+            <iframe class="video__iframe video__iframe--{{ instance.video.player_type }}" id="video-{{ instance.pk }}-{{ instance.video.pk }}" src="{{ instance.video.player_url }}" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; fullscreen" referrerpolicy="strict-origin-when-cross-origin"></iframe>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary

OIP does not include a refferer header, which is required for youtube to load content.
Fix: add referrerpolicy="strict-origin-when-cross-origin"

## Issue References

- Github Issue: #2212 

## Checklist

- [x] CHANGELOG.rst updated