### PR TITLE
fix: [#2290] include betrokkene_type in fetch_zaak_roles cache key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,9 @@ Nieuwe features
 Bugfixes
 --------
 
-* ...
+* [:gh:`2290`]: Correctie van cache key voor ``fetch_zaak_roles`` om
+  ``betrokkene_type`` parameter op te nemen, waardoor verkeerde cache hits worden
+  voorkomen.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -366,7 +366,7 @@ class ZakenClient(ZgwAPIClient):
         return status
 
     @cache_result(
-        "{self.base_url}:zaak_roles:{zaak_url}:{role_desc_generic}",
+        "{self.base_url}:zaak_roles:{zaak_url}:{role_desc_generic}:{betrokkene_type}",
         timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
     )
     def fetch_zaak_roles(


### PR DESCRIPTION
The fetch_zaak_roles method accepts a betrokkene_type parameter that affects the HTTP request (it's passed as betrokkeneType query param). Previously, this parameter was not included in the cache key, which could cause incorrect cache hits when the same zaak_url and role_desc_generic are used with different betrokkene_type values.

Closes: #2290