### PR TITLE
Dependabot/warnings 13 04 26

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,13 +13,22 @@ const preview: Preview = {
   parameters: {
     reactIntl,
     controls: { matchers: { color: /(background|color)$/i, date: /Date$/ } },
+
     options: {
       storySort: {
         method: 'alphabetical',
         order: ['Introduction', 'Developers', 'Preact'],
       },
     },
+
     layout: 'centered',
+
+    a11y: {
+      // 'todo' - show a11y violations in the test UI only
+      // 'error' - fail CI on a11y violations
+      // 'off' - skip a11y checks entirely
+      test: 'todo',
+    },
   },
   tags: ['autodocs'],
   initialGlobals: {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,6 +107,10 @@ Onderhoud
   testopzet is herschreven: gedeelde test-utilities zijn ondergebracht in ``react/lib/testing/``, Storybook-decorators
   en web component-decorators zijn gesplitst in afzonderlijke modules, en de Vitest-configuratie is bijgewerkt. Daarnaast
   zijn de CI-workflow en Storybook-configuratie samengevoegd en gemoderniseerd.
+* [:gh:`2412`, :cve:`CVE-2026-39364`, :cve:`CVE-2026-4800`]: ``vite`` bijgewerkt naar versie ``7.3.2``.
+* ``storybook`` bijgewerkt naar versie ``10.3.5``.
+* ``lodash`` bijgewerkt naar versie ``4.18.1``.
+* ``lodash-es`` override bijgewerkt om :cve:`CVE-2026-4800` te mitigeren.
 
 2.1.1 (2026-03-19)
 ==================

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "htmx-ext-response-targets": "^2.0.4",
         "htmx.org": "^2.0.4",
         "leaflet": "^1.7.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "material-icons": "^1.13.12",
         "microscope-sass": "latest",
         "preact": "^10.27.3",
@@ -53,10 +53,10 @@
         "@babel/core": "latest",
         "@formatjs/cli": "^6.7.2",
         "@preact/preset-vite": "^2.10.2",
-        "@storybook/addon-a11y": "^10.2.10",
-        "@storybook/addon-docs": "^10.2.10",
-        "@storybook/addon-vitest": "^10.2.10",
-        "@storybook/preact-vite": "^10.2.10",
+        "@storybook/addon-a11y": "^10.3.5",
+        "@storybook/addon-docs": "^10.3.5",
+        "@storybook/addon-vitest": "^10.3.5",
+        "@storybook/preact-vite": "^10.3.5",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
@@ -78,11 +78,11 @@
         "postcss-selector-lint": "^1.0.2",
         "prettier": "^3.6.2",
         "sass-embedded": "^1.97.3",
-        "storybook": "^10.2.10",
+        "storybook": "^10.3.5",
         "storybook-react-intl": "^10.1.1",
         "type-fest": "^5.2.0",
         "typescript": "^5.8.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitest": "^4.1.1"
       },
       "optionalDependencies": {
@@ -1386,12 +1386,6 @@
       "integrity": "sha512-YZXOOkX9wZ4niq1nkcb+rLse1EcvVjRSyaHP5H2kYbWxXNH1oL41WLzg+sfh/v7swm47TYzXyxCKe7s66DWPbw==",
       "license": "EUPL-1.2"
     },
-    "node_modules/@gemeente-denhaag/file/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
     "node_modules/@gemeente-denhaag/icons": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-4.0.1.tgz",
@@ -2317,9 +2311,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.3.tgz",
-      "integrity": "sha512-1yELCE8NXUJKcfS2k97pujtVw4z95PCwyoy2I6VAPiG/nRnJI8M6ned08YmCMEJhLBgGA1+GBh9HO4uk+xPcYA==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.5.tgz",
+      "integrity": "sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2331,20 +2325,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.3"
+        "storybook": "^10.3.5"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.3.tgz",
-      "integrity": "sha512-trJQTpOtuOEuNv1Rn8X2Sopp5hSPpb0u0soEJ71BZAbxe4d2Y1d/1MYcxBdRKwncum6sCTsnxTpqQ/qvSJKlTQ==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.5.tgz",
+      "integrity": "sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.3.3",
+        "@storybook/csf-plugin": "10.3.5",
         "@storybook/icons": "^2.0.1",
-        "@storybook/react-dom-shim": "10.3.3",
+        "@storybook/react-dom-shim": "10.3.5",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2354,13 +2348,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.3"
+        "storybook": "^10.3.5"
       }
     },
     "node_modules/@storybook/addon-vitest": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.3.3.tgz",
