### PR TITLE
:accessibility: [#2272] Implement help text to contact form email and…

### DIFF
--- a/src/open_inwoner/openklant/forms.py
+++ b/src/open_inwoner/openklant/forms.py
@@ -33,12 +33,14 @@ class ContactForm(forms.Form):
     email = forms.EmailField(
         label=_("E-mailadres"),
         required=False,
+        help_text=_("Verplicht als telefoonnummer leeg is."),
     )
     phonenumber = forms.CharField(
         label=_("Telefoonnummer"),
         max_length=15,
         validators=[DutchPhoneNumberValidator()],
         required=False,
+        help_text=_("Verplicht als e-mailadres leeg is."),
     )
     question = forms.CharField(
         label=_("Vraag"),


### PR DESCRIPTION
## Summary

Implement help text to contact form email and phone number to indicate one of two is required

## Issue References

- Github Issue: #2272 

## Checklist

- [x] CHANGELOG.rst updated same as #2268 