### PR TITLE
:lock: Bumb cssnano to v^7.1.3 and override immutable to v^5.1.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Onderhoud
 ---------
 
 * [:gh:`2283`]: De grafiek en filters op de Mijn Afval pagina zijn niet meer zichtbaar wanneer er geen data beschikbaar is.
+* [:gh:`2303`, :cve:`CVE-2026-29074`, :cve:`CVE-2026-29063`]: ``cssnano`` bijgewerkt om :cve:`CVE-2026-29074` te mitigeren en
+  ``immutable`` override bijgewerkt om :cve:`CVE-2026-29063` te mitigeren.
 
 2.1.0 (2026-03-04)
 ==================

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,13 +64,13 @@
         "autoprefixer": "^10.4.23",
         "babel-plugin-formatjs": "^10.5.39",
         "concurrently": "^9.2.1",
-        "cssnano": "^7.1.2",
+        "cssnano": "^7.1.3",
         "jsdom": "^27.2.0",
         "picocolors": "^1.1.1",
         "postcss": "^8.5.6",
         "postcss-selector-lint": "^1.0.2",
         "prettier": "^3.6.2",
-        "sass-embedded": "latest",
+        "sass-embedded": "^1.97.3",
         "storybook": "^10.2.14",
         "type-fest": "^5.2.0",
         "typescript": "^5.8.3",
@@ -3947,11 +3947,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-builder": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT/X11"
-    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4022,6 +4017,8 @@
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4129,6 +4126,8 @@
     },
     "node_modules/colord": {
       "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4139,6 +4138,8 @@
     },
     "node_modules/commander": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4242,7 +4243,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.3.0",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4297,6 +4300,8 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4307,13 +4312,13 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.2.tgz",
-      "integrity": "sha512-HYOPBsNvoiFeR1eghKD5C3ASm64v9YVyJB4Ivnl2gqKoQYvjjN/G0rztvKQq8OxocUtC6sjqY8jwYngIB4AByA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.3.tgz",
+      "integrity": "sha512-mLFHQAzyapMVFLiJIn7Ef4C2UCEvtlTlbyILR6B5ZsUAV3D/Pa761R5uC1YPhyBkRd3eqaDm2ncaNrD7R4mTRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano-preset-default": "^7.0.10",
+        "cssnano-preset-default": "^7.0.11",
         "lilconfig": "^3.1.3"
       },
       "engines": {
@@ -4328,40 +4333,42 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "7.0.10",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.11.tgz",
+      "integrity": "sha512-waWlAMuCakP7//UCY+JPrQS1z0OSLeOXk2sKWJximKWGupVxre50bzPlvpbUwZIDylhf/ptf0Pk+Yf7C+hoa3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "css-declaration-sorter": "^7.2.0",
         "cssnano-utils": "^5.0.1",
         "postcss-calc": "^10.1.1",
-        "postcss-colormin": "^7.0.5",
-        "postcss-convert-values": "^7.0.8",
-        "postcss-discard-comments": "^7.0.5",
+        "postcss-colormin": "^7.0.6",
+        "postcss-convert-values": "^7.0.9",
+        "postcss-discard-comments": "^7.0.6",
         "postcss-discard-duplicates": "^7.0.2",
         "postcss-discard-empty": "^7.0.1",
         "postcss-discard-overridden": "^7.0.1",
         "postcss-merge-longhand": "^7.0.5",
-        "postcss-merge-rules": "^7.0.7",
+        "postcss-merge-rules": "^7.0.8",
         "postcss-minify-font-values": "^7.0.1",
         "postcss-minify-gradients": "^7.0.1",
-        "postcss-minify-params": "^7.0.5",
-        "postcss-minify-selectors": "^7.0.5",
+        "postcss-minify-params": "^7.0.6",
+        "postcss-minify-selectors": "^7.0.6",
         "postcss-normalize-charset": "^7.0.1",
         "postcss-normalize-display-values": "^7.0.1",
         "postcss-normalize-positions": "^7.0.1",
         "postcss-normalize-repeat-style": "^7.0.1",
         "postcss-normalize-string": "^7.0.1",
         "postcss-normalize-timing-functions": "^7.0.1",
-        "postcss-normalize-unicode": "^7.0.5",
+        "postcss-normalize-unicode": "^7.0.6",
         "postcss-normalize-url": "^7.0.1",
         "postcss-normalize-whitespace": "^7.0.1",
         "postcss-ordered-values": "^7.0.2",
-        "postcss-reduce-initial": "^7.0.5",
+        "postcss-reduce-initial": "^7.0.6",
         "postcss-reduce-transforms": "^7.0.1",
-        "postcss-svgo": "^7.1.0",
-        "postcss-unique-selectors": "^7.0.4"
+        "postcss-svgo": "^7.1.1",
+        "postcss-unique-selectors": "^7.0.5"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4372,6 +4379,8 @@
     },
     "node_modules/cssnano-utils": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
