### PR TITLE
feat: validate file length in zgw document download view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Bugfixes
   het URL te wijzigen. De cache-timeout van ``fetch_single_status`` is gelijkgesteld
   aan ``CACHE_ZGW_ZAKEN_TIMEOUT`` (standaard 60 seconden), zodat de zakenlijst
   dezelfde versheid garandeert als de zaakdetailpagina.
+* [:gh:`2289`] Validate content-length in ZGW document downloads to prevent broken downloads
+  when the backend returns error messages instead of file content.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -828,7 +828,6 @@ class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
             raise PermissionDenied()
 
         # retrieve and stream content
-        content_stream = None
         content_stream = api_group.documenten_client.download_document(
             info_object.inhoud
         )
@@ -836,13 +835,59 @@ class CaseDocumentDownloadView(CaseLogMixin, CaseAccessMixin, View):
         if not content_stream:
             raise Http404
 
+        # Validate the actual content length matches the expected size. Note that this
+        # is best-effort: if somehow content-length is malformed or bestandsomvang is
+        # missing, we revert to just streaming the file and hoping for the best (the
+        # behavior prior to introducing this check).
+        actual_content_length = content_stream.headers.get("Content-Length")
+        try:
+            parsed_content_length = (
+                int(actual_content_length) if actual_content_length else None
+            )
+        except (ValueError, TypeError):
+            logger.warning(
+                "Document content-length header is malformed",
+                info_object_uuid=info_object_uuid,
+                actual_content_length=actual_content_length,
+            )
+            parsed_content_length = None
+
+        if (
+            parsed_content_length is not None
+            and info_object.bestandsomvang is not None
+            and parsed_content_length != info_object.bestandsomvang
+        ):
+            logger.warning(
+                "Document size mismatch",
+                info_object_uuid=info_object_uuid,
+                expected_size=info_object.bestandsomvang,
+                actual_size=parsed_content_length,
+            )
+            messages.error(
+                request,
+                _(
+                    "Het document kon niet worden gedownload vanwege een fout in de gegevens."
+                ),
+            )
+            return HttpResponseRedirect(
+                reverse(
+                    "cases:case_detail",
+                    kwargs={
+                        "api_group_id": self.kwargs["api_group_id"],
+                        "object_id": self.zaak.uuid,
+                    },
+                )
+            )
+
         self.log_case_document_downloaded(self.zaak, info_object.bestandsnaam)
 
         headers = {
             "Content-Disposition": f'attachment; filename="{info_object.bestandsnaam}"',
             "Content-Type": info_object.formaat,
-            "Content-Length": info_object.bestandsomvang,
         }
+        if info_object.bestandsomvang is not None:
+            headers["Content-Length"] = str(info_object.bestandsomvang)
+
         response = StreamingHttpResponse(content_stream, headers=headers)
         return response
 

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -522,6 +522,78 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
 
         self.app.get(self.informatie_object_file.url, user=self.user, status=404)
 
+    def test_document_download_with_size_mismatch_shows_error(self, m):
+        self._setUpAccessMocks(m)
+        m.get(self.informatie_object["url"], json=self.informatie_object)
+        # Content-Length differs from informatie_object["bestandsomvang"], triggering the mismatch
+        content_wrong_length = b"wrong content"
+        m.get(
+            self.informatie_object["inhoud"],
+            content=content_wrong_length,
+            headers={"Content-Length": str(len(content_wrong_length))},
+        )
+
+        response = self.app.get(
+            self.informatie_object_file.url,
+            user=self.user,
+            status=302,
+            auto_follow=False,
+        )
+
+        expected_redirect = f"/cases/{self.api_group.id}/{self.zaak['uuid']}/status/"
+        self.assertEqual(response.location, expected_redirect)
+
+        # Follow the redirect to access messages
+        response_redirect = response.follow()
+        messages = [str(message) for message in response_redirect.context["messages"]]
+        self.assertIn(
+            "Het document kon niet worden gedownload vanwege een fout in de gegevens.",
+            messages,
+        )
+
+    def test_document_download_missing_bestandsomvang_still_returns_file(self, m):
+        informatie_object_no_size = {**self.informatie_object, "bestandsomvang": None}
+        self._setUpAccessMocks(m)
+        m.get(self.informatie_object["url"], json=informatie_object_no_size)
+        m.get(
+            self.informatie_object["inhoud"],
+            content=self.informatie_object_content,
+            headers={"Content-Length": str(len(self.informatie_object_content))},
+        )
+
+        response = self.app.get(self.informatie_object_file.url, user=self.user)
+
+        self.assertEqual(response.body, self.informatie_object_content)
+
+    def test_document_download_malformed_content_length_header_still_returns_file(
+        self, m
+    ):
+        self._setUpAccessMocks(m)
+        m.get(self.informatie_object["url"], json=self.informatie_object)
+        m.get(
+            self.informatie_object["inhoud"],
+            content=self.informatie_object_content,
+            headers={"Content-Length": "not-a-number"},
+        )
+
+        response = self.app.get(self.informatie_object_file.url, user=self.user)
+
+        self.assertEqual(response.body, self.informatie_object_content)
+
+    def test_document_download_missing_content_length_header_still_returns_file(
+        self, m
+    ):
+        self._setUpAccessMocks(m)
+        m.get(self.informatie_object["url"], json=self.informatie_object)
+        m.get(
+            self.informatie_object["inhoud"],
+            content=self.informatie_object_content,
+        )
+
+        response = self.app.get(self.informatie_object_file.url, user=self.user)
+
+        self.assertEqual(response.body, self.informatie_object_content)
+
     def test_document_download_request_uses_service_credentials(self, m):
         server = CertificateFactory(label="server", cert_only=True)
         client = CertificateFactory(label="client", key_pair=True)


### PR DESCRIPTION
If the ZGW document backend is misbehaving, for instance because
an intermediate service gateway is broken and returns some kind
of XML message, the user will see a broken download message,
because the announced content-length will not in fact match the
content. In those cases, it's better UX to log and display an
error message.