### PR TITLE
[#2203] Replace all static utrecht-paragraphs with --nl web components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Deployment aandachtspunten
 
 Nieuwe features
 ---------------
+* [:gh:`2203`, :oip-nlds:`41`, :oip-nlds:`42`]: Alle utrecht paragrafen vervangen door 'nl' paragrafen
+  waardoor hun huisstijl overschrijfbaar wordt met de nieuwe candidate NL design-tokens.
 * [:gh:`2203`, :oip-nlds:`41`, :oip-nlds:`42`]: Nieuwe --nl NLDS prefix paragraph toegevoegd als
   web-component, zodat deze hergebruikt kan worden.
 * [:gh:`2211`]: Elasticsearch ondersteunt nu HTTP basic authenticatie via de

--- a/src/open_inwoner/accounts/templates/accounts/email_verification.html
+++ b/src/open_inwoner/accounts/templates/accounts/email_verification.html
@@ -8,7 +8,7 @@
         {% render_card tinted=True  %}
             {% get_solo 'configurations.SiteConfiguration' as config %}
             <h1 class="utrecht-heading-1">{% trans "E-mail is verzonden" %}</h1><br>
-            {% if verification_text %}<p class="utrecht-paragraph">{{ verification_text|linebreaksbr }}</p><br>{% endif %}
+            {% if verification_text %}<nl-paragraph>{{ verification_text|linebreaksbr }}</nl-paragraph><br>{% endif %}
             <form method="POST" id="email-verification-form" action="{{ request.get_full_path }}" class="form" novalidate>
                 {% csrf_token %}
                 {% form_actions primary_icon='arrow_forward' primary_text=button_text %}

--- a/src/open_inwoner/accounts/templates/accounts/invite_accept.html
+++ b/src/open_inwoner/accounts/templates/accounts/invite_accept.html
@@ -6,9 +6,9 @@
 <h1 class="utrecht-heading-1">
     {% trans "Accept an invitation" %}
 </h1>
-<p class="utrecht-paragraph">
+<nl-paragraph>
     {% blocktranslate with inviter_name=object.inviter.get_full_name %}Accept invitation from {{ inviter_name }} and join Open Inwoner Platform {% endblocktranslate %}
-</p>
+</nl-paragraph>
 
 {% render_form id="invite-form" method="POST" form=form extra_classes="form--flex" %}
     {% csrf_token %}

--- a/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
+++ b/src/open_inwoner/accounts/templates/accounts/registration_necessary.html
@@ -7,7 +7,7 @@
         {% render_column start=5 span=5 %}
             {% get_solo 'configurations.SiteConfiguration' as config %}
             <h1 class="utrecht-heading-1">{% trans "Registratie voltooien" %}</h1><br>
-            {% if config.registration_text %}<p class="utrecht-paragraph">{{ config.registration_text|urlize|linebreaksbr }}</p>{% endif %}
+            {% if config.registration_text %}<nl-paragraph>{{ config.registration_text|urlize|linebreaksbr }}</nl-paragraph>{% endif %}
             <form method="POST" id="necessary-form" action="{{ request.get_full_path }}" class="form form__choice-list" novalidate>
                 {% csrf_token %}
 

--- a/src/open_inwoner/accounts/templates/django_registration/registration_complete.html
+++ b/src/open_inwoner/accounts/templates/django_registration/registration_complete.html
@@ -3,5 +3,5 @@
 
 {% block content %}
 <h1 class="utrecht-heading-1">{% trans "Succes" %}</h1>
-<p class="utrecht-paragraph">{% trans "U bent nu geregistreerd" %}</p>
+<nl-paragraph>{% trans "U bent nu geregistreerd" %}</nl-paragraph>
 {% endblock content %}

--- a/src/open_inwoner/accounts/templates/registration/add_phone_number_1.html
+++ b/src/open_inwoner/accounts/templates/registration/add_phone_number_1.html
@@ -4,14 +4,14 @@
 {% block content %}
     {{ block.super }}
 
-    <p class="utrecht-paragraph">
+    <nl-paragraph>
         {% blocktrans trimmed %}
             Het nummer van uw mobiele telefoon is nog niet bij de Open Inwoner Platform bekend
             en is nodig voor toegang tot deze website.
         {% endblocktrans %}
         {% trans 'Vul alstublieft het nummer van uw mobiele telefoon in. ' %}
         {% trans 'U ontvangt nadat u op <em>bevestigen</em> klikt een SMS bericht met daarin een code.' %}
-    </p>
+    </nl-paragraph>
 
     {% render_form id="add-phonenumber-1-form" form=wizard.form no_action=True method="POST" %}
         {% csrf_token %}

--- a/src/open_inwoner/accounts/templates/registration/add_phone_number_2.html
+++ b/src/open_inwoner/accounts/templates/registration/add_phone_number_2.html
@@ -4,11 +4,11 @@
 {% block content %}
     {{ block.super }}
 
-    <p class="utrecht-paragraph">
+    <nl-paragraph>
         {% trans 'U ontvangt een SMS bericht op uw mobiele telefoon nummer met daarin een code. ' %}
         {% trans 'Vul hieronder de code in. Geen bericht ontvangen? ' %}
         {% trans 'Kies <em>Vorige</em> om uw telefoon nummer te controleren en eventueel aan te passen.' %}
-    </p>
+    </nl-paragraph>
 
     {% render_form id="add-phonenumber-2-form" form=wizard.form no_action=True method="POST" %}
         {% csrf_token %}

--- a/src/open_inwoner/accounts/templates/registration/verify_token.html
+++ b/src/open_inwoner/accounts/templates/registration/verify_token.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <h2 class="utrecht-heading-2">{% trans 'Account verificatie' %}</h2>
-    <p class="utrecht-paragraph">
+    <nl-paragraph>
         {% blocktrans trimmed %}
             U ontvangt binnen 1 minuut een sms-bericht op uw mobiele telefoon.
             Vul de code die in het bericht staat hieronder in en klik op
@@ -11,7 +11,7 @@
             Mocht het niet lukken om de code binnen deze tijd in te voeren, klik
             dan op <em>Verstuur nieuwe SMS</em>.
         {% endblocktrans %}
-    </p>
+    </nl-paragraph>
 
     {% render_form id="verify-token-form" form=form no_action=True method="POST" %}
         {% csrf_token %}

--- a/src/open_inwoner/components/templates/components/Action/Actions.html
+++ b/src/open_inwoner/components/templates/components/Action/Actions.html
@@ -7,7 +7,7 @@
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
         <div class="actions__filter-container filter__container">
-            <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
+            <nl-paragraph>{% trans "Filter op:" %}</nl-paragraph>
             {% date_field action_form.end_date no_label=True no_help=True icon="today" %}
             {% input action_form.is_for no_label=True no_help=True icon="person" %}
             {% input action_form.status no_label=True no_help=True icon="expand_more" %}
@@ -24,7 +24,7 @@
                         </h3>
                     </section>
                     {% if action.description %}
-                        <p class="utrecht-paragraph">{{ action.description }}</p>
+                        <nl-paragraph>{{ action.description }}</nl-paragraph>
                     {% endif %}
                     {% if action.file %}
                         {% url "profile:action_download" uuid=action.uuid as download_url %}
@@ -94,7 +94,7 @@
                 {% endif %}
             </div>
         {% empty %}
-            <div class="table__item"><p class="utrecht-paragraph"><strong>{% trans "er zijn geen acties gevonden met de huidige filters of er zijn geen acties" %}</strong></p></div>
+            <div class="table__item"><nl-paragraph><strong>{% trans "er zijn geen acties gevonden met de huidige filters of er zijn geen acties" %}</strong></nl-paragraph></div>
         {% endfor %}
     </div>
     {% if actions|length > 3 %}

--- a/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
+++ b/src/open_inwoner/components/templates/components/Card/DescriptionCard.html
@@ -8,7 +8,7 @@
                 <span class="link link__text">{{ title }}</span>
             </h2>
         {% endif %}
-        <p class="utrecht-paragraph">{{ description }}</p>
+        <nl-paragraph>{{ description }}</nl-paragraph>
         {% if object.end_date %}
             <div class="card__tabled">
                 <div>{% trans "Einddatum" %}:</div>

--- a/src/open_inwoner/components/templates/components/Card/LocationCard.html
+++ b/src/open_inwoner/components/templates/components/Card/LocationCard.html
@@ -5,8 +5,8 @@
         <h3 class="utrecht-heading-3 card__heading-3">{% link href=location.get_absolute_url primary=True text=location_name %}</h3>
     {% endif %}
         <div class="card__body--flex container--no-margin">
-            <p class="utrecht-paragraph">{{ address_line_1 }}</p>
-            <p class="utrecht-paragraph">{{ address_line_2 }}</p>
+            <nl-paragraph>{{ address_line_1 }}</nl-paragraph>
+            <nl-paragraph>{{ address_line_2 }}</nl-paragraph>
             {% if phonenumber %}
                 {% link href='tel:'|addstr:phonenumber secondary=True text=phonenumber %}
             {% endif %}

--- a/src/open_inwoner/components/templates/components/Card/ProductCard.html
+++ b/src/open_inwoner/components/templates/components/Card/ProductCard.html
@@ -15,7 +15,7 @@
             <div class="card__content">
             <h2 class="card__heading-2"><span class="link link__text">{{ title }}</span></h2>
     {% endif %}
-            <p class="utrecht-paragraph">{{ description }}</p>
+            <nl-paragraph>{{ description }}</nl-paragraph>
             {% if object.end_date %}
             <div class="card__tabled">
                 <div>{% trans "Einddatum" %}:</div>

--- a/src/open_inwoner/components/templates/components/Contact/ContactForm.html
+++ b/src/open_inwoner/components/templates/components/Contact/ContactForm.html
@@ -26,9 +26,9 @@
                 {% if form_object.captcha %}
                     <div class="form__control ">
                         <div class="captcha">
-                            <p class="utrecht-paragraph">
+                            <nl-paragraph>
                                 {{ form_object.captcha.label }}<span class="label__label--required"> * </span>
-                            </p>
+                            </nl-paragraph>
                             <label class="label captcha__label">
                                 <span class="captcha__check">
                                     {{ form_object.request_session.captcha_question }}

--- a/src/open_inwoner/components/templates/components/File/FileList.html
+++ b/src/open_inwoner/components/templates/components/File/FileList.html
@@ -14,7 +14,7 @@
                 {% file_item file_info allow_delete=allow_delete show_download=show_download %}
             </li>
         {% empty %}
-            <li><p class="utrecht-paragraph">{% trans "Er zijn nog geen bestanden geüpload" %}</p></li>
+            <li><nl-paragraph>{% trans "Er zijn nog geen bestanden geüpload" %}</nl-paragraph></li>
         {% endfor %}
     </ul>
 </div>

--- a/src/open_inwoner/components/templates/components/Form/Autocomplete.html
+++ b/src/open_inwoner/components/templates/components/Form/Autocomplete.html
@@ -10,7 +10,7 @@
         <input id="{{ field.auto_id }}-autocomplete" name="{{ field.name }}-autocomplete" class="input" type="search" spellcheck=false autocomplete="off" autocapitalize="off" {% include "django/forms/widgets/attrs.html" with widget=field.field.widget %}>
 
         {% if field.help_text %}
-            <p class="utrecht-paragraph">{{ field.help_text }}</p>
+            <nl-paragraph>{{ field.help_text }}</nl-paragraph>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/DateField.html
+++ b/src/open_inwoner/components/templates/components/Form/DateField.html
@@ -6,7 +6,7 @@
         {% if not no_label %}{{ field.label }}{% endif %}
         {{ field|addclass:"input datefield" }}
         {% if field.help_text and not no_help %}
-            <p class="utrecht-paragraph">{{ field.help_text }}</p>
+            <nl-paragraph>{{ field.help_text }}</nl-paragraph>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/ImageCrop.html
+++ b/src/open_inwoner/components/templates/components/Form/ImageCrop.html
@@ -5,7 +5,7 @@
         {{ field.label }}
         {{ field|addclass:"image-ratio" }}
         {% if field.help_text and not no_help %}
-            <p class="utrecht-paragraph">{{ field.help_text }}</p>
+            <nl-paragraph>{{ field.help_text }}</nl-paragraph>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Input.html
+++ b/src/open_inwoner/components/templates/components/Form/Input.html
@@ -9,7 +9,7 @@
         </span>
         {% field_as_widget field "input" form_id %}
         {% if field.help_text and not no_help %}
-            <p class="utrecht-paragraph">{{ field.help_text }}</p>
+            <nl-paragraph>{{ field.help_text }}</nl-paragraph>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/MultipleCheckbox.html
+++ b/src/open_inwoner/components/templates/components/Form/MultipleCheckbox.html
@@ -8,7 +8,7 @@
     </div>
 
     {% if field.help_text %}
-        <p class="utrecht-paragraph">{{ field.help_text }}</p>
+        <nl-paragraph>{{ field.help_text }}</nl-paragraph>
     {% endif %}
 
     {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/MultipleRadio.html
+++ b/src/open_inwoner/components/templates/components/Form/MultipleRadio.html
@@ -15,7 +15,7 @@
     </fieldset>
 
     {% if field.help_text %}
-        <p class="utrecht-paragraph">{{ field.help_text }}</p>
+        <nl-paragraph>{{ field.help_text }}</nl-paragraph>
     {% endif %}
 
     {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Form/Textarea.html
+++ b/src/open_inwoner/components/templates/components/Form/Textarea.html
@@ -5,7 +5,7 @@
         {% firstof field.label label %}
         {{ field|addclass:"textarea" }}
         {% if field.help_text %}
-            <p class="utrecht-paragraph">{{ field.help_text }}</p>
+            <nl-paragraph>{{ field.help_text }}</nl-paragraph>
         {% endif %}
 
         {% if field.errors %}

--- a/src/open_inwoner/components/templates/components/Header/AccessibilitySkipLink.html
+++ b/src/open_inwoner/components/templates/components/Header/AccessibilitySkipLink.html
@@ -1,9 +1,9 @@
 {% load i18n link_tags %}
 
-<p class="utrecht-paragraph">
+<nl-paragraph>
     {% trans "Doorgaan naar hoofdinhoud" as link_text %}
  <a href="#content" class="utrecht-skip-link utrecht-skip-link--visible-on-focus utrecht-skip-link--focus-visible" aria-label="{{ link_text }}" title="{{ link_text }}">
     <span class="skip-link__text">{{ link_text }}</span>
     <span aria-hidden="true" class="material-icons ">south</span>
     </a>
-</p>
+</nl-paragraph>

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -106,7 +106,7 @@
             </section>
 
             <section class="accessibility-header__mobilenav">
-                <p class="utrecht-paragraph">Toegankelijkheid:</p>
+                <nl-paragraph>Toegankelijkheid:</nl-paragraph>
                 {% accessibility_header request=request desktop=False %}
                 <span class="spacer"></span>
             </section>

--- a/src/open_inwoner/components/templates/components/List/ListItem.html
+++ b/src/open_inwoner/components/templates/components/List/ListItem.html
@@ -5,7 +5,7 @@
     {% if strong %}
         <p class="utrecht-heading-4">{{ text }}</p>
     {% else %}
-        <p class="utrecht-paragraph">{{ text }}</p>
+        <nl-paragraph>{{ text }}</nl-paragraph>
     {% endif %}
     {% if description %}<p class="utrecht-paragraph utrecht-paragraph--oip utrecht-paragraph--oip-muted">{{ description }}</p>{% endif %}
     {% if href %}</a>{% endif %}

--- a/src/open_inwoner/components/templates/components/Messages/Message.html
+++ b/src/open_inwoner/components/templates/components/Messages/Message.html
@@ -7,7 +7,7 @@
             {% url "inbox:download" uuid=message.uuid as download_url %}
             {% link href=download_url text=message.file secondary=True download=True %}
         {% else %}
-            <p class="utrecht-paragraph">{{ message.content|linebreaksbr }}</p>
+            <nl-paragraph>{{ message.content|linebreaksbr }}</nl-paragraph>
         {% endif %}
     </div>
 

--- a/src/open_inwoner/components/templates/components/Notification/Notification.html
+++ b/src/open_inwoner/components/templates/components/Notification/Notification.html
@@ -15,7 +15,7 @@
             role="status"
          {% endif %} tabindex="-1">
         {% if title %}<h2 class="utrecht-heading-2">{{ title }}</h2>{% endif %}
-        {% if notification %}<p class="utrecht-paragraph">{{ notification }}</p>{% endif %}
+        {% if notification %}<nl-paragraph>{{ notification }}</nl-paragraph>{% endif %}
         {% if action %}{% button href=action text=action_text %}{% endif %}
         {% if contents %}
             {{ contents }}

--- a/src/open_inwoner/components/templates/components/Product/finder.html
+++ b/src/open_inwoner/components/templates/components/Product/finder.html
@@ -2,7 +2,7 @@
 
 {% render_column span=6 compact=True extra_classes="product-finder" %}
     <h2 class="utrecht-heading-2">{{configurable_text.home_page.home_product_finder_title}}</h2>
-    <p class="utrecht-paragraph">{{configurable_text.home_page.home_product_finder_intro|linebreaksbr}}</p>
+    <nl-paragraph>{{configurable_text.home_page.home_product_finder_intro|linebreaksbr}}</nl-paragraph>
 
     <div class="product-finder__form">
         {% if not conditions_done %}

--- a/src/open_inwoner/openklant/tests/test_cms_plugins.py
+++ b/src/open_inwoner/openklant/tests/test_cms_plugins.py
@@ -58,10 +58,12 @@ class ContactFormPluginRenderTest(TestCase):
         )
 
         self.assertIn(
-            f'<p class="utrecht-paragraph">{description_authenticated_user}</p>', html
+            f'<nl-paragraph><p class="nl-paragraph">{description_authenticated_user}</p></nl-paragraph>',
+            html,
         )
         self.assertNotIn(
-            f'<p class="utrecht-paragraph">{description_anonymous_user}</p>', html
+            f'<nl-paragraph><p class="nl-paragraph">{description_anonymous_user}</p></nl-paragraph>',
+            html,
         )
 
     def test_contact_form_plugin_anonymous_user(self):
@@ -93,8 +95,10 @@ class ContactFormPluginRenderTest(TestCase):
         )
 
         self.assertNotIn(
-            f'<p class="utrecht-paragraph">{description_authenticated_user}</p>', html
+            f'<nl-paragraph><p class="nl-paragraph">{description_authenticated_user}</p></nl-paragraph>',
+            html,
         )
         self.assertIn(
-            f'<p class="utrecht-paragraph">{description_anonymous_user}</p>', html
+            f'<nl-paragraph><p class="nl-paragraph">{description_anonymous_user}</p></nl-paragraph>',
+            html,
         )

--- a/src/open_inwoner/openklant/tests/test_cms_plugins.py
+++ b/src/open_inwoner/openklant/tests/test_cms_plugins.py
@@ -58,11 +58,11 @@ class ContactFormPluginRenderTest(TestCase):
         )
 
         self.assertIn(
-            f'<nl-paragraph><p class="nl-paragraph">{description_authenticated_user}</p></nl-paragraph>',
+            f'<p class="nl-paragraph">{description_authenticated_user}</p>',
             html,
         )
         self.assertNotIn(
-            f'<nl-paragraph><p class="nl-paragraph">{description_anonymous_user}</p></nl-paragraph>',
+            f'<p class="nl-paragraph">{description_anonymous_user}</p>',
             html,
         )
 
