### PR TITLE
[#2270] Add live region for HTMX content, update spinners

### DIFF
--- a/src/open_inwoner/js/components/cases/spinner.js
+++ b/src/open_inwoner/js/components/cases/spinner.js
@@ -1,12 +1,29 @@
+const notifyLoading = (e) => {
+  // Generic: announce loading for any HTMX element with data-spinner-live-region
+  const regionId = e.detail.elt && e.detail.elt.dataset.spinnerLiveRegion;
+  if (!regionId) return;
+  const region = document.getElementById(regionId);
+  if (region) region.textContent = 'Gegevens laden...';
+};
+
+const dismissNotifyLoading = (e) => {
+  // Generic: announce loaded for any HTMX element with data-spinner-live-region
+  const regionId = e.detail.elt && e.detail.elt.dataset.spinnerLiveRegion;
+  if (!regionId) return;
+  const region = document.getElementById(regionId);
+  if (region) region.textContent = 'Gegevens zijn geladen.';
+};
+
 document.addEventListener('DOMContentLoaded', function () {
   const htmx = window.htmx;
 
   // Show the spinner before an HTMX request starts
   htmx.on('htmx:beforeRequest', function (e) {
+    if (!e.detail) return;
+
     if (
-      e.detail &&
-      (e.detail.target.id === 'cases-content' ||
-        e.detail.target.id === 'submissions-content')
+      e.detail.target.id === 'cases-content' ||
+      e.detail.target.id === 'submissions-content'
     ) {
       // Show the spinner
       document
@@ -17,14 +34,17 @@ document.addEventListener('DOMContentLoaded', function () {
         .getElementById('cases-content')
         .classList.add('cases__spinner--hide');
     }
+
+    notifyLoading(e);
   });
 
   // Hide the spinner after the content is swapped
   htmx.on('htmx:afterSwap', function (e) {
+    if (!e.detail) return;
+
     if (
-      e.detail &&
-      (e.detail.target.id === 'cases-content' ||
-        e.detail.target.id === 'submissions-content')
+      e.detail.target.id === 'cases-content' ||
+      e.detail.target.id === 'submissions-content'
     ) {
       // Hide the spinner
       document
@@ -35,5 +55,7 @@ document.addEventListener('DOMContentLoaded', function () {
         .getElementById('cases-content')
         .classList.remove('cases__spinner--hide');
     }
+
+    dismissNotifyLoading(e);
   });
 });

--- a/src/open_inwoner/react/components/Spinner/Spinner.tsx
+++ b/src/open_inwoner/react/components/Spinner/Spinner.tsx
@@ -17,7 +17,7 @@ const LoadingSpinner: AC<ILoadingSpinnerProps> = ({
           name={iconName}
           extraClassName={['spinner-icon', 'rotate']}
         />
-        <div class="spinner__content" role="status">
+        <div class="spinner__content" aria-hidden="true">
           {loadingText}
         </div>
       </div>

--- a/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
+++ b/src/open_inwoner/templates/cms/plugins/zaken/zaken.html
@@ -21,10 +21,13 @@
             {% endfor %}
         </oip-home-plugin-section>
     {% else %}
+        <div id="zaken-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
         <div
+            id="zaken-htmx-container"
             hx-get="{{ hx_get_url }}"
             hx-trigger="load"
-            hx-swap="outerHTML">
+            hx-swap="outerHTML"
+            data-spinner-live-region="zaken-live-region">
             <oip-home-plugin-section
                 title="{{ plugin_title }}"
                 next-url="{{ mijn_zaken_url }}"

--- a/src/open_inwoner/templates/pages/cases/list_outer.html
+++ b/src/open_inwoner/templates/pages/cases/list_outer.html
@@ -1,6 +1,10 @@
 {% extends 'master.html' %}
 {% load i18n icon_tags static %}
 
+{% block notifications %}
+    <div id="spinner-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+{% endblock notifications %}
+
 {% block sidebar_content %}
     {% include "components/Sidenav/Sidenav.html" %}
 {% endblock %}
@@ -9,9 +13,9 @@
     <div class="cases" id="cases-content"></div>
 
     <div class="loader-container" id="spinner-container">
-        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-content">
+        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-content" data-spinner-live-region="spinner-live-region">
             {% icon icon="rotate_right" extra_classes="spinner-icon rotate" %}
-            <div class="spinner__content" role="status">{% trans "Gegevens laden..." %}</div>
+            <div class="spinner__content" aria-hidden="true">{% trans "Gegevens laden..." %}</div>
         </div>
     </div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -1,5 +1,8 @@
 {% load i18n utils anchor_menu_tags card_tags file_tags form_tags grid_tags solo_tags link_tags button_tags icon_tags notification_tags render_tags %}
 
+{# Screenreader live region - responds to Spinner js - maybe not necessary #}
+{#<div id="spinner-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>#}
+
 {# Messages #}
 <div class="container container--no-margin" id="cases-status-messages-oob" hx-swap-oob="true">
     {% notifications messages closable=True %}

--- a/src/open_inwoner/templates/pages/cases/status_outer.html
+++ b/src/open_inwoner/templates/pages/cases/status_outer.html
@@ -2,6 +2,7 @@
 {% load i18n icon_tags %}
 
 {% block notifications %}
+    <div id="spinner-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
     <div id="cases-status-messages-oob"></div>
 {% endblock notifications %}
 
@@ -9,9 +10,9 @@
     <div class="case-detail" id="cases-detail-content"><div>
 
     <div class="loader-container" id="spinner-container">
-        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-detail-content">
+        <div class="spinner" id="spinner-id" hx-get="{{ hxget }}" hx-trigger="load" hx-target="#cases-detail-content" data-spinner-live-region="spinner-live-region">
             {% icon icon="rotate_right" extra_classes="spinner-icon rotate" %}
-            <div class="spinner__content" role="status">{% trans "Gegevens laden..." %}</div>
+            <div class="spinner__content" aria-hidden="true">{% trans "Gegevens laden..." %}</div>
         </div>
     </div>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/plans/detail.html
+++ b/src/open_inwoner/templates/pages/plans/detail.html
@@ -1,6 +1,11 @@
 {% extends 'master.html' %}
 {% load i18n button_tags card_tags map_tags utils icon_tags file_tags action_tags dropdown_tags anchor_menu_tags notification_tags %}
 
+{% block notifications %}
+    {{ block.super }}
+    <div id="plan-spinner-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+{% endblock notifications %}
+
 {% block sidebar_content %}
     {% anchor_menu anchors=anchors desktop=True export_button=True %}
 {% endblock sidebar_content %}
@@ -99,11 +104,12 @@
                      hx-get="{% url 'collaborate:plan_add_file' uuid=object.uuid %}"
                      hx-target="#form_upload"
                      hx-swap="outerHTML"
-                     hx-trigger="revealed">
+                     hx-trigger="revealed"
+                     data-spinner-live-region="plan-spinner-live-region">
                     <div class="loader-container" id="spinner-container">
                         <div class="spinner" id="spinner-id">
                             {% icon icon="rotate_right" extra_classes="spinner-icon rotate" %}
-                            <div class="spinner__content" role="status"><p class="utrecht-paragraph--small">{% trans "Gegevens laden..." %}</p></div>
+                            <div class="spinner__content" aria-hidden="true"><p class="utrecht-paragraph--small">{% trans "Gegevens laden..." %}</p></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Adding live regions (role=status) for templates that are swapped with HTMX and need a Spinner.

## Issue References


## Checklist

- [ ] CHANGELOG.rst updated
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created
      <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
