### PR TITLE
fix: [#2108] prevent Sentry exception truncation from structlog JSON …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,8 +70,10 @@ Bugfixes
 * [:gh:`2256`]: Probleem opgelost waarbij externe link-iconen bij product-veelgestelde vragen ontbraken.
 * [:gh:`2108`]: Sentry exception truncatie opgelost: structlog's JSON serialisatie converteerde
   exceptions naar strings voordat Sentry de volledige stack traces kon vastleggen.
-  ``LoggingIntegration`` toegevoegd om exceptions te onderscheppen voordat structlog
-  ze formatteert, waardoor Sentry nu volledige exception informatie ontvangt.
+  Custom ``SentryStructlogProcessor`` geïmplementeerd om exceptions direct vanuit structlog te
+  onderscheppen voordat ``format_exc_info`` ze formatteert. Dit zorgt ervoor dat Sentry
+  volledige exception objecten met stack traces ontvangt, inclusief alle structlog context
+  als "Additional Data". De ``before_send`` hook filtert duplicate message events.
 * [:gh:`2263`]: Het woord 'E-mailmeldingen' is onterecht met een hoofdletter is geschreven in de
   zaakmeldingen optie.
 

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -12,6 +12,7 @@ from maykin_common.health_checks import (
     default_health_check_subsets,
 )
 
+from .structlog_sentry import SentryStructlogProcessor
 from .utils import config, get_sentry_integrations
 
 # Build paths inside the project, so further paths can be defined relative to
@@ -416,6 +417,9 @@ LOGGING = {
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
                 structlog.stdlib.PositionalArgumentsFormatter(),
+                # Sentry's LoggingIntegration captures exceptions from stdlib loggers
+                # before this formatting happens
+                structlog.processors.format_exc_info,
             ],
         },
         "plain_console": {
@@ -427,6 +431,9 @@ LOGGING = {
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
                 structlog.stdlib.PositionalArgumentsFormatter(),
+                # Sentry's LoggingIntegration captures exceptions from stdlib loggers
+                # before this formatting happens
+                structlog.processors.format_exc_info,
             ],
         },
         "outgoing_requests": {"()": HttpFormatter},
@@ -540,9 +547,13 @@ structlog.configure(
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
-        # NOTE: format_exc_info must come AFTER we've potentially sent to Sentry.
-        # The stdlib logging integration will handle sending exceptions to Sentry
-        # before they get formatted to strings here.
+        # Capture exceptions for Sentry BEFORE any formatting happens.
+        # This ensures Sentry receives raw exception objects with full stack traces
+        # and all the context from the event dict.
+        SentryStructlogProcessor(),
+        # Format exceptions for display in logs. This happens AFTER Sentry has
+        # captured the raw exception, so both Sentry (proper exception) and logs
+        # (formatted traceback) work correctly.
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
@@ -958,6 +969,7 @@ if SENTRY_DSN:
         traces_sample_rate=0,
         integrations=get_sentry_integrations(),
         send_default_pii=True,
+        before_send=SentryStructlogProcessor.before_send,
     )
 
 # Elastic APM

