### PR TITLE
feat: [#2353] strip file extension from document title on upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Nieuwe features
   wordt de verbinding met Elasticsearch beveiligd met een gebruikersnaam en wachtwoord.
   De Docker Compose- en CI-configuratie zijn bijgewerkt om ``xpack.security.enabled``
   in te schakelen.
+* [:gh:`2353`]: Bij het uploaden van een document naar een zaak wordt de bestandsextensie
+  nu verwijderd uit de documenttitel (bijv. ``rapport.pdf`` krijgt als titel ``rapport``).
+  De bestandsextensie in de documentenlijst wordt nu afgeleid van het ``formaat``-veld
+  (en als fallback ``bestandsnaam``) in plaats van de titel, zodat de extensie correct wordt
+  weergegeven ook wanneer eSuite het document heeft omgezet naar PDF/A.
+  Daarnaast is de interne weergave van bestanden in templates gerefactored om de
+  conversielogica te centraliseren en de templatetags eenvoudiger te maken.
 * ...
 * [:gh:`2268`]: WCAG toegankelijkheidsverbeteringen uit rapport gemeente Enschede toegepast.
 

--- a/src/open_inwoner/cms/cases/tests/test_document_upload.py
+++ b/src/open_inwoner/cms/cases/tests/test_document_upload.py
@@ -1,0 +1,79 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import RequestFactory, TestCase, override_settings
+
+from open_inwoner.accounts.tests.factories import DigidUserFactory
+from open_inwoner.cms.cases.views.mixins import CaseLogMixin
+from open_inwoner.cms.cases.views.status import CaseDocumentUploadFormView
+from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
+from open_inwoner.utils.test import ClearCachesMixin
+
+
+def _make_view(user, api_group_id, zaak):
+    request = RequestFactory().post("/")
+    request.user = user
+    request.session = {}
+
+    view = CaseDocumentUploadFormView()
+    view.request = request
+    view.args = ()
+    view.kwargs = {"api_group_id": api_group_id, "object_id": str(zaak.uuid)}
+    view.zaak = zaak
+    return view, request
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class CaseDocumentUploadTitleTest(ClearCachesMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = DigidUserFactory(bsn="900222086")
+        self.api_group = ZGWApiGroupConfigFactory()
+
+        self.mock_zaak = MagicMock()
+        self.mock_zaak.bronorganisatie = "123456789"
+        self.mock_zaak.uuid = uuid.UUID("d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d")
+
+        self.mock_iot = MagicMock()
+        self.mock_iot.informatieobjecttype_url = "http://example.com/iot/1/"
+
+        self.mock_api_group = MagicMock()
+        self.mock_api_group.documenten_client.upload_document.return_value = {
+            "url": "http://example.com/docs/1",
+            "titel": "placeholder",
+        }
+        self.mock_api_group.zaken_client.connect_case_with_document.return_value = {
+            "url": "http://example.com/zio/1"
+        }
+
+    def _call_handle_upload(self, filename):
+        view, request = _make_view(self.user, self.api_group.id, self.mock_zaak)
+
+        mock_file = SimpleUploadedFile(filename, b"content")
+        mock_form = MagicMock()
+        mock_form.cleaned_data = {"files": [mock_file], "type": self.mock_iot}
+
+        with (
+            patch(
+                "open_inwoner.cms.cases.views.status.ZGWApiGroupConfig.objects.get",
+                return_value=self.mock_api_group,
+            ),
+            patch.object(CaseLogMixin, "log_case_document_uploaded"),
+            patch("open_inwoner.cms.cases.views.status.messages.add_message"),
+        ):
+            view.handle_document_upload(request, mock_form)
+
+        return self.mock_api_group.documenten_client.upload_document.call_args
+
+    def test_title_excludes_extension(self):
+        cases = [
+            ("report.pdf", "report"),
+            ("report", "report"),
+            ("report.tar.gz", "report.tar"),
+        ]
+        for filename, expected_title in cases:
+            with self.subTest(filename=filename):
+                self.mock_api_group.documenten_client.upload_document.reset_mock()
+                call_args = self._call_handle_upload(filename)
+                self.assertEqual(call_args.args[2], expected_title)

--- a/src/open_inwoner/cms/cases/tests/test_htmx.py
+++ b/src/open_inwoner/cms/cases/tests/test_htmx.py
@@ -251,7 +251,7 @@ class CasesPlaywrightTests(
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
-            titel="uploaded_document_title.txt",
+            titel="uploaded_document_title",
             bestandsomvang=123,
         )
 
@@ -275,7 +275,7 @@ class CasesPlaywrightTests(
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_test_file.txt",
-            titel="uploaded_test_file.txt",
+            titel="uploaded_test_file",
             bestandsomvang=len(self.uploaded_zaak_informatie_object_content),
         )
         self.klant = generate_oas_component_cached(
@@ -575,11 +575,12 @@ class CasesPlaywrightTests(
             appends created item to `uploads`.
             """
             request_body = json.loads(request.body)
-            file_name = request_body["titel"]
+            titel = request_body["titel"]
+            bestandsnaam = request_body["bestandsnaam"]
 
-            # Create a UUID based on a seed derived from the file name.
+            # Create a UUID based on a seed derived from the titel.
             # This makes sure the two test cases have unique entries.
-            seed = file_name.ljust(16, "0").encode("utf-8")
+            seed = titel.ljust(16, "0").encode("utf-8")
             uuid = UUID(bytes=seed)
 
             uploaded_informatie_object = generate_oas_component_cached(
@@ -591,8 +592,8 @@ class CasesPlaywrightTests(
                 informatieobjecttype=self.informatie_object_type["url"],
                 status="definitief",
                 vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
-                bestandsnaam=file_name,
-                titel=file_name,
+                bestandsnaam=bestandsnaam,
+                titel=titel,
                 bestandsomvang=request_body["bestandsomvang"],
             )
             m.get(uploaded_informatie_object["url"], json=uploaded_informatie_object)
@@ -658,8 +659,8 @@ class CasesPlaywrightTests(
 
         # Check that the case does now have two uploaded documents.
         expect(notification_list_items).to_have_count(2)
-        expect(notification_list_items.last).to_contain_text("document_two.pdf")
-        expect(notification_list_items.first).to_contain_text("document_1.txt")
+        expect(notification_list_items.last).to_contain_text("document_two")
+        expect(notification_list_items.first).to_contain_text("document_1")
         expect(file_list_items).to_have_count(2)
         expect(file_list_items.first).to_contain_text("document_1")
         expect(file_list_items.first).to_contain_text("(txt, 9 bytes)")

--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -1,7 +1,6 @@
-import dataclasses
 import datetime as dt
+import os
 from collections import defaultdict
-from datetime import datetime
 from typing import Iterable, Protocol, cast
 
 from django.conf import settings
@@ -32,6 +31,7 @@ from zgw_consumers.api_models.constants import RolOmschrijving, RolTypes
 
 from open_inwoner.accounts.models import User
 from open_inwoner.cms.cases.forms import CaseContactForm, CaseUploadForm
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.mail.service import send_contact_confirmation_mail
 from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.models import (
@@ -68,14 +68,6 @@ from open_inwoner.utils.views import CommonPageMixin
 from .mixins import CaseAccessMixin, CaseLogMixin, OuterCaseAccessMixin
 
 logger = structlog.stdlib.get_logger(__name__)
-
-
-@dataclasses.dataclass
-class SimpleFile:
-    name: str
-    size: int
-    url: str
-    created: datetime | None = None
 
 
 class VragenService(Protocol):
@@ -737,7 +729,7 @@ class InnerCaseDetailView(
     @staticmethod
     def get_case_document_files(
         zaak: Zaak, api_group: ZGWApiGroupConfig
-    ) -> list[SimpleFile]:
+    ) -> list[FileItem]:
         client = api_group.zaken_client
         case_info_objects = client.fetch_zaak_information_objects(zaak.url)
 
@@ -765,21 +757,17 @@ class InnerCaseDetailView(
                 info_obj, config.document_max_confidentiality
             ):
                 continue
-            # restructure into something understood by the FileList template tag
+
+            url = reverse(
+                "cases:document_download",
+                kwargs={
+                    "object_id": zaak.uuid,
+                    "info_id": info_obj.uuid,
+                    "api_group_id": api_group.id,
+                },
+            )
             documents.append(
-                SimpleFile(
-                    name=getattr(info_obj, "titel", None),
-                    size=info_obj.bestandsomvang,
-                    url=reverse(
-                        "cases:document_download",
-                        kwargs={
-                            "object_id": zaak.uuid,
-                            "info_id": info_obj.uuid,
-                            "api_group_id": api_group.id,
-                        },
-                    ),
-                    created=getattr(case_info_obj, "registratiedatum", None),
-                )
+                FileItem.from_informatieobject(info_obj, case_info_obj, url)
             )
 
         # `registratiedatum` and `titel` should be present, but not guaranteed by schema
@@ -907,7 +895,7 @@ class CaseDocumentUploadFormView(CaseAccessMixin, CaseLogMixin, FormView):
         created_documents = []
 
         for file in files:
-            title = file.name
+            title = os.path.splitext(file.name)[0] or file.name
             document_type = cleaned_data["type"]
             source_organization = self.zaak.bronorganisatie
 

--- a/src/open_inwoner/components/file_item.py
+++ b/src/open_inwoner/components/file_item.py
@@ -1,0 +1,94 @@
+import dataclasses
+import mimetypes
+import pathlib
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from django.core.files import File as DjangoFile
+
+from filer.models.filemodels import File as FilerFile
+
+if TYPE_CHECKING:
+    from open_inwoner.openzaak.api_models import InformatieObject, ZaakInformatieObject
+
+
+IMAGE_TYPES = [
+    "jpg",
+    "jpeg",
+    "jpe",
+    "jfif",
+    "jfi",
+    "jif",
+    "png",
+    "svg",
+    "gif",
+    "webp",
+    "tiff",
+    "tif",
+]
+
+
+@dataclasses.dataclass
+class FileItem:
+    """DTO used by the file_item and file_list template tags to render file metadata."""
+
+    name: str
+    extension: str
+    size: int
+    url: str
+    is_image: bool
+    created: datetime | None = None
+    description: str | None = None
+
+    @classmethod
+    def from_filer_file(cls, file: FilerFile, name: str | None = None) -> "FileItem":
+        resolved_name = name or (
+            file.name if file.name else pathlib.Path(file.label).stem
+        )
+        return cls(
+            name=resolved_name,
+            extension=file.extension,
+            size=file.size,
+            url=file.url,
+            is_image=file.file_type == "Image",
+            description=file.description,
+        )
+
+    @classmethod
+    def from_informatieobject(
+        cls,
+        info_obj: "InformatieObject",
+        case_info_obj: "ZaakInformatieObject",
+        url: str,
+    ) -> "FileItem":
+        guessed = (
+            mimetypes.guess_extension(info_obj.formaat) if info_obj.formaat else None
+        )
+        extension = (guessed or "").lstrip(".") or pathlib.Path(
+            info_obj.bestandsnaam or info_obj.titel
+        ).suffix.lstrip(".")
+        return cls(
+            name=pathlib.Path(info_obj.titel).stem,
+            extension=extension,
+            size=info_obj.bestandsomvang,
+            url=url,
+            is_image=extension.lower() in IMAGE_TYPES,
+            created=case_info_obj.registratiedatum,
+        )
+
+    @classmethod
+    def from_django_file(
+        cls,
+        file: DjangoFile,
+        name: str | None = None,
+        url: str | None = None,
+    ) -> "FileItem":
+        pathed = pathlib.Path(file.name)
+        extension = pathed.suffix.lstrip(".")
+        return cls(
+            name=name or pathed.stem,
+            extension=extension,
+            size=file.size,
+            url=url or file.url,
+            is_image=extension.lower() in IMAGE_TYPES,
+        )

--- a/src/open_inwoner/components/templates/components/File/FileList.html
+++ b/src/open_inwoner/components/templates/components/File/FileList.html
@@ -9,10 +9,9 @@
         {% endif %}
     {% endif %}
     <ul class="file-list__list">
-        {% for file in files %}
-            {% url download_view uuid=file.uuid as download_url %}
+        {% for file_info in files %}
             <li class="file-list__list-item">
-                {% file file=file.file created=created name=file.name uuid=file.uuid allow_delete=allow_delete download_url=download_url show_download=show_download %}
+                {% file_item file_info allow_delete=allow_delete show_download=show_download %}
             </li>
         {% empty %}
             <li><p class="utrecht-paragraph">{% trans "Er zijn nog geen bestanden geüpload" %}</p></li>

--- a/src/open_inwoner/components/templatetags/file_tags.py
+++ b/src/open_inwoner/components/templatetags/file_tags.py
@@ -1,30 +1,13 @@
+import dataclasses
 import datetime
-import pathlib
 
 from django import template
 from django.conf import settings
 
-from filer.models.filemodels import File
-
-from open_inwoner.cms.cases.views.status import SimpleFile
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.utils.time import instance_is_new
 
 register = template.Library()
-
-IMAGE_TYPES = [
-    "jpg",
-    "jpeg",
-    "jpe",
-    "jfif",
-    "jfi",
-    "jif",
-    "png",
-    "svg",
-    "gif",
-    "webp",
-    "tiff",
-    "tif",
-]
 
 
 @register.inclusion_tag("components/File/FileList.html")
@@ -33,43 +16,18 @@ def file_list(files, **kwargs):
     Generate a list of files with the correct spacing.
 
     Usage:
-        {% file_list files=Product.files.all %}
-        {% file_list files=Product.files.all title="Bestanden" h1=True %}
+        {% file_list files=product_files %}
+        {% file_list files=product_files title="Bestanden" h1=True %}
 
     Variables:
-        + files: array | this is the list of file that need to be rendered.
+        + files: list[FileItem] | pre-converted FileItem objects to render.
         - h1: bool | render the title in a h1 instead of a h4.
         - title: string | the title that should be used.
-        - download_view: sting | the view name to download file (used for private files)
 
     Extra context:
         + show_download: bool | We enable the download button for the files.
     """
     return {**kwargs, "files": files, "show_download": True}
-
-
-@register.inclusion_tag("components/File/FileList.html")
-def case_document_list(documents: list[SimpleFile], **kwargs) -> dict:
-    """
-    Shows multiple case documents in a file_list.
-
-    Usage:
-        {% case_document_list documents %}
-
-    Variables:
-        + documents: SimpleFile[]
-
-    Extra context:
-        + show_download: bool | We disable the download button for the files.
-    """
-
-    files = [
-        {
-            "file": document,
-        }
-        for document in documents
-    ]
-    return {**kwargs, "documents": documents, "files": files, "show_download": True}
 
 
 @register.inclusion_tag("components/File/FileTable.html")
@@ -89,70 +47,29 @@ def file_table(files, **kwargs):
 
 
 @register.inclusion_tag("components/File/File.html")
-def file(file, **kwargs):
+def file_item(file: FileItem, **kwargs):
     """
-    Render in a file that needs to be displayed. This can be a filer file or a django filefield.
+    Render a FileItem object for display.
 
     Usage:
-        {% file model.filefield %}
+        {% file_item file_info %}
 
     Variables:
-        + file: File | the file that needs to be displayed.
+        + file: FileItem | the pre-converted file info to display.
         - allow_delete: bool | If you want to show a delete button.
-        - download_url: url | If there is a special view to download (used for private files)
         - show_download: bool | If you want to show the download button.
-
-    Extra context:
-        - description: str | The description of the (filer) file.
-        - is_image: bool | if the file that is given is an image.
-        - extension: string | the extension type of the file.
-        - size: string | the size of the file in bytes.
-        - url: string | the file location. the download link.
-        - name: string | the name of the file.
     """
-    if isinstance(file, File):
-        kwargs.update(
-            is_image=file.file_type == "Image",
-            description=file.description,
-            extension=file.extension,
-            size=file.size,
-            url=file.url,
-        )
-        if not kwargs.get("name"):
-            kwargs.update(
-                name=file.name
-                if file.name
-                else file.label.replace(f".{file.extension}", ""),
-            )
-    else:
-        try:
-            pathed = pathlib.Path(file.name)
-            extension = pathed.suffix.replace(".", "")
-            kwargs.update(
-                is_image=extension.lower() in IMAGE_TYPES,
-                extension=extension,
-                size=file.size,
-                url=file.url,
-            )
-            if not kwargs.get("name"):
-                kwargs.update(
-                    name=pathed.stem,
-                )
-        except AttributeError:
-            kwargs.update(is_image=False, extension="", size=0, url="", name=str(file))
+    if not isinstance(file, FileItem):
+        raise TypeError(f"Expected a FileItem instance, got {type(file).__name__!r}")
 
-    if kwargs.get("download_url"):
-        kwargs["url"] = kwargs["download_url"]
-
-    created = getattr(file, "created", None)
-    kwargs["created"] = created
+    context = {**dataclasses.asdict(file), **kwargs}
 
     if instance_is_new(
         file, "created", datetime.timedelta(days=settings.DOCUMENT_RECENT_DAYS)
     ):
-        kwargs["recently_added"] = True
+        context["recently_added"] = True
 
-    if "show_download" not in kwargs:
-        kwargs["show_download"] = True
+    if "show_download" not in context:
+        context["show_download"] = True
 
-    return {**kwargs}
+    return context

--- a/src/open_inwoner/components/tests/test_file_tags.py
+++ b/src/open_inwoner/components/tests/test_file_tags.py
@@ -1,0 +1,309 @@
+import io
+from datetime import date, datetime
+
+from django.core.files import File as DjangoFile
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase, TestCase
+
+from filer.models.filemodels import File as FilerFile
+
+from open_inwoner.components.file_item import FileItem
+from open_inwoner.components.templatetags.file_tags import file_item as file_tag
+from open_inwoner.openzaak.api_models import InformatieObject, ZaakInformatieObject
+from open_inwoner.utils.test import temp_media_root
+from open_inwoner.utils.tests.factories import FilerImageFactory
+
+CREATED = datetime(2024, 1, 1)
+
+
+def make_info_object(**overrides) -> InformatieObject:
+    defaults = dict(
+        url="http://example.com/documenten/1",
+        identificatie="DOC-001",
+        bronorganisatie="123456782",
+        creatiedatum=date(2024, 1, 1),
+        titel="rapport.pdf",
+        vertrouwelijkheidaanduiding="openbaar",
+        auteur="test",
+        status="definitief",
+        formaat="application/pdf",
+        taal="nl",
+        versie=1,
+        bestandsnaam="rapport.pdf",
+        inhoud="http://example.com/documenten/1/download",
+        bestandsomvang=1024,
+        informatieobjecttype="http://example.com/catalogus/iot/1",
+        locked=False,
+    )
+    return InformatieObject(**{**defaults, **overrides})
+
+
+def make_zaak_info_object(**overrides) -> ZaakInformatieObject:
+    defaults = dict(
+        url="http://example.com/zaakinformatieobjecten/1",
+        informatieobject="http://example.com/documenten/1",
+        zaak="http://example.com/zaken/1",
+        titel="",
+        registratiedatum=datetime(2024, 6, 15),
+    )
+    return ZaakInformatieObject(**{**defaults, **overrides})
+
+
+def make_django_file(name="rapport.pdf"):
+    f = DjangoFile(io.BytesIO(b"content"), name=name)
+    f.size = 42
+    f.url = "/media/rapport.pdf"
+    return f
+
+
+class TestFileItemFromDjangoFile(SimpleTestCase):
+    def test_extension_and_name_from_file_name(self):
+        self.assertEqual(
+            FileItem.from_django_file(make_django_file("rapport.pdf")),
+            FileItem(
+                name="rapport",
+                extension="pdf",
+                size=42,
+                url="/media/rapport.pdf",
+                is_image=False,
+            ),
+        )
+
+    def test_is_image_for_jpg(self):
+        self.assertEqual(
+            FileItem.from_django_file(make_django_file("foto.jpg")),
+            FileItem(
+                name="foto",
+                extension="jpg",
+                size=42,
+                url="/media/rapport.pdf",
+                is_image=True,
+            ),
+        )
+
+    def test_no_extension(self):
+        self.assertEqual(
+            FileItem.from_django_file(make_django_file("rapport")),
+            FileItem(
+                name="rapport",
+                extension="",
+                size=42,
+                url="/media/rapport.pdf",
+                is_image=False,
+            ),
+        )
+
+    def test_name_override(self):
+        self.assertEqual(
+            FileItem.from_django_file(
+                make_django_file("rapport.pdf"), name="Jaarverslag"
+            ),
+            FileItem(
+                name="Jaarverslag",
+                extension="pdf",
+                size=42,
+                url="/media/rapport.pdf",
+                is_image=False,
+            ),
+        )
+
+    def test_url_override(self):
+        self.assertEqual(
+            FileItem.from_django_file(
+                make_django_file("rapport.pdf"), url="/custom/download/"
+            ),
+            FileItem(
+                name="rapport",
+                extension="pdf",
+                size=42,
+                url="/custom/download/",
+                is_image=False,
+            ),
+        )
+
+
+@temp_media_root()
+class TestFileItemFromFilerFile(TestCase):
+    def test_document_file(self):
+        f = FilerFile.objects.create(
+            original_filename="verslag.pdf",
+            file=SimpleUploadedFile("verslag.pdf", b"pdf content"),
+            name="Verslag",
+            description="Jaarverslag",
+        )
+        self.assertEqual(
+            FileItem.from_filer_file(f),
+            FileItem(
+                name="Verslag",
+                extension="pdf",
+                size=f.size,
+                url=f.url,
+                is_image=False,
+                description="Jaarverslag",
+            ),
+        )
+
+    def test_image_file(self):
+        f = FilerImageFactory(name="Foto")
+        self.assertEqual(
+            FileItem.from_filer_file(f),
+            FileItem(
+                name="Foto",
+                extension=f.extension,
+                size=f.size,
+                url=f.url,
+                is_image=True,
+                description=f.description,
+            ),
+        )
+
+    def test_name_falls_back_to_label_without_extension(self):
+        f = FilerFile.objects.create(
+            original_filename="verslag.pdf",
+            file=SimpleUploadedFile("verslag.pdf", b"pdf content"),
+        )
+        self.assertEqual(
+            FileItem.from_filer_file(f),
+            FileItem(
+                name="verslag",
+                extension="pdf",
+                size=f.size,
+                url=f.url,
+                is_image=False,
+                description=f.description,
+            ),
+        )
+
+    def test_name_override(self):
+        f = FilerFile.objects.create(
+            original_filename="verslag.pdf",
+            file=SimpleUploadedFile("verslag.pdf", b"pdf content"),
+            name="Verslag",
+        )
+        self.assertEqual(
+            FileItem.from_filer_file(f, name="Override"),
+            FileItem(
+                name="Override",
+                extension="pdf",
+                size=f.size,
+                url=f.url,
+                is_image=False,
+                description=f.description,
+            ),
+        )
+
+
+# ---- file_item tag ----
+
+
+class TestFileItemTag(SimpleTestCase):
+    def _make_file_info(self, **kwargs):
+        defaults = dict(
+            name="rapport",
+            extension="pdf",
+            size=1024,
+            url="/download/rapport/",
+            is_image=False,
+        )
+        return FileItem(**{**defaults, **kwargs})
+
+    def test_basic_rendering(self):
+        fi = self._make_file_info()
+        self.assertEqual(
+            file_tag(fi),
+            {
+                "name": "rapport",
+                "extension": "pdf",
+                "size": 1024,
+                "url": "/download/rapport/",
+                "is_image": False,
+                "created": None,
+                "description": None,
+                "show_download": True,
+            },
+        )
+
+    def test_kwargs_override_context(self):
+        fi = self._make_file_info()
+        result = file_tag(fi, show_download=False, allow_delete=True)
+        self.assertEqual(result["show_download"], False)
+        self.assertEqual(result["allow_delete"], True)
+
+    def test_raises_for_unknown_type(self):
+        with self.assertRaises(TypeError):
+            file_tag(object())
+
+    def test_raises_for_plain_string(self):
+        with self.assertRaises(TypeError):
+            file_tag("rapport.pdf")
+
+
+class TestFileItemFromInformatieObject(SimpleTestCase):
+    def test_basic(self):
+        info_obj = make_info_object(
+            titel="rapport.pdf",
+            formaat="application/pdf",
+            bestandsnaam="rapport.pdf",
+            bestandsomvang=2048,
+        )
+        case_info_obj = make_zaak_info_object(registratiedatum=datetime(2024, 6, 15))
+        result = FileItem.from_informatieobject(info_obj, case_info_obj, "/download/1/")
+        self.assertEqual(
+            result,
+            FileItem(
+                name="rapport",
+                extension="pdf",
+                size=2048,
+                url="/download/1/",
+                is_image=False,
+                created=datetime(2024, 6, 15),
+            ),
+        )
+
+    def test_extension_from_formaat_mime_type(self):
+        info_obj = make_info_object(
+            formaat="image/png", bestandsnaam="foto.png", titel="foto.png"
+        )
+        result = FileItem.from_informatieobject(
+            info_obj, make_zaak_info_object(), "/dl/"
+        )
+        self.assertEqual(result.extension, "png")
+        self.assertTrue(result.is_image)
+
+    def test_extension_falls_back_to_bestandsnaam_when_no_formaat(self):
+        info_obj = make_info_object(
+            formaat="", bestandsnaam="verslag.docx", titel="verslag"
+        )
+        result = FileItem.from_informatieobject(
+            info_obj, make_zaak_info_object(), "/dl/"
+        )
+        self.assertEqual(result.extension, "docx")
+
+    def test_extension_falls_back_to_titel_when_no_bestandsnaam(self):
+        info_obj = make_info_object(formaat="", bestandsnaam="", titel="verslag.docx")
+        result = FileItem.from_informatieobject(
+            info_obj, make_zaak_info_object(), "/dl/"
+        )
+        self.assertEqual(result.extension, "docx")
+        self.assertEqual(result.name, "verslag")
+
+    def test_name_uses_stem_of_titel(self):
+        info_obj = make_info_object(titel="jaarverslag 2024.pdf")
+        result = FileItem.from_informatieobject(
+            info_obj, make_zaak_info_object(), "/dl/"
+        )
+        self.assertEqual(result.name, "jaarverslag 2024")
+
+    def test_created_from_registratiedatum(self):
+        case_info_obj = make_zaak_info_object(registratiedatum=datetime(2023, 3, 7))
+        result = FileItem.from_informatieobject(
+            make_info_object(), case_info_obj, "/dl/"
+        )
+        self.assertEqual(result.created, datetime(2023, 3, 7))
+
+    def test_created_is_none_when_registratiedatum_is_none(self):
+        case_info_obj = make_zaak_info_object(registratiedatum=None)
+        result = FileItem.from_informatieobject(
+            make_info_object(), case_info_obj, "/dl/"
+        )
+        self.assertIsNone(result.created)

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -30,7 +30,8 @@ from open_inwoner.accounts.tests.factories import (
     eHerkenningUserFactory,
     eHerkenningVestigingUserFactory,
 )
-from open_inwoner.cms.cases.views.status import InnerCaseDetailView, SimpleFile
+from open_inwoner.cms.cases.views.status import InnerCaseDetailView
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.openklant.api_models import ObjectContactMoment
 from open_inwoner.openklant.constants import (
     KlantenServiceType,
@@ -302,6 +303,7 @@ class TestCaseDetailView(
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
+            formaat="text/plain",
             titel="uploaded_document_title.txt",
             bestandsomvang=123,
         )
@@ -315,6 +317,7 @@ class TestCaseDetailView(
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
+            formaat="text/plain",
             titel="another_document_title.txt",
             bestandsomvang=123,
         )
@@ -328,6 +331,7 @@ class TestCaseDetailView(
             status="definitief",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
+            formaat="text/plain",
             titel="yet_another_document_title.txt",
             bestandsomvang=123,
         )
@@ -366,6 +370,7 @@ class TestCaseDetailView(
             status="gearchiveerd",
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
             bestandsnaam="uploaded_document.txt",
+            formaat="text/plain",
             titel="uploaded_document_title.txt",
             bestandsomvang=123,
         )
@@ -730,8 +735,9 @@ class TestCaseDetailView(
         #
         # documents
         #
-        self.informatie_object_file = SimpleFile(
-            name="uploaded_document_title.txt",
+        self.informatie_object_file = FileItem(
+            name="uploaded_document_title",
+            extension="txt",
             size=123,
             url=reverse(
                 "cases:document_download",
@@ -741,12 +747,14 @@ class TestCaseDetailView(
                     "api_group_id": self.api_group.id,
                 },
             ),
+            is_image=False,
             created=dateutil.parser.parse(
                 self.zaak_informatie_object_old["registratiedatum"]
             ),
         )
-        self.informatie_object_file_2 = SimpleFile(
-            name="another_document_title.txt",
+        self.informatie_object_file_2 = FileItem(
+            name="another_document_title",
+            extension="txt",
             size=123,
             url=reverse(
                 "cases:document_download",
@@ -756,12 +764,14 @@ class TestCaseDetailView(
                     "api_group_id": self.api_group.id,
                 },
             ),
+            is_image=False,
             created=dateutil.parser.parse(
                 self.zaak_informatie_object_new["registratiedatum"]
             ),
         )
-        self.informatie_object_file_no_date = SimpleFile(
-            name="yet_another_document_title.txt",
+        self.informatie_object_file_no_date = FileItem(
+            name="yet_another_document_title",
+            extension="txt",
             size=123,
             url=reverse(
                 "cases:document_download",
@@ -771,9 +781,11 @@ class TestCaseDetailView(
                     "api_group_id": self.api_group.id,
                 },
             ),
+            is_image=False,
         )
-        self.informatie_object_file_archived = SimpleFile(
-            name="document_archived.txt",
+        self.informatie_object_file_archived = FileItem(
+            name="uploaded_document_title",
+            extension="txt",
             size=123,
             url=reverse(
                 "cases:document_download",
@@ -783,6 +795,7 @@ class TestCaseDetailView(
                     "api_group_id": self.api_group.id,
                 },
             ),
+            is_image=False,
             created=dateutil.parser.parse(
                 self.zaak_informatie_object_new["registratiedatum"]
             ),
@@ -1027,8 +1040,9 @@ class TestCaseDetailView(
             titel="uploaded_document_title.txt",
             bestandsomvang=123,
         )
-        self.informatie_object_file_alt = SimpleFile(
-            name="uploaded_document_title.txt",
+        self.informatie_object_file_alt = FileItem(
+            name="uploaded_document_title",
+            extension="txt",
             size=123,
             url=reverse(
                 "cases:document_download",
@@ -1038,6 +1052,7 @@ class TestCaseDetailView(
                     "api_group_id": self.api_group_alt.id,
                 },
             ),
+            is_image=False,
             created=dateutil.parser.parse(
                 self.zaak_informatie_object_new["registratiedatum"]
             ),
@@ -1689,9 +1704,9 @@ class TestCaseDetailView(
         self.assertEqual(len(documents), 3)
 
         # order should be reverse of list order from response
-        self.assertEqual(documents[0].name, self.informatie_object_2["titel"])
-        self.assertEqual(documents[1].name, self.informatie_object["titel"])
-        self.assertEqual(documents[1].name, self.informatie_object_archived["titel"])
+        self.assertEqual(documents[0].name, "another_document_title")
+        self.assertEqual(documents[1].name, "uploaded_document_title")
+        self.assertEqual(documents[1].name, "uploaded_document_title")
 
     def test_document_ordering_by_name(self, m):
         """
@@ -1749,9 +1764,9 @@ class TestCaseDetailView(
         documents = response.context.get("zaak")["documents"]
 
         # order of #1 and #2 should be reversed
-        self.assertEqual(documents[0].name, self.informatie_object_2["titel"])
-        self.assertEqual(documents[1].name, self.informatie_object["titel"])
-        self.assertEqual(documents[2].name, self.informatie_object_no_date["titel"])
+        self.assertEqual(documents[0].name, "another_document_title")
+        self.assertEqual(documents[1].name, "uploaded_document_title")
+        self.assertEqual(documents[2].name, "yet_another_document_title")
 
     @freeze_time("2021-01-12 17:00:00")
     def test_new_docs(self, m):

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -20,7 +20,7 @@ from zgw_consumers.constants import AuthTypes
 
 from open_inwoner.accounts.choices import LoginTypeChoices
 from open_inwoner.accounts.tests.factories import UserFactory
-from open_inwoner.cms.cases.views.status import SimpleFile
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.openzaak.clients import build_documenten_clients, build_zaken_clients
 from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
@@ -164,8 +164,9 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
             titel="",
             auteur="Open Inwoner Platform",
         )
-        self.informatie_object_file = SimpleFile(
-            name="my_document.txt",
+        self.informatie_object_file = FileItem(
+            name="",
+            extension="txt",
             size=len(self.informatie_object_content),
             url=reverse(
                 "cases:document_download",
@@ -175,6 +176,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
                     "api_group_id": self.api_group.id,
                 },
             ),
+            is_image=False,
         )
 
         #
@@ -248,8 +250,9 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
             titel="",
             auteur="Open Inwoner Platform",
         )
-        self.informatie_object_file_alt = SimpleFile(
-            name="my_alt_document.txt",
+        self.informatie_object_file_alt = FileItem(
+            name="",
+            extension="txt",
             size=len(self.informatie_object_content_alt),
             url=reverse(
                 "cases:document_download",
@@ -259,6 +262,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
                     "api_group_id": self.api_group_alt.id,
                 },
             ),
+            is_image=False,
         )
         self.zaak_informatie_object_alt = generate_oas_component_cached(
             "zrc",
@@ -381,7 +385,7 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
         self.assertEqual(log.content_object, self.user)
         expected = _("Document van zaak gedownload {case}: {filename}").format(
             case=self.zaak["identificatie"],
-            filename=self.informatie_object_file.name,
+            filename=self.informatie_object["bestandsnaam"],
         )
         self.assertEqual(log.extra_data["message"], expected)
 

--- a/src/open_inwoner/pdc/views.py
+++ b/src/open_inwoner/pdc/views.py
@@ -8,6 +8,7 @@ from django.views.generic import DetailView, FormView, ListView, TemplateView
 
 from view_breadcrumbs import BaseBreadcrumbMixin, ListBreadcrumbMixin
 
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.pdc.models.product import ProductCondition
 from open_inwoner.questionnaire.models import QuestionnaireStep
@@ -221,6 +222,9 @@ class ProductDetailView(
         context["related_products_start"] = 6 if product.links.exists() else 1
         context["product_links"] = product.links.order_by("pk")
         context["display_social"] = config.display_social
+        context["product_files"] = [
+            FileItem.from_filer_file(pf.file) for pf in product.files.all() if pf.file
+        ]
         return context
 
 

--- a/src/open_inwoner/questionnaire/tests/factories.py
+++ b/src/open_inwoner/questionnaire/tests/factories.py
@@ -3,6 +3,7 @@ from django.utils.text import slugify
 import factory
 
 from open_inwoner.questionnaire.models import QuestionnaireStep, QuestionnaireStepFile
+from open_inwoner.utils.tests.factories import FilerFileFactory
 
 
 class QuestionnaireStepFactory(factory.django.DjangoModelFactory):
@@ -28,6 +29,7 @@ class QuestionnaireStepFactory(factory.django.DjangoModelFactory):
 
 class QuestionnaireStepFileFactory(factory.django.DjangoModelFactory):
     questionnaire_step = factory.SubFactory(QuestionnaireStepFactory)
+    file = factory.SubFactory(FilerFileFactory)
 
     class Meta:
         model = QuestionnaireStepFile

--- a/src/open_inwoner/questionnaire/tests/test_models.py
+++ b/src/open_inwoner/questionnaire/tests/test_models.py
@@ -135,5 +135,5 @@ class QuestionnaireStepFileTestCase(TestCase):
         QuestionnaireStepFileFactory.create()
 
     def test_str(self):
-        questionnaire_step_file = QuestionnaireStepFileFactory.create()
+        questionnaire_step_file = QuestionnaireStepFileFactory.create(file=None)
         self.assertEqual(_("Geen bestand geselecteerd."), str(questionnaire_step_file))

--- a/src/open_inwoner/questionnaire/tests/test_views.py
+++ b/src/open_inwoner/questionnaire/tests/test_views.py
@@ -20,7 +20,7 @@ from open_inwoner.questionnaire.views import (
     QUESTIONNAIRE_SESSION_KEY,
     QuestionnaireStepView,
 )
-from open_inwoner.utils.test import SessionMiddleware
+from open_inwoner.utils.test import SessionMiddleware, temp_media_root
 
 from .factories import QuestionnaireStepFactory, QuestionnaireStepFileFactory
 
@@ -138,6 +138,7 @@ class QuestionnaireStepViewTestCase(TestCase):
         response = self.client.get(path)
         self.assertContains(response, "foo")
 
+    @temp_media_root()
     def test_render_file(self):
         root = QuestionnaireStepFactory.create(code="foo", slug="foo")
         QuestionnaireStepFileFactory.create(questionnaire_step=root)

--- a/src/open_inwoner/questionnaire/views.py
+++ b/src/open_inwoner/questionnaire/views.py
@@ -11,6 +11,7 @@ from django.views.generic import FormView, ListView, RedirectView, TemplateView
 from view_breadcrumbs import BaseBreadcrumbMixin
 
 from open_inwoner.accounts.models import Document
+from open_inwoner.components.file_item import FileItem
 from open_inwoner.utils.mixins import ExportMixin
 from open_inwoner.utils.views import CommonPageMixin, LogMixin
 
@@ -88,6 +89,16 @@ class QuestionnaireStepView(CommonPageMixin, BaseBreadcrumbMixin, FormView):
         instance = self.get_object()
 
         return {**super().get_form_kwargs(), "instance": instance}
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        instance = self.get_object()
+        context["questionnaire_files"] = [
+            FileItem.from_filer_file(step_file.file)
+            for step_file in instance.questionnairestepfile_set.all()
+            if step_file.file
+        ]
+        return context
 
     def form_valid(self, form: QuestionnaireStepForm):
         questionnaire_step = form.cleaned_data["answer"]

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -65,7 +65,7 @@
                         <h2 class="utrecht-heading-2 {% if zaak.new_docs %}indicator{% endif %}" id="documents">{% trans 'Eerder toegevoegde documenten' %}</h2>
                         {% if zaak.new_docs %}{% icon icon="fiber_manual_record" outlined=False extra_classes="file__file--recent" %}{% endif %}
                     </div>
-                    {% case_document_list zaak.documents %}
+                    {% file_list files=zaak.documents %}
                 </section>
             {% endif %}
 

--- a/src/open_inwoner/templates/pages/product/detail.html
+++ b/src/open_inwoner/templates/pages/product/detail.html
@@ -65,8 +65,8 @@
             {% include "components/Faq/Faq.html" with questions=object.question_set.all only %}
         {% endif %}
 
-        {% if object.files.exists %}
-            {% file_list files=object.files.all title=_("Bestanden") %}
+        {% if product_files %}
+            {% file_list files=product_files title=_("Bestanden") %}
         {% endif %}
 
         {# Conditions #}

--- a/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
+++ b/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
@@ -46,9 +46,9 @@
                     {{ form.instance.content|safe }}
                 {% endif %}
 
-                {% if form.instance.questionnairestepfile_set.exists %}
+                {% if questionnaire_files %}
                     <hr class="divider">
-                    {% file_list files=form.instance.questionnairestepfile_set.all title=_("Bestanden") %}
+                    {% file_list files=questionnaire_files title=_("Bestanden") %}
                 {% endif %}
 
                 {% if form.instance.related_products.published.exists %}

--- a/src/open_inwoner/utils/tests/factories.py
+++ b/src/open_inwoner/utils/tests/factories.py
@@ -1,7 +1,21 @@
 import factory
-from filer.models import Image as FilerImage
+from filer.models import File as FilerFile, Image as FilerImage
 
 from open_inwoner.accounts.tests.factories import UserFactory
+
+
+class FilerFileFactory(factory.django.DjangoModelFactory):
+    """
+    Use with temp_media_root decorator to store files in a temp location.
+
+    from open_inwoner.utils.test import temp_media_root
+    """
+
+    file = factory.django.FileField(filename="document.pdf", data=b"pdf content")
+    owner = factory.SubFactory(UserFactory)
+
+    class Meta:
+        model = FilerFile
 
 
 class FilerImageFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
In eSuite, uploaded documents can be converted to PDF/A, and some
gemeenten configure OIP to return this converted PDF via the ZGW API.
Because the document title was set to the full filename including
extension (e.g. foobar.docx), this caused a counterintuitive situation
where the document would download as a PDF despite the title suggesting
otherwise.

The fix strips the extension from the title on upload. No information is
lost: the original filename is stored separately on the document and
reflects the true source format. In eSuite installs with PDF/A
conversion enabled, the filename will already have been updated to
foobar.pdf, making the title-without-extension the correct neutral
representation in both cases.

This commit also takes the opportunity to generally clean up
the use of the file list/file tags. It moves the logic for building
the expected DTO objects in the views themselves, making the tag
logic simpler and dedicated to display concerns. Given the different
sources of file (Filer, Django File Field, ZGW API), it was quite
hard to follow what the expected types were and what edge cases
we had to consider. This change uses an explicit DTO with explicit
side-effect less conversion functions to make clear both the expected
shape and the point of conversion.

Closes: https://github.com/maykinmedia/open-inwoner/issues/2353