### PR TITLE
fix: [#2314] bump PyJWT to address crit-header vulnerability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,8 @@ Onderhoud
 * [:gh:`2283`]: De grafiek en filters op de Mijn Afval pagina zijn niet meer zichtbaar wanneer er geen data beschikbaar is.
 * [:gh:`2303`, :cve:`CVE-2026-29074`, :cve:`CVE-2026-29063`]: ``cssnano`` bijgewerkt om :cve:`CVE-2026-29074` te mitigeren en
   ``immutable`` override bijgewerkt om :cve:`CVE-2026-29063` te mitigeren.
+* [:gh:`2314`, :cve:`CVE-2026-32597`]: ``PyJWT`` bijgewerkt naar versie ``2.10.1`` om
+  kwetsbaarheid in ``crit`` header te mitigeren.
 
 2.1.0 (2026-03-04)
 ==================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -556,7 +556,7 @@ pyee==12.0.0
     # via playwright
 pygments==2.19.2
     # via rich
-pyjwt==2.8.0
+pyjwt==2.12.1
     # via
     #   gemma-zds-client
     #   messagebird

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -996,7 +996,7 @@ pygments==2.19.2
     #   rich
     #   sphinx
     #   sphinx-tabs
-pyjwt==2.8.0
+pyjwt==2.12.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1110,7 +1110,7 @@ pygments==2.19.2
     #   rich
     #   sphinx
     #   sphinx-tabs
-pyjwt==2.8.0
+pyjwt==2.12.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
See https://github.com/maykinmedia/open-inwoner/security/dependabot/523 / CVE-2026-32597.

Closes: #2314