+      "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4383,6 +4392,8 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4395,6 +4406,8 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4408,6 +4421,8 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -5169,7 +5184,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
     },
     "node_modules/indent-string": {
@@ -5641,11 +5658,15 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5959,6 +5980,8 @@
     },
     "node_modules/postcss-calc": {
       "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5972,24 +5995,14 @@
         "postcss": "^8.4.38"
       }
     },
-    "node_modules/postcss-calc/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-colormin": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.6.tgz",
+      "integrity": "sha512-oXM2mdx6IBTRm39797QguYzVEWzbdlFiMNfq88fCCN1Wepw3CYmJ/1/Ifa/KjWo+j5ZURDl2NTldLJIw51IeNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.3",
         "postcss-value-parser": "^4.2.0"
@@ -6002,11 +6015,13 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "7.0.8",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.9.tgz",
+      "integrity": "sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -6017,11 +6032,13 @@
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.6.tgz",
+      "integrity": "sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^7.1.0"
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -6030,20 +6047,10 @@
         "postcss": "^8.4.32"
       }
     },
-    "node_modules/postcss-discard-comments/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-discard-duplicates": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
+      "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6055,6 +6062,8 @@
     },
     "node_modules/postcss-discard-empty": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
+      "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6066,6 +6075,8 @@
     },
     "node_modules/postcss-discard-overridden": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
+      "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6077,6 +6088,8 @@
     },
     "node_modules/postcss-merge-longhand": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
+      "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6091,14 +6104,16 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "7.0.7",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.8.tgz",
+      "integrity": "sha512-BOR1iAM8jnr7zoQSlpeBmCsWV5Uudi/+5j7k05D0O/WP3+OFMPD86c1j/20xiuRtyt45bhxw/7hnhZNhW2mNFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^5.0.1",
-        "postcss-selector-parser": "^7.1.0"
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -6107,20 +6122,10 @@
         "postcss": "^8.4.32"
       }
     },
-    "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-minify-font-values": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
+      "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6135,6 +6140,8 @@
     },
     "node_modules/postcss-minify-gradients": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
+      "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6150,11 +6157,13 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.6.tgz",
+      "integrity": "sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "cssnano-utils": "^5.0.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -6166,12 +6175,14 @@
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.6.tgz",
+      "integrity": "sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
-        "postcss-selector-parser": "^7.1.0"
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -6180,20 +6191,10 @@
         "postcss": "^8.4.32"
       }
     },
-    "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-normalize-charset": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
+      "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6205,6 +6206,8 @@
     },
     "node_modules/postcss-normalize-display-values": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
+      "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6219,6 +6222,8 @@
     },
     "node_modules/postcss-normalize-positions": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
+      "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6233,6 +6238,8 @@
     },
     "node_modules/postcss-normalize-repeat-style": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