@@ -95,10 +95,10 @@ class ContactFormPluginRenderTest(TestCase):
         )
 
         self.assertNotIn(
-            f'<nl-paragraph><p class="nl-paragraph">{description_authenticated_user}</p></nl-paragraph>',
+            f'<p class="nl-paragraph">{description_authenticated_user}</p>',
             html,
         )
         self.assertIn(
-            f'<nl-paragraph><p class="nl-paragraph">{description_anonymous_user}</p></nl-paragraph>',
+            f'<p class="nl-paragraph">{description_anonymous_user}</p>',
             html,
         )

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -1623,7 +1623,7 @@ class TestCaseDetailView(
         response = self.app.get(self.case_detail_url, user=self.user)
 
         # Assert link is rendered with correct classes (get_rendered_content adds them)
-        self.assertContains(response, '<p class="utrecht-paragraph">')
+        self.assertContains(response, '<p class="nl-paragraph">')
         self.assertContains(
             response, '<a class="link link--secondary" href="https://example.com">'
         )
@@ -2456,9 +2456,9 @@ class TestCaseDetailView(
         self.assertEqual(info_card.text.strip(), "info\nFoobar")
 
         # Regression test: verify HTML tags are rendered with classes, not escaped
-        # get_rendered_content adds "utrecht-paragraph" class to <p> tags
-        self.assertContains(response, '<p class="utrecht-paragraph">Foo</p>')
-        self.assertContains(response, '<p class="utrecht-paragraph">bar</p>')
+        # get_rendered_content adds "nl-paragraph" class to <p> tags
+        self.assertContains(response, '<p class="nl-paragraph">Foo</p>')
+        self.assertContains(response, '<p class="nl-paragraph">bar</p>')
         self.assertNotContains(response, "&lt;p&gt;")
 
     def test_document_upload_description_prosemirror_html_assignment(self, m):
@@ -2503,8 +2503,8 @@ class TestCaseDetailView(
         )
 
         # Verify HTML is rendered with classes, not escaped
-        # get_rendered_content adds "utrecht-paragraph" class to <p> tags
-        self.assertContains(response, '<p class="utrecht-paragraph">')
+        # get_rendered_content adds "nl-paragraph" class to <p> tags
+        self.assertContains(response, '<p class="nl-paragraph">')
         self.assertContains(response, "<strong>Important:</strong>")
         self.assertContains(response, "<em>all required documents</em>")
         # get_rendered_content adds "link link--secondary" class to external links

--- a/src/open_inwoner/react/components/KVKBranchSelector/KVKBranchSelector.tsx
+++ b/src/open_inwoner/react/components/KVKBranchSelector/KVKBranchSelector.tsx
@@ -10,6 +10,7 @@ import {
 } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useIntl } from 'react-intl';
+import { Paragraph } from '../Paragraph';
 
 export interface ComboBoxItem {
   id: string;
@@ -321,13 +322,10 @@ const KVKBranchSelector: AC<KVKBranchSelectorProps> = ({
         className="utrecht-form-field utrecht-form-field--text"
         ref={containerRef}
       >
-        <p
-          className="utrecht-paragraph"
-          style={{ color: 'var(--color-red-notification)' }}
-        >
+        <Paragraph style={{ color: 'var(--color-red-notification)' }}>
           Er is een probleem opgetreden bij het laden van de vestigingen.
           Probeer de pagina te vernieuwen.
-        </p>
+        </Paragraph>
       </div>
     );
   }

--- a/src/open_inwoner/scss/components/Typography/P.scss
+++ b/src/open_inwoner/scss/components/Typography/P.scss
@@ -69,10 +69,24 @@ body [class^='utrecht-heading'] + .utrecht-paragraph,
   }
 }
 
