### PR TITLE
fix: [#2332] send both kvk and vestigingsnummer to ZGW backend if bot…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:gh:`2332`]: KVK-nummer en vestigingsnummer worden nu beide meegestuurd naar het
+  ZGW-backend bij het ophalen van zaken voor een eHerkenning-gebruiker met een vestiging,
+  in plaats van alleen het vestigingsnummer.
 * [:gh:`2329`]: ``attr_consuming_service_index`` wordt nu correct doorgegeven als
   queryparameter aan de eHerkenning SAML loginpagina, op basis van de waarde in de
   eHerkenning configuratie. Het ontbreken hiervan kon leiden tot authenticatiefouten.

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -101,13 +101,10 @@ class ZakenClient(ZgwAPIClient):
             max_requests=max_requests or settings.ZGW_MAX_REQUESTS,
             zaak_identificatie=identificatie,
         )
-        if vestigingsnummer:
-            return fetch_zaken_for_company(
-                vestigingsnummer=vestigingsnummer,
-            )
-        if user_kvk or user_rsin:
+        if vestigingsnummer or user_kvk or user_rsin:
             user_kvk_or_rsin = user_rsin if user_rsin else user_kvk
             return fetch_zaken_for_company(
+                vestigingsnummer=vestigingsnummer,
                 kvk_or_rsin=user_kvk_or_rsin,
             )
 