+      "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6247,6 +6254,8 @@
     },
     "node_modules/postcss-normalize-string": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
+      "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6261,6 +6270,8 @@
     },
     "node_modules/postcss-normalize-timing-functions": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
+      "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6274,11 +6285,13 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.6.tgz",
+      "integrity": "sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -6290,6 +6303,8 @@
     },
     "node_modules/postcss-normalize-url": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
+      "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6304,6 +6319,8 @@
     },
     "node_modules/postcss-normalize-whitespace": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
+      "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6318,6 +6335,8 @@
     },
     "node_modules/postcss-ordered-values": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
+      "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6332,11 +6351,13 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "7.0.5",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.6.tgz",
+      "integrity": "sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -6348,6 +6369,8 @@
     },
     "node_modules/postcss-reduce-transforms": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
+      "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6368,13 +6391,29 @@
         "postcss": "latest"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-svgo": {
-      "version": "7.1.0",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.1.tgz",
+      "integrity": "sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "svgo": "^4.0.0"
+        "svgo": "^4.0.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >= 18"
@@ -6384,29 +6423,19 @@
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "7.0.4",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.5.tgz",
+      "integrity": "sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^7.1.0"
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
-      }
-    },
-    "node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -6700,9 +6729,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
-      "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6721,14 +6750,13 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.2.tgz",
-      "integrity": "sha512-lKJcskySwAtJ4QRirKrikrWMFa2niAuaGenY2ElHjd55IwHUiur5IdKu6R1hEmGYMs4Qm+6rlRW0RvuAkmcryg==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
+      "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
-        "buffer-builder": "^0.2.0",
         "colorjs.io": "^0.5.0",
         "immutable": "^5.0.2",
         "rxjs": "^7.4.0",
@@ -6743,30 +6771,30 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-all-unknown": "1.97.2",
-        "sass-embedded-android-arm": "1.97.2",
-        "sass-embedded-android-arm64": "1.97.2",
-        "sass-embedded-android-riscv64": "1.97.2",
-        "sass-embedded-android-x64": "1.97.2",
-        "sass-embedded-darwin-arm64": "1.97.2",
-        "sass-embedded-darwin-x64": "1.97.2",
-        "sass-embedded-linux-arm": "1.97.2",
-        "sass-embedded-linux-arm64": "1.97.2",
-        "sass-embedded-linux-musl-arm": "1.97.2",
-        "sass-embedded-linux-musl-arm64": "1.97.2",
-        "sass-embedded-linux-musl-riscv64": "1.97.2",
-        "sass-embedded-linux-musl-x64": "1.97.2",
-        "sass-embedded-linux-riscv64": "1.97.2",
-        "sass-embedded-linux-x64": "1.97.2",
-        "sass-embedded-unknown-all": "1.97.2",
-        "sass-embedded-win32-arm64": "1.97.2",
-        "sass-embedded-win32-x64": "1.97.2"
+        "sass-embedded-all-unknown": "1.97.3",
+        "sass-embedded-android-arm": "1.97.3",
+        "sass-embedded-android-arm64": "1.97.3",
+        "sass-embedded-android-riscv64": "1.97.3",
+        "sass-embedded-android-x64": "1.97.3",
+        "sass-embedded-darwin-arm64": "1.97.3",
+        "sass-embedded-darwin-x64": "1.97.3",
+        "sass-embedded-linux-arm": "1.97.3",
+        "sass-embedded-linux-arm64": "1.97.3",
+        "sass-embedded-linux-musl-arm": "1.97.3",
+        "sass-embedded-linux-musl-arm64": "1.97.3",
+        "sass-embedded-linux-musl-riscv64": "1.97.3",
+        "sass-embedded-linux-musl-x64": "1.97.3",
+        "sass-embedded-linux-riscv64": "1.97.3",
+        "sass-embedded-linux-x64": "1.97.3",
+        "sass-embedded-unknown-all": "1.97.3",
+        "sass-embedded-win32-arm64": "1.97.3",
+        "sass-embedded-win32-x64": "1.97.3"
       }
     },
     "node_modules/sass-embedded-all-unknown": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.97.2.tgz",
