### PR TITLE
chore: bump typing-extensions to 4.15.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Onderhoud
   kwetsbaarheid in ``crit`` header te mitigeren.
 * [:gh:`2295`]: Zaken-kaartjes op de homepage gebruiken nu het ``arrow_forward`` icoon en hebben een gelijke hoogte.
 * [:gh:`2318`]: ``vitest`` en ``@vitest/ui`` bijgewerkt naar versie ``4.1.0``.
+* [:gh:`2372`]: ``typing-extensions`` bijgewerkt naar versie ``4.15.0``.
 
 2.1.0 (2026-03-04)
 ==================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -671,7 +671,7 @@ tinyhtml5==2.0.0
     # via weasyprint
 typer==0.21.1
     # via maykin-common
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via
     #   -r requirements/base.in
     #   elasticsearch

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1234,7 +1234,7 @@ typer==0.21.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-common
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1418,7 +1418,7 @@ typer==0.21.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-common
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

Pydantic <= 2.9 requires typing-extensions >= 4.12

## Checklist

- [x] CHANGELOG.rst updated