--- a/src/open_inwoner/conf/structlog_sentry.py
+++ b/src/open_inwoner/conf/structlog_sentry.py
@@ -1,0 +1,193 @@
+"""
+Custom structlog processor for Sentry integration.
+
+This processor captures exceptions from structlog events and sends them to Sentry
+BEFORE format_exc_info runs, ensuring Sentry receives raw exception objects with
+full stack traces instead of formatted strings or JSON blobs.
+"""
+
+import logging  # noqa: TID251 - Used for log level constants only
+import sys
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import _IGNORED_LOGGERS
+from sentry_sdk.utils import event_from_exception
+from structlog.types import EventDict, WrappedLogger
+
+
+class SentryStructlogProcessor:
+    """
+    Structlog processor that sends exceptions to Sentry.
+
+    This processor should be placed BEFORE format_exc_info in the processor chain
+    to ensure it captures raw exception objects.
+    """
+
+    def __init__(
+        self,
+        level: int = logging.INFO,
+        event_level: int = logging.ERROR,
+    ):
+        """
+        Initialize the Sentry processor.
+
+        Args:
+            level: Minimum level for breadcrumbs (default: INFO)
+            event_level: Minimum level for Sentry events (default: ERROR)
+        """
+        self.level = level
+        self.event_level = event_level
+
+    @staticmethod
+    def before_send(event, hint):
+        """
+        Filter out log message events that are duplicates of exceptions already captured.
+
+        Our custom SentryStructlogProcessor captures exceptions directly from structlog before
+        they're formatted. However, Django's integration also tries to capture the
+        formatted log output, resulting in duplicate events where one is a proper
+        exception and the other is a JSON blob message.
+
+        This hook filters out the JSON blob messages by checking if:
+        1. The event has no exception (it's just a message)
+        2. The message looks like it came from structlog (contains 'sentry_event_id')
+        3. There's an exception in the hint (meaning an exception was already captured)
+        """
+        # If this event has an exception, let it through (it's from our SentryStructlogProcessor)
+        if event.get("exception"):
+            return event
+
+        # Check if this is a duplicate message event
+        # Our SentryProcessor adds 'sentry_event_id' to the log, so if the message
+        # contains that, it's a duplicate of an already-sent exception
+        message = event.get("message", "")
+        if "sentry_event_id" in str(message):
+            # This is a duplicate - the real exception was already sent
+            return None
+
+        # Also check the log record's message directly
+        if log_record := hint.get("log_record"):
+            # Check if the log record has an exception (was already captured)
+            if getattr(log_record, "exc_info", None):
+                # This is a log message with an exception that was already captured
+                # by our SentryStructlogProcessor, so drop it
+                return None
+
+            # Check the formatted message from the log record
+            record_message = getattr(log_record, "message", "")
+            if "sentry_event_id" in str(record_message):
+                return None
+
+            # Also check getMessage() which includes formatted args
+            try:
+                full_message = log_record.getMessage()
+                if "sentry_event_id" in str(full_message):
+                    return None
+            except Exception:  # noqa: S110
+                # Silently ignore - we're in a Sentry filter hook, logging here
+                # could cause infinite loops
+                pass
+
+        return event
+
+    def __call__(
+        self, logger: WrappedLogger, method_name: str, event_dict: EventDict
+    ) -> EventDict:
+        """
+        Process the event and send to Sentry if appropriate.
+
+        Args:
+            logger: The wrapped logger instance
+            method_name: The name of the method called (e.g., "info", "error")
+            event_dict: The event dictionary
+
+        Returns:
+            The unmodified event_dict (this processor doesn't modify events)
+        """
+        # Skip if explicitly requested
+        if event_dict.pop("sentry_skip", False):
+            return event_dict
+
+        # Check if logger is in ignored list
+        logger_name = event_dict.get("logger")
+        if logger_name and any(
+            logger_name.startswith(ignored) for ignored in _IGNORED_LOGGERS
+        ):
+            return event_dict
+
+        # Get the log level
+        level_name = event_dict.get("level", "").upper()
+        try:
+            level_value = getattr(logging, level_name, logging.INFO)
+        except AttributeError:
+            level_value = logging.INFO
+
+        # Only process if level is high enough
+        if level_value < self.event_level:
+            return event_dict
+
+        # Extract exception info and convert to standard tuple format
+        exc_info = event_dict.get("exc_info")
+        match exc_info:
+            case None:
+                return event_dict
+            case tuple():
+                exc_tuple = exc_info
+            case BaseException():
+                exc_tuple = (type(exc_info), exc_info, exc_info.__traceback__)
+            case True:
+                exc_tuple = sys.exc_info()
+            case _:
+                return event_dict
+
+        # Return early if we don't have a valid exception
+        if not exc_tuple or exc_tuple == (None, None, None) or exc_tuple[1] is None:
+            return event_dict
+
+        try:
+            with sentry_sdk.push_scope() as scope:
+                # Add all event_dict fields as extra context
+                # Make sure we serialize complex objects to strings
+                for key, value in event_dict.items():
+                    if key not in (
+                        "exc_info",
+                        "event",
+                        "logger",
+                        "level",
+                        "timestamp",
+                    ):
+                        try:
+                            # Try to add the value as-is, Sentry will serialize it
+                            scope.set_extra(key, value)
+                        except Exception:
+                            # If that fails, convert to string
+                            scope.set_extra(key, str(value))
+
+                # If there's a log message, use it as the event title
+                if event_message := event_dict.get("event"):
+                    scope.set_tag("log_message", str(event_message))
+
+                    client = sentry_sdk.get_client()
+                    event, hint = event_from_exception(
+                        exc_tuple,
+                        client_options=client.options,
+                        mechanism={"type": "logging", "handled": True},
+                    )
+
+                    # Set the event message as the main title
+                    event["message"] = str(event_message)
+
+                    event_id = sentry_sdk.capture_event(event, hint=hint)
+                else:
+                    # No custom message, just capture the exception normally
+                    event_id = sentry_sdk.capture_exception(exc_tuple[1])
+
+                # Add a marker to the event dict for the before_send hook to detect duplicates
+                if event_id:
+                    event_dict["sentry_event_id"] = event_id
+        except Exception:  # noqa: S110
+            # Don't let Sentry processing break the logging pipeline
+            # We can't log here as it could cause infinite loops
+            pass
+
+        return event_dict

