### PR TITLE
:sparkles: Fix typo so that mijn afval filter PR passes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:ui": "vitest --ui",
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
-    "watch": "vite build --watch --mode development --debug"
+    "watch": "vite build --watch --mode development"
   },
   "repository": {
     "type": "git",

--- a/src/open_inwoner/mijn_afval/tests/test_views.py
+++ b/src/open_inwoner/mijn_afval/tests/test_views.py
@@ -74,7 +74,7 @@ class ExtractFilterOptionsTest(TestCase):
         self.assertEqual(options["afval_types"][1]["value"], "restafval")
 
         # Verify year range calculated from ledigingen
-        self.assertListEqual(options["period"], [2025, 2023])
+        self.assertListEqual(options["periode"], [2025, 2023])
 
     def test_extract_filter_options_no_ledigingen(self):
         profiel = AfvalProfiel(
@@ -93,7 +93,7 @@ class ExtractFilterOptionsTest(TestCase):
         options = _extract_filter_options(profiel)
 
         # Verify emptry period options when no ledigingen
-        self.assertListEqual(options["period"], [])
+        self.assertListEqual(options["periode"], [])
 
     def test_extract_filter_options_same_year(self):
         profiel = AfvalProfiel(
@@ -123,7 +123,7 @@ class ExtractFilterOptionsTest(TestCase):
         options = _extract_filter_options(profiel)
 
         # Verify single period options
-        self.assertListEqual(options["period"], [2024])
+        self.assertListEqual(options["periode"], [2024])
 
 
 class ConvertPeriodToDatesTest(TestCase):


### PR DESCRIPTION
## Summary

Small change to make sure the CI passes after a typo: `period` -> `periode`.