### PR TITLE
:bug: [#2309] Fix alignment of registration complete notification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Bugfixes
   foutafhandeling door niet-primitieve types om te zetten naar veilige placeholders. Bevat
   recursie-bescherming en uitgebreide tests.
 * [:gh:`2278`]: Correctie in de sortering zaken. Alle zaken worden nu gesorteerd op startdatum.
+* [:gh:`2309`]: Uitlijning melding "Registratie voltooid" zonder banner afbeelding opgelost.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/views/_view.scss
+++ b/src/open_inwoner/scss/views/_view.scss
@@ -6,7 +6,7 @@
     }
   }
   &---pages-root {
-    &:has(.notifications .notification) {
+    &:has(.banner ~ div > .notifications .notification) {
       .notifications {
         margin-top: calc(-1 * var(--spacing-giant));
       }


### PR DESCRIPTION
## Summary

Notification was not correct aligned if there is no banner image set. This caused the notification to be partially visible under the header. I added a check to make sure the negative margin-top is only applied if the notification comes after the banner image.

## Issue References

- Github Issue: #2309 

## Checklist

- [x] CHANGELOG.rst updated