+/// Web components
+
 // Context styles for elements that directly follow the web component paragraph
 
 // Home page plug-ins
 nl-paragraph + .card-container,
 nl-paragraph + .map {
   margin-block-start: var(--spacing-large);
+}
+
+/// HTML only
+
+// Product pages
+
+.nl-paragraph + .card-container {
+  margin-block-start: var(--spacing-large);
+}
+
+.nl-paragraph + .nl-paragraph {
+  margin-block-start: var(--font-line-height-body);
 }

--- a/src/open_inwoner/templates/404.html
+++ b/src/open_inwoner/templates/404.html
@@ -7,5 +7,5 @@
 
 {% block content %}
 <h1 class="utrecht-heading-1">{% trans "Sorry, the requested page could not be found (404)" %}</h1>
-<p class="utrecht-paragraph">{% link href="/" text=_("Ga naar de home pagina") %}</p>
+<nl-paragraph>{% link href="/" text=_("Ga naar de home pagina") %}</nl-paragraph>
 {% endblock content %}

--- a/src/open_inwoner/templates/cms/cms_flatpage.html
+++ b/src/open_inwoner/templates/cms/cms_flatpage.html
@@ -1,4 +1,4 @@
 {% load render_tags cms_tags %}
 
 <h1 class="utrecht-heading-1">{{ cms_flatpage_plugin.title }}</h1>
