### PR TITLE
fix: [#2416] replace filter_horizontal with autocomplete_fields for large M2M relations in admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,10 @@ Bugfixes
   maken had, niet het inloggen). Het alternatieve nummer wordt nu geleegd als het gelijk
   is aan het primaire nummer.
 * [:gh:`2378`]: Probleem opgelost waar markdown in ssd uitkering pdf niet correct wordt gerenderd.
+* [:gh:`2416`]: Beheerpagina's voor gebruikers, plannen en uitnodigingen konden vastlopen of
+  crashen op productie wanneer er veel gebruikers in het systeem staan. De keuzelijsten voor
+  contacten, categorieën, plandeelnemers en uitnodigingen laden nu alleen zoekresultaten op
+  aanvraag in plaats van alle records tegelijk in te laden.
 * [:gh:`2390`]: Probleem opgelost waarbij de hoogte van de waarschuwingsbanner onjuist werd weergegeven.
 * [:gh:`2398`]: Probleem opgelost waarbij DigiD-gebruikers na uitloggen werden
   doorgestuurd naar een niet-bestaande URL wanneer OIDC niet was ingeschakeld. Omdat de

--- a/src/open_inwoner/accounts/admin.py
+++ b/src/open_inwoner/accounts/admin.py
@@ -184,9 +184,12 @@ class _UserAdmin(ImageCroppingMixin, UserAdmin):
     )
     search_fields = ("first_name", "infix", "last_name", "email")
     ordering = ("last_login",)
-    filter_horizontal = (
+    autocomplete_fields = (
         "user_contacts",
         "contacts_for_approval",
+        "selected_categories",
+    )
+    filter_horizontal = (
         "groups",
         "user_permissions",
     )
@@ -308,6 +311,7 @@ class InviteAdmin(admin.ModelAdmin):
     list_display = ("inviter", "invitee_email", "invitee", "accepted", "created_on")
     list_filter = ("inviter", "invitee")
     readonly_fields = ("key",)
+    autocomplete_fields = ("inviter", "invitee")
 
 
 @admin.register(OpenIDEIDASConfig)

--- a/src/open_inwoner/plans/admin.py
+++ b/src/open_inwoner/plans/admin.py
@@ -14,6 +14,7 @@ class ActionTemplateInlineAdmin(admin.TabularInline):
 class PlanContactInlineAdmin(admin.TabularInline):
     model = PlanContact
     extra = 1
+    autocomplete_fields = ("user",)
 
 
 @admin.register(PlanTemplate)
@@ -23,7 +24,7 @@ class PlanTemplateAdmin(admin.ModelAdmin):
         "goal",
     )
     inlines = [ActionTemplateInlineAdmin]
-    filter_horizontal = ("related_categories",)
+    autocomplete_fields = ("related_categories",)
 
 
 @admin.register(Plan)
@@ -35,4 +36,3 @@ class PlanAdmin(UUIDAdminFirstInOrder, admin.ModelAdmin):
         "created_by",
     )
     inlines = [PlanContactInlineAdmin, ActionInlineAdmin]
-    filter_horizontal = ("plan_contacts",)


### PR DESCRIPTION
User-pointing M2M fields (user_contacts, contacts_for_approval) and the selected_categories field on _UserAdmin were loading every row in the related table into the page, causing production admin pages to break under a large user/category dataset.

Replace those fields with autocomplete_fields, which uses Select2 + AJAX and only fetches matching rows as the admin types. Apply the same fix to PlanContactInlineAdmin.user and PlanTemplateAdmin.related_categories. Also remove PlanAdmin.filter_horizontal for plan_contacts (through-model with extra fields; the PlanContactInlineAdmin already manages it).

Closes: #2416