-      "integrity": "sha512-9bbUAgraZhHh35WuWJn/83B0KvkcsP8dNpzbhssMeWQTfu92TR3DqRNeGTNSlyZvhbGfwiwT3TfBzzM4dX1feg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.3.5.tgz",
+      "integrity": "sha512-PQDeeMwoF55kvzlhFqVKOryBJskkVk71AbDh7F0y8PdRRxlGbTvIUkKXktHZWBdESo0dV6BkeVxGQ4ZpiFxirg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2375,7 +2369,7 @@
         "@vitest/browser": "^3.0.0 || ^4.0.0",
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/runner": "^3.0.0 || ^4.0.0",
-        "storybook": "^10.3.3",
+        "storybook": "^10.3.5",
         "vitest": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -2394,13 +2388,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.3.tgz",
-      "integrity": "sha512-awspKCTZvXyeV3KabL0id62mFbxR5u/5yyGQultwCiSb2/yVgBfip2MAqLyS850pvTiB6QFVM9deOyd2/G/bEA==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.5.tgz",
+      "integrity": "sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.3.3",
+        "@storybook/csf-plugin": "10.3.5",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2408,14 +2402,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.3",
+        "storybook": "^10.3.5",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.3.tgz",
-      "integrity": "sha512-Utlh7zubm+4iOzBBfzLW4F4vD99UBtl2Do4edlzK2F7krQIcFvR2ontjAE8S1FQVLZAC3WHalCOS+Ch8zf3knA==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.5.tgz",
+      "integrity": "sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2428,7 +2422,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.3.3",
+        "storybook": "^10.3.5",
         "vite": "*",
         "webpack": "*"
       },
@@ -2466,9 +2460,9 @@
       }
     },
     "node_modules/@storybook/preact": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-10.3.3.tgz",
-      "integrity": "sha512-0lhMqWyEzj0gPBXjLdvU7qBKHAodcsa8vNYzTU+iwWMsl2reM+6qnd1M9tIXxKueyVRI+0yLjrZU284NBsx6mw==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-10.3.5.tgz",
+      "integrity": "sha512-w6N9L5KSGRc8XHC/7XGKYWevhb5sq7Oqkued6FrihXEaBSmCZ4RUUPclfMvr/P2/cpTK6yBRMMj7M56DcOYQwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2481,18 +2475,18 @@
       },
       "peerDependencies": {
         "preact": "^8.0.0||^10.0.0",
-        "storybook": "^10.3.3"
+        "storybook": "^10.3.5"
       }
     },
     "node_modules/@storybook/preact-vite": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-10.3.3.tgz",