--- a/src/open_inwoner/conf/tests/test_structlog_sentry.py
+++ b/src/open_inwoner/conf/tests/test_structlog_sentry.py
@@ -1,0 +1,251 @@
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+from django.test import TestCase
+
+from open_inwoner.conf.structlog_sentry import SentryStructlogProcessor
+
+
+@patch("open_inwoner.conf.structlog_sentry.sentry_sdk")
+class SentryStructlogProcessorTests(TestCase):
+    def setUp(self):
+        self.processor = SentryStructlogProcessor()
+        self.logger = Mock()
+        self.method_name = "error"
+
+    def test_events_without_exc_info_are_passed_through_unchanged(self, mock_sentry):
+        event_dict = {"event": "Something happened", "level": "error"}
+
+        result = self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.capture_exception.assert_not_called()
+        mock_sentry.capture_event.assert_not_called()
+        self.assertEqual(result, event_dict)
+
+    def test_sentry_skip_flag_prevents_capture_and_is_removed_from_result(
+        self, mock_sentry
+    ):
+        exc_info = self._create_exception()
+        event_dict = {
+            "event": "Test error",
+            "level": "error",
+            "exc_info": exc_info,
+            "sentry_skip": True,
+        }
+
+        result = self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.capture_exception.assert_not_called()
+        mock_sentry.capture_event.assert_not_called()
+        self.assertNotIn("sentry_skip", result)
+
+    def test_events_below_error_level_are_not_sent_to_sentry(self, mock_sentry):
+        exc_info = self._create_exception()
+        event_dict = {
+            "event": "Test warning",
+            "level": "warning",
+            "exc_info": exc_info,
+        }
+
+        self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.capture_exception.assert_not_called()
+        mock_sentry.capture_event.assert_not_called()
+
+    def test_event_message_becomes_sentry_title_with_context_as_extras(
+        self, mock_sentry
+    ):
+        exc_info = self._create_exception()
+        event_dict = {
+            "event": "Invalid externe taak",
+            "level": "error",
+            "exc_info": exc_info,
+            "object_type_uuid": "123-456",
+            "request_id": "req-789",
+        }
+
+        mock_scope = MagicMock()
+        mock_sentry.push_scope.return_value.__enter__.return_value = mock_scope
+        mock_sentry.get_client.return_value.options = {}
+
+        mock_event = {
+            "exception": {"values": [{"value": "Original exception message"}]},
+            "message": "Original message",
+        }
+        mock_sentry.utils.event_from_exception.return_value = (
+            mock_event,
+            {"exc_info": exc_info},
+        )
+        mock_sentry.capture_event.return_value = "event-id-123"
+
+        result = self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.push_scope.assert_called_once()
+        mock_scope.set_extra.assert_any_call("object_type_uuid", "123-456")
+        mock_scope.set_extra.assert_any_call("request_id", "req-789")
+        mock_scope.set_tag.assert_called_once_with(
+            "log_message", "Invalid externe taak"
+        )
+        self.assertEqual(mock_event["message"], "Invalid externe taak")
+        self.assertEqual(
+            mock_event["exception"]["values"][0]["value"],
+            "Original exception message",
+        )
+        self.assertEqual(result["sentry_event_id"], "event-id-123")
+
+    def test_exception_without_event_message_uses_capture_exception_directly(
+        self, mock_sentry
+    ):
+        exc_info = self._create_exception()
+        event_dict = {
+            "level": "error",
+            "exc_info": exc_info,
+        }
+
+        mock_scope = MagicMock()
+        mock_sentry.push_scope.return_value.__enter__.return_value = mock_scope
+        mock_sentry.capture_exception.return_value = "event-id-456"
+
+        result = self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.capture_exception.assert_called_once()
+        mock_sentry.capture_event.assert_not_called()
+        self.assertEqual(result["sentry_event_id"], "event-id-456")
+
+    def test_exc_info_as_baseexception_instance_is_converted_to_tuple(
+        self, mock_sentry
+    ):
+        try:
+            raise ValueError("Test error")
+        except ValueError as e:
+            exc = e
+
+        event_dict = {
+            "event": "Test error",
+            "level": "error",
+            "exc_info": exc,
+        }
+
+        mock_scope = MagicMock()
+        mock_sentry.push_scope.return_value.__enter__.return_value = mock_scope
+        mock_sentry.get_client.return_value.options = {}
+        mock_event = {
+            "exception": {"values": [{"value": "Original"}]},
+            "message": "Original",
+        }
+        mock_sentry.utils.event_from_exception.return_value = (
+            mock_event,
+            {"exc_info": exc},
+        )
+        mock_sentry.capture_event.return_value = "event-id-789"
+
+        result = self.processor(self.logger, self.method_name, event_dict)
+
+        mock_sentry.push_scope.assert_called_once()
+        self.assertEqual(result["sentry_event_id"], "event-id-789")
+
+    def test_exc_info_true_calls_sys_exc_info_to_get_current_exception(
+        self, mock_sentry
+    ):
+        try:
+            raise ValueError("Test error")
+        except ValueError:
+            event_dict = {
+                "event": "Test error",
+                "level": "error",
+                "exc_info": True,
+            }
+
+            mock_scope = MagicMock()
+            mock_sentry.push_scope.return_value.__enter__.return_value = mock_scope
+            mock_sentry.get_client.return_value.options = {}
+            mock_event = {
+                "exception": {"values": [{"value": "Original"}]},
+                "message": "Original",
+            }
+            mock_sentry.utils.event_from_exception.return_value = (
+                mock_event,
+                {},
+            )
+            mock_sentry.capture_event.return_value = "event-id-abc"
+
+            result = self.processor(self.logger, self.method_name, event_dict)
+
+            mock_sentry.push_scope.assert_called_once()
+            self.assertEqual(result["sentry_event_id"], "event-id-abc")
+
+    def test_before_send_allows_events_with_exceptions(self, _mock_sentry):
+        event = {"exception": {"values": [{"type": "ValueError"}]}}
+        hint = {}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertEqual(result, event)
+
+    def test_before_send_filters_message_events_containing_sentry_event_id(
+        self, _mock_sentry
+    ):
+        event = {
+            "message": "Some log message with sentry_event_id='abc-123' in it",
+        }
+        hint = {}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertIsNone(result)
+
+    def test_before_send_filters_log_records_with_exc_info(self, _mock_sentry):
+        event = {"message": "Some message"}
+        log_record = Mock()
+        log_record.exc_info = (ValueError, ValueError("test"), None)
+        hint = {"log_record": log_record}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertIsNone(result)
+
+    def test_before_send_filters_log_records_with_sentry_event_id_in_message_attr(
+        self, _mock_sentry
+    ):
+        event = {"message": "Some message"}
+        log_record = Mock()
+        log_record.exc_info = None
+        log_record.message = "Log with sentry_event_id='xyz'"
+        hint = {"log_record": log_record}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertIsNone(result)
+
+    def test_before_send_filters_log_records_with_sentry_event_id_in_get_message(
+        self, _mock_sentry
+    ):
+        event = {"message": "Some message"}
+        log_record = Mock()
+        log_record.exc_info = None
+        log_record.message = "Clean message"
+        log_record.getMessage.return_value = "Message with sentry_event_id='123'"
+        hint = {"log_record": log_record}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertIsNone(result)
+
+    def test_before_send_allows_normal_log_messages_without_markers(self, _mock_sentry):
+        event = {"message": "A normal log message without any markers"}
+        log_record = Mock()
+        log_record.exc_info = None
+        log_record.message = "Normal message"
+        log_record.getMessage.return_value = "Normal message"
+        hint = {"log_record": log_record}
+
+        result = SentryStructlogProcessor.before_send(event, hint)
+
+        self.assertEqual(result, event)
+
+    def _create_exception(self):
+        """Helper to create a valid exception tuple."""
+        try:
+            raise ValueError("Test exception")
+        except ValueError:
+            return sys.exc_info()

