### PR TITLE
[#2420] Raise ImproperlyConfigured on missing SSD API service

### DIFF
--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
+from django.core.exceptions import ImproperlyConfigured
 from django.template import loader
 from django.template.defaultfilters import date as django_date
 from django.utils import timezone
@@ -44,10 +45,6 @@ class SSDBaseClient(ABC):
         }
 
     def _get_auth_kwargs(self) -> dict:
-        if not self.config.service:
-            logger.error("SSD client used without SOAP service")
-            return {}
-
         cert = self.config.service.get_cert()
         verify = self.config.service.get_verify()
         return {
@@ -72,6 +69,9 @@ class SSDBaseClient(ABC):
 
     def templated_request(self, **kwargs) -> Response | None:
         """Wrap around `requests.post` with headers, auth details, request body"""
+
+        if not self.config.service:
+            raise ImproperlyConfigured("SSD config missing API service")
 
         auth_kwargs = self._get_auth_kwargs()
         headers = self._get_headers()

--- a/src/open_inwoner/ssd/tests/test_client.py
+++ b/src/open_inwoner/ssd/tests/test_client.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 import requests_mock
@@ -127,6 +128,13 @@ class SSDClientRequestInterfaceTest(TestCase):
                 ssd_client.config.service.client_certificate.private_key.path,
             ),
         )
+
+    def test_missing_ssd_service_returns_none(self, mock_request_body):
+        ssd_client = ConcreteSSDClient()
+        ssd_client.config = SSDConfigFactory.build(service=None)
+
+        with self.assertRaises(ImproperlyConfigured):
+            ssd_client.templated_request(bsn="dummy", period="dummy")
 
     @patch("open_inwoner.ssd.client.requests.post", side_effect=ConnectionError)
     def test_requests_exception(self, mock_request_body, mock_request_post):


### PR DESCRIPTION
## Summary

The error handling in the SSD client was confused: a missing API service in the configuration would lead to `AttributeError`. We now check for the missing service and raise `ImproperlyConfigured` with an informative error essage.

## Issue References

Closes #2420

## Checklist

- [ ] CHANGELOG.rst updated
