### PR TITLE
:sparkles: [#2305] Make sure the zaken cases spinner handles errors.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Bugfixes
 * [:gh:`2298`]: Verbeterde foutafhandeling voor vragen en antwoorden in OpenKlant2,
   zodat één foutief geformuleerde vraag of antwoord niet verhindert dat de overige vragen
   en antwoorden worden weergegeven.
+* [:gh:`2305`]: Mijn Zaken overzicht blijft niet meer hangen op een spinner wanneer er een fout optreedt.
 
 Onderhoud
 ---------

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "escape-html": "^1.0.3",
         "flatpickr": "^4.6.9",
         "gumshoejs": "^5.1.2",
+        "htmx-ext-response-targets": "^2.0.4",
         "htmx.org": "^2.0.4",
         "leaflet": "^1.7.1",
         "lodash": "^4.17.23",
@@ -5529,6 +5530,14 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/htmx-ext-response-targets": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/htmx-ext-response-targets/-/htmx-ext-response-targets-2.0.4.tgz",
+      "integrity": "sha512-Q/yfH0N2A40j903mr6ldGV3qLWMQeufROylYIbYQLBGrCpmydflxXmQwDOEhEWdPnBTgiHofkAo0gQ3S1BmyxQ==",
+      "dependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/htmx.org": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "escape-html": "^1.0.3",
     "flatpickr": "^4.6.9",
     "gumshoejs": "^5.1.2",
+    "htmx-ext-response-targets": "^2.0.4",
     "htmx.org": "^2.0.4",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.23",

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 from uuid import UUID
 
+from django.http import HttpResponse
 from django.test import override_settings, tag
 from django.utils.translation import gettext as _
 
@@ -664,3 +665,37 @@ class CasesPlaywrightTests(
         expect(file_list_items.first).to_contain_text("(txt, 9 bytes)")
         expect(file_list_items.last).to_contain_text("document_two")
         expect(file_list_items.last).to_contain_text("(pdf, 9 bytes)")
+
+    def test_cases_spinner_hides_on_fetch_error(self, m, contactmoment_mock):
+        """When the ZGW API fails, the view returns an error template and the spinner is hidden."""
+        with patch("open_inwoner.cms.cases.views.cases.CaseListService") as MockService:
+            MockService.return_value.get_zaken.side_effect = RuntimeError("API error")
+            MockService.return_value.get_formulieren.return_value = []
+
+            context = self.browser.new_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_reverse("cases:index"))
+
+            error_message = page.get_by_text(
+                _(
+                    "Er is iets misgegaan bij het ophalen van uw zaken. Ververs de pagina of probeer het later opnieuw."
+                )
+            )
+            expect(error_message).to_be_visible()
+            expect(page.locator("#spinner-container")).not_to_be_visible()
+
+    def test_cases_spinner_hides_on_http_error(self, m, contactmoment_mock):
+        """When the cases content request returns a non-2xx, the spinner hides and error message is shown."""
+        with patch(
+            "open_inwoner.cms.cases.views.cases.InnerCaseListView.get"
+        ) as mock_get:
+            mock_get.return_value = HttpResponse(status=503)
+
+            context = self.browser.new_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_reverse("cases:index"))
+
+            expect(page.locator("#any-error")).to_have_text(
+                _("We konden geen zaken ophalen. Probeer het later opnieuw.")
+            )
+            expect(page.locator("#spinner-container")).not_to_be_visible()

--- a/src/open_inwoner/cms/cases/views/cases.py
+++ b/src/open_inwoner/cms/cases/views/cases.py
@@ -1,5 +1,6 @@
 from typing import Sequence
 
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -62,6 +63,13 @@ class InnerCaseListView(
 
     def page_title(self):
         return _("Mijn zaken")
+
+    def get(self, request, *args, **kwargs):
+        try:
+            return super().get(request, *args, **kwargs)
+        except Exception:
+            logger.exception("Failed to fetch cases")
+            return render(request, self.template_name, {"fetch_error": True})
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/src/open_inwoner/js/components/cases/spinner.js
+++ b/src/open_inwoner/js/components/cases/spinner.js
@@ -36,4 +36,25 @@ document.addEventListener('DOMContentLoaded', function () {
         .classList.remove('cases__spinner--hide');
     }
   });
+
+  // Hide the spinner if there was a responseError.
+  htmx.on('htmx:responseError', function (e) {
+    if (
+      e.detail &&
+      (e.detail.target.id === 'cases-content' ||
+        e.detail.target.id === 'submissions-content')
+    ) {
+      // Hide the spinner
+      document
+        .getElementById('spinner-container')
+        .classList.add('loader-container--hide');
+      // Show the error message (replicates hx-target-error without the extension)
+      const anyError = document.getElementById('any-error');
+      if (anyError) {
+        anyError.textContent =
+          anyError.dataset.errorMessage ||
+          'Er is iets misgegaan bij het ophalen van uw zaken. Ververs de pagina of probeer het later opnieuw.';
+      }
+    }
+  });
 });

--- a/src/open_inwoner/js/components/index.js
+++ b/src/open_inwoner/js/components/index.js
@@ -1,4 +1,5 @@
 import * as htmxModule from 'htmx.org';
+import 'htmx-ext-response-targets';
 
 // Ensure we get the correct export
 const htmx = htmxModule.default || htmxModule;

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -1,5 +1,9 @@
 {% load link_tags button_tags i18n grid_tags icon_tags list_tags pagination_tags utils %}
 
+{% if fetch_error %}
+    <p class="utrecht-paragraph">{% trans "Er is iets misgegaan bij het ophalen van uw zaken. Ververs de pagina of probeer het later opnieuw." %}</p>
+{% else %}
+
 <h1 class="utrecht-heading-1" id="cases">{{ page_title }} ({{ paginator.count }})</h1>
 <p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-title-text">{{ title_text }}</p>
 
@@ -101,4 +105,6 @@
 
 {% if zaken %}
     {% pagination page_obj=page_obj paginator=paginator request=request hxget=hxget hxtarget='#cases-content' %}
+{% endif %}
+
 {% endif %}

--- a/src/open_inwoner/templates/pages/cases/list_outer.html
+++ b/src/open_inwoner/templates/pages/cases/list_outer.html
@@ -6,10 +6,11 @@
 {% endblock %}
 
 {% block content %}
+    <div class="cases" id="any-error" data-error-message="{% trans 'We konden geen zaken ophalen. Probeer het later opnieuw.' %}"></div>
     <div class="cases" id="cases-content"></div>
 
     <div class="loader-container" id="spinner-container">
-        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-content">
+        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-content" hx-target-error="#any-error">
             {% icon icon="rotate_right" extra_classes="spinner-icon rotate" %}
             <div class="spinner__content" role="status">{% trans "Gegevens laden..." %}</div>
         </div>


### PR DESCRIPTION
## Summary

Make sure the zaken cases spinner handles errors.

## Issue References

- Github Issue: #2305

## Checklist

- [x] CHANGELOG.rst updated