### PR TITLE
:bug: [#2426] Fix feeditem status text - which is no longer wrapped w…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,6 +87,8 @@ Bugfixes
   single logout-functie van DigiD SAML is komen te vervallen, wordt de DigiD-sessie niet
   langer actief beëindigd en worden gebruikers nu correct doorgestuurd naar de standaard
   uitlogpagina.
+* [:gh:`2426`]: De zaakstatus feedmelding toont de statusomschrijving nu tussen dubbele aanhalingstekens
+  (bijv. ``"Aanvraag is in behandeling"``) in plaats van een HTML ``<span>``-element.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/userfeed/hooks/case_status.py
+++ b/src/open_inwoner/userfeed/hooks/case_status.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import escape, format_html
 from django.utils.translation import gettext_lazy as _
 
 from open_inwoner.accounts.models import User
@@ -70,7 +69,7 @@ def case_status_seen(user: User, case: Zaak):
 
 class CaseStatusUpdateFeedItem(FeedItem):
     base_title = _("Case status update")
-    base_message = _("Case status has been changed to '{status}'")
+    base_message = _('Case status has been changed to "{status}"')
 
     cms_apps = ["cases"]
 
@@ -101,11 +100,7 @@ class CaseStatusUpdateFeedItem(FeedItem):
     @property
     def message(self) -> str:
         status_text = self.get_data("status_omschrijving") or _("No data available")
-        html = escape(self.base_message)
-        status = format_html('<span class="status">{}</span>', status_text)
-        html = format_html(html, status=status)
-
-        return html
+        return str(self.base_message).format(status=status_text)
 
     @property
     def action_url(self) -> str:

--- a/src/open_inwoner/userfeed/tests/hooks/test_case_status.py
+++ b/src/open_inwoner/userfeed/tests/hooks/test_case_status.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.html import escape, strip_tags
+from django.utils.html import strip_tags
 from django.utils.translation import gettext as _, ngettext
 
 from zgw_consumers.api_models.base import factory
@@ -60,8 +60,10 @@ class FeedHookTest(TestCase):
         self.assertEqual(item.is_completed, False)
         self.assertEqual(item.status_indicator, StatusIndicators.info)
         self.assertEqual(
-            strip_tags(item.message),
-            escape(_("Case status has been changed to 'initial'")),
+            item.message,
+            str(_('Case status has been changed to "{status}"')).format(
+                status="initial"
+            ),
         )
         self.assertEqual(item.title, case.zaaktype.omschrijving)
         self.assertEqual(
@@ -103,11 +105,9 @@ class FeedHookTest(TestCase):
         # check item changed
         item = feed.items[0]
         self.assertEqual(
-            strip_tags(item.message),
-            escape(
-                _("Case status has been changed to '{status}'").format(
-                    status=status2.statustype.statustekst
-                )
+            item.message,
+            str(_('Case status has been changed to "{status}"')).format(
+                status=status2.statustype.statustekst
             ),
         )
         self.assertEqual(item.title, case.zaaktype.omschrijving)
@@ -175,8 +175,10 @@ class FeedHookTest(TestCase):
                 self.assertEqual(item.status_indicator, StatusIndicators.warning)
                 self.assertEqual(item.status_text, "my_status_text")
                 self.assertEqual(
-                    strip_tags(item.message),
-                    escape(_("Case status has been changed to 'initial'")),
+                    item.message,
+                    str(_('Case status has been changed to "{status}"')).format(
+                        status="initial"
+                    ),
                 )
                 self.assertEqual(item.title, expected_zaak_title)
                 self.assertEqual(


### PR DESCRIPTION
## Summary

Fix feeditem status text - which is no longer wrapped with a span.status

## Issue References

- Github Issue: #2426 

## Checklist

- [x] CHANGELOG.rst updated