### PR TITLE
✨ [#2280] Fix some styling issues for the tasks plugin on home

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,8 @@ Nieuwe features
   ``UrlTaakRecord``) gescheiden van Objects API envelope models
   (``ExternFormulierTaakObject``, ``UrlTaakObject``).
 * [:gh:`2255`]: Titels en tabellen toegevoegd aan de product-veelgestelde-vragen tekstopties.
+* [:gh:`2280`]: Verbeteringen doorgevoerd aan de Mijn Taken-plugin op de homepagina. De titel heeft extra spacing
+  gekregen, kaartjes openen nu in een nieuw tabblad en de aanduiding ‘Soort:’ is verwijderd.
 
 Bugfixes
 --------

--- a/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
+++ b/src/open_inwoner/scss/components/UserFeed/UserFeed.scss
@@ -8,6 +8,10 @@
       display: flex;
       justify-content: space-between;
     }
+
+    &--tasks {
+      margin-bottom: var(--spacing-extra-large);
+    }
   }
 
   &__summary {

--- a/src/open_inwoner/templates/cms/plugins/tasks/tasks.html
+++ b/src/open_inwoner/templates/cms/plugins/tasks/tasks.html
@@ -2,7 +2,7 @@
 
 {% if instance and tasks %}
 <section class="plugin userfeed">
-    <header class="userfeed__header">
+    <header class="userfeed__header userfeed__header--tasks">
         <div class="heading-2__indicator">
             <h2 class="utrecht-heading-2">
                 {{ instance.title }}
@@ -12,11 +12,11 @@
 
     <div class="card-container card-container--columns-2 plugin-card">
         {% for task in tasks %}
-            <a href="{{ task.task_url }}" class="card card--status card--status--info {% if task.status != "open" %}card--completed{% endif %}">
+            <a href="{{ task.task_url }}" class="card card--status card--status--info {% if task.status != "open" %}card--completed{% endif %}" target="_blank">
                 <div class="userfeed__marker userfeed__marker--info"></div>
 
                 <div class="card__body card__body--tabled">
-                <h3 class="utrecht-heading-3 userfeed__title">Status: {{ task.status }} {% if task.soort %}- Soort: {{ task.soort }}{% endif %}</h3>
+                <h3 class="utrecht-heading-3 userfeed__title">Status: {{ task.status }}</h3>
                   {% include "components/StatusIndicator/StatusIndicator.html" with status_indicator=info status_indicator_text="Let op!" %}
                     <p class="userfeed-card__description">
                         <span class="status">{{ task.titel }}</span>


### PR DESCRIPTION
## Summary

Fix some styling issues for the tasks plugin on home
Added target _blank, margin below title and removed soort from card

## Issue References

- Github Issue: #2280 

## Checklist

- [x] CHANGELOG.rst updated