-<p class="utrecht-paragraph">{{ cms_flatpage_plugin.content|prosemirror_content|safe }}</p>
+<nl-paragraph>{{ cms_flatpage_plugin.content|prosemirror_content|safe }}</nl-paragraph>

--- a/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
+++ b/src/open_inwoner/templates/cms/collaborate/active_plans_plugin.html
@@ -11,8 +11,8 @@
                 {% render_card image_object_fit="cover" href=plan.get_absolute_url %}
                 <div class="card__content">
                     <h3 class="utrecht-heading-3 card__heading-3 plan-list">{{ plan.title }}</h3>
-                    <p class="utrecht-paragraph">{{ plan.goal|truncatewords:20 }}</p>
-                    <p class="utrecht-paragraph">{{ plan.description|truncatewords:20 }}</p>
+                    <nl-paragraph>{{ plan.goal|truncatewords:20 }}</nl-paragraph>
+                    <nl-paragraph>{{ plan.description|truncatewords:20 }}</nl-paragraph>
                     <span class="spacer"></span>
                     <span class="button button--icon-before button--transparent">
                     {% icon icon="arrow_forward" outlined=True %}
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
         {% else %}
-            <p class="utrecht-paragraph">{{ configurable_text.plans_page.plans_no_plans_message }}</p>
+            <nl-paragraph>{{ configurable_text.plans_page.plans_no_plans_message }}</nl-paragraph>
         {% endif %}
     </section>
 {% endif %}

--- a/src/open_inwoner/templates/cms/contactform/form_inner.html
+++ b/src/open_inwoner/templates/cms/contactform/form_inner.html
@@ -1,6 +1,6 @@
 {% load cms_tags i18n render_tags %}
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Contactformulier" %}</h1>
-    <p class="utrecht-paragraph">{{ form_description|prosemirror_content|safe }}</p>
+    <nl-paragraph>{{ form_description|prosemirror_content|safe }}</nl-paragraph>
     {% include "components/Contact/ContactForm.html" with form_object=form has_form_configuration=has_form_configuration csrf_token=csrf_token only %}
 {% endblock content %}

--- a/src/open_inwoner/templates/cms/contactform/form_inner.html
+++ b/src/open_inwoner/templates/cms/contactform/form_inner.html
@@ -1,6 +1,6 @@
 {% load cms_tags i18n render_tags %}
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Contactformulier" %}</h1>
-    <nl-paragraph>{{ form_description|prosemirror_content|safe }}</nl-paragraph>
+    <div>{{ form_description|prosemirror_content|safe }}</div>
     {% include "components/Contact/ContactForm.html" with form_object=form has_form_configuration=has_form_configuration csrf_token=csrf_token only %}
 {% endblock content %}

--- a/src/open_inwoner/templates/cms/fullwidth.html
+++ b/src/open_inwoner/templates/cms/fullwidth.html
@@ -34,7 +34,7 @@
                         {% if not request.user.is_authenticated %}
                             <section class="grid__welcome">
                                 <h1 class="utrecht-heading-1">{{ configurable_text.home_page.home_welcome_title }}</h1>
-                                <p class="utrecht-paragraph">{{ configurable_text.home_page.home_welcome_intro|linebreaksbr }}</p>
+                                <nl-paragraph>{{ configurable_text.home_page.home_welcome_intro|linebreaksbr }}</nl-paragraph>
                             </section>
                         {% else %}
                             {% placeholder 'banner_text' %}

--- a/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
+++ b/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
@@ -8,9 +8,9 @@
             {% for step in steps %}
             <li>
                 <h4>{% trans "Question:" %}</h4>
-                <p class="utrecht-paragraph">{{ step.question }}</p>
+                <nl-paragraph>{{ step.question }}</nl-paragraph>
                 <h4>{% trans "Answer:" %}</h4>
-                <p class="utrecht-paragraph">{{ step.answer }}</p>
+                <nl-paragraph>{{ step.answer }}</nl-paragraph>
             </li>
             {% endfor %}
         </ol>
@@ -18,14 +18,14 @@
 
     <div class="qa_results">
         <h4 class="utrecht-heading-4">{{ last_step.question }}</h4>
-        <p class="utrecht-paragraph">{{ last_step.content.html|safe}}</p>
+        <nl-paragraph>{{ last_step.content.html|safe}}</p>
         {% if related_products.exists %}
             <h4>{% trans "Related products:" %}</h4>
             <ol>
                 {% for product in related_products %}
                 <li>
                     <h4>{{ product.name }}</h4>
-                    <p class="utrecht-paragraph">{{ product.summary }}</p>
+                    <nl-paragraph>{{ product.summary }}</p>
                 </li>
                 {% endfor %}
             </ol>

--- a/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
+++ b/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
@@ -18,14 +18,14 @@
 
     <div class="qa_results">
         <h4 class="utrecht-heading-4">{{ last_step.question }}</h4>
-        <nl-paragraph>{{ last_step.content.html|safe}}</p>
+        <nl-paragraph>{{ last_step.content.html|safe}}</nl-paragraph>
         {% if related_products.exists %}
             <h4>{% trans "Related products:" %}</h4>
             <ol>
                 {% for product in related_products %}
                 <li>
                     <h4>{{ product.name }}</h4>
-                    <nl-paragraph>{{ product.summary }}</p>
+                    <nl-paragraph>{{ product.summary }}</nl-paragraph>
                 </li>
                 {% endfor %}
             </ol>

--- a/src/open_inwoner/templates/flatpages/default.html
+++ b/src/open_inwoner/templates/flatpages/default.html
@@ -5,5 +5,5 @@
 
 {% block content %}
   <h1 class="utrecht-heading-1">{{ flatpage.title }}</h1>
-  <p class="utrecht-paragraph">{{ flatpage.content|prosemirror_content|safe }}</p>
+  <nl-paragraph>{{ flatpage.content|prosemirror_content|safe }}</nl-paragraph>
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/cases/403.html
+++ b/src/open_inwoner/templates/pages/cases/403.html
@@ -1,4 +1,4 @@
 {% load i18n link_tags %}
 
 <h1 class="utrecht-heading-1">{% trans "Sorry, you don't have access to this page (403)" %}</h1>
-<p class="utrecht-paragraph">{% link href="pages-root" text=_("Ga naar de home pagina") %}</p>
+<nl-paragraph>{% link href="pages-root" text=_("Ga naar de home pagina") %}</nl-paragraph>

--- a/src/open_inwoner/templates/pages/cases/contact_form.html
+++ b/src/open_inwoner/templates/pages/cases/contact_form.html
@@ -1,13 +1,13 @@
 {% load i18n form_tags button_tags icon_tags %}
 
 <h2 class="utrecht-heading-2" id="contact">{% trans 'Stel een vraag' %}</h2>
-<p class="utrecht-paragraph">
+<nl-paragraph>
     {% blocktrans trimmed %}
     Door middel van dit formulier kunt u een vraag stellen over deze zaak.
     U dient ten minste uw telefoonnummer of uw e-mailadres in te vullen.
     Indien u uw e-mailadres invult krijgt u een bevestiging per mail.
     {% endblocktrans %}
