### PR TITLE
[#2256] Resolve issue where external link icons did not show up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,7 @@ Bugfixes
   ZGW catalogus gechecked worden op valide waarden voor de prosemirror velden.
 * [:gh:`2212`]: ``referrerpolicy="strict-origin-when-cross-origin"`` toegevoegd aan de video
   iframe om het site-brede referrerbeleid te overschrijven voor dit specifieke element.
+* [:gh:`2256`]: Probleem opgelost waarbij externe link-iconen bij product-veelgestelde vragen ontbraken.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/components/templates/components/Faq/Faq.html
+++ b/src/open_inwoner/components/templates/components/Faq/Faq.html
@@ -14,7 +14,7 @@
                     {% firstof 'question-'|add:id|add:'-answer' as answer_id %}
                     {% link bold=True href='#'|add:answer_id icon='keyboard_arrow_down' secondary=True text=question.question toggle="open"  %}
                 </h3>
-                <div id="{{ answer_id }}" class="faq__answer">{{ question.answer.html|safe }}</div>
+                <div id="{{ answer_id }}" class="faq__answer">{{ question.answer.html|prosemirror_content|safe }}</div>
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary

This issue is solved by adding `prosemirror_content` as template filter. This filter should have been replaced during the change from CKEditor to Django-Prosemirror.

## Issue References

- Github Issue: #2256 

## Checklist

- [x] CHANGELOG.rst updated