@@ -189,6 +186,11 @@ class ZakenClient(ZgwAPIClient):
         :param vestigingsnummer: - used to filter the zaken by a vestigingsnummer
         """
 
+        if not (kvk_or_rsin or vestigingsnummer):
+            raise ValueError(
+                "You must set either a `kvk_or_rsin` or `vestigingsnummer`"
+            )
+
         config = OpenZaakConfig.get_solo()
 
         params = {
@@ -210,10 +212,9 @@ class ZakenClient(ZgwAPIClient):
 
         if vestigingsnummer:
             params.update({vestigingsnummer_param: vestigingsnummer})
-        elif kvk_or_rsin:
+
+        if kvk_or_rsin:
             params.update({kvk_rsin_param: kvk_or_rsin})
-        else:
-            return []
 
         if zaak_identificatie:
             params.update({"identificatie": zaak_identificatie})

--- a/src/open_inwoner/openzaak/tests/test_cases.py
+++ b/src/open_inwoner/openzaak/tests/test_cases.py
@@ -453,6 +453,7 @@ class CaseListMocks:
                     {
                         "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
                         "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer": self.eherkenning_user_vestiging.vestiging,
+                        "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": identifier,
                     }
                 )
                 .url,
@@ -878,15 +879,29 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     # Register additional mocks for OpenZaak 1.20+ parameters
                     if use_openzaak_120_params:
                         for group in self.api_groups:
-                            zrc_root = group.zrc_service.api_root.rstrip("/")
                             if user.vestiging:
                                 m.get(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__vestigingsNummer={user.vestiging}",
+                                    furl(group.zrc_service.api_root + "zaken")
+                                    .add(
+                                        {
+                                            "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                            "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__vestigingsNummer": user.vestiging,
+                                            "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer": user.kvk,
+                                        }
+                                    )
+                                    .url,
                                     json={"results": []},
                                 )
                             else:
                                 m.get(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer={user.kvk}",
+                                    furl(group.zrc_service.api_root + "zaken")
+                                    .add(
+                                        {
+                                            "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                            "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer": user.kvk,
+                                        }
+                                    )
+                                    .url,
                                     json={"results": []},
                                 )
 
@@ -898,41 +913,42 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     self.client.force_login(user=user)
                     self.client.get(self.inner_url, HTTP_HX_REQUEST="true")
 
-                    used_urls = {
-                        req.url
+                    used_qs = [
+                        dict(furl(req.url).args)
                         for req in m.request_history
                         if req.path == "/api/v1/zaken" and req.method == "GET"
-                    }
+                    ]
 
-                    # Build expected URLs based on user type and flag
-                    expected_urls = set()
-                    for group in self.api_groups:
-                        zrc_root = group.zrc_service.api_root.rstrip("/")
-
-                        if use_openzaak_120_params:
-                            if user.vestiging:
-                                # OpenZaak 1.20+ vestiging parameter
-                                expected_urls.add(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__vestigingsNummer={user.vestiging}"
-                                )
-                            else:
-                                # OpenZaak 1.20+ KvK parameter
-                                expected_urls.add(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer={user.kvk}"
-                                )
+                    # Build expected QS based on user type and flag
+                    if use_openzaak_120_params:
+                        if user.vestiging:
+                            expected_qs = {
+                                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__vestigingsNummer": user.vestiging,
+                                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer": user.kvk,
+                            }
                         else:
-                            if user.vestiging:
-                                # Legacy vestiging parameter
-                                expected_urls.add(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__vestiging__vestigingsNummer={user.vestiging}"
-                                )
-                            else:
-                                # Legacy KvK/RSIN parameter
-                                expected_urls.add(
-                                    f"{zrc_root}/zaken?maximaleVertrouwelijkheidaanduiding=beperkt_openbaar&rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId={user.kvk}"
-                                )
+                            expected_qs = {
+                                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__kvkNummer": user.kvk,
+                            }
+                    else:
+                        if user.vestiging:
+                            expected_qs = {
+                                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer": user.vestiging,
+                                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": user.kvk,
+                            }
+                        else:
+                            expected_qs = {
+                                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.beperkt_openbaar,
+                                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": user.kvk,
+                            }
 
-                    self.assertEqual(used_urls, expected_urls)
+                    # One request per API group, all with same params
+                    self.assertEqual(len(used_qs), len(self.api_groups))
+                    for qs in used_qs:
+                        self.assertEqual(qs, expected_qs)
 
     def test_list_zaken_for_kvk_user_with_vestigingsnummer(self, m):
         for mock in self.mocks:
@@ -978,7 +994,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 if req.hostname == zaken_root and req.path == "/api/v1/zaken"
             ][0]
 
-            self.assertEqual(len(list_zaken_req.qs), 2)
+            self.assertEqual(len(list_zaken_req.qs), 3)
             self.assertEqual(
                 list_zaken_req.qs,
                 {
@@ -988,12 +1004,19 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
                         self.eherkenning_user_vestiging.vestiging
                     ],
+                    "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                        self.eherkenning_user_vestiging.kvk
+                    ],
                 },
             )
 
     def test_list_zaken_for_rsin_user_with_vestigingsnummer(self, m):
         for mock in self.mocks:
             mock._setUpMocks(m)
+
+        for group in self.api_groups:
+            group.fetch_eherkenning_zaken_with_rsin = True
+            group.save()
 
         self.client.force_login(user=self.eherkenning_user_vestiging)
 
@@ -1036,7 +1059,7 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                 if req.hostname == zaken_root and req.path == "/api/v1/zaken"
             ][0]
 
-            self.assertEqual(len(list_zaken_req.qs), 2)
+            self.assertEqual(len(list_zaken_req.qs), 3)
             self.assertEqual(
                 list_zaken_req.qs,
                 {
@@ -1045,6 +1068,9 @@ class CaseListViewTests(AssertTimelineLogMixin, ClearCachesMixin, TransactionTes
                     ],
                     "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
                         self.eherkenning_user_vestiging.vestiging
+                    ],
+                    "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                        self.eherkenning_user_vestiging.rsin
                     ],
                 },
             )

--- a/src/open_inwoner/openzaak/tests/test_clients.py
+++ b/src/open_inwoner/openzaak/tests/test_clients.py
@@ -5,7 +5,11 @@ from django.test import TestCase
 
 import requests
 import requests_mock
-from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
+from zgw_consumers.api_models.constants import (
+    RolOmschrijving,
+    RolTypes,
+    VertrouwelijkheidsAanduidingen,
+)
 from zgw_consumers.constants import APITypes
 
 from open_inwoner.openzaak.clients import (
@@ -19,7 +23,7 @@ from open_inwoner.openzaak.clients import (
     build_zgw_client_from_service,
 )
 from open_inwoner.openzaak.exceptions import MultiZgwClientProxyError
-from open_inwoner.openzaak.models import ZGWApiGroupConfig
+from open_inwoner.openzaak.models import OpenZaakConfig, ZGWApiGroupConfig
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import (
@@ -584,3 +588,124 @@ class MultiZgwClientProxyTests(PlainTestCase):
         result = proxy.fetch_rows()
 
         self.assertEqual([row.exception is None for row in result], [True, False])
+
+
+@requests_mock.Mocker()
+class FetchZakenForCompanyTests(TestCase):
+    def setUp(self):
+        self.api_group = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ZAKEN_ROOT,
+        )
+        self.zaken_client = build_zgw_client_from_service(
+            self.api_group.zrc_service,
+            use_openzaak_120_params=False,
+            fetch_rollen_with_betrokkene_type=False,
+        )
+        config = OpenZaakConfig.get_solo()
+        config.zaak_max_confidentiality = (
+            VertrouwelijkheidsAanduidingen.beperkt_openbaar
+        )
+        config.save()
+
+    def test_raises_value_error_when_neither_kvk_nor_vestigingsnummer_given(self, m):
+        with self.assertRaises(ValueError):
+            self.zaken_client.fetch_zaken_for_company()
+
+    def test_sends_both_kvk_and_vestigingsnummer_when_both_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(
+            kvk_or_rsin="12345678",
+            vestigingsnummer="987654321",
+        )
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                    "12345678"
+                ],
+                "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
+                    "987654321"
+                ],
+            },
+        )
+
+    def test_sends_only_vestigingsnummer_when_only_vestigingsnummer_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(vestigingsnummer="987654321")
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
+                    "987654321"
+                ],
+            },
+        )
+
+    def test_sends_only_kvk_when_only_kvk_provided(self, m):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken_for_company(kvk_or_rsin="12345678")
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                    "12345678"
+                ],
+            },
+        )
+
+    def test_fetch_zaken_sends_both_kvk_and_vestigingsnummer_when_both_provided(
+        self, m
+    ):
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+        self.zaken_client.fetch_zaken(user_kvk="12345678", vestigingsnummer="987654321")
+
+        self.assertEqual(len(m.request_history), 1)
+        req = m.request_history[0]
+        self.assertEqual(
+            req.qs,
+            {
+                "maximalevertrouwelijkheidaanduiding": [
+                    VertrouwelijkheidsAanduidingen.beperkt_openbaar
+                ],
+                "rol__betrokkeneidentificatie__nietnatuurlijkpersoon__innnnpid": [
+                    "12345678"
+                ],
+                "rol__betrokkeneidentificatie__vestiging__vestigingsnummer": [
+                    "987654321"
+                ],
+            },
+        )


### PR DESCRIPTION
…h are present

We initially built the infrastructure to store both kvk and vestiging in our user model and send both to OpenKlant, but did not update the ZakenClient: eSuite also expects both parameters if there's ambiguity.

Closes: #2332


```

{
    "headers": 
{
    "API-version": "1.0.0",
    "Content-Type": "application/problem+json"
},
    "body": {
    "code": "INTERNAL",
    "title": "IllegalStateException: findBedrijf leverde '2' resultaten op, terwijl er 1 resultaat werd verwacht. KvkNummer: 'null', Vestigingsnummer: '990000036919'",
    "status": 500,
    "detail": "IllegalStateException: findBedrijf leverde '2' resultaten op, terwijl er 1 resultaat werd verwacht. KvkNummer: 'null', Vestigingsnummer: '990000036919'",
    "instance": "da77b7a5-403f-4abe-b5ce-faf72fe06e38"
}
}
```