-</p>
+</nl-paragraph>
 
 {% render_form form=contact_form method="POST" id="contact-form" hxpost=hxpost_contact_action hxtarget="#cases-contact-form" extra_classes="contact-form" %}
     {% csrf_token %}

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -38,7 +38,7 @@
 <div class="card__grid">
 {% render_grid %}
     {% if not zaken %}
-        <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen lopende zaken." %}</strong></p>
+        <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen lopende zaken." %}</strong></nl-paragraph>
     {% endif %}
 
     {% for zaak in zaken %}

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -1,7 +1,7 @@
 {% load link_tags button_tags i18n grid_tags icon_tags list_tags pagination_tags utils %}
 
 {% if fetch_error %}
-    <p class="utrecht-paragraph">{% trans "Er is iets misgegaan bij het ophalen van uw zaken. Ververs de pagina of probeer het later opnieuw." %}</p>
+    <nl-paragraph>{% trans "Er is iets misgegaan bij het ophalen van uw zaken. Ververs de pagina of probeer het later opnieuw." %}</nl-paragraph>
 {% else %}
 
 <h1 class="utrecht-heading-1" id="cases">{{ page_title }} ({{ paginator.count }})</h1>
@@ -38,7 +38,7 @@
 <div class="card__grid">
 {% render_grid %}
     {% if not zaken %}
-        <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen lopende zaken." %}</strong></p>
+        <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen lopende zaken." %}</strong></p>
     {% endif %}
 
     {% for zaak in zaken %}

--- a/src/open_inwoner/templates/pages/cases/status_inner.html
+++ b/src/open_inwoner/templates/pages/cases/status_inner.html
@@ -49,9 +49,9 @@
             {% elif zaak.external_upload_enabled %}
                 <h2 class="utrecht-heading-2" id="documents-upload">{% trans "Document toevoegen" %}</h2>
                 {% if zaak.case_type_config_description %}
-                    <p class="utrecht-paragraph">{{ zaak.case_type_config_description }}</p>
+                    <nl-paragraph>{{ zaak.case_type_config_description }}</nl-paragraph>
                 {% else %}
