### PR TITLE
PP-400: Upgrade to Django 5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,9 @@ Onderhoud
 
 * [:gh:`2414`]: ClamAV Python-client (``clamd``) toegevoegd.
 * [:gh:`2455`]: ``django-admin-index`` bijgewerkt naar versie ``4.0.0``.
+* [:gh:`2366`, :gh:`2371`]: ``Django`` bijgewerkt naar versie ``5.2``, samen met
+  ``easy-thumbnails`` (2.10.1), ``django-debug-toolbar`` (6.3.0),
+  ``django-silk`` (5.5.0) en ``django-cms`` (4.1.10).
 
 2.2.0 (2026-04-20)
 ==================

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ pydantic[email]
 typing-extensions
 
 # Framework libraries
-Django>=4.2,<5.0
+Django>=5.2,<6.0
 django-admin-index
 django-axes
 django-filer

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -57,7 +57,7 @@ django-structlog
 jinja2
 
 # django cms
-django-cms==4.1.3
+django-cms==4.1.10
 djangocms-versioning
 djangocms-alias<3
 djangocms-link

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -191,7 +191,7 @@ django-classy-tags==4.0.0
     # via
     #   django-cms
     #   django-sekizai
-django-cms==4.1.3
+django-cms==4.1.10
     # via
     #   -r requirements/base.in
     #   aldryn-apphooks-config

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -350,7 +350,7 @@ docutils==0.21.2
     # via django-setup-configuration
 drf-spectacular==0.20.1
     # via -r requirements/base.in
-easy-thumbnails[svg]==2.8.5
+easy-thumbnails[svg]==2.10.1
     # via
     #   django-filer
     #   djangocms-picture

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ ape-pie==0.2.0
     #   objects-api-client-django
     #   open-klant-client
     #   zgw-consumers
-asgiref==3.7.2
+asgiref==3.11.1
     # via
     #   django
     #   django-htmx
@@ -100,7 +100,7 @@ defusedxml==0.7.1
     # via odfpy
 diff-match-patch==20200713
     # via django-import-export
-django==4.2.30
+django==5.2.13
     # via
     #   -r requirements/base.in
     #   django-admin-index
@@ -179,7 +179,7 @@ django-autoslug==1.9.8
     # via -r requirements/base.in
 django-axes==5.25.0
     # via -r requirements/base.in
-django-celery-beat==2.6.0
+django-celery-beat==2.9.0
     # via -r requirements/base.in
 django-celery-monitor @ git+https://github.com/maykinmedia/django-celery-monitor@74b12529dcdd6923a4deed4c4b6fd3c9fc56eecd#egg=django_celery_monitor
     # via -r requirements/base.in
@@ -206,7 +206,7 @@ django-cors-headers==3.10.0
     # via -r requirements/base.in
 django-csp==3.7
     # via -r requirements/base.in
-django-csp-reports==1.9.1
+django-csp-reports==1.10.0
     # via -r requirements/base.in
 django-digid-eherkenning[oidc] @ git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning
     # via -r requirements/base.in
@@ -214,7 +214,7 @@ django-elasticsearch-dsl==8.2
     # via -r requirements/base.in
 django-extra-fields==3.0.2
     # via -r requirements/base.in
-django-filer==3.1.1
+django-filer==3.4.4
     # via
     #   -r requirements/base.in
     #   djangocms-picture
@@ -673,7 +673,9 @@ sqlparse==0.5.5
 structlog==25.4.0
     # via django-structlog
 svglib==1.5.1
-    # via easy-thumbnails
+    # via
+    #   django-filer
+    #   easy-thumbnails
 tablib[html, ods, xls, xlsx, yaml]==3.1.0
     # via django-import-export
 tinycss2==1.5.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -298,7 +298,7 @@ django-classy-tags==4.0.0
     #   -r requirements/base.txt
     #   django-cms
     #   django-sekizai
-django-cms==4.1.3
+django-cms==4.1.10
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -23,7 +23,7 @@ ape-pie==0.2.0
     #   objects-api-client-django
     #   open-klant-client
     #   zgw-consumers
-asgiref==3.7.2
+asgiref==3.11.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -182,7 +182,7 @@ diff-match-patch==20200713
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-import-export
-django==4.2.30
+django==5.2.13
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -274,7 +274,7 @@ django-axes==5.25.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-celery-beat==2.6.0
+django-celery-beat==2.9.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -320,7 +320,7 @@ django-csp==3.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-csp-reports==1.9.1
+django-csp-reports==1.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -338,7 +338,7 @@ django-extra-fields==3.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-filer==3.1.1
+django-filer==3.4.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1237,6 +1237,7 @@ svglib==1.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-filer
     #   easy-thumbnails
 tablib[html, ods, xls, xlsx, yaml]==3.1.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -584,7 +584,7 @@ drf-spectacular==0.20.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-easy-thumbnails[svg]==2.8.5