-      "integrity": "sha512-Fj75+vOIDv1T/dGDwEpQ5hgjXxa2SmMeShPa8yrh2sUz1U44bbmY4YSWPCdg8wb7LnwiY21B2KRFM+HF42yO4g==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.97.3.tgz",
+      "integrity": "sha512-t6N46NlPuXiY3rlmG6/+1nwebOBOaLFOOVqNQOC2cJhghOD4hh2kHNQQTorCsbY9S1Kir2la1/XLBwOJfui0xg==",
       "cpu": [
         "!arm",
         "!arm64",
@@ -6777,13 +6805,13 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "sass": "1.97.2"
+        "sass": "1.97.3"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.97.2.tgz",
-      "integrity": "sha512-BPT9m19ttY0QVHYYXRa6bmqmS3Fa2EHByNUEtSVcbm5PkIk1ntmYkG9fn5SJpIMbNmFDGwHx+pfcZMmkldhnRg==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.97.3.tgz",
+      "integrity": "sha512-cRTtf/KV/q0nzGZoUzVkeIVVFv3L/tS1w4WnlHapphsjTXF/duTxI8JOU1c/9GhRPiMdfeXH7vYNcMmtjwX7jg==",
       "cpu": [
         "arm"
       ],
@@ -6798,9 +6826,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.97.2.tgz",
-      "integrity": "sha512-pF6I+R5uThrscd3lo9B3DyNTPyGFsopycdx0tDAESN6s+dBbiRgNgE4Zlpv50GsLocj/lDLCZaabeTpL3ubhYA==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.97.3.tgz",
+      "integrity": "sha512-aiZ6iqiHsUsaDx0EFbbmmA0QgxicSxVVN3lnJJ0f1RStY0DthUkquGT5RJ4TPdaZ6ebeJWkboV4bra+CP766eA==",
       "cpu": [
         "arm64"
       ],
@@ -6815,9 +6843,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.97.2.tgz",
-      "integrity": "sha512-fprI8ZTJdz+STgARhg8zReI2QhhGIT9G8nS7H21kc3IkqPRzhfaemSxEtCqZyvDbXPcgYiDLV7AGIReHCuATog==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.97.3.tgz",
+      "integrity": "sha512-zVEDgl9JJodofGHobaM/q6pNETG69uuBIGQHRo789jloESxxZe82lI3AWJQuPmYCOG5ElfRthqgv89h3gTeLYA==",
       "cpu": [
         "riscv64"
       ],
@@ -6832,9 +6860,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.97.2.tgz",
-      "integrity": "sha512-RswwSjURZxupsukEmNt2t6RGvuvIw3IAD5sDq1Pc65JFvWFY3eHqCmH0lG0oXqMg6KJcF0eOxHOp2RfmIm2+4w==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.97.3.tgz",
+      "integrity": "sha512-3ke0le7ZKepyXn/dKKspYkpBC0zUk/BMciyP5ajQUDy4qJwobd8zXdAq6kOkdiMB+d9UFJOmEkvgFJHl3lqwcw==",
       "cpu": [
         "x64"
       ],
@@ -6849,9 +6877,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.97.2.tgz",
-      "integrity": "sha512-xcsZNnU1XZh21RE/71OOwNqPVcGBU0qT9A4k4QirdA34+ts9cDIaR6W6lgHOBR/Bnnu6w6hXJR4Xth7oFrefPA==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.97.3.tgz",
+      "integrity": "sha512-fuqMTqO4gbOmA/kC5b9y9xxNYw6zDEyfOtMgabS7Mz93wimSk2M1quQaTJnL98Mkcsl2j+7shNHxIS/qpcIDDA==",
       "cpu": [
         "arm64"
       ],
@@ -6866,9 +6894,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.97.2.tgz",
-      "integrity": "sha512-T/9DTMpychm6+H4slHCAsYJRJ6eM+9H9idKlBPliPrP4T8JdC2Cs+ZOsYqrObj6eOtAD0fGf+KgyNhnW3xVafA==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.97.3.tgz",
+      "integrity": "sha512-b/2RBs/2bZpP8lMkyZ0Px0vkVkT8uBd0YXpOwK7iOwYkAT8SsO4+WdVwErsqC65vI5e1e5p1bb20tuwsoQBMVA==",
       "cpu": [
         "x64"
       ],
@@ -6883,9 +6911,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.97.2.tgz",
-      "integrity": "sha512-yDRe1yifGHl6kibkDlRIJ2ZzAU03KJ1AIvsAh4dsIDgK5jx83bxZLV1ZDUv7a8KK/iV/80LZnxnu/92zp99cXQ==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.97.3.tgz",
+      "integrity": "sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==",
       "cpu": [
         "arm"
       ],
@@ -6900,9 +6928,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.97.2.tgz",
-      "integrity": "sha512-Wh+nQaFer9tyE5xBPv5murSUZE/+kIcg8MyL5uqww6be9Iq+UmZpcJM7LUk+q8klQ9LfTmoDSNFA74uBqxD6IA==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.97.3.tgz",
+      "integrity": "sha512-IP1+2otCT3DuV46ooxPaOKV1oL5rLjteRzf8ldZtfIEcwhSgSsHgA71CbjYgLEwMY9h4jeal8Jfv3QnedPvSjg==",
       "cpu": [
         "arm64"
       ],
@@ -6917,9 +6945,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.97.2.tgz",
-      "integrity": "sha512-GIO6xfAtahJAWItvsXZ3MD1HM6s8cKtV1/HL088aUpKJaw/2XjTCveiOO2AdgMpLNztmq9DZ1lx5X5JjqhS45g==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.97.3.tgz",
+      "integrity": "sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==",
       "cpu": [
         "arm"
       ],
@@ -6934,9 +6962,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.97.2.tgz",
-      "integrity": "sha512-NfUqZSjHwnHvpSa7nyNxbWfL5obDjNBqhHUYmqbHUcmqBpFfHIQsUPgXME9DKn1yBlBc3mWnzMxRoucdYTzd2Q==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.97.3.tgz",
+      "integrity": "sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==",
       "cpu": [
         "arm64"
       ],
@@ -6951,9 +6979,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.97.2.tgz",
-      "integrity": "sha512-qtM4dJ5gLfvyTZ3QencfNbsTEShIWImSEpkThz+Y2nsCMbcMP7/jYOA03UWgPfEOKSehQQ7EIau7ncbFNoDNPQ==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.97.3.tgz",
+      "integrity": "sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==",
       "cpu": [
         "riscv64"
       ],
@@ -6968,9 +6996,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.97.2.tgz",
-      "integrity": "sha512-ZAxYOdmexcnxGnzdsDjYmNe3jGj+XW3/pF/n7e7r8y+5c6D2CQRrCUdapLgaqPt1edOPQIlQEZF8q5j6ng21yw==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.97.3.tgz",
+      "integrity": "sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==",
       "cpu": [
         "x64"
       ],
@@ -6985,9 +7013,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.97.2.tgz",
-      "integrity": "sha512-reVwa9ZFEAOChXpDyNB3nNHHyAkPMD+FTctQKECqKiVJnIzv2EaFF6/t0wzyvPgBKeatA8jszAIeOkkOzbYVkQ==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.97.3.tgz",
+      "integrity": "sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==",
       "cpu": [
         "riscv64"
       ],
@@ -7002,9 +7030,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.97.2.tgz",
-      "integrity": "sha512-bvAdZQsX3jDBv6m4emaU2OMTpN0KndzTAMgJZZrKUgiC0qxBmBqbJG06Oj/lOCoXGCxAvUOheVYpezRTF+Feog==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.97.3.tgz",
+      "integrity": "sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==",
       "cpu": [
         "x64"
       ],
@@ -7019,9 +7047,9 @@
       }
     },
     "node_modules/sass-embedded-unknown-all": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.2.tgz",
