### PR TITLE
feat: [#2363] notify both users when contact invitation is accepted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Deployment aandachtspunten
   aangezet. Host, poort en time-out zijn instelbaar via de beheeromgeving
   (standaardwaarden: host ``clamav``, poort ``3310``, time-out ``30``
   seconden).
+* [:gh:`2363`]: ``manage.py add_missing_templates`` is toegevoegd aan het
+  opstartsscript (``bin/docker_start.sh``) en wordt voortaan automatisch
+  uitgevoerd bij elke deploy.
 
 Nieuwe features
 ---------------
@@ -21,6 +24,10 @@ Nieuwe features
   siteconfiguratie en is van toepassing op alle bestandsuploads binnen de
   applicatie (zaken en plannen). Wanneer een geïnfecteerd bestand wordt
   gedetecteerd, wordt de upload geweigerd.
+* [:gh:`2363`]: Gebruikers ontvangen nu automatisch een e-mailnotificatie wanneer
+  een uitnodiging voor contact is geaccepteerd en de koppeling tot stand is gekomen.
+  Zowel de uitnodiger als de uitgenodigde ontvangen een bericht zodra ze aan elkaar
+  zijn gekoppeld als contactpersoon.
 
 Bugfixes
 --------

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -23,6 +23,10 @@ ${SCRIPTPATH}/wait_for_db.sh
 >&2 echo "Apply database migrations"
 python src/manage.py migrate
 
+# Ensure all mail-editor templates exist in the database
+>&2 echo "Loading mail templates"
+python src/manage.py add_missing_templates
+
 ##
 # uWSGI settings
 ##

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import F, Q, UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
@@ -1155,6 +1155,52 @@ class Invite(models.Model):
         }
 
         return template.send_email([self.invitee_email], context)
+
+    @transaction.atomic
+    def accept(self, user: "User") -> bool:
+        """
+        Mark the invite as accepted by user and establish the contact relationship.
+        Sends notification emails to both parties if this is a new connection.
+        Returns True if the connection was newly created, False if it already existed.
+        """
+        is_new = not self.accepted
+
+        if is_new:
+            self.accepted = True
+            self.invitee = user
+            self.save()
+
+        if not self.inviter.has_contact(user):
+            self.inviter.user_contacts.add(user)
+
+        if is_new:
+            self.send_accepted_emails()
+
+        return is_new
+
+    # Because django-yubin queues outgoing mails in the database, this ensures either
+    # all or none will be queued. The main call-site is in `accept()` which is also
+    # atomic, but it can't hurt to have an extra savepoint.
+    @transaction.atomic
+    def send_accepted_emails(self):
+        contacts_url = settings.BASE_URL + reverse("profile:contact_list")
+        template = find_template("contact_invitation_accepted")
+        template.send_email(
+            [self.inviter.email],
+            {
+                "contact_name": self.invitee.get_full_name(),
+                "email": self.inviter.email,
+                "contacts_link": contacts_url,
+            },
+        )
+        template.send_email(
+            [self.invitee.email],
+            {
+                "contact_name": self.inviter.get_full_name(),
+                "email": self.invitee.email,
+                "contacts_link": contacts_url,
+            },
+        )
 
     def get_absolute_url(self) -> str:
         return reverse("profile:invite_accept", kwargs={"key": self.key})

--- a/src/open_inwoner/accounts/tests/test_invite.py
+++ b/src/open_inwoner/accounts/tests/test_invite.py
@@ -1,10 +1,13 @@
 from datetime import timedelta
 
+from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from django_webtest import WebTest
+
+from open_inwoner.configurations.models import SiteConfiguration
 
 from .factories import InviteFactory, UserFactory
 
@@ -92,3 +95,58 @@ class InvitePageTests(WebTest):
             self.app.session["invite_url"],
             f"{reverse('django_registration_register')}?invite={invite.key}",
         )