+easy-thumbnails[svg]==2.10.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -625,7 +625,7 @@ drf-spectacular==0.20.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-easy-thumbnails[svg]==2.8.5
+easy-thumbnails[svg]==2.10.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,8 +44,6 @@ attrs==21.2.0
     #   -r requirements/ci.txt
     #   glom
     #   jsonschema
-autopep8==1.5.7
-    # via django-silk
 babel==2.15.0
     # via
     #   -c requirements/ci.txt
@@ -504,7 +502,7 @@ django-setup-configuration==0.9.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-django-silk==5.1.0
+django-silk==5.5.0
     # via -r requirements/dev.in
 django-simple-certmanager==2.5.0
     # via
@@ -1096,8 +1094,6 @@ psycopg2==2.9.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-pycodestyle==2.11.1
-    # via autopep8
 pycparser==2.20
     # via
     #   -c requirements/ci.txt
@@ -1438,8 +1434,6 @@ tinyhtml5==2.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-toml==0.10.2
-    # via autopep8
 tomli==1.2.1
     # via pep517
 typer==0.21.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -357,7 +357,7 @@ django-csp-reports==1.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-debug-toolbar==3.2.2
+django-debug-toolbar==6.3.0
     # via -r requirements/dev.in
 django-digid-eherkenning[oidc] @ git+https://github.com/maykinmedia/django-digid-eherkenning@8be5292813d58eda2910cd0a535baa39fc566006#egg=django-digid-eherkenning
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,7 +26,7 @@ ape-pie==0.2.0
     #   objects-api-client-django
     #   open-klant-client
     #   zgw-consumers
-asgiref==3.7.2
+asgiref==3.11.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -213,7 +213,7 @@ diff-match-patch==20200713
     #   django-import-export
 distlib==0.3.9
     # via virtualenv
-django==4.2.30
+django==5.2.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -307,7 +307,7 @@ django-axes==5.25.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-celery-beat==2.6.0
+django-celery-beat==2.9.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -353,7 +353,7 @@ django-csp==3.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-csp-reports==1.9.1
+django-csp-reports==1.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -375,7 +375,7 @@ django-extra-fields==3.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-filer==3.1.1
+django-filer==3.4.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1415,6 +1415,7 @@ svglib==1.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-filer
     #   easy-thumbnails
 tablib[html, ods, xls, xlsx, yaml]==3.1.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -331,7 +331,7 @@ django-classy-tags==4.0.0
     #   -r requirements/ci.txt
     #   django-cms
     #   django-sekizai
-django-cms==4.1.3
+django-cms==4.1.10
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/open_inwoner/accounts/management/commands/createinitialsuperuser.py
+++ b/src/open_inwoner/accounts/management/commands/createinitialsuperuser.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.core.mail import send_mail
 from django.core.management.base import BaseCommand
 from django.urls import exceptions, reverse
+from django.utils.crypto import get_random_string
 
 
 class Command(BaseCommand):
@@ -24,7 +25,7 @@ class Command(BaseCommand):
             )
             return
 
-        password = User.objects.make_random_password(length=20)
+        password = get_random_string(length=20)
         User.objects.create_superuser(email=email, password=password)
 
         try:

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -2250,10 +2250,14 @@ class TestLoginLogoutFunctionality(AssertRedirectsMixin, WebTest):
 
     def test_logout(self):
         """Test that a user is able to log out and page redirects to root endpoint."""
-        # Log out user and redirection
-        logout_response = self.app.get(reverse("logout"), user=self.user)
+        # Django 5 LogoutView requires POST and enforces @csrf_protect at the view
+        # level, bypassing django-webtest's middleware-level CSRF disable. Use
+        # Django's test client instead, which disables CSRF checks entirely.
+        self.client.force_login(self.user)
+        logout_response = self.client.post(reverse("logout"))
         self.assertRedirects(logout_response, reverse("login"))
-        self.assertFalse(logout_response.follow().context["user"].is_authenticated)
+        followed = self.client.get(reverse("login"))
+        self.assertFalse(followed.context["user"].is_authenticated)
 
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")

--- a/src/open_inwoner/accounts/tests/test_inbox_start_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_start_page.py
@@ -37,10 +37,10 @@ class InboxPageTests(WebTest):
         self.assertEqual(
             receiver_choices,
             [
-                [
+                (
                     str(active_contact.uuid),
                     active_contact.get_full_name(),
-                ]
+                )
             ],
         )
 

