### PR TITLE
:bug: [#2257] Resolve issue where first row of a product table is always a th

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -141,6 +141,8 @@ Bugfixes
 * [:gh:`2256`]: Probleem opgelost waarbij externe link-iconen bij product-veelgestelde vragen ontbraken.
 * [:gh:`2263`]: Het woord 'E-mailmeldingen' is onterecht met een hoofdletter is geschreven in de
   zaakmeldingen optie.
+* [:gh:`2257`]: Probleem opgelost waarbij de eerste rij van een productteksttabel altijd een header-rij is,
+  ook wanneer dit was uitgeschakeld.
 
 Onderhoud
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Bugfixes
 * [:gh:`2320`]: Verbeterde controles op de rol van betrokkenen: gebruikers hebben alleen toegang
   tot een zaak en worden alleen op de hoogte gebracht van wijzigingen in een zaak als ze de juiste
   rol hebben.
+* [:gh:`2257`]: Probleem opgelost waarbij de eerste rij van een productteksttabel altijd een header-rij is,
+  ook wanneer dit was uitgeschakeld.
 
 Onderhoud
 ---------
@@ -141,8 +143,6 @@ Bugfixes
 * [:gh:`2256`]: Probleem opgelost waarbij externe link-iconen bij product-veelgestelde vragen ontbraken.
 * [:gh:`2263`]: Het woord 'E-mailmeldingen' is onterecht met een hoofdletter is geschreven in de
   zaakmeldingen optie.
-* [:gh:`2257`]: Probleem opgelost waarbij de eerste rij van een productteksttabel altijd een header-rij is,
-  ook wanneer dit was uitgeschakeld.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/components/Table/Table.scss
+++ b/src/open_inwoner/scss/components/Table/Table.scss
@@ -108,53 +108,85 @@
   &--content {
     display: table;
     border-collapse: separate;
+    border-spacing: 0;
     margin-top: var(--spacing-giant);
     margin-bottom: var(--spacing-giant);
 
-    .table__item {
-      border-right: 1px solid var(--color-gray-light);
-      word-wrap: break-word;
-      text-wrap: initial;
-    }
-
-    .table__item:first-of-type {
-      border-left: 1px solid var(--color-gray-light);
-      font-weight: bold;
-    }
-
-    .table__item:not(:first-of-type) {
-      text-align: right;
-      padding-right: var(--spacing-giant);
-    }
-
-    .table__row:first-child .table__header {
-      font-family: var(--font-family-heading);
-      font-weight: bold;
-      border-top: 1px solid var(--color-gray-dark-900);
-      border-bottom: 1px solid var(--color-gray-dark-900);
-    }
-
-    .table__header:first-of-type {
-      border-left: 1px solid var(--color-gray-dark-900);
+    // Border radiuses
+    .table__row:first-child :first-child {
       border-top-left-radius: var(--border-radius);
     }
-
-    .table__header:last-of-type {
-      border-right: 1px solid var(--color-gray-dark-900);
+    .table__row:first-child :last-child {
       border-top-right-radius: var(--border-radius);
     }
-
-    .table__header:not(:first-of-type) {
-      text-align: right;
-      padding-right: var(--spacing-giant);
-    }
-
-    .table__row:last-of-type .table__item:first-of-type {
+    .table__row:last-child :first-child {
       border-bottom-left-radius: var(--border-radius);
     }
-
-    .table__row:last-of-type .table__item:last-of-type {
+    .table__row:last-child :last-child {
       border-bottom-right-radius: var(--border-radius);
+    }
+
+    // Borders — default
+    .table__row .table__item {
+      border: 1px solid var(--color-gray-light);
+      word-wrap: break-word;
+      text-wrap: initial;
+
+      &:not(:first-child) {
+        text-align: right;
+        padding-right: var(--spacing-giant);
+      }
+
+      // Item + Item: avoid double border
+      & + .table__item {
+        border-left: none;
+      }
+
+      // Item + Header: item yields, header's dark border shows
+      &:has(+ .table__header) {
+        border-right: none;
+      }
+    }
+
+    .table__row .table__header {
+      border: 1px solid var(--color-gray-dark-900);
+
+      &:not(:first-child) {
+        text-align: right;
+        padding-right: var(--spacing-giant);
+      }
+
+      //- Header + (Header): no border between adjacent headers
+      &:has(+ .table__header) {
+        border-right: none;
+      }
+      & + .table__header {
+        border-left: none;
+      }
+
+      //- Header + (Item): item takes the header's border visually
+      & + .table__item {
+        border-left: none;
+      }
+    }
+
+    // Avoid double borders between rows
+    .table__row + .table__row {
+      .table__header,
+      .table__item {
+        border-top: none;
+      }
+    }
+
+    // (Item) above Header.
+    // This does not work in combination with merged cells.
+    // There are max 8 initial columns created with ProseMirror, more can be added.
+    // This CSS supports 12 columns.
+    @for $i from 1 through 12 {
+      .table__row:has(+ .table__row > .table__header:nth-child(#{$i}))
+        > .table__item:nth-child(#{$i}) {
+        border-bottom: 1px solid var(--color-gray-dark-900);
+      }
     }
   }
 
@@ -202,22 +234,6 @@
     *[class*='Icons'] {
       color: var(--color-gray-lighter);
       font-size: var(--font-size-body);
-    }
-  }
-
-  // TH styling for tables without THEAD elements
-
-  &--content {
-    .table__row:first-child .table__item {
-      border-top: 1px solid var(--color-gray-light);
-    }
-
-    .table__row:first-of-type .table__item:first-of-type {
-      border-top-left-radius: var(--border-radius);
-    }
-
-    .table__row:first-of-type .table__item:last-of-type {
-      border-top-right-radius: var(--border-radius);
     }
   }
 }

--- a/src/open_inwoner/scss/components/Table/Table.scss
+++ b/src/open_inwoner/scss/components/Table/Table.scss
@@ -209,19 +209,14 @@
 
   &--content {
     .table__row:first-child .table__item {
-      font-family: var(--font-family-heading);
-      font-weight: bold;
-      border-top: 1px solid var(--color-gray-dark-900);
-      border-bottom: 1px solid var(--color-gray-dark-900);
+      border-top: 1px solid var(--color-gray-light);
     }
 
     .table__row:first-of-type .table__item:first-of-type {
-      border-left: 1px solid var(--color-gray-dark-900);
       border-top-left-radius: var(--border-radius);
     }
 
     .table__row:first-of-type .table__item:last-of-type {
-      border-right: 1px solid var(--color-gray-dark-900);
       border-top-right-radius: var(--border-radius);
     }
   }

--- a/src/open_inwoner/utils/html.py
+++ b/src/open_inwoner/utils/html.py
@@ -24,21 +24,6 @@ CLASS_ADDERS = [
 ]
 
 
-def convert_first_row_to_th(html_tables):
-    """
-    Converts the first row of all tables from td to th.
-    """
-    for table in html_tables.find_all("table"):
-        first_row = table.find("tr")
-        if first_row:
-            for cell in first_row.find_all("td"):
-                th = html_tables.new_tag("th")
-                th.string = cell.string
-                th.attrs = cell.attrs
-                th["class"] = "table__header"
-                cell.replace_with(th)
-
-
 def get_rendered_content(content) -> str:
     """
     Takes object's content as an input and returns the rendered one.
@@ -112,8 +97,6 @@ def get_product_rendered_content(product):
         html = product.content.html
 
     soup = BeautifulSoup(html, "html.parser")
-
-    convert_first_row_to_th(soup)
 
     for tag, class_name in CLASS_ADDERS:
         for element in soup.find_all(tag):


### PR DESCRIPTION
## Summary

Resolve issue where first row of a product table is always a `th`

> [!NOTE]
> This PR has resolved the issue where the first row always is rendered as a `th`. However the styling of this first row is still different than a regular row. I am not sure if this should be fixed as well.

## Issue References

- Github Issue: #2257 

## Checklist

- [x] CHANGELOG.rst updated