+
+    def test_accepted_emails_sent_to_both_users_when_logged_in(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(inviter=inviter, invitee=invitee)
+        url = invite.get_absolute_url()
+
+        self.app.get(url, user=invitee)
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(inviter.email, recipients)
+        self.assertIn(invitee.email, recipients)
+
+    def test_accepted_emails_sent_to_both_users_via_registration(self):
+        config = SiteConfiguration.get_solo()
+        config.login_allow_registration = True
+        config.save()
+
+        inviter = UserFactory()
+        invite = InviteFactory.create(inviter=inviter)
+        url = f"{reverse('django_registration_register')}?invite={invite.key}"
+
+        page = self.app.get(url)
+        form = page.forms["registration-form"]
+        form["email"] = invite.invitee_email
+        form["first_name"] = invite.invitee_first_name
+        form["last_name"] = invite.invitee_last_name
+        form["password1"] = "SomePassword1!"
+        form["password2"] = "SomePassword1!"
+        form.submit()
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(inviter.email, recipients)
+        self.assertIn(invite.invitee_email, recipients)
+
+    def test_accepted_emails_sent_to_both_users_via_necessary_fields(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(
+            inviter=inviter,
+            invitee=invitee,
+            invitee_email=invitee.email,
+        )
+        url = f"{reverse('profile:registration_necessary')}?invite={invite.key}"
+
+        page = self.app.get(url, user=invitee)
+        form = page.forms["necessary-form"]
+        form["first_name"] = invitee.first_name
+        form["last_name"] = invitee.last_name
+        form["email"] = invitee.email
+        form.submit()
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(inviter.email, recipients)
+        self.assertIn(invitee.email, recipients)

--- a/src/open_inwoner/accounts/tests/test_models.py
+++ b/src/open_inwoner/accounts/tests/test_models.py
@@ -1,0 +1,50 @@
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from .factories import InviteFactory, UserFactory
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class InviteAcceptTests(TestCase):
+    def test_accept_establishes_contact_relationship(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(inviter=inviter, invitee=invitee)
+
+        result = invite.accept(invitee)
+
+        self.assertTrue(result)
+        self.assertIn(invitee, inviter.user_contacts.all())
+        self.assertIn(inviter, invitee.user_contacts.all())
+
+    def test_accept_returns_false_when_already_accepted(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(inviter=inviter, invitee=invitee)
+        invite.accept(invitee)
+
+        result = invite.accept(invitee)
+
+        self.assertFalse(result)
+
+    def test_send_accepted_emails_sends_to_both_parties(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(inviter=inviter, invitee=invitee)
+        invite.accept(invitee)
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(inviter.email, recipients)
+        self.assertIn(invitee.email, recipients)
+
+    def test_accepted_emails_not_sent_twice_on_double_accept(self):
+        inviter = UserFactory()
+        invitee = UserFactory()
+        invite = InviteFactory.create(inviter=inviter, invitee=invitee)
+
+        invite.accept(invitee)
+        count_after_first = len(mail.outbox)
+
+        invite.accept(invitee)
+
+        self.assertEqual(len(mail.outbox), count_after_first)

--- a/src/open_inwoner/accounts/views/invite.py
+++ b/src/open_inwoner/accounts/views/invite.py
@@ -52,12 +52,7 @@ class InviteAcceptView(LogMixin, CommonPageMixin, UpdateView):
 
         # mark invitation as accepted and add inviter to the user's contacts as well
         if user.is_authenticated and invite.accepted is False:
-            invite.accepted = True
-            invite.invitee = user
-            invite.save()
-
-            inviter = invite.inviter
-            user.user_contacts.add(inviter)
+            invite.accept(user)
             self.log_system_action(_("invitation automatically accepted"), invite)
 
             messages.add_message(
@@ -65,7 +60,7 @@ class InviteAcceptView(LogMixin, CommonPageMixin, UpdateView):
                 messages.SUCCESS,
                 _(
                     "{inviter} is toegevoegd aan uw contactpersonen.".format(
-                        inviter=inviter.email
+                        inviter=invite.inviter.email
                     )
                 ),
             )

--- a/src/open_inwoner/accounts/views/registration.py
+++ b/src/open_inwoner/accounts/views/registration.py
@@ -60,19 +60,6 @@ class InviteMixin(CommonPageMixin):
 
         return get_object_or_404(Invite, key=invite_key)
 
-    def add_invitee(self, invite, user):
-        """update invite and related contact"""
-        if not invite.invitee:
-            invite.accepted = True
-            invite.invitee = user
-            invite.save()
-
-        #  update inviter - invitee relationship
-        inviter_contacts = invite.inviter.user_contacts.all()
-        invitee = invite.invitee
-        if invitee not in inviter_contacts:
-            invite.inviter.user_contacts.add(invitee)
-
 
 class CustomRegistrationView(RegistrationLogMixin, InviteMixin, RegistrationView):
     form_class = CustomRegistrationForm
@@ -89,7 +76,7 @@ class CustomRegistrationView(RegistrationLogMixin, InviteMixin, RegistrationView
 
         invite = form.cleaned_data["invite"]
         if invite:
-            self.add_invitee(invite, user)
+            invite.accept(user)
             self.log_invite_accepted()
 
         # Remove invite url from user's session
@@ -200,7 +187,7 @@ class NecessaryFieldsUserView(
 
         invite = form.cleaned_data["invite"]
         if invite:
-            self.add_invitee(invite, user)
+            invite.accept(user)
 
         self.log_necessary_fields_completed(
             user,

--- a/src/open_inwoner/conf/parts/contact_invitation_accepted.html
+++ b/src/open_inwoner/conf/parts/contact_invitation_accepted.html
@@ -1,0 +1,57 @@
+<table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" class="table-mail">
+    <tbody>
+    <tr>
+        <td class="td-mail td__padding-all" colspan="6">
+            <p>Beste inwoner,</p>
+            <p>&nbsp;</p>
+            <p>U bent nu als contactpersoon gekoppeld aan {{ contact_name }} op {{
+            site_name }}. Dit betekent dat u samen aan een plan kunt gaan werken en
+            berichten kunt uitwisselen.</p>
+        </td>
+    </tr>
+    <tr>
+        <td class="td-mail td__padding-right td__padding-left" colspan="6">
+            <p><a href="{{ contacts_link }}" class="button--primary">Ga naar 'Mijn contacten'</a></p>
+        </td>
+    </tr>
+    <tr>
+        <td class="spacing__extra" colspan="6">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td class="td-mail td__padding-all" colspan="6">
+            <p>Met vriendelijke groet,</p>
+            <p>&nbsp;</p>
+            <p>{{ site_name }}</p>
+        </td>
+    </tr>
+    <tr class="tr-mail">
+        <td class="td-mail spacer-bottom td__padding-zero" colspan="6">
+            <!-- <hr> styling -->
+        </td>
+    </tr>
+    <tr>
+        <td class="td-mail td__padding-top td__padding-right td__padding-left" colspan="6">
+            <p>Dit bericht is automatisch verzonden. U kunt <strong>niet reageren</strong> op deze e-mail. </p>
+            <p>&nbsp;</p>
+            <p><strong>Contact opnemen</strong></p>
+        </td>
+    </tr>
+    <tr>
+        <td class="td--responsive td-mail td__padding-right td__padding-bottom td__padding-left td__leftcell" colspan="2"><p><a href="{{ contact_page }}">Ga naar onze contactpagina</a></p>
+        </td>
+        <td class="td--responsive td-mail td__padding-right td__padding-bottom td__padding-left td__rightcell td__nowrap" colspan="4"><p><a href="tel:{{ contact_phonenumber }}" data-rel="external">Bel {{ contact_phonenumber }}</a></p></td>
+    </tr>
+    <tr class="tr-mail border-top">
+        <td class="td-mail border-top td__padding-zero" colspan="6">
+            <!-- <hr> styling --> &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td class="td-mail td__padding-right td__padding-bottom td__padding-left" colspan="6">
+            <p>Pas hier uw <a href="{{ profile_notifications }}">voorkeuren</a> aan voor de meldingen. </p>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/open_inwoner/conf/parts/maileditor.py
+++ b/src/open_inwoner/conf/parts/maileditor.py
@@ -102,6 +102,57 @@ MAIL_EDITOR_CONF = {
             },
         ],
     },
+    "contact_invitation_accepted": {
+        "name": _("Contact Invitation Accepted Email"),
+        "description": _(
+            "This email is sent to both users when an invitation is accepted "
+            "and a contact connection is established."
+        ),
+        "subject_default": "U bent nu als contactpersoon gekoppeld op {{ site_name }}",
+        "body_default": _readfile("contact_invitation_accepted.html"),
+        "subject": [
+            {
+                "name": "site_name",
+                "description": _("Name of the site."),
+            },
+            {
+                "name": "contact_name",
+                "description": _("Full name of the newly connected contact."),
+            },
+        ],
+        "body": [
+            {
+                "name": "contact_name",
+                "description": _("Full name of the newly connected contact."),
+            },
+            {
+                "name": "site_name",
+                "description": _("Name of the site"),
+            },
+            {
+                "name": "contacts_link",
+                "description": _("Link to the contacts list page."),
+            },
+            {"name": "email", "description": _("Email of the recipient.")},
+            {
+                "name": "contact_page",
+                "description": _(
+                    "Link to contact page configured in Site Configuration"
+                ),
+            },
+            {
+                "name": "contact_phonenumber",
+                "description": _("The callable link to the configured phonenumber"),
+                "example": "14010",
+            },
+            {
+                "name": "profile_notifications",
+                "description": _(
+                    "The link to the notifications and unsubscribe settings"
+                ),
+            },
+        ],
+    },
     "new_messages": {
         "name": _("New Message Email"),
         "description": _(


### PR DESCRIPTION
When an invited user accepts a contact invitation — either by registering via the invite link or by visiting the link while already logged in — both the inviter and the invitee now receive an email notification confirming the new connection.

The connection logic is consolidated into a single Invite.accept(user) model method, replacing the duplicated inline code in InviteAcceptView and the now-removed InviteMixin.add_invitee(). Email sending is idempotent: notifications are only sent on the first acceptance, using the existing settings.BASE_URL so no request object needs to be threaded through to the model layer.

A new mail-editor template (contact_invitation_accepted) is introduced for the notification email, following the existing template conventions.

Closes #2363
