### PR TITLE
fix: [#2332] send both kvk and vestigingsnummer to ZGW backend if bot…

### DIFF
--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -189,6 +189,11 @@ class ZakenClient(ZgwAPIClient):
         :param vestigingsnummer: - used to filter the zaken by a vestigingsnummer
         """
 
+        if not (kvk_or_rsin or vestigingsnummer):
+            raise ValueError(
+                "You must set either a `kvk_or_rsin` or `vestigingsnummer`"
+            )
+
         config = OpenZaakConfig.get_solo()
 
         params = {
@@ -210,10 +215,9 @@ class ZakenClient(ZgwAPIClient):
 
         if vestigingsnummer:
             params.update({vestigingsnummer_param: vestigingsnummer})
-        elif kvk_or_rsin:
+
+        if kvk_or_rsin:
             params.update({kvk_rsin_param: kvk_or_rsin})
-        else:
-            return []
 
         if zaak_identificatie:
             params.update({"identificatie": zaak_identificatie})

--- a/src/open_inwoner/openzaak/tests/test_clients.py
+++ b/src/open_inwoner/openzaak/tests/test_clients.py
@@ -5,7 +5,11 @@ from django.test import TestCase
 
 import requests
 import requests_mock
-from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
+from zgw_consumers.api_models.constants import (
+    RolOmschrijving,
+    RolTypes,
+    VertrouwelijkheidsAanduidingen,
+)
 from zgw_consumers.constants import APITypes
 
 from open_inwoner.openzaak.clients import (
@@ -19,7 +23,7 @@ from open_inwoner.openzaak.clients import (
     build_zgw_client_from_service,
 )
 from open_inwoner.openzaak.exceptions import MultiZgwClientProxyError
-from open_inwoner.openzaak.models import ZGWApiGroupConfig
+from open_inwoner.openzaak.models import OpenZaakConfig, ZGWApiGroupConfig
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import (
@@ -584,3 +588,97 @@ class MultiZgwClientProxyTests(PlainTestCase):
         result = proxy.fetch_rows()
 
         self.assertEqual([row.exception is None for row in result], [True, False])
+
+
+@requests_mock.Mocker()
+class FetchZakenForCompanyTests(TestCase):
+    def setUp(self):
+        self.api_group = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ZAKEN_ROOT,
+        )
+        self.zaken_client = build_zgw_client_from_service(
+            self.api_group.zrc_service,
+            use_openzaak_120_params=False,
+            fetch_rollen_with_betrokkene_type=False,
+        )
+        config = OpenZaakConfig.get_solo()
+        config.zaak_max_confidentiality = (
+            VertrouwelijkheidsAanduidingen.beperkt_openbaar
+        )
+        config.save()
+
+    def test_raises_value_error_when_neither_kvk_nor_vestigingsnummer_given(self, m):
+        with self.assertRaises(ValueError):
+            self.zaken_client.fetch_zaken_for_company()
+
+    def test_sends_both_kvk_and_vestigingsnummer_when_both_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(
+            kvk_or_rsin="12345678",
+            vestigingsnummer="987654321",
+        )
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                    "12345678"
+                ],
+                "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
+                    "987654321"
+                ],
+            },
+        )
+
+    def test_sends_only_vestigingsnummer_when_only_vestigingsnummer_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(vestigingsnummer="987654321")
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
+                    "987654321"
+                ],
+            },
+        )
+
+    def test_sends_only_kvk_when_only_kvk_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(kvk_or_rsin="12345678")
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                    "12345678"
+                ],
+            },
+        )


### PR DESCRIPTION
…h are present

We initially built the infrastructure to store both kvk and vestiging in our user model and send both to OpenKlant, but did not update the ZakenClient: eSuite also expects both parameters if there's ambiguity.

Closes: #2332

Esuite error:

```

{
    "headers": 
{
    "API-version": "1.0.0",
    "Content-Type": "application/problem+json"
},
    "body": {
    "code": "INTERNAL",
    "title": "IllegalStateException: findBedrijf leverde '2' resultaten op, terwijl er 1 resultaat werd verwacht. KvkNummer: 'null', Vestigingsnummer: '990000036919'",
    "status": 500,
    "detail": "IllegalStateException: findBedrijf leverde '2' resultaten op, terwijl er 1 resultaat werd verwacht. KvkNummer: 'null', Vestigingsnummer: '990000036919'",
    "instance": "da77b7a5-403f-4abe-b5ce-faf72fe06e38"
}
}
```