-                    <p class="utrecht-paragraph">{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</p>
+                    <nl-paragraph>{% trans "By clicking the button below you can upload a document. This is an external link and you will be redirected to a different system." %}</nl-paragraph>
                 {% endif %}
                 {% button_row %}
                     {% button href=zaak.external_upload_url text=_("Document uploaden") title=_("Opens new window") primary=True icon="open_in_new" icon_position="after" %}
@@ -93,6 +93,6 @@
         {% endrender_column %}
     {% endrender_grid %}
 {% else %}
-    <p class="utrecht-paragraph"><strong>{% trans 'There is no available data at the moment.' %}</strong></p>
+    <nl-paragraph><strong>{% trans 'There is no available data at the moment.' %}</strong></nl-paragraph>
 {% endif %}
 </div>

--- a/src/open_inwoner/templates/pages/category/list.html
+++ b/src/open_inwoner/templates/pages/category/list.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="categories__content">
     <h1 class="utrecht-heading-1">{{configurable_text.theme_page.theme_title}}</h1>
-    <p class="utrecht-paragraph">{{configurable_text.theme_page.theme_intro|linebreaksbr}}</p>
+    <nl-paragraph>{{configurable_text.theme_page.theme_intro|linebreaksbr}}</nl-paragraph>
 
     {% include "components/Card/CardContainer.html" with categories=object_list only %}
 </div>

--- a/src/open_inwoner/templates/pages/contactmoment/detail.html
+++ b/src/open_inwoner/templates/pages/contactmoment/detail.html
@@ -42,6 +42,6 @@
         {% endrender_grid %}
 
     {% else %}
-        <p class="utrecht-paragraph"><strong>{% trans 'There is no available data at the moment.' %}</strong></p>
+        <nl-paragraph><strong>{% trans 'There is no available data at the moment.' %}</strong></nl-paragraph>
     {% endif %}
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -14,12 +14,12 @@
         <div class="form-container">
             <div class="form-heading">
                 <h2 class="utrecht-heading-2">{% trans "Stel een vraag" %}</h2>
-                <p class="utrecht-paragraph">
+                <nl-paragraph>
                 {% blocktrans trimmed %}
                     Heeft u een vraag? Dan kunt u deze hier stellen.
                     Een van onze medewerkers beantwoord uw vraag z.s.m.
                 {% endblocktrans %}
-                </p>
+                </nl-paragraph>
             </div>
             <div class="button-row">
                 {% button href="#question-form" text=_("Stel een vraag") title=_("Stel een vraag") primary=True icon="arrow_downward" icon_position="after" %}
@@ -33,7 +33,7 @@
         {% if paginator.count %}
             <h2 class="contactmomenten__title">{% trans "Eerder gestelde vragen" %}</h2>
         {% else %}
-            <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></p>
+            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></p>
         {% endif %}
 
         {% render_grid %}
@@ -78,7 +78,7 @@
         <div class="form-container">
             <div class="form-heading">
                 <h2 class="utrecht-heading-2">{% trans "Stel een vraag" %}</h2>
-                <p class="utrecht-paragraph">
+                <nl-paragraph>
                 {% blocktrans trimmed %}
                     Heeft u een vraag? Dan kunt u deze hier stellen.
                     Een van onze medewerkers beantwoord uw vraag z.s.m.

--- a/src/open_inwoner/templates/pages/contactmoment/list.html
+++ b/src/open_inwoner/templates/pages/contactmoment/list.html
@@ -33,7 +33,7 @@
         {% if paginator.count %}
             <h2 class="contactmomenten__title">{% trans "Eerder gestelde vragen" %}</h2>
         {% else %}
-            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></p>
+            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen vragen." %}</strong></nl-paragraph>
         {% endif %}
 
         {% render_grid %}
@@ -83,7 +83,7 @@
                     Heeft u een vraag? Dan kunt u deze hier stellen.
                     Een van onze medewerkers beantwoord uw vraag z.s.m.
                 {% endblocktrans %}
-                </p>
+                </nl-paragraph>
             </div>
             <div>
                 {% url 'cases:contactmoment_list' as from_action %}

--- a/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
+++ b/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
@@ -11,8 +11,10 @@
     {% render_grid %}
         {% render_column start=1 span=12 %}
             <h1 class="utrecht-heading-1" id="title">{{ page_heading }}</h1>
+            foo bar
             {% if page_description %}
                 <p class="utrecht-paragraph utrecht-paragraph--lead">{{ page_description }}</p>
+                <nl-paragraph purpose="lead">{{ page_description }}</nl-paragraph>
             {% endif %}
             {% if filter_options %}
                 {# Filter Component #}
@@ -43,7 +45,7 @@
                     </oip-accordion>
                 </article>
             {% empty %}
-                <p class="utrecht-paragraph">{% trans "Geen afvalgegevens beschikbaar." %}</p>
+                <nl-paragraph>{% trans "Geen afvalgegevens beschikbaar." %}</nl-paragraph>
             {% endfor %}
         {% endrender_column %}
     {% endrender_grid %}

--- a/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
+++ b/src/open_inwoner/templates/pages/mijn_afval/afval-profiel.html
@@ -11,7 +11,6 @@
     {% render_grid %}
         {% render_column start=1 span=12 %}
             <h1 class="utrecht-heading-1" id="title">{{ page_heading }}</h1>
-            foo bar
             {% if page_description %}
                 <p class="utrecht-paragraph utrecht-paragraph--lead">{{ page_description }}</p>
                 <nl-paragraph purpose="lead">{{ page_description }}</nl-paragraph>

--- a/src/open_inwoner/templates/pages/plans/create-with-template.html
+++ b/src/open_inwoner/templates/pages/plans/create-with-template.html
@@ -19,7 +19,7 @@
                         {% csrf_token %}
                         {% date_field form.end_date icon="calendar_today" icon_position="after" %}
                         <div class="plan__contacts">
-                            <p class="utrecht-paragraph">Contactpersoon</p>
+                            <nl-paragraph>Contactpersoon</nl-paragraph>
                             {% checkboxes form.plan_contacts %}
                         </div>
                         <div>

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -28,7 +28,7 @@
 
                         {% date_field form.end_date icon="calendar_today" icon_position="after" %}
                         <div class="plan__contacts">
-                            <p class="utrecht-paragraph">Contactpersoon</p>
+                            <nl-paragraph>Contactpersoon</nl-paragraph>
                             {% checkboxes form.plan_contacts %}
                         </div>
 

--- a/src/open_inwoner/templates/pages/plans/create.html
+++ b/src/open_inwoner/templates/pages/plans/create.html
@@ -28,7 +28,7 @@
 
                         {% date_field form.end_date icon="calendar_today" icon_position="after" %}
                         <div class="plan__contacts">
-                            <nl-paragraph>Contactpersoon</nl-paragraph>
+                            <nl-paragraph>{% trans 'Contactpersoon' %}</nl-paragraph>
                             {% checkboxes form.plan_contacts %}
                         </div>
 

--- a/src/open_inwoner/templates/pages/plans/detail.html
+++ b/src/open_inwoner/templates/pages/plans/detail.html
@@ -60,11 +60,11 @@
         </div>
         <div class="tabled__inner">
             <h3 class="utrecht-heading-3">{% trans "Doel" %}</h3>
-            <p class="utrecht-paragraph">{{ object.goal|linebreaksbr }}</p>
+            <nl-paragraph>{{ object.goal|linebreaksbr }}</nl-paragraph>
 
             {% if object.description %}
                 <h3 class="utrecht-heading-3" id="description">{% trans "Description" %}</h3>
-                <p class="utrecht-paragraph">{{ object.description|linebreaksbr }}</p>
+                <nl-paragraph>{{ object.description|linebreaksbr }}</nl-paragraph>
             {% endif %}
         </div>
     </section>
@@ -123,13 +123,13 @@
         <div class="tabled__inner">
         {% if object.note %}
             <div class="wysiwyg">
-                <p class="utrecht-paragraph">{{ object.note|linebreaksbr }}</p>
+                <nl-paragraph>{{ object.note|linebreaksbr }}</nl-paragraph>
             </div>
         {% else %}
-            <p class="utrecht-paragraph"><strong>{% trans "Er zijn nog geen notities toegevoegd." %}</strong></p>
-            <p class="utrecht-paragraph--oip">
+            <nl-paragraph><strong>{% trans "Er zijn nog geen notities toegevoegd." %}</strong></nl-paragraph>
+            <nl-paragraph>
                 {% trans "Klik op 'Bewerk' om een nieuwe notitie toe te voegen. Deze kan later nog worden aangevuld." %}
-            </p>
+            </nl-paragraph>
         {% endif %}
         </div>
     </section>

--- a/src/open_inwoner/templates/pages/plans/goal_edit.html
+++ b/src/open_inwoner/templates/pages/plans/goal_edit.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Doel en omschrijving aanpassen" %}</h1>
-    <p class="utrecht-paragraph">
+    <nl-paragraph>
         {{configurable_text.plans_page.plans_edit_message}}
-    </p>
+    </nl-paragraph>
 
     {% render_grid %}
         {% render_column start=4 span=6 %}

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -25,7 +25,7 @@
                     {% button text=_("Filter") type="button" bordered=True %}
                 </div>
                 <div class="plan-filter__container filter__container">
-                    <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
+                    <nl-paragraph>{% trans "Filter op:" %}</nl-paragraph>
                     {% input plan_filter_form.plan_contacts no_label=True no_help=True icon="person" %}
                     {% input plan_filter_form.status no_label=True no_help=True icon="expand_more" %}
                     <div class="plan-filter__search-container">
@@ -74,7 +74,7 @@
         {% if plans.plan_list %}
             {% include "components/Card/CardContainer.html" with plans=plans.plan_list columns=2 only %}
         {% else %}
-            <p class="utrecht-paragraph"><strong>{% trans "U heeft op dit moment nog geen samenwerkingsplannen." %}</strong></p>
+            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen samenwerkingsplannen." %}</strong></p>
         {% endif %}
     {% endif %}
 

--- a/src/open_inwoner/templates/pages/plans/list.html
+++ b/src/open_inwoner/templates/pages/plans/list.html
@@ -74,7 +74,7 @@
         {% if plans.plan_list %}
             {% include "components/Card/CardContainer.html" with plans=plans.plan_list columns=2 only %}
         {% else %}
-            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen samenwerkingsplannen." %}</strong></p>
+            <nl-paragraph><strong>{% trans "U heeft op dit moment nog geen samenwerkingsplannen." %}</strong></nl-paragraph>
         {% endif %}
     {% endif %}
 

--- a/src/open_inwoner/templates/pages/plans/note_edit.html
+++ b/src/open_inwoner/templates/pages/plans/note_edit.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Notitie maken en aanvullen" %}</h1>
-    <p class="utrecht-paragraph">
+    <nl-paragraph>
         {% trans "Voeg een notitie toe en/of vul een bestaande notitie aan met nieuwe tekst." %}
-    </p>
+    </nl-paragraph>
 
     {% render_grid %}
         {% render_column start=4 span=7 %}

--- a/src/open_inwoner/templates/pages/product/detail.html
+++ b/src/open_inwoner/templates/pages/product/detail.html
@@ -150,7 +150,7 @@
 
                                 {% if contact.email %}
                                     {% render_column span=6 %}
-                                        <p class="utrecht-paragraph">{{ contact.organization|default:_('E-mail')}}</p>
+                                        <nl-paragraph>{{ contact.organization|default:_('E-mail')}}</nl-paragraph>
                                     {% endrender_column %}
 
                                     {% render_column start=7 span=6 %}

--- a/src/open_inwoner/templates/pages/product/finder.html
+++ b/src/open_inwoner/templates/pages/product/finder.html
@@ -17,7 +17,7 @@
                     </li>
 		{% empty %}
 		<li class="product-filter__item">
-		  <p class="utrecht-paragraph">{% trans "Geen producten gevonden" %}</p>
+		  <nl-paragraph>{% trans "Geen producten gevonden" %}</nl-paragraph>
 		</li>
                 {% endfor %}
             </ul>

--- a/src/open_inwoner/templates/pages/product/location_detail.html
+++ b/src/open_inwoner/templates/pages/product/location_detail.html
@@ -9,16 +9,16 @@
         <div class="location__details">
             <div class="location__address">
                 {% if object.address_line_1 %}
-                    <p class="utrecht-paragraph">{{ object.address_line_1 }}</p>
+                    <nl-paragraph>{{ object.address_line_1 }}</nl-paragraph>
                 {% endif %}
-                <p class="utrecht-paragraph">{{ object.address_line_2 }}</p>
+                <nl-paragraph>{{ object.address_line_2 }}</nl-paragraph>
             </div>
             <div class="location__contact">
                 {% if object.phonenumber %}
-                    <p class="utrecht-paragraph">{{ object.phonenumber }}</p>
+                    <nl-paragraph>{{ object.phonenumber }}</nl-paragraph>
                 {% endif %}
                 {% if object.email %}
-                    <p class="utrecht-paragraph">{{ object.email }}</p>
+                    <nl-paragraph>{{ object.email }}</nl-paragraph>
                 {% endif %}
             </div>
         </div>

--- a/src/open_inwoner/templates/pages/profile/appointments.html
+++ b/src/open_inwoner/templates/pages/profile/appointments.html
@@ -43,7 +43,7 @@
     {% endrender_grid %}
     </div>
 {% else %}
-    <p class="utrecht-paragraph"><strong>{% trans "Geen afspraken beschikbaar" %}</strong></p>
+    <nl-paragraph><strong>{% trans "Geen afspraken beschikbaar" %}</strong></nl-paragraph>
 {% endif %}
 
 {% endblock %}

--- a/src/open_inwoner/templates/pages/profile/categories.html
+++ b/src/open_inwoner/templates/pages/profile/categories.html
@@ -5,9 +5,9 @@
 <h1 class="utrecht-heading-1" id="title">
     {% trans "Mijn Interessegebieden" %}
 </h1>
-<p class="utrecht-paragraph">
+<nl-paragraph>
     {% trans "Selecteer hier welke onderwerpen u interesseren, om op maat gemaakte inhoud voorgeschoteld te krijgen en nog beter te kunnen zoeken en vinden" %}
-</p>
+</nl-paragraph>
 
 {% form form_object=form method="POST" id="change-categories" submit_text=_("Opslaan") secondary_href='profile:detail' secondary_text=_('Terug') secondary_icon='arrow_backward' secondary_icon_position="before" extra_classes="select-grid" %}
 {% endblock content %}

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -25,7 +25,7 @@
                 <div class="approval__single">
                     <nl-paragraph>
                         {% blocktrans with full_name=pending_approval.get_full_name %}{{ full_name }} wil u toevoegen als contactpersoon.{% endblocktrans %}
-                    </p>
+                    </nl-paragraph>
                     {% url 'profile:contact_approval' uuid=pending_approval.uuid as approval_url %}
                     {% render_form form=None method="POST" form_action=approval_url id="approval_form" spaceless=True show_notifications=True %}
                         {% csrf_token %}
@@ -40,7 +40,7 @@
                 <ul class="approval__list">
                     {% for approval in pending_approvals %}
                         <li class="approval__list-item">
-                            <nl-paragraph>{{approval.get_full_name}}</p>
+                            <nl-paragraph>{{approval.get_full_name}}</nl-paragraph>
                             {% url 'profile:contact_approval' uuid=approval.uuid as approval_url %}
                             {% render_form form=None method="POST" form_action=approval_url id="approval_form" spaceless=True show_notifications=True %}
                                 {% csrf_token %}
@@ -74,7 +74,7 @@
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
         <div class="contacts__filter-container filter__container">
-            <nl-paragraph>{% trans "Filter op:" %}</p>
+            <nl-paragraph>{% trans "Filter op:" %}</nl-paragraph>
             {% input form.type no_label=True no_help=True icon="expand_more" class="label input" id="id_type" %}
         </div>
     </div>
@@ -87,7 +87,9 @@
                 <td class="table__item">{% trans "Soort contact" %}</td>
                 <td class="table__item">{% trans "E-mailadres" %}</td>
                 <td class="table__item">{% trans "Telefoonnummer" %}</td>
-		<td class="table__item" {% if inbox_page_is_published %}colspan="2" {% else %}colspan="1"{% endif %}{% trans "Actief" %}&nbsp;</td>
+                <td class="table__item" {% if inbox_page_is_published %}colspan="2"{% else %}colspan="1"{% endif %}>
+                    {% trans "Actief" %}&nbsp;
+                </td>
                 <td class="table__item">&nbsp;</td>
             </tr>
         </thead>

--- a/src/open_inwoner/templates/pages/profile/contacts/list.html
+++ b/src/open_inwoner/templates/pages/profile/contacts/list.html
@@ -18,12 +18,12 @@
         <div class="approval">
             <div class="approval__header">
                 <h2 class="utrecht-heading-2">{% trans "U bent toegevoegd als contactpersoon" %}</h2>
-                <p class="utrecht-paragraph">{% trans "By accepting you agree on sharing your personal data (first name, last name and phonenumber)." %}</p>
+                <nl-paragraph>{% trans "By accepting you agree on sharing your personal data (first name, last name and phonenumber)." %}</nl-paragraph>
             </div>
             {% if approvals_count == 1 %}
                 {% with pending_approvals.get as pending_approval %}
                 <div class="approval__single">
-                    <p class="utrecht-paragraph">
+                    <nl-paragraph>
                         {% blocktrans with full_name=pending_approval.get_full_name %}{{ full_name }} wil u toevoegen als contactpersoon.{% endblocktrans %}
                     </p>
                     {% url 'profile:contact_approval' uuid=pending_approval.uuid as approval_url %}
@@ -40,7 +40,7 @@
                 <ul class="approval__list">
                     {% for approval in pending_approvals %}
                         <li class="approval__list-item">
-                            <p class="utrecht-paragraph">{{approval.get_full_name}}</p>
+                            <nl-paragraph>{{approval.get_full_name}}</p>
                             {% url 'profile:contact_approval' uuid=approval.uuid as approval_url %}
                             {% render_form form=None method="POST" form_action=approval_url id="approval_form" spaceless=True show_notifications=True %}
                                 {% csrf_token %}
@@ -74,7 +74,7 @@
             {% button text=_("Filter") type="button" bordered=True %}
         </div>
         <div class="contacts__filter-container filter__container">
-            <p class="utrecht-paragraph">{% trans "Filter op:" %}</p>
+            <nl-paragraph>{% trans "Filter op:" %}</p>
             {% input form.type no_label=True no_help=True icon="expand_more" class="label input" id="id_type" %}
         </div>
     </div>

--- a/src/open_inwoner/templates/pages/profile/me.html
+++ b/src/open_inwoner/templates/pages/profile/me.html
@@ -152,7 +152,7 @@
                 <h2 class="utrecht-heading-2" id="newsletters">{% trans "Nieuwsbrieven" %}</h2>
             </header>
         </div>
-            <p class="utrecht-paragraph">{% trans "Vink de nieuwsbrieven aan die u wilt ontvangen. Wilt u een nieuwsbrief niet meer ontvangen? Haal het vinkje dan weg. Sla daarna uw keuze op." %}</p>
+            <nl-paragraph>{% trans "Vink de nieuwsbrieven aan die u wilt ontvangen. Wilt u een nieuwsbrief niet meer ontvangen? Haal het vinkje dan weg. Sla daarna uw keuze op." %}</nl-paragraph>
             <form method="POST" id="newsletter-form" class="form" novalidate>
                 {% csrf_token %}
                 {% with form.fields.newsletters.remarks_mapping as remarks_mapping %}
@@ -358,9 +358,9 @@
             </header>
         </div>
             <div class="tabled">
-                <p class="utrecht-paragraph">
+                <nl-paragraph>
                     {% trans "Wilt u uw profiel verwijderen? Dan worden al uw persoonlijke voorkeuren verwijderd binnen deze MijnOmgeving. Uw persoonsgegevens en uw zaken worden niet verwijderd." %}
-                </p>
+                </nl-paragraph>
             </div>
             {% render_form form=form method="POST" id="delete-form" extra_classes="confirm" spaceless=True data_confirm_title=_("Weet u zeker dat u uw profiel wilt verwijderen?") data_confirm_text=_("Hiermee worden alleen uw persoonlijke voorkeuren binnen deze MijnOmgeving verwijderd. Uw persoonsgegevens en uw zaken worden niet verwijderd.") data_confirm_cancel=_("Nee, annuleren") data_confirm_default=_("Ja, verwijderen") %}
             {% csrf_token %}

--- a/src/open_inwoner/templates/pages/profile/mydata.html
+++ b/src/open_inwoner/templates/pages/profile/mydata.html
@@ -12,10 +12,10 @@
             {% trans "Persoonlijke gegevens" %}
         </h1>
 
-        <p class="utrecht-paragraph">
+        <nl-paragraph>
             {% trans "Hier ziet u een beperkte set van gegevens die van u zijn opgeslagen in de Basisregistratie Personen (BRP). Al uw persoonlijke gegevens kunt u vinden op " %}
             {% link href="https://mijn.overheid.nl" text="mijn.overheid.nl" primary=True %}
-        </p>
+        </nl-paragraph>
 
         <!-- BRP personal data -->
         {% with request.user as user %}

--- a/src/open_inwoner/templates/pages/profile/notifications.html
+++ b/src/open_inwoner/templates/pages/profile/notifications.html
@@ -15,7 +15,7 @@
             <ul class="choice-list choice-list-multiple">
 
             <h3 class="utrecht-heading-3">{% trans "Ontvang berichten over" %}</h3>
-                <p class="utrecht-paragraph">{% trans "Kies voor welk onderwerp u meldingen wilt ontvangen" %}</p>
+                <nl-paragraph>{% trans "Kies voor welk onderwerp u meldingen wilt ontvangen" %}</nl-paragraph>
 
                 {% if form.cases_notifications %}
                     <li class="choice-list-multiple__item">

--- a/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
+++ b/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
@@ -14,7 +14,7 @@
             </header>
 
             {% if form.instance.get_description %}
-                <p class="utrecht-paragraph">{{ form.instance.get_description }}</p>
+                <nl-paragraph>{{ form.instance.get_description }}</nl-paragraph>
             {% endif %}
 
             {% step_indicator form.instance.depth form.instance.depth object_list=form.instance.get_tree_path object_list_str='question_subject' %}

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -100,7 +100,7 @@
                         {% if configurable_text.search_page.search_zero_results_text.html %}
                             {{ configurable_text.search_page.search_zero_results_text.html|safe }}
                         {% else %}
-                            <p class="utrecht-paragraph">{% trans "Probeer het nog eens met deze tips:" %}</p>
+                            <nl-paragraph>{% trans "Probeer het nog eens met deze tips:" %}</nl-paragraph>
                             <ul class="ul">
                                 <li class="li">{% trans "Zorg ervoor dat alle woorden goed gespeld zijn." %}</li>
                                 <li class="li">{% trans "Probeer andere zoektermen." %}</li>

--- a/src/open_inwoner/templates/registration/password_change_done.html
+++ b/src/open_inwoner/templates/registration/password_change_done.html
@@ -3,5 +3,5 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset was successful" %}</h1>
-    <p class="utrecht-paragraph">{% trans "Your password has been changed." %}</p>
+    <nl-paragraph>{% trans "Your password has been changed." %}</nl-paragraph>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_change_form.html
+++ b/src/open_inwoner/templates/registration/password_change_form.html
@@ -11,7 +11,7 @@
         {% render_column start=0 span=8 %}
 
             <h1 class="utrecht-heading-1">{% trans "Password reset" %}</h1>
-            <p class="utrecht-paragraph">{% trans "For security reasons, please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
+            <nl-paragraph>{% trans "For security reasons, please enter your old password and your new password twice so we can make sure you have not made any typo." %}</nl-paragraph>
 
             {% render_form id="password-change-form" method="POST" form=form %}
                 {% csrf_token %}

--- a/src/open_inwoner/templates/registration/password_reset_complete.html
+++ b/src/open_inwoner/templates/registration/password_reset_complete.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset complete" %}</h1>
-    <p class="utrecht-paragraph">{% trans "Your password has been set. You can now continue and log in." %}</p>
+    <nl-paragraph>{% trans "Your password has been set. You can now continue and log in." %}</nl-paragraph>
 
     {% with login_url as login_url %}
-        <p class="utrecht-paragraph">{% button href=login_url text=_("Log in") primary=True %}</p>
+        <nl-paragraph>{% button href=login_url text=_("Log in") primary=True %}</nl-paragraph>
     {% endwith %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_confirm.html
+++ b/src/open_inwoner/templates/registration/password_reset_confirm.html
@@ -4,10 +4,10 @@
 {% block content %}
     {% if validlink %}
         <h1 class="utrecht-heading-1">{% trans "Enter new password" %}</h1>
-        <p class="utrecht-paragraph">{% trans "Please enter your old password and your new password twice so we can make sure you have not made any typo." %}</p>
+        <nl-paragraph>{% trans "Please enter your old password and your new password twice so we can make sure you have not made any typo." %}</nl-paragraph>
         {% form form_object=form method="POST" submit_text=_('Change my password') id="password-reset-confirm" %}
     {% else %}
         <h1 class="utrecht-heading-1">{% trans "Password reset failed" %}</h1>
-        <p class="utrecht-paragraph">{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>
+        <nl-paragraph>{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</nl-paragraph>
     {% endif %}
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_done.html
+++ b/src/open_inwoner/templates/registration/password_reset_done.html
@@ -3,6 +3,6 @@
 
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans "Password reset email sent" %}</h1>
-    <p class="utrecht-paragraph">{% trans "We have sent you instructions on how to set your password, if an account exists with the email address you entered. You should receive this shortly." %}</p>
-    <p class="utrecht-paragraph">{% trans "If you did not receive an email, please make sure you entered the email address you registered with and check your spam folder." %}</p>
+    <nl-paragraph>{% trans "We have sent you instructions on how to set your password, if an account exists with the email address you entered. You should receive this shortly." %}</nl-paragraph>
+    <nl-paragraph>{% trans "If you did not receive an email, please make sure you entered the email address you registered with and check your spam folder." %}</nl-paragraph>
 {% endblock content %}

--- a/src/open_inwoner/templates/registration/password_reset_form.html
+++ b/src/open_inwoner/templates/registration/password_reset_form.html
@@ -6,8 +6,8 @@
     {% render_grid %}
         {% render_column start=0 span=6 %}
             <h1 class="utrecht-heading-1">{% trans "Reset password" %}</h1>
-            <p class="utrecht-paragraph">{% trans "Forgot your password? Enter your email address below. Then you will receive an email with instructions to set a new password." %}</p>
-            <p class="utrecht-paragraph">{% trans "Please note: this only works if you do are not using DigiD to log in." %}</p>
+            <nl-paragraph>{% trans "Forgot your password? Enter your email address below. Then you will receive an email with instructions to set a new password." %}</nl-paragraph>
+            <nl-paragraph>{% trans "Please note: this only works if you do are not using DigiD to log in." %}</nl-paragraph>
 
             {% render_form id="password-reset-form" method="POST" form=form %}
                 {% csrf_token %}

--- a/src/open_inwoner/utils/html.py
+++ b/src/open_inwoner/utils/html.py
@@ -13,7 +13,7 @@ CLASS_ADDERS = [
     ("h6", "utrecht-heading-6"),
     ("img", "image"),
     ("li", "li"),
-    ("p", "utrecht-paragraph"),
+    ("p", "nl-paragraph"),
     ("a", "link link--secondary"),
     ("table", "table table--content"),
     ("thead", "table__heading"),

--- a/src/open_inwoner/utils/tests/test_product_content_rendering.py
+++ b/src/open_inwoner/utils/tests/test_product_content_rendering.py
@@ -28,7 +28,7 @@ class GetProductRenderedContentTest(TestCase):
         html = str(rendered)
 
         # Check that paragraph has proper class
-        self.assertIn('class="utrecht-paragraph"', html)
+        self.assertIn('class="nl-paragraph"', html)
         self.assertIn("This is a test paragraph", html)
 
     def test_renders_ctabutton_with_link(self):


### PR DESCRIPTION
## Summary

To keep the number of file-changes limited, this PR only changes all of the static utrecht-paragraphs with the new `--nl` candidate web component.
So not yet making changes for the muted/compact/small variants (!)

### Notable things

- Some Django tests won't be able to test rendered javascript and can only test for the existence of the surrounding `<nl-paragraph>` web component ,so won't be able to detect the `<p class="nl-paragraph">` element inside.
- In `src/open_inwoner/utils/html.py` we need to change the classes for WYSIWYG elements from rich text editors, those are not web components, just P-tags that need a class.
- most changes in this PR are an easy find-all-and-replace-all change where all utrecht paragraphs are replaced with the NL web component, so not yet changing all the paragraphs with modifiers (will be a separate PR because it required tokens changing)
- no changes in the Paragraph.tsx here, but once the Shadow DOM PR #2310 has been merged I will add a new issue for updating the paragraph component accordingly for Storybook testing etc.

## Issue References

No changes in design tokens package needed for this PR.

## Checklist

- [x] CHANGELOG.rst updated
