### PR TITLE
fix: [#2398] use standard logout URL for DigiD when OIDC is disabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,11 @@ Bugfixes
   is aan het primaire nummer.
 * [:gh:`2378`]: Probleem opgelost waar markdown in ssd uitkering pdf niet correct wordt gerenderd.
 * [:gh:`2390`]: Probleem opgelost waarbij de hoogte van de waarschuwingsbanner onjuist werd weergegeven.
+* [:gh:`2398`]: Probleem opgelost waarbij DigiD-gebruikers na uitloggen werden
+  doorgestuurd naar een niet-bestaande URL wanneer OIDC niet was ingeschakeld. Omdat de
+  single logout-functie van DigiD SAML is komen te vervallen, wordt de DigiD-sessie niet
+  langer actief beëindigd en worden gebruikers nu correct doorgestuurd naar de standaard
+  uitlogpagina.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -684,7 +684,9 @@ class User(AbstractBaseUser, PermissionsMixin):
                 return (
                     reverse("digid_oidc:logout")
                     if OpenIDDigiDConfig.get_solo().enabled
-                    else reverse("digid:logout")
+                    # Digid no longer supports rp-initiated logout, so we don't worry
+                    # about clearing the DigiD session, and just kill our own session.
+                    else reverse("logout")
                 )
             case LoginTypeChoices.eherkenning:
                 return reverse("eherkenning_oidc:logout")

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -109,9 +109,7 @@ class ProfileViewTests(WebTest):
                 mock_solo.return_value.enabled = oidc_enabled
 
                 logout_url = (
-                    reverse("digid_oidc:logout")
-                    if oidc_enabled
-                    else reverse("digid:logout")
+                    reverse("digid_oidc:logout") if oidc_enabled else reverse("logout")
                 )
 
                 response = self.app.get(self.url, user=self.digid_user)

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -185,7 +185,7 @@ class UserTests(TestCase):
 
         # Test with OIDC disabled
         mock_digid_config.get_solo.return_value.enabled = False
-        self.assertEqual(user.get_logout_url(), reverse("digid:logout"))
+        self.assertEqual(user.get_logout_url(), reverse("logout"))
 
     def test_get_logout_url_returns_correct_option_for_login_type(self):
         test_cases = [


### PR DESCRIPTION
DigiD SAML single logout has been deprecated, so the rp-initiated logout URL is no longer valid. Fall back to the standard logout URL instead of the (non-existent) DigiD SAML logout endpoint.

Closes: #2398
