### PR TITLE
tests: persist Playwright traces in e2e and expose them as CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,13 @@ jobs:
           ES_PASSWORD: elastic
           OTEL_SDK_DISABLED: true
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-test-results-${{ matrix.browser }}
+          path: test-results/
+
   #
   # Docs
   #

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ src/open_inwoner/static/fonts/material-icons/
 *storybook.log
 storybook-static/
 coverage/
+
+# Playwright traces
+test-results/

--- a/src/open_inwoner/accounts/tests/test_action_views.py
+++ b/src/open_inwoner/accounts/tests/test_action_views.py
@@ -346,7 +346,7 @@ class ActionsPlaywrightTests(PlaywrightSyncLiveServerTestCase):
 
         mock_solo.return_value.cookiebanner_enabled = False
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))

--- a/src/open_inwoner/accounts/tests/test_inbox_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_page.py
@@ -272,7 +272,7 @@ class InboxPagePlaywrightTests(PlaywrightSyncLiveServerTestCase):
         """
 
     def test_polling(self):
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.contact_1_conversation_url)

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -443,7 +443,7 @@ class CasesPlaywrightTests(
     def test_cases(self, m, contactmoment_mock):
         self._setUpMocks(m)
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("cases:index"))
@@ -606,7 +606,7 @@ class CasesPlaywrightTests(
         )
 
         # Setup.
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
         page = context.new_page()
         page.goto(
             self.live_reverse(
@@ -672,7 +672,7 @@ class CasesPlaywrightTests(
             MockService.return_value.get_zaken.side_effect = RuntimeError("API error")
             MockService.return_value.get_formulieren.return_value = []
 
-            context = self.browser.new_context(storage_state=self.user_login_state)
+            context = self.get_context(storage_state=self.user_login_state)
             page = context.new_page()
             page.goto(self.live_reverse("cases:index"))
 
@@ -691,7 +691,7 @@ class CasesPlaywrightTests(
         ) as mock_get:
             mock_get.return_value = HttpResponse(status=503)
 
-            context = self.browser.new_context(storage_state=self.user_login_state)
+            context = self.get_context(storage_state=self.user_login_state)
             page = context.new_page()
             page.goto(self.live_reverse("cases:index"))
 

--- a/src/open_inwoner/configurations/tests/test_analytics.py
+++ b/src/open_inwoner/configurations/tests/test_analytics.py
@@ -132,7 +132,7 @@ class CookieBannerPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTest
     def test_cookie_accept(self):
         config = SiteConfiguration.get_solo()
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))
@@ -156,7 +156,7 @@ class CookieBannerPlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTest
     def test_cookie_reject(self):
         config = SiteConfiguration.get_solo()
 
-        context = self.browser.new_context(storage_state=self.user_login_state)
+        context = self.get_context(storage_state=self.user_login_state)
 
         page = context.new_page()
         page.goto(self.live_reverse("profile:action_list"))

--- a/src/open_inwoner/pdc/tests/test_product.py
+++ b/src/open_inwoner/pdc/tests/test_product.py
@@ -446,7 +446,7 @@ class ProductPagePlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestC
             content="Some content [CTABUTTON]", link="https://www.example.com"
         )
 
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
 
         page.goto(

--- a/src/open_inwoner/plans/tests/test_htmx.py
+++ b/src/open_inwoner/plans/tests/test_htmx.py
@@ -35,13 +35,12 @@ class PlansHTMXTest(PlaywrightSyncLiveServerTestCase):
         self.config.cookie_info_text = ""
         self.config.save()
 
-        self.context = self.browser.new_context(
+        self.context = self.get_context(
             base_url=self.live_server_url,
             storage_state=self.user_login_state,
         )
 
     def tearDown(self) -> None:
-        self.context.close()
         return super().tearDown()
 
     def test_plan_file_upload_e2e(self):

--- a/src/open_inwoner/search/tests/test_page.py
+++ b/src/open_inwoner/search/tests/test_page.py
@@ -235,7 +235,7 @@ class SearchPagePlaywrightTests(
         config.save()
 
     def test_basic_search(self):
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
 
         # search to find both products
@@ -244,7 +244,7 @@ class SearchPagePlaywrightTests(
         expect(page.locator(".card")).to_have_count(2)
 
     def test_search_form_delegates_copy_query_value(self):
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
         page.goto(self.live_reverse("search:search", params={"query": "summary"}))
 
@@ -273,7 +273,7 @@ class SearchPagePlaywrightTests(
 
         for form_id, view_size, open_menu in self.form_delegates:
             with self.subTest(form_id):
-                context = self.browser.new_context(
+                context = self.get_context(
                     viewport={"width": view_size, "height": 1024},
                 )
                 page = context.new_page()
@@ -288,10 +288,9 @@ class SearchPagePlaywrightTests(
                 expect(page.locator(".card")).to_have_count(1)
 
                 page.close()
-                context.close()
 
     def test_search_with_filters(self):
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
 
         # search to find both products
@@ -369,7 +368,7 @@ class SearchPagePlaywrightTests(
         _test_search("Category 2", self.product2.name)
 
     def test_search_mobile_dialog(self):
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
         page.set_viewport_size(
             {
@@ -402,7 +401,7 @@ class SearchPagePlaywrightTests(
 
     def test_search_with_filter_combinations(self):
         # NOTE it isn't great to generate query-strings outside the form but we test the form above
-        context = self.browser.new_context()
+        context = self.get_context()
         page = context.new_page()
 
         tests = [

--- a/src/open_inwoner/utils/tests/playwright.py
+++ b/src/open_inwoner/utils/tests/playwright.py
@@ -1,17 +1,23 @@
 import os
 from collections.abc import Callable
+from pathlib import Path
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.files.base import ContentFile
 from django.urls import reverse
 
 from furl import furl
-from playwright.sync_api import Browser, Playwright, sync_playwright
+from playwright.sync_api import Browser, BrowserContext, Playwright, sync_playwright
 
 from open_inwoner.accounts.models import User
 from open_inwoner.configurations.choices import CustomFontName
 from open_inwoner.utils.files import OverwriteStorage
 from open_inwoner.utils.test import temp_media_root
+
+_REPO_ROOT = Path(__file__).parents[4]
+PLAYWRIGHT_TRACE_DIR = os.environ.get(
+    "PLAYWRIGHT_TRACE_DIR", str(_REPO_ROOT / "test-results")
+)
 
 BROWSER_DRIVERS = {
     # keys for the E2E_DRIVER environment variable (likely from test matrix)
@@ -37,6 +43,9 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
 
     to set the browser define E2E_DRIVER environment variable, with a value from the BROWSER_DRIVERS dictionary above.
 
+    traces are saved automatically for every test to PLAYWRIGHT_TRACE_DIR (default: /tmp/playwright-traces/).
+    view them with: playwright show-trace <path-to-trace.zip>
+
     usage:
 
     from playwright.sync_api import expect
@@ -44,7 +53,8 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
     class MyPageTest(PlaywrightSyncLiveServerTestCase):
         def test_my_page():
             # get a new context for test isolation
-            context = self.browser.new_context()
+            # tracing starts automatically and is saved on tearDown
+            context = self.get_context()
 
             # open a page
             page = context.new_page()
@@ -65,8 +75,8 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
 
             user_state = self.get_user_bsn_login_state(user)
 
-            # user_state now has the cookies (etc) for the logged-in user and can be (re)used to get new context's
-            context = self.browser.new_context(storage_state=user_state)
+            # user_state now has the cookies (etc) for the logged-in user and can be (re)used to get new contexts
+            context = self.get_context(storage_state=user_state)
             ...
     """
 
