### PR TITLE
PP-405: Improve error handling in SSD app

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,8 @@ Bugfixes
 * [:gh:`2426`]: De zaakstatus feedmelding toont de statusomschrijving nu tussen dubbele aanhalingstekens
   (bijv. ``"Aanvraag is in behandeling"``) in plaats van een HTML ``<span>``-element.
 * Correctie aangebracht in de controle van 'request.path' bij het ophalen van menu-items voor de 'SideMenu'.
+* [:gh:`2421`]: verbeterde foutafhandeling voor de SSD-app: geldige XML-respons met 'fwi' (fout, waarschuwing,
+  informatie) wordt nu correct verwerkt.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
+from django.core.exceptions import ImproperlyConfigured
 from django.template import loader
 from django.template.defaultfilters import date as django_date
 from django.utils import timezone
@@ -44,10 +45,6 @@ class SSDBaseClient(ABC):
         }
 
     def _get_auth_kwargs(self) -> dict:
-        if not self.config.service:
-            logger.error("SSD client used without SOAP service")
-            return {}
-
         cert = self.config.service.get_cert()
         verify = self.config.service.get_verify()
         return {
@@ -72,6 +69,9 @@ class SSDBaseClient(ABC):
 
     def templated_request(self, **kwargs) -> Response | None:
         """Wrap around `requests.post` with headers, auth details, request body"""
+
+        if not self.config.service:
+            raise ImproperlyConfigured("SSD config missing service")
 
         auth_kwargs = self._get_auth_kwargs()
         headers = self._get_headers()

--- a/src/open_inwoner/ssd/exceptions.py
+++ b/src/open_inwoner/ssd/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import Protocol, Self
 
 from .service.jaaropgave import JaarOpgaveInfoResponse
 from .service.uitkering import (
@@ -6,20 +6,31 @@ from .service.uitkering import (
 )
 
 
+class Melding(Protocol):
+    code: str | None
+    tekst: str | None
+
+
 class SSDClientException(Exception):
-    response: JaarOpgaveInfoResponse | UitkeringInfoResponse | None
+    """Exception class for technical errors (config issues, network errors, malformed XML etc.)"""
 
     def __init__(self, message: str | None = None):
         super().__init__(message or "SSD client error")
+
+
+class SSDServiceFaultException(Exception):
+    """Exception class for domain faults (valid XML response with 'fout' code)"""
+
+    def __init__(self, meldingen: list[Melding], message: str | None = None):
+        self.meldingen = meldingen
+        super().__init__(message)
 
     @classmethod
     def from_xml_response(
         cls, xml_response: JaarOpgaveInfoResponse | UitkeringInfoResponse
     ) -> Self:
-        # fout, waarschuwing, informatie
+        # fout, waarschuwing, informatie (the exception is raised only for fout)
         fwi = xml_response.fwi
-        error_messages = ", ".join(
-            e.tekst for e in (fwi.fout or fwi.waarshuwing or fwi.informatie,) if e
-        )
+        teksten = ", ".join(m.tekst for m in fwi.fout if m.tekst)
 
-        return cls(message=error_messages)
+        return cls(meldingen=fwi.fout, message=teksten)

--- a/src/open_inwoner/ssd/tests/files/uitkering_fwi_fout.xml
+++ b/src/open_inwoner/ssd/tests/files/uitkering_fwi_fout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:fwi="http://www.centric.nl/GWS/FWI/v0200" xmlns:gwsd="http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient/v0600" xmlns:ns3="http://www.centric.nl/GWS/Header/v0201" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+ <SOAP-ENV:Header>
+  <wsa:MessageID>447B2E69-F59E-4949-B31F-F1B6A0C80CDD</wsa:MessageID>
+  <wsa:Action>http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient-v0600/UitkeringsSpecificatieInfoResponse</wsa:Action>
+ </SOAP-ENV:Header>
+ <SOAP-ENV:Body>
+  <gwsd:UitkeringsSpecificatieInfoResponse>
+   <fwi:FWI>
+    <Fout>
+     <Code>01</Code>
+     <Tekst>BSN 999972042 voldoet niet aan de elfproef.</Tekst>
+    </Fout>
+   </fwi:FWI>
+  </gwsd:UitkeringsSpecificatieInfoResponse>
+ </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/open_inwoner/ssd/tests/files/uitkering_fwi_waarschuwing.xml
+++ b/src/open_inwoner/ssd/tests/files/uitkering_fwi_waarschuwing.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:fwi="http://www.centric.nl/GWS/FWI/v0200" xmlns:gwsd="http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient/v0600" xmlns:ns3="http://www.centric.nl/GWS/Header/v0201" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+ <SOAP-ENV:Header>
+  <wsa:MessageID>447B2E69-F59E-4949-B31F-F1B6A0C80CDD</wsa:MessageID>
+  <wsa:Action>http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient-v0600/UitkeringsSpecificatieInfoResponse</wsa:Action>
+ </SOAP-ENV:Header>
+ <SOAP-ENV:Body>
+  <gwsd:UitkeringsSpecificatieInfoResponse>
+   <fwi:FWI>
+    <Waarschuwing>
+     <Code>02</Code>
+     <Tekst>Waarschuwing: gegevens mogelijk niet actueel.</Tekst>
+    </Waarschuwing>
+   </fwi:FWI>
+  </gwsd:UitkeringsSpecificatieInfoResponse>
+ </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/open_inwoner/ssd/tests/test_client.py
+++ b/src/open_inwoner/ssd/tests/test_client.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 import requests_mock
@@ -139,6 +140,13 @@ class SSDClientRequestInterfaceTest(TestCase):
 
         with self.assertRaises(SSDClientException):
             ssd_client.templated_request(**context)
+
+    def test_missing_ssd_service_returns_none(self, mock_request_body):
+        ssd_client = ConcreteSSDClient()
+        ssd_client.config = SSDConfigFactory.build(service=None)
+
+        with self.assertRaises(ImproperlyConfigured):
+            ssd_client.templated_request(bsn="dummy", period="dummy")
 
 
 class UitkeringClientTest(TestCase):

--- a/src/open_inwoner/ssd/tests/test_views.py
+++ b/src/open_inwoner/ssd/tests/test_views.py
@@ -10,6 +10,7 @@ contents is tested in `test_xml_parsing.py`
 from http import HTTPStatus
 from unittest.mock import patch
 
+from django.contrib.messages import get_messages
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -20,6 +21,8 @@ from pyquery import PyQuery
 
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.ssd.client import UitkeringClient
+from open_inwoner.ssd.exceptions import SSDClientException, SSDServiceFaultException
+from open_inwoner.ssd.service.uitkering.fwi_resolved import Melding
 from open_inwoner.ssd.tests.factories import SSDConfigFactory
 from open_inwoner.ssd.tests.mocks import (
     mock_jaaropgave_response,
@@ -117,6 +120,41 @@ class TestMonthlyBenefitsFormView(TestCase):
 
         with self.assertRaises(ValueError):
             self.client.post(url, data={"report_date": "bad-user-input"})
+
+    @patch(
+        "open_inwoner.ssd.client.UitkeringClient.get_reports",
+        side_effect=SSDClientException("technical failure"),
+    )
+    @freeze_time("1985-12-25")
+    def test_uitkering_post_ssd_client_exception_shows_technical_error(
+        self, mock_report
+    ):
+        url = reverse("ssd:monthly_benefits_index")
+        self.client.login(email=self.user.email, password="12345")
+
+        response = self.client.post(url, data={"report_date": "1985-12-25"})
+
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        self.assertTrue(any("try again later" in m for m in messages))
+
+    @patch(
+        "open_inwoner.ssd.client.UitkeringClient.get_reports",
+        side_effect=SSDServiceFaultException(
+            meldingen=[Melding(code="01", tekst="BSN voldoet niet aan de elfproef.")],
+            message="BSN voldoet niet aan de elfproef.",
+        ),
+    )
+    @freeze_time("1985-12-25")
+    def test_uitkering_post_ssd_service_fault_exception_shows_contact_municipality(
+        self, mock_report
+    ):
+        url = reverse("ssd:monthly_benefits_index")
+        self.client.login(email=self.user.email, password="12345")
+
+        response = self.client.post(url, data={"report_date": "1985-12-25"})
+
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        self.assertTrue(any("contact the municipality" in m for m in messages))
 
     @patch("open_inwoner.ssd.models.SSDConfig.get_solo")
     def test_uitkering_get_reports_not_enabled(self, mock_solo):

--- a/src/open_inwoner/ssd/tests/test_xml.py
+++ b/src/open_inwoner/ssd/tests/test_xml.py
@@ -2,10 +2,12 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
+from open_inwoner.ssd.exceptions import SSDServiceFaultException
 from open_inwoner.ssd.service.jaaropgave import JaarOpgaveInfoResponse
 from open_inwoner.ssd.service.uitkering import (
     UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
 )
+from open_inwoner.ssd.service.uitkering.fwi_resolved import Fwi, Melding
 from open_inwoner.ssd.templatetags.ssd_tags import (
     format_currency,
     format_date_month_name,
@@ -14,19 +16,14 @@ from open_inwoner.ssd.templatetags.ssd_tags import (
     format_string,
     get_detail_value_for_column,
 )
-from open_inwoner.ssd.xml import get_jaaropgaven, get_uitkeringen
+from open_inwoner.ssd.xml import (
+    JAAROPGAVE_INFO_RESPONSE_NODE,
+    UITKERING_INFO_RESPONSE_NODE,
+    get_jaaropgaven,
+    get_uitkeringen,
+)
 
 from .utils import get_component_value, mock_get_report_info
-
-JAAROPGAVE_INFO_RESPONSE_NODE = (
-    "//{http://www.centric.nl/GWS/Diensten/JaarOpgaveClient/v0400}"
-    "JaarOpgaveInfoResponse"
-)
-
-UITKERING_INFO_RESPONSE_NODE = (
-    "//{http://www.centric.nl/GWS/Diensten/UitkeringsSpecificatieClient/v0600}"
-    "UitkeringsSpecificatieInfoResponse"
-)
 
 FILES_DIR = Path(__file__).parent.resolve() / "files"
 
@@ -335,3 +332,37 @@ class SSDTagTest(TestCase):
             with self.subTest(i=i):
                 res = get_detail_value_for_column(detail, column_index)
                 self.assertEqual(res, expected)
+
+
+class SSDServiceFaultExceptionTest(TestCase):
+    def _make_response(self, meldingen: list[Melding]) -> UitkeringInfoResponse:
+        return UitkeringInfoResponse(fwi=Fwi(fout=meldingen))
+
+    def test_from_xml_response_sets_meldingen(self):
+        melding = Melding(code="01", tekst="BSN voldoet niet aan de elfproef.")
+        xml_response = self._make_response([melding])
+
+        exc = SSDServiceFaultException.from_xml_response(xml_response)
+
+        self.assertEqual(exc.meldingen, [melding])
+
+    def test_from_xml_response_builds_message_from_tekst(self):
+        xml_response = self._make_response(
+            [
+                Melding(code="01", tekst="Eerste fout."),
+                Melding(code="02", tekst="Tweede fout."),
+            ]
+        )
+
+        exc = SSDServiceFaultException.from_xml_response(xml_response)
+
+        self.assertEqual(str(exc), "Eerste fout., Tweede fout.")
+
+    def test_from_xml_response_skips_meldingen_without_tekst(self):
+        xml_response = self._make_response(
+            [Melding(code="01", tekst=None), Melding(code="02", tekst="Fout.")]
+        )
+
+        exc = SSDServiceFaultException.from_xml_response(xml_response)
+
+        self.assertEqual(str(exc), "Fout.")

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -18,7 +19,7 @@ from view_breadcrumbs import BaseBreadcrumbMixin
 from open_inwoner.utils.views import CommonPageMixin
 
 from .client import JaaropgaveClient, UitkeringClient
-from .exceptions import SSDClientException
+from .exceptions import SSDClientException, SSDServiceFaultException
 from .forms import MonthlyReportsForm, YearlyReportsForm
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -56,13 +57,26 @@ class BenefitsFormView(
 
             try:
                 pdf_content = ssd_client.get_reports(bsn, report_date, request_url)
+            except (ImproperlyConfigured, SSDServiceFaultException) as exc:
+                logger.warning(
+                    "SSD service fault",
+                    meldingen=[m.tekst for m in exc.meldingen],
+                )
+                messages.error(
+                    request=request,
+                    message=_(
+                        "Your report(s) could not be retrieved due to technical problems. "
+                        "Please contact the municipality."
+                    ),
+                )
+                pdf_content = None
             except SSDClientException:
                 logger.exception("SSD client error")
                 messages.error(
                     request=request,
                     message=_(
                         "Your report(s) could not be retrieved due to technical problems. "
-                        "Please try again later"
+                        "Please try again later."
                     ),
                 )
                 pdf_content = None

--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -1,6 +1,7 @@
 from typing import Any, TypedDict, cast
 
 import requests
+import structlog
 from lxml import etree  # nosec
 from lxml.etree import LxmlError, XMLSyntaxError  # nosec
 from xsdata.exceptions import ParserError
@@ -14,7 +15,7 @@ from open_inwoner.ssd.service.jaaropgave.body_reaction_resolved import (
     SpecificatieJaarOpgave,
 )
 
-from .exceptions import SSDClientException
+from .exceptions import SSDClientException, SSDServiceFaultException
 from .service.jaaropgave import Client, JaarOpgaveInfoResponse
 from .service.uitkering import (
     UitkeringsSpecificatieInfoResponse as UitkeringInfoResponse,
@@ -30,7 +31,8 @@ UITKERING_INFO_RESPONSE_NODE = (
     "UitkeringsSpecificatieInfoResponse"
 )
 
-FAULT_NODE = "//{http://schemas.xmlsoap.org/soap/envelope/}Fault"
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def _get_report_info(
@@ -68,7 +70,7 @@ def _get_report_info(
 
     # fout, waarschuwing, informatie
     if info_response.fwi:
-        raise SSDClientException.from_xml_response(xml_response=info_response)
+        raise SSDServiceFaultException.from_xml_response(xml_response=info_response)
 
     return info_response
 


### PR DESCRIPTION
## Summary

The SSD app had only one exception class which was used for different error types. The PR distinguishes between technical errors (e.g. network errors) and domain faults (valid response from the API service with fault code and message), which are handled differently by the view.

## Issue References

Fixes #2421 

## Checklist

- [x] CHANGELOG.rst updated
