### PR TITLE
fix: [#2298] check for malformed OpenKlant2 questions/answers individually

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@ Bugfixes
   weer te geven. ``status.description`` en ``document_upload_description`` gebruiken nu
   het ``prosemirror_content`` filter in plaats van direct de ``.html`` property of
   zonder filter, zodat opmaak (vet, cursief, links) correct wordt gerenderd.
+* [:gh:`2298`]: Verbeterde foutafhandeling voor vragen en antwoorden in OpenKlant2,
+  zodat één foutief geformuleerde vraag of antwoord niet verhindert dat de overige vragen
+  en antwoorden worden weergegeven.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1802,11 +1802,29 @@ class OpenKlant2Service(
             answer_objs = []
             for answer_uuid in answer_uuids:
                 answer = klantcontact_uuid_to_klantcontact_object[answer_uuid]
-                answer_objs.append(OpenKlant2Answer.from_klantcontact(answer))
+                try:
+                    answer_objs.append(OpenKlant2Answer.from_klantcontact(answer))
+                except ValueError:
+                    logger.warning("OpenKlant2Answer without content (inhoud)")
+                except (KeyError, TypeError):
+                    logger.exception(
+                        "Unexpected error creating OpenKlant2Answer for klantcontact",
+                        answer_uuid=answer["uuid"],
+                    )
 
-            question_objs.append(
-                OpenKlant2Question.from_klantcontact_and_answers(question, answer_objs)
-            )
+            try:
+                question_objs.append(
+                    OpenKlant2Question.from_klantcontact_and_answers(
+                        question, answer_objs
+                    )
+                )
+            except ValueError:
+                logger.warning("OpenKlant2Question without content (inhoud)")
+            except (KeyError, TypeError):
+                logger.exception(
+                    "Unexpected error creating OpenKlant2Question for klantcontact",
+                    question_uuid=question["uuid"],
+                )
 
         question_objs.sort(key=lambda o: o.plaatsgevonden_op)
         return question_objs

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -752,3 +752,119 @@ class OpenKlant2QuestionAnswerTestCase(TestCase):
         self.assertEqual(q3.answers[0].answer, "Second answer to Q3")
         self.assertEqual(q3.answers[1].answer, "First answer to Q3")
         self.assertEqual(q3.answer.answer, "Second answer to Q3")
+
+    def test_questions_for_partij_missing_inhoud(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        service = OpenKlant2Service(config=self.config)
+
+        # Question 1: question misses inhoud
+        q1_kc = {
+            "uuid": "q-uuid-1",
+            "inhoud": None,
+            "onderwerp": "Topic 1",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0001",
+            "plaatsgevondenOp": "2024-10-01T10:00:00Z",
+            "url": "http://example.com/q1",
+            "gingOverOnderwerpobjecten": [],
+        }
+
+        # Question 2: one answer with missing inhoud
+        q2_kc = {
+            "uuid": "q-uuid-2",
+            "inhoud": "Question 2?",
+            "onderwerp": "Topic 2",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0002",
+            "plaatsgevondenOp": "2024-10-02T10:00:00Z",
+            "url": "http://example.com/q2",
+            "gingOverOnderwerpobjecten": [{"uuid": "oo-q2"}],
+        }
+        a2_kc = {
+            "uuid": "a-uuid-2",
+            "inhoud": None,
+            "onderwerp": "Topic 2",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0003",
+            "plaatsgevondenOp": "2024-10-02T11:00:00Z",
+            "url": "http://example.com/a2",
+            "gingOverOnderwerpobjecten": [{"uuid": "oo-a2"}],
+        }
+
+        # Question 3: two answers, one with and one without inhoud
+        q3_kc = {
+            "uuid": "q-uuid-3",
+            "inhoud": "Question 3?",
+            "onderwerp": "Topic 3",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0004",
+            "plaatsgevondenOp": "2024-10-03T10:00:00Z",
+            "url": "http://example.com/q3",
+            "gingOverOnderwerpobjecten": [{"uuid": "oo-q3"}],
+        }
+        a3_1_kc = {
+            "uuid": "a-uuid-3-1",
+            "inhoud": None,
+            "onderwerp": "Topic 3",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0005",
+            "plaatsgevondenOp": "2024-10-03T11:00:00Z",
+            "url": "http://example.com/a3-1",
+            "gingOverOnderwerpobjecten": [{"uuid": "oo-a3-1"}],
+        }
+        a3_2_kc = {
+            "uuid": "a-uuid-3-2",
+            "inhoud": "Second answer to Q3",
+            "onderwerp": "Topic 3",
+            "kanaal": "oip_mijn_vragen",
+            "taal": "nld",
+            "nummer": "0006",
+            "plaatsgevondenOp": "2024-10-03T12:00:00Z",
+            "url": "http://example.com/a3-2",
+            "gingOverOnderwerpobjecten": [{"uuid": "oo-a3-2"}],
+        }
+
+        # Onderwerp_objecten representing answers
+        q2_oo = {"uuid": "oo-q2", "wasKlantcontact": None}
+        a2_oo = {"uuid": "oo-a2", "wasKlantcontact": {"uuid": "q-uuid-2"}}
+        q3_oo = {"uuid": "oo-q3", "wasKlantcontact": None}
+        a3_1_oo = {"uuid": "oo-a3-1", "wasKlantcontact": {"uuid": "q-uuid-3"}}
+        a3_2_oo = {"uuid": "oo-a3-2", "wasKlantcontact": {"uuid": "q-uuid-3"}}
+
+        mock_client.onderwerp_object.retrieve.side_effect = [
+            q2_oo,
+            a2_oo,
+            q3_oo,
+            a3_1_oo,
+            a3_2_oo,
+        ]
+
+        with patch.object(
+            service,
+            "klantcontacten_for_partij",
+            return_value=[q1_kc, q2_kc, a2_kc, q3_kc, a3_1_kc, a3_2_kc],
+        ):
+            questions = service.questions_for_partij("partij-uuid")
+
+        self.assertEqual(len(questions), 2)
+
+        # q1 (inhoud=None) is skipped entirely
+        self.assertFalse(any(q.question_kcm_uuid == "q-uuid-1" for q in questions))
+
+        # q2 is present but its answer (inhoud=None) is skipped
+        q2 = next(q for q in questions if q.question_kcm_uuid == "q-uuid-2")
+        self.assertEqual(q2.question, "Question 2?")
+        self.assertEqual(len(q2.answers), 0)
+
+        # q3 is present; a3_1 (inhoud=None) is skipped, a3_2 survives
+        q3 = next(q for q in questions if q.question_kcm_uuid == "q-uuid-3")
+        self.assertEqual(q3.question, "Question 3?")
+        self.assertEqual(len(q3.answers), 1)
+        self.assertEqual(q3.answers[0].answer, "Second answer to Q3")


### PR DESCRIPTION
## Summary

The OpenKlant2 service lacked error handling for malformed OpenKlant2 questions and answers. A single question/answer without content (inhoud) prevented all questions/answers from being returned. The PR fixes this by checking each question + answer for errors individually.

## Issue References

Fixes #2298 

## Checklist

- [x] CHANGELOG.rst updated