-      "integrity": "sha512-3uauEIUxPmnDD363QvDeJYqA6H7wvx+16erX0Mxb5/Qzu0EKQ2mslFlP1CDkG6+rZ/fJ9puowSMJ7wSHmpbd+g==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-10.3.5.tgz",
+      "integrity": "sha512-punwZQRfpEF+WXmpSqXr7mrN7gKnjJ6amg5GqN+ALE3QaIVN+NcCclHOkM7f/7+1007iqtyWsfZVI8dVQ2I/MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "10.3.3",
-        "@storybook/preact": "10.3.3"
+        "@storybook/builder-vite": "10.3.5",
+        "@storybook/preact": "10.3.5"
       },
       "funding": {
         "type": "opencollective",
@@ -2500,13 +2494,13 @@
       },
       "peerDependencies": {
         "preact": ">=10",
-        "storybook": "^10.3.3"
+        "storybook": "^10.3.5"
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.3.tgz",
-      "integrity": "sha512-lkhuh4G3UTreU9M3Iz5Dt32c6U+l/4XuvqLtbe1sDHENZH6aPj7y0b5FwnfHyvuTvYRhtbo29xZrF5Bp9kCC0w==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.5.tgz",
+      "integrity": "sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2516,7 +2510,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.3"
+        "storybook": "^10.3.5"
       }
     },
     "node_modules/@tarekraafat/autocomplete.js": {
@@ -4197,6 +4191,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -6697,16 +6698,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.chunk": {
@@ -8889,9 +8889,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.3.tgz",
-      "integrity": "sha512-tMoRAts9EVqf+mEMPLC6z1DPyHbcPe+CV1MhLN55IKsl0HxNjvVGK44rVPSePbltPE6vIsn4bdRj6CCUt8SJwQ==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.5.tgz",
+      "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8902,6 +8902,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
         "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "open": "^10.2.0",
         "recast": "^0.23.5",
@@ -9526,9 +9527,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@gemeente-denhaag/action": "^4.0.1",
     "@gemeente-denhaag/file": "^2.3.0",
     "@gemeente-denhaag/side-navigation": "^4.0.2",
+    "@maykinmedia/preact-custom-element": "github:maykinmedia/preact-custom-element#5b3701126d62a7de458099f1186f66d34878766d",
     "@open-inwoner/design-tokens": "^0.0.28",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "@utrecht/button-css": "^2.3.1",
@@ -64,11 +65,10 @@
     "htmx-ext-response-targets": "^2.0.4",
     "htmx.org": "^2.0.4",
     "leaflet": "^1.7.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "material-icons": "^1.13.12",
     "microscope-sass": "latest",
     "preact": "^10.27.3",
-    "@maykinmedia/preact-custom-element": "github:maykinmedia/preact-custom-element#5b3701126d62a7de458099f1186f66d34878766d",
     "proj4leaflet": "^1.0.2",
     "react-intl": "^7.1.11"
   },
@@ -76,10 +76,10 @@
     "@babel/core": "latest",
     "@formatjs/cli": "^6.7.2",
     "@preact/preset-vite": "^2.10.2",
-    "@storybook/addon-a11y": "^10.2.10",
-    "@storybook/addon-docs": "^10.2.10",
-    "@storybook/addon-vitest": "^10.2.10",
-    "@storybook/preact-vite": "^10.2.10",
+    "@storybook/addon-a11y": "^10.3.5",
+    "@storybook/addon-docs": "^10.3.5",
+    "@storybook/addon-vitest": "^10.3.5",
+    "@storybook/preact-vite": "^10.3.5",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
@@ -101,11 +101,11 @@
     "postcss-selector-lint": "^1.0.2",
     "prettier": "^3.6.2",
     "sass-embedded": "^1.97.3",
-    "storybook": "^10.2.10",
+    "storybook": "^10.3.5",
     "storybook-react-intl": "^10.1.1",
     "type-fest": "^5.2.0",
     "typescript": "^5.8.3",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^4.1.1"
   },
   "overrides": {
@@ -115,7 +115,8 @@
     "immutable": "^5.1.5",
     "@utrecht/component-library-react": {
       "vega": "^6.0.0"
-    }
+    },
+    "lodash-es": "^4.18.1"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "*",


### PR DESCRIPTION
## Summary

* ``vite`` bijgewerkt naar versie ``7.3.2``.
* ``storybook`` bijgewerkt naar versie ``10.3.5``.
* ``lodash`` bijgewerkt naar versie ``4.18.1``.
* ``lodash-es`` override bijgewerkt om `CVE-2026-4800` te mitigeren.


> [!IMPORTANT]
> This PR resolves all open NPM vulnerablities

## Issue References

- Github Issue: #2412 

## Checklist

- [x] CHANGELOG.rst updated