--- a/src/open_inwoner/accounts/tests/test_logging.py
+++ b/src/open_inwoner/accounts/tests/test_logging.py
@@ -210,7 +210,7 @@ class TestProfile(WebTest):
         )
 
     def test_logout_is_logged(self):
-        self.app.get(reverse("logout"), user=self.user)
+        self.app.post(reverse("logout"), user=self.user)
         log_entry = TimelineLog.objects.last()
 
         self.assertEqual(

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -977,9 +977,9 @@ class ProfileDeleteTest(WebTest):
         response = response.forms["delete-form"].submit()
         self.assertIsNone(self.regular_users.first())
 
-        # check redirect
+        # check redirect directly to login (no longer via logout)
         self.assertRedirects(
-            self.app.get(response.url),
+            response,
             reverse("login"),
             status_code=302,
             target_status_code=200,
@@ -996,9 +996,9 @@ class ProfileDeleteTest(WebTest):
         response = response.forms["delete-form"].submit()
         self.assertIsNone(self.regular_users.first())
 
-        # check redirect
+        # check redirect directly to login (no longer via logout)
         self.assertRedirects(
-            self.app.get(response.url),
+            response,
             reverse("login"),
             status_code=302,
             target_status_code=200,

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -215,7 +215,7 @@ class MyProfileView(
             instance.delete()
             request.session.flush()
 
-            return redirect(reverse("logout"))
+            return redirect(reverse("login"))
         else:
             messages.warning(request, _("Uw account kon niet worden verwijderd"))
             return redirect("profile:detail")

--- a/src/open_inwoner/cms/extensions/cms_menus.py
+++ b/src/open_inwoner/cms/extensions/cms_menus.py
@@ -32,11 +32,8 @@ class MenuModifier(Modifier):
     def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
         if post_cut:
             page_nodes = {n.id: n for n in nodes if n.attr["is_page"]}
-            pages = (
-                Page.objects.filter(id__in=page_nodes.keys())
-                # optimise and only retrieve id and related object
-                .only("id")
-                .select_related("commonextension")
+            pages = Page.objects.filter(id__in=page_nodes.keys()).select_related(
+                "commonextension"
             )
             num_indicators = 0
 

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -1,5 +1,7 @@
+import datetime
 import os
 
+import django.utils.timezone
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
@@ -15,6 +17,11 @@ from maykin_common.health_checks import (
 
 from .structlog_sentry import SentryStructlogProcessor
 from .utils import config, get_sentry_integrations
+
+# django.utils.timezone.utc was removed in Django 5.0. Restore it as a
+# compatibility shim for third-party packages (e.g. zgw-consumers-oas) that
+# haven't been updated yet.
+django.utils.timezone.utc = datetime.timezone.utc
 
 # Build paths inside the project, so further paths can be defined relative to
 # the code root.

--- a/src/open_inwoner/configurations/choices.py
+++ b/src/open_inwoner/configurations/choices.py
@@ -13,8 +13,8 @@ class OpenIDDisplayChoices(models.TextChoices):
 
 
 class CustomFontName(models.TextChoices):
-    body = _("body_font_regular"), _("Text body font")
-    body_italic = _("body_font_italic"), _("Text body font italic")
-    body_bold = _("body_font_bold"), _("Text body font bold")
-    body_bold_italic = _("body_font_bold_italic"), _("Text body font bold italic")
-    heading = _("heading_font"), _("Heading font")
+    body = "body_font_regular", _("Text body font")
+    body_italic = "body_font_italic", _("Text body font italic")
+    body_bold = "body_font_bold", _("Text body font bold")
+    body_bold_italic = "body_font_bold_italic", _("Text body font bold italic")
+    heading = "heading_font", _("Heading font")


### PR DESCRIPTION
## Summary

Bumps Django from 4.2 to 5.2 and updates dependent packages:

  - easy-thumbnails -> 2.10.1
  - django-debug-toolbar -> 6.3.0
  - django-silk -> 5.5.0
  - django-cms -> 4.1.10 (fixes a template error introduced by Django 5's updated `change_list_object_tools.html`)

  Code changes for Django 5 compatibility:
  - Replaced django.utils.timezone.utc (removed in Django 5) with a compatibility shim
  - Updated `TextChoices` values, `LogoutView` usage, `BaseUserManager.make_random_password()` calls

## Issue References
Closes #2366
Closes #2371 

## Checklist

- [x] CHANGELOG.rst updated