### PR TITLE
[#2295] Update zaken plugin card with: consisten height and arrow_forward icon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Onderhoud
   ``immutable`` override bijgewerkt om :cve:`CVE-2026-29063` te mitigeren.
 * [:gh:`2314`, :cve:`CVE-2026-32597`]: ``PyJWT`` bijgewerkt naar versie ``2.10.1`` om
   kwetsbaarheid in ``crit`` header te mitigeren.
+* [:gh:`2295`]: Zaken-kaartjes op de homepage gebruiken nu het ``arrow_forward`` icoon en hebben een gelijke hoogte.
 
 2.1.0 (2026-03-04)
 ==================

--- a/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.tsx
+++ b/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.tsx
@@ -45,7 +45,7 @@ const HomePluginCard: AC<HomepageCardTypes> = ({
           </p>
         </div>
 
-        <MaterialIcon name="east" />
+        <MaterialIcon name="arrow_forward" />
       </div>
     </a>
   );

--- a/src/open_inwoner/react/components/HomePluginSection/HomePluginSection.scss
+++ b/src/open_inwoner/react/components/HomePluginSection/HomePluginSection.scss
@@ -86,6 +86,7 @@
 .plugin__grid {
   display: grid;
   grid-template-columns: repeat(1, 1fr);
+  grid-auto-rows: 1fr;
 
   @media (min-width: 768px) {
     grid-template-columns: repeat(var(--plugin-columns, 2), 1fr);


### PR DESCRIPTION
## Summary

These icon has changed from 'east' to 'arrow_forward', all rows have now an equal height (uses the height of the highest card).

## Issue References

- Github Issue: #2295 

## Checklist

- [x] CHANGELOG.rst updated