@@ -74,6 +84,7 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
     browser: Browser
 
     _old_async_unsafe: str
+    _traced_contexts: list[BrowserContext]
 
     @classmethod
     def launch_browser(cls, playwright: Playwright) -> Browser:
@@ -118,6 +129,34 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
 
         cls.browser.close()
         cls.playwright.stop()
+
+    def setUp(self):
+        super().setUp()
+        self._traced_contexts = []
+        os.makedirs(PLAYWRIGHT_TRACE_DIR, exist_ok=True)
+
+    def get_context(self, **kwargs) -> BrowserContext:
+        """
+        Create a new browser context with tracing and video recording enabled.
+
+        Use this instead of self.browser.new_context() so that a trace and
+        video are automatically saved to PLAYWRIGHT_TRACE_DIR on tearDown.
+        """
+        kwargs.setdefault("record_video_dir", PLAYWRIGHT_TRACE_DIR)
+        context = self.browser.new_context(**kwargs)
+        context.tracing.start(screenshots=True, snapshots=True, sources=True)
+        self._traced_contexts.append(context)
+        return context
+
+    def tearDown(self):
+        test_id = f"{self.__class__.__name__}.{self._testMethodName}"
+
+        for i, context in enumerate(self._traced_contexts):
+            suffix = f"_{i}" if i > 0 else ""
+            trace_path = os.path.join(PLAYWRIGHT_TRACE_DIR, f"{test_id}{suffix}.zip")
+            context.tracing.stop(path=trace_path)
+
+        super().tearDown()
 
     @classmethod
     def live_url(cls, path="/", star=False):


### PR DESCRIPTION
The general effort here is to start expanding our Playwright footprint a bit, what with all the webcomponent and frontend changes in the pipeline.

This ensures the Playwright traces are published in CI, see for instance: https://github.com/maykinmedia/open-inwoner/actions/runs/23550996777#artifacts

To see why this is useful, download one of the `e2e-test-results-*` files, unpack, and upload one of the zip files to:
https://trace.playwright.dev/
