### PR TITLE
:art: [#2390] Fix warning banner text margin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,7 @@ Bugfixes
   maken had, niet het inloggen). Het alternatieve nummer wordt nu geleegd als het gelijk
   is aan het primaire nummer.
 * [:gh:`2378`]: Probleem opgelost waar markdown in ssd uitkering pdf niet correct wordt gerenderd.
+* [:gh:`2390`]: Probleem opgelost waarbij de hoogte van de waarschuwingsbanner onjuist werd weergegeven.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/components/WarningHeader/WarningHeader.scss
+++ b/src/open_inwoner/scss/components/WarningHeader/WarningHeader.scss
@@ -17,6 +17,10 @@
 
     .warning-header__text {
       padding: var(--spacing-tiny) 0 0 0;
+
+      p {
+        margin: 0;
+      }
     }
 
     *[class*='icons'],


### PR DESCRIPTION
## Summary

The content of the warning text is now wrapped inside multiple <p> tags. This is new behavior since the usage of prosemirror. CKEditor did not use multiple <p> tags.

## Issue References

- Github Issue: #2390

## Checklist

- [x] CHANGELOG.rst updated