--- a/src/open_inwoner/conf/utils.py
+++ b/src/open_inwoner/conf/utils.py
@@ -1,4 +1,3 @@
-import logging  # noqa: S001, TID251 (needed for Sentry LoggingIntegration level constants)
 import os
 from shutil import which
 from subprocess import CalledProcessError, check_output
@@ -8,12 +7,7 @@ from django.conf import settings
 
 import structlog
 from decouple import Csv, config as _config, undefined
-from sentry_sdk.integrations import (
-    DidNotEnable,
-    django,
-    logging as sentry_logging,
-    redis,
-)
+from sentry_sdk.integrations import DidNotEnable, django, redis
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -46,11 +40,10 @@ def get_sentry_integrations() -> list:
     default = [
         django.DjangoIntegration(),
         redis.RedisIntegration(),
-        # Capture exceptions from stdlib logging before structlog formats them
-        sentry_logging.LoggingIntegration(
-            level=logging.INFO,  # Capture INFO+ as breadcrumbs for context
-            event_level=logging.ERROR,  # Send ERROR+ as events to Sentry
-        ),
+        # NOTE: We use a custom SentryStructlogProcessor in structlog to capture
+        # exceptions directly from the event dict before any formatting happens. This
+        # ensures Sentry receives proper exception objects instead of formatted strings
+        # or JSON blobs. The LoggingIntegration is disabled to prevent interference.
     ]
     extra = []
 


### PR DESCRIPTION
…serialization

Structlog's JSON serialization was causing Sentry to receive truncated exception information as JSON blobs instead of proper exception objects with full stack traces.

Changes:
- Created custom SentryProcessor in structlog_sentry.py that captures exceptions directly from structlog events before format_exc_info runs
- Processor extracts all event_dict fields and sends them to Sentry as "Additional Data" context
- Uses log event message as Sentry exception title while preserving full stack trace and exception type
- Added before_send hook as static method to filter duplicate message events from Django integration
- Disabled LoggingIntegration to prevent interference with custom processor
- Placed SentryProcessor before format_exc_info in processor chain so both Sentry (raw exceptions) and logs (formatted tracebacks) work correctly

Closes: #2108 