### PR TITLE
fix: [#2329] do not omit attr_consuming_service_index in eHerkenning…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:gh:`2329`]: ``attr_consuming_service_index`` wordt nu correct doorgegeven als
+  queryparameter aan de eHerkenning SAML loginpagina, op basis van de waarde in de
+  eHerkenning configuratie. Het ontbreken hiervan kon leiden tot authenticatiefouten.
 * [:gh:`2326`]: Correctie van Nederlandse vertalingen voor 'verwerking' header in
   Haalcentraal BRP configuratie (was onjuist vertaald als 'doelbinding').
 * [:gh:`2323`]: Correctie van Centric BRP HTTP header namen voor iConnect integratie

--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -160,9 +160,10 @@
                                         {% endwith %}
                                     {% endrender_card %}
                                 {% else %}
+                                    {% get_solo 'digid_eherkenning.eherkenningconfiguration' as eherkenning_saml_config %}
                                     {% render_card direction='horizontal' tinted=True compact=True %}
                                         {% url 'eherkenning:login' as href %}
-                                        {% with href|addnexturl:next as href_with_next %}
+                                        {% with href|addnexturl:next|add_attr_consuming_service_index:eherkenning_saml_config.eh_attribute_consuming_service_index as href_with_next %}
                                             <a href="{{ href_with_next }}" class="link eherkenning-logo">
                                                 <img class="eherkenning-logo__image" src="{% static 'accounts/eherkenning.png' %}" height=40 alt="eHerkenning inlogpagina">
                                             </a>

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -10,6 +10,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext as _
 
 import requests_mock
+from digid_eherkenning.models import EherkenningConfiguration
 from django_webtest import WebTest
 from furl import furl
 from pyquery import PyQuery
@@ -2117,7 +2118,39 @@ class TestLoginLogoutFunctionality(AssertRedirectsMixin, WebTest):
                     f"[title='{eherkenning_login_title}']"
                 )
 
-                self.assertEqual(eherkenning_login_link.attr("href"), login_url)
+                self.assertTrue(
+                    eherkenning_login_link.attr("href").startswith(login_url)
+                )
+
+    def test_login_page_eherkenning_saml_url_includes_attr_consuming_service_index(
+        self,
+    ):
+        site_config = SiteConfiguration.get_solo()
+        site_config.eherkenning_enabled = True
+        site_config.save()
+
+        oidc_config = OpenIDEHerkenningConfig.get_solo()
+        oidc_config.enabled = False
+        oidc_config.save()
+
+        saml_config = EherkenningConfiguration.get_solo()
+
+        for index in ["9052", ""]:
+            with self.subTest(eh_attribute_consuming_service_index=index):
+                saml_config.eh_attribute_consuming_service_index = index
+                saml_config.save()
+
+                response = self.app.get(reverse("login"))
+
+                eherkenning_login_link = response.pyquery(
+                    f"[title='{_('Inloggen met eHerkenning')}']"
+                )
+                actual_args = furl(eherkenning_login_link.attr("href")).args
+
+                if index:
+                    self.assertEqual(actual_args["attr_consuming_service_index"], index)
+                else:
+                    self.assertNotIn("attr_consuming_service_index", actual_args)
 
     def test_login_for_inactive_user_shows_appropriate_message(self):
         # Change user to inactive

--- a/src/open_inwoner/components/templatetags/link_tags.py
+++ b/src/open_inwoner/components/templatetags/link_tags.py
@@ -127,3 +127,15 @@ def addnexturl(href, next_url):
     f = furl(href)
     f.args["next"] = next_url
     return f.url
+
+
+@register.filter
+def add_attr_consuming_service_index(href, index):
+    """
+    Appends attr_consuming_service_index query parameter to href if set.
+    """
+    if not index:
+        return href
+    f = furl(href)
+    f.args["attr_consuming_service_index"] = index
+    return f.url

--- a/src/open_inwoner/components/tests/test_link_tags.py
+++ b/src/open_inwoner/components/tests/test_link_tags.py
@@ -1,0 +1,28 @@
+from django.test import SimpleTestCase
+
+from open_inwoner.components.templatetags.link_tags import (
+    add_attr_consuming_service_index,
+)
+
+
+class AddAttrConsumingServiceIndexFilterTest(SimpleTestCase):
+    def test_appends_index_when_set(self):
+        result = add_attr_consuming_service_index("/eherkenning/login/", "9052")
+        self.assertEqual(
+            result, "/eherkenning/login/?attr_consuming_service_index=9052"
+        )
+
+    def test_no_op_when_empty_string(self):
+        result = add_attr_consuming_service_index("/eherkenning/login/", "")
+        self.assertEqual(result, "/eherkenning/login/")
+
+    def test_no_op_when_none(self):
+        result = add_attr_consuming_service_index("/eherkenning/login/", None)
+        self.assertEqual(result, "/eherkenning/login/")
+
+    def test_preserves_existing_query_params(self):
+        result = add_attr_consuming_service_index(
+            "/eherkenning/login/?next=%2F", "9052"
+        )
+        self.assertIn("next=%2F", result)
+        self.assertIn("attr_consuming_service_index=9052", result)


### PR DESCRIPTION
… SAML login

If available, the eHerkenning login view from digid_eherkenning expects the attr_consuming_service_index to be passed as a query parameter from the config. Failure to do so where it is expected can lead to authentication errors.

Closes: #2329.