-      "integrity": "sha512-86tcYwohjPgSZtgeU9K4LikrKBJNf8ZW/vfsFbdzsRlvc73IykiqanufwQi5qIul0YHuu9lZtDWyWxM2dH/Rsg==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.3.tgz",
+      "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -7032,13 +7060,13 @@
         "!win32"
       ],
       "dependencies": {
-        "sass": "1.97.2"
+        "sass": "1.97.3"
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.97.2.tgz",
-      "integrity": "sha512-Cv28q8qNjAjZfqfzTrQvKf4JjsZ6EOQ5FxyHUQQeNzm73R86nd/8ozDa1Vmn79Hq0kwM15OCM9epanDuTG1ksA==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.97.3.tgz",
+      "integrity": "sha512-RDGtRS1GVvQfMGAmVXNxYiUOvPzn9oO1zYB/XUM9fudDRnieYTcUytpNTQZLs6Y1KfJxgt5Y+giRceC92fT8Uw==",
       "cpu": [
         "arm64"
       ],
@@ -7053,9 +7081,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.97.2.tgz",
-      "integrity": "sha512-DVxLxkeDCGIYeyHLAvWW3yy9sy5Ruk5p472QWiyfyyG1G1ASAR8fgfIY5pT0vE6Rv+VAKVLwF3WTspUYu7S1/Q==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.97.3.tgz",
+      "integrity": "sha512-SFRa2lED9UEwV6vIGeBXeBOLKF+rowF3WmNfb/BzhxmdAsKofCXrJ8ePW7OcDVrvNEbTOGwhsReIsF5sH8fVaw==",
       "cpu": [
         "x64"
       ],
@@ -7108,9 +7136,14 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -7409,30 +7442,20 @@
       "license": "MIT"
     },
     "node_modules/stylehacks": {
-      "version": "7.0.7",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.8.tgz",
+      "integrity": "sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
-        "postcss-selector-parser": "^7.1.0"
+        "browserslist": "^4.28.1",
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
-      }
-    },
-    "node_modules/stylehacks/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/supports-color": {
@@ -7447,7 +7470,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7457,7 +7482,7 @@
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo.js"
@@ -7727,6 +7752,8 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -88,13 +88,13 @@
     "autoprefixer": "^10.4.23",
     "babel-plugin-formatjs": "^10.5.39",
     "concurrently": "^9.2.1",
-    "cssnano": "^7.1.2",
+    "cssnano": "^7.1.3",
     "jsdom": "^27.2.0",
     "picocolors": "^1.1.1",
     "postcss": "^8.5.6",
     "postcss-selector-lint": "^1.0.2",
     "prettier": "^3.6.2",
-    "sass-embedded": "latest",
+    "sass-embedded": "^1.97.3",
     "storybook": "^10.2.14",
     "type-fest": "^5.2.0",
     "typescript": "^5.8.3",
@@ -105,7 +105,8 @@
     "form-data": ">=2.5.4 || <3.0.0 || >=3.0.4 || <4.0.0 || >=4.0.4",
     "playwright": ">=1.57.1",
     "date-fns": "^4.1.0",
-    "rollup": "^4.59.0"
+    "rollup": "^4.59.0",
+    "immutable": "^5.1.5"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "*",


### PR DESCRIPTION
## Summary

Bumb cssnano to v^7.1.3 and override immutable to v^5.1.5

## Issue References

- Github Issue: #2303 

## Checklist

- [x] CHANGELOG.rst updated