### PR TITLE
fix: [#2331] don't let klant sync failures block user registration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Bugfixes
 * [:gh:`2384`]: Foutieve verwijzingen naar ``case`` (in plaats van ``zaak``) in de
   zaakstatus template zijn gecorrigeerd. Dit veroorzaakte onjuiste weergave van de
   afsluitende status, resultaatomschrijving en upload-knop in de zaakdetailpagina.
+* [:gh:`2331`]: Een fout bij het synchroniseren van gebruikersgegevens met eSuite of
+  OpenKlant2 tijdens registratie blokkeert de registratie niet langer. De fout wordt
+  gelogd en de registratie wordt succesvol afgerond.
 * [:gh:`2355`]: De importeer-views voor catalogus- en zaaktype-configuraties
   controleren nu of de gebruiker wijzigingsrechten heeft op het betreffende model,
   in plaats van enkel te vereisen dat de gebruiker een beheerdersaccount heeft.

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -2040,6 +2040,68 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
             user=user,
         )
 
+    @patch("open_inwoner.accounts.views.registration.OpenKlant2Service")
+    def test_openklant_service_exception_does_not_block_registration(
+        self, mock_service_class
+    ):
+        """An unexpected exception from the OpenKlant2 service must not block registration."""
+        OpenKlant2ConfigFactory()
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.OPENKLANT2.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        mock_service_class.return_value.get_or_create_partij_for_user.side_effect = (
+            Exception("unexpected error")
+        )
+
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+
+    @patch("open_inwoner.accounts.views.registration.eSuiteKlantenService")
+    def test_esuite_service_exception_does_not_block_registration(
+        self, mock_service_class
+    ):
+        """An unexpected exception from the eSuite service must not block registration."""
+        ESuiteConfigFactory()
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = KlantenServiceType.ESUITE.value
+        config.save()
+
+        user = UserFactory(
+            first_name="",
+            last_name="",
+            email="old@example.com",
+            login_type=LoginTypeChoices.digid,
+        )
+
+        mock_service_class.return_value.get_or_create_klant.side_effect = Exception(
+            "unexpected error"
+        )
+
+        response = self.app.get(self.url, user=user)
+        form = response.forms["necessary-form"]
+        form["email"] = "new@example.com"
+        form["first_name"] = "John"
+        form["last_name"] = "Doe"
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestLoginLogoutFunctionality(AssertRedirectsMixin, WebTest):

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -182,11 +182,21 @@ class NecessaryFieldsUserView(
         updated_openklant = False
 
         if klanten_config.has_api_service_configured(KlantenServiceType.ESUITE):
-            self.update_klant_via_esuite(form)
-            updated_esuite = True
+            try:
+                self.update_klant_via_esuite(form)
+                updated_esuite = True
+            except Exception:
+                logger.exception(
+                    "Failed to update klant via eSuite during registration"
+                )
         if klanten_config.has_api_service_configured(KlantenServiceType.OPENKLANT2):
-            self.update_klant_via_openklant(form)
-            updated_openklant = True
+            try:
+                self.update_klant_via_openklant(form)
+                updated_openklant = True
+            except Exception:
+                logger.exception(
+                    "Failed to update klant via OpenKlant2 during registration"
+                )
 
         invite = form.cleaned_data["invite"]
         if invite:


### PR DESCRIPTION
Wrap the eSuite and OpenKlant2 update calls in form_valid with a try/except so that unexpected exceptions are logged but do not propagate, allowing registration to complete successfully.

Closes: #2331

