### PR TITLE
fix: [#2108] prevent Sentry exception truncation from structlog JSON …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,10 @@ Bugfixes
 * [:gh:`2212`]: ``referrerpolicy="strict-origin-when-cross-origin"`` toegevoegd aan de video
   iframe om het site-brede referrerbeleid te overschrijven voor dit specifieke element.
 * [:gh:`2256`]: Probleem opgelost waarbij externe link-iconen bij product-veelgestelde vragen ontbraken.
+* [:gh:`2108`]: Sentry exception truncatie opgelost: structlog's JSON serialisatie converteerde
+  exceptions naar strings voordat Sentry de volledige stack traces kon vastleggen.
+  ``LoggingIntegration`` toegevoegd om exceptions te onderscheppen voordat structlog
+  ze formatteert, waardoor Sentry nu volledige exception informatie ontvangt.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -540,6 +540,9 @@ structlog.configure(
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
+        # NOTE: format_exc_info must come AFTER we've potentially sent to Sentry.
+        # The stdlib logging integration will handle sending exceptions to Sentry
+        # before they get formatted to strings here.
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,

--- a/src/open_inwoner/conf/utils.py
+++ b/src/open_inwoner/conf/utils.py
@@ -1,3 +1,4 @@
+import logging  # noqa: S001, TID251 (needed for Sentry LoggingIntegration level constants)
 import os
 from shutil import which
 from subprocess import CalledProcessError, check_output
@@ -7,7 +8,12 @@ from django.conf import settings
 
 import structlog
 from decouple import Csv, config as _config, undefined
-from sentry_sdk.integrations import DidNotEnable, django, redis
+from sentry_sdk.integrations import (
+    DidNotEnable,
+    django,
+    logging as sentry_logging,
+    redis,
+)
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -40,6 +46,13 @@ def get_sentry_integrations() -> list:
     default = [
         django.DjangoIntegration(),
         redis.RedisIntegration(),
+        # Capture exceptions from stdlib logging before structlog formats them
+        sentry_logging.LoggingIntegration(
+            level=logging.INFO,  # breadcrumbs
+            # do not send any logs as event to Sentry at all - these must be scraped by
+            # the (container) infrastructure instead.
+            event_level=None,
+        ),
     ]
     extra = []
 


### PR DESCRIPTION
…serialization

Structlog's `format_exc_info` processor was converting exceptions to JSON strings before Sentry could capture the full stack traces, resulting in truncated or missing exception details in Sentry reports.

Added Sentry's LoggingIntegration to capture exceptions from stdlib logging before structlog processes them. This ensures:
- Sentry receives complete exception information with full stack traces
- Local logs still get properly formatted JSON output
- No truncation or loss of exception details when using logger.exception() or exc_info=True

The LoggingIntegration is configured with:
- level=None: Captures log records at all levels
- event_level=None: Only creates Sentry events when explicitly using logger.exception() or exc_info=True (prevents noise from info/debug logs)

The key is that Sentry's integration runs in the stdlib logging layer before structlog's ProcessorFormatter converts exceptions to strings.

Closes: #2108
