### PR TITLE
fix: [#2320] check for correct betrokkene rol when accessing single zaak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,9 @@ Bugfixes
   zodat één foutief geformuleerde vraag of antwoord niet verhindert dat de overige vragen
   en antwoorden worden weergegeven.
 * [:gh:`2305`]: Mijn Zaken overzicht blijft niet meer hangen op een spinner wanneer er een fout optreedt.
+* [:gh:`2320`]: Verbeterde controles op de rol van betrokkenen: gebruikers hebben alleen toegang
+  tot een zaak en worden alleen op de hoogte gebracht van wijzigingen in een zaak als ze de juiste
+  rol hebben.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/cases/views/mixins.py
+++ b/src/open_inwoner/cms/cases/views/mixins.py
@@ -132,38 +132,60 @@ class CaseAccessMixin(AccessMixin):
             client = api_group.zaken_client
             self.zaak = client.fetch_single_zaak(object_id)
             if self.zaak:
-                # check if we have a role in this case
+                # check if we have the correct role in this case
+                config = OpenZaakConfig.get_solo()
+                limit_access_to_role = config.limit_user_visible_cases_to_role
                 if request.user.bsn:
-                    if not client.fetch_roles_for_zaak_and_bsn(
+                    rollen = client.fetch_roles_for_zaak_and_bsn(
                         self.zaak.url, request.user.bsn
+                    )
+                    if not rollen or (
+                        limit_access_to_role
+                        and not any(
+                            rol.omschrijving_generiek == limit_access_to_role
+                            for rol in rollen
+                        )
                     ):
                         logger.info(
-                            "CaseAccessMixin - permission denied via bsn: no role for the case",
+                            "CaseAccessMixin - permission denied via bsn: no or incorrect role for the case",
                             zaak_url=self.zaak.url,
                         )
                         return self.handle_no_permission()
                 elif request.user.kvk:
                     identifier = self.request.user.kvk
-                    config = OpenZaakConfig.get_solo()
                     if api_group.fetch_eherkenning_zaken_with_rsin:
                         identifier = self.request.user.rsin
 
                     vestigingsnummer = request.user.vestiging
                     if vestigingsnummer:
-                        if not client.fetch_roles_for_zaak_and_vestigingsnummer(
+                        rollen = client.fetch_roles_for_zaak_and_vestigingsnummer(
                             self.zaak.url, vestigingsnummer
+                        )
+                        if not rollen or (
+                            limit_access_to_role
+                            and not any(
+                                rol.omschrijving_generiek == limit_access_to_role
+                                for rol in rollen
+                            )
                         ):
                             logger.info(
-                                "CaseAccessMixin - permission denied via vestigingsnummer: no role for the case",
+                                "CaseAccessMixin - permission denied via vestigingsnummer: no or incorrect role for the case",
                                 zaak_url=self.zaak.url,
                             )
                             return self.handle_no_permission()
                     else:
-                        if not client.fetch_roles_for_zaak_and_kvk_or_rsin(
+                        rollen = client.fetch_roles_for_zaak_and_kvk_or_rsin(
                             self.zaak.url, identifier
+                        )
+                        if not rollen or (
+                            limit_access_to_role
+                            and not any(
+                                rol.omschrijving_generiek == limit_access_to_role
+                                for rol in rollen
+                            )
                         ):
                             logger.info(
-                                "CaseAccessMixin - permission denied via kvk/rsin: no role for the case",
+                                "CaseAccessMixin - permission denied via kvk/rsin: no or incorrect role for the case",
                                 zaak_url=self.zaak.url,
                             )
                             return self.handle_no_permission()

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -90,7 +90,12 @@ def handle_zaken_notification(notification: Notification):
         )
         return
 
-    inform_users = _get_initiator_users_from_roles(roles, api_group=api_group)
+    config = OpenZaakConfig.get_solo()
+    inform_users = _get_initiator_users_from_roles(
+        roles,
+        api_group=api_group,
+        limit_access_to_role=config.limit_user_visible_cases_to_role,
+    )
     if not inform_users:
         log_system_action(
             f"ignored {r} notification: no users with bsn/nnp_id as (mede)initiators in zaak {zaak_url}",
@@ -597,17 +602,24 @@ def _handle_status_update(
 # - - - - -
 
 
-def _get_np_initiator_bsns_from_roles(roles: list[Rol]) -> list[str]:
+def _get_np_initiator_bsns_from_roles(
+    roles: list[Rol], limit_access_to_role: str = ""
+) -> list[str]:
     """
     iterate over Rollen and for all natural-person initiators return their BSN
+
+    If `limit_access_to_role` is set, only roles with that specific omschrijving_generiek
+    are included; otherwise both initiator and medeinitiator are included.
     """
     ret = set()
+    allowed_rollen = (
+        (limit_access_to_role,)
+        if limit_access_to_role
+        else (RolOmschrijving.initiator, RolOmschrijving.medeinitiator)
+    )
 
     for role in roles:
-        if role.omschrijving_generiek not in (
-            RolOmschrijving.initiator,
-            RolOmschrijving.medeinitiator,
-        ):
+        if role.omschrijving_generiek not in allowed_rollen:
             continue
         if role.betrokkene_type != RolTypes.natuurlijk_persoon:
             continue
@@ -621,17 +633,24 @@ def _get_np_initiator_bsns_from_roles(roles: list[Rol]) -> list[str]:
     return list(ret)
 
 
-def _get_nnp_initiator_nnp_id_from_roles(roles: list[Rol]) -> list[str]:
+def _get_nnp_initiator_nnp_id_from_roles(
+    roles: list[Rol], limit_access_to_role: str = ""
+) -> list[str]:
     """
     iterate over Rollen and for all non-natural-person initiators return their nnpId
+
+    If `limit_access_to_role` is set, only roles with that specific omschrijving_generiek
+    are included; otherwise both initiator and medeinitiator are included.
     """
     ret = set()
+    allowed_rollen = (
+        (limit_access_to_role,)
+        if limit_access_to_role
+        else (RolOmschrijving.initiator, RolOmschrijving.medeinitiator)
+    )
 
     for role in roles:
-        if role.omschrijving_generiek not in (
-            RolOmschrijving.initiator,
-            RolOmschrijving.medeinitiator,
-        ):
+        if role.omschrijving_generiek not in allowed_rollen:
             continue
         if role.betrokkene_type != RolTypes.niet_natuurlijk_persoon:
             continue
@@ -646,18 +665,26 @@ def _get_nnp_initiator_nnp_id_from_roles(roles: list[Rol]) -> list[str]:
 
 
 def _get_initiator_users_from_roles(
-    roles: list[Rol], api_group: ZGWApiGroupConfig
+    roles: list[Rol],
+    api_group: ZGWApiGroupConfig,
+    limit_access_to_role: str = "",
 ) -> list[User]:
     """
     iterate over Rollen and return User objects for initiators
+
+    If `limit_access_to_role` is set, only users with that specific role are returned.
     """
     users = []
 
-    bsn_list = _get_np_initiator_bsns_from_roles(roles)
+    bsn_list = _get_np_initiator_bsns_from_roles(
+        roles, limit_access_to_role=limit_access_to_role
+    )
     if bsn_list:
         users += list(User.objects.filter(bsn__in=bsn_list, is_active=True))
 
-    nnp_id_list = _get_nnp_initiator_nnp_id_from_roles(roles)
+    nnp_id_list = _get_nnp_initiator_nnp_id_from_roles(
+        roles, limit_access_to_role=limit_access_to_role
+    )
     if nnp_id_list:
         if api_group.fetch_eherkenning_zaken_with_rsin:
             id_filter = {"rsin__in": nnp_id_list}

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -50,7 +50,7 @@ from open_inwoner.openklant.tests.validators import (
     PartijValidator,
 )
 from open_inwoner.openzaak.api_models import Status, StatusType, Zaak
-from open_inwoner.openzaak.constants import StatusIndicators
+from open_inwoner.openzaak.constants import StatusIndicators, ZaakBetrokkeneRol
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.tests.factories import (
     ZaakTypeConfigFactory,
@@ -2073,6 +2073,212 @@ class TestCaseDetailView(
                 self.assertContains(
                     response, _("Sorry, you don't have access to this page (403)")
                 )
+
+    def test_no_access_when_incorrect_role_for_user_bsn(self, m):
+        """
+        Even if the user has a role for the case, access is denied when
+        `limit_user_visible_cases_to_role` is set and the role doesn't match.
+        """
+        self.zaak_config.limit_user_visible_cases_to_role = ZaakBetrokkeneRol.initiator
+        self.zaak_config.save()
+
+        non_initiator_rollen = [
+            rol
+            for rol in RolOmschrijving.values
+            if rol != RolOmschrijving.initiator.value
+        ] + [""]
+
+        for rol_omschrijving in non_initiator_rollen:
+            with self.subTest(rol_omschrijving=rol_omschrijving):
+                non_initiator_rol = generate_oas_component_cached(
+                    "zrc",
+                    "schemas/Rol",
+                    url=f"{ZAKEN_ROOT}rollen/bb353aa-ad2c-4a07-ae75-15add5823",
+                    omschrijvingGeneriek=rol_omschrijving,
+                    betrokkeneType=RolTypes.natuurlijk_persoon,
+                    betrokkeneIdentificatie={
+                        "inpBsn": self.user.bsn,
+                    },
+                )
+
+                m.get(self.zaak["url"], json=self.zaak)
+                m.get(self.zaaktype["url"], json=self.zaaktype)
+                m.get(
+                    f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                    json=paginated_response([non_initiator_rol]),
+                )
+
+                response = self.app.get(self.case_detail_url, user=self.user)
+
+                self.assertTemplateUsed("pages/cases/403.html")
+                self.assertContains(
+                    response, _("Sorry, you don't have access to this page (403)")
+                )
+
+        with self.subTest(no_role=True):
+            m.get(self.zaak["url"], json=self.zaak)
+            m.get(self.zaaktype["url"], json=self.zaaktype)
+            m.get(
+                f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                json=paginated_response([]),
+            )
+
+            response = self.app.get(self.case_detail_url, user=self.user)
+
+            self.assertTemplateUsed("pages/cases/403.html")
+            self.assertContains(
+                response, _("Sorry, you don't have access to this page (403)")
+            )
+
+    def test_no_access_when_incorrect_role_for_user_kvk_or_rsin(self, m):
+        """
+        Even if the eherkenning user has a role for the case, access is denied when
+        `limit_user_visible_cases_to_role` is set and the role doesn't match.
+        """
+        self.zaak_config.limit_user_visible_cases_to_role = ZaakBetrokkeneRol.initiator
+        self.zaak_config.save()
+
+        non_initiator_rollen = [
+            rol
+            for rol in RolOmschrijving.values
+            if rol != RolOmschrijving.initiator.value
+        ] + [""]
+
+        for rol_omschrijving in non_initiator_rollen:
+            with self.subTest(rol_omschrijving=rol_omschrijving):
+                non_initiator_role_kvk = generate_oas_component_cached(
+                    "zrc",
+                    "schemas/Rol",
+                    url=f"{ZAKEN_ROOT}rollen/cc353aa-ad2c-4a07-ae75-15add5824",
+                    omschrijvingGeneriek=rol_omschrijving,
+                    betrokkeneType=RolTypes.niet_natuurlijk_persoon,
+                    betrokkeneIdentificatie={
+                        "innNnpId": self.eherkenning_user.kvk,
+                    },
+                )
+                non_initiator_role_rsin = generate_oas_component_cached(
+                    "zrc",
+                    "schemas/Rol",
+                    url=f"{ZAKEN_ROOT}rollen/cc353aa-ad2c-4a07-ae75-15add5825",
+                    omschrijvingGeneriek=rol_omschrijving,
+                    betrokkeneType=RolTypes.niet_natuurlijk_persoon,
+                    betrokkeneIdentificatie={
+                        "innNnpId": self.eherkenning_user.rsin,
+                    },
+                )
+
+                m.get(self.zaak["url"], json=self.zaak)
+                m.get(self.zaaktype["url"], json=self.zaaktype)
+                m.get(
+                    f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                    json=paginated_response(
+                        [non_initiator_role_kvk, non_initiator_role_rsin]
+                    ),
+                )
+
+                for fetch_eherkenning_zaken_with_rsin in [True, False]:
+                    with self.subTest(
+                        fetch_eherkenning_zaken_with_rsin=fetch_eherkenning_zaken_with_rsin
+                    ):
+                        self.zaak_config.fetch_eherkenning_zaken_with_rsin = (
+                            fetch_eherkenning_zaken_with_rsin
+                        )
+                        self.zaak_config.save()
+
+                        response = self.app.get(
+                            self.case_detail_url, user=self.eherkenning_user
+                        )
+
+                        self.assertTemplateUsed("pages/cases/403.html")
+                        self.assertContains(
+                            response,
+                            _("Sorry, you don't have access to this page (403)"),
+                        )
+
+        with self.subTest(no_role=True):
+            m.get(self.zaak["url"], json=self.zaak)
+            m.get(self.zaaktype["url"], json=self.zaaktype)
+            m.get(
+                f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                json=paginated_response([]),
+            )
+
+            for fetch_eherkenning_zaken_with_rsin in [True, False]:
+                with self.subTest(
+                    fetch_eherkenning_zaken_with_rsin=fetch_eherkenning_zaken_with_rsin
+                ):
+                    self.zaak_config.fetch_eherkenning_zaken_with_rsin = (
+                        fetch_eherkenning_zaken_with_rsin
+                    )
+                    self.zaak_config.save()
+
+                    response = self.app.get(
+                        self.case_detail_url, user=self.eherkenning_user
+                    )
+
+                    self.assertTemplateUsed("pages/cases/403.html")
+                    self.assertContains(
+                        response,
+                        _("Sorry, you don't have access to this page (403)"),
+                    )
+
+    def test_no_access_when_incorrect_role_for_vestigingsnummer(self, m):
+        """
+        Even if the vestiging user has a role for the case, access is denied when
+        `limit_user_visible_cases_to_role` is set and the role doesn't match.
+        """
+        self.client.force_login(user=self.vestiging_user)
+
+        self.zaak_config.limit_user_visible_cases_to_role = ZaakBetrokkeneRol.initiator
+        self.zaak_config.save()
+
+        non_initiator_rollen = [
+            rol
+            for rol in RolOmschrijving.values
+            if rol != RolOmschrijving.initiator.value
+        ] + [""]
+
+        for rol_omschrijving in non_initiator_rollen:
+            with self.subTest(rol_omschrijving=rol_omschrijving):
+                non_initiator_role_vestiging = generate_oas_component_cached(
+                    "zrc",
+                    "schemas/Rol",
+                    url=f"{ZAKEN_ROOT}rollen/dd353aa-ad2c-4a07-ae75-15add5826",
+                    omschrijvingGeneriek=rol_omschrijving,
+                    betrokkeneType=RolTypes.vestiging,
+                    betrokkeneIdentificatie={
+                        "vestigingsNummer": self.vestiging_user.vestiging,
+                    },
+                )
+
+                m.get(self.zaak["url"], json=self.zaak)
+                m.get(self.zaaktype["url"], json=self.zaaktype)
+                m.get(
+                    f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                    json=paginated_response([non_initiator_role_vestiging]),
+                )
+
+                response = self.client.get(self.case_detail_url)
+
+                self.assertTemplateUsed("pages/cases/403.html")
+                self.assertContains(
+                    response, _("Sorry, you don't have access to this page (403)")
+                )
+
+        with self.subTest(no_role=True):
+            m.get(self.zaak["url"], json=self.zaak)
+            m.get(self.zaaktype["url"], json=self.zaaktype)
+            m.get(
+                f"{ZAKEN_ROOT}rollen?zaak={self.zaak['url']}",
+                json=paginated_response([]),
+            )
+
+            response = self.client.get(self.case_detail_url)
+
+            self.assertTemplateUsed("pages/cases/403.html")
+            self.assertContains(
+                response, _("Sorry, you don't have access to this page (403)")
+            )
 
     def test_no_access_if_fetch_eherkenning_zaken_with_rsin_and_user_has_no_rsin(
         self, m

--- a/src/open_inwoner/openzaak/tests/test_notification_utils.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_utils.py
@@ -11,8 +11,10 @@ from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
 from open_inwoner.accounts.tests.factories import DigidUserFactory, UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openzaak.api_models import Status, StatusType, Zaak, ZaakType
+from open_inwoner.openzaak.constants import ZaakBetrokkeneRol
 from open_inwoner.openzaak.notifications import (
     _get_initiator_users_from_roles,
+    _get_nnp_initiator_nnp_id_from_roles,
     _get_np_initiator_bsns_from_roles,
     send_case_update_email,
 )
@@ -107,7 +109,49 @@ class NotificationHandlerUtilsTestCase(TestCase):
         self.assertIn(zaak_url, body_html)
         self.assertIn(config.name, body_html)
 
-    # TODO we're missing a similar test for get_nnp_initiator_nnp_id_from_roles()
+    def test_get_nnp_initiator_nnp_id_from_roles(self):
+        find_rol_1 = generate_rol(
+            RolTypes.niet_natuurlijk_persoon,
+            {"innNnpId": "100000001"},
+            RolOmschrijving.initiator,
+        )
+        find_rol_2 = generate_rol(
+            RolTypes.niet_natuurlijk_persoon,
+            {"innNnpId": "100000002"},
+            RolOmschrijving.medeinitiator,
+        )
+        roles = [
+            find_rol_1,
+            find_rol_2,
+            # duplicate NNP ID
+            generate_rol(
+                RolTypes.niet_natuurlijk_persoon,
+                {"innNnpId": "100000001"},
+                RolOmschrijving.medeinitiator,
+            ),
+            # bad type
+            generate_rol(
+                RolTypes.natuurlijk_persoon,
+                {"innNnpId": "404000001"},
+                RolOmschrijving.initiator,
+            ),
+            # bad description
+            generate_rol(
+                RolTypes.niet_natuurlijk_persoon,
+                {"innNnpId": "404000002"},
+                RolOmschrijving.behandelaar,
+            ),
+            # bad identification
+            generate_rol(
+                RolTypes.niet_natuurlijk_persoon,
+                {"not_the_expected_field": 123},
+                RolOmschrijving.initiator,
+            ),
+        ]
+        expected = {"100000001", "100000002"}
+        actual = _get_nnp_initiator_nnp_id_from_roles(roles)
+        self.assertEqual(set(actual), expected)
+
     def test_get_np_initiator_bsns_from_roles(self):
         # roles we're interested in
         find_rol_1 = generate_rol(
@@ -239,3 +283,69 @@ class NotificationHandlerUtilsTestCase(TestCase):
         actual = _get_initiator_users_from_roles(roles, api_group=self.api_group)
 
         self.assertEqual(set(actual), expected)
+
+    def test_get_np_initiator_bsns_from_roles__limit_access_to_role(self):
+        """When limit_access_to_role is set, only roles with that omschrijving are included."""
+        initiator_rol = generate_rol(
+            RolTypes.natuurlijk_persoon,
+            {"inpBsn": "100000001"},
+            RolOmschrijving.initiator,
+        )
+        medeinitiator_rol = generate_rol(
+            RolTypes.natuurlijk_persoon,
+            {"inpBsn": "100000002"},
+            RolOmschrijving.medeinitiator,
+        )
+        roles = [initiator_rol, medeinitiator_rol]
+
+        actual = _get_np_initiator_bsns_from_roles(
+            roles, limit_access_to_role=ZaakBetrokkeneRol.initiator
+        )
+
+        self.assertEqual(actual, ["100000001"])
+
+    def test_get_nnp_initiator_nnp_id_from_roles__limit_access_to_role(self):
+        """When limit_access_to_role is set, only roles with that omschrijving are included."""
+        initiator_rol = generate_rol(
+            RolTypes.niet_natuurlijk_persoon,
+            {"innNnpId": "100000001"},
+            RolOmschrijving.initiator,
+        )
+        medeinitiator_rol = generate_rol(
+            RolTypes.niet_natuurlijk_persoon,
+            {"innNnpId": "100000002"},
+            RolOmschrijving.medeinitiator,
+        )
+        roles = [initiator_rol, medeinitiator_rol]
+
+        actual = _get_nnp_initiator_nnp_id_from_roles(
+            roles, limit_access_to_role=ZaakBetrokkeneRol.initiator
+        )
+
+        self.assertEqual(actual, ["100000001"])
+
+    def test_get_initiator_users_from_roles__limit_access_to_role(self):
+        """When limit_access_to_role is set, medeinitiator users are excluded."""
+        user_initiator = DigidUserFactory(bsn="100000001")
+        user_medeinitiator = DigidUserFactory(bsn="100000002")
+
+        roles = [
+            generate_rol(
+                RolTypes.natuurlijk_persoon,
+                {"inpBsn": user_initiator.bsn},
+                RolOmschrijving.initiator,
+            ),
+            generate_rol(
+                RolTypes.natuurlijk_persoon,
+                {"inpBsn": user_medeinitiator.bsn},
+                RolOmschrijving.medeinitiator,
+            ),
+        ]
+
+        actual = _get_initiator_users_from_roles(
+            roles,
+            api_group=self.api_group,
+            limit_access_to_role=ZaakBetrokkeneRol.initiator,
+        )
+
+        self.assertEqual(actual, [user_initiator])


### PR DESCRIPTION
## Summary

The `CaseAccessMixin` only checked if the user had *some* role for the zaak they're trying to access, not if they have the *correct* role (e.g. the role 'initiator' when visibility is restricted to the initiator of a case via `OpenZaakConfig`).

## Issue References

Fixes #2320

## Checklist

- [x] CHANGELOG.rst updated