### PR TITLE
Skip contactform enabled check when accessing 'Mijn vragen' list

### DIFF
--- a/src/open_inwoner/accounts/views/contactmoments.py
+++ b/src/open_inwoner/accounts/views/contactmoments.py
@@ -126,6 +126,13 @@ class KlantContactMomentListView(
     template_name = "pages/contactmoment/list.html"
     paginate_by = 9
 
+    def dispatch(self, request, *args, **kwargs):
+        # This page is always accessible to users with BSN/KVK (checked by
+        # KlantContactMomentAccessMixin). ContactFormView.dispatch() would gate it on
+        # contact_registration_enabled, but that flag only controls whether the embedded
+        # form renders - skip it and go straight to the access mixin.
+        return super(ContactFormView, self).dispatch(request, *args, **kwargs)
+
     @cached_property
     def crumbs(self):
         return [(_("Mijn vragen"), reverse("cases:contactmoment_list"))]

--- a/src/open_inwoner/openklant/tests/test_views.py
+++ b/src/open_inwoner/openklant/tests/test_views.py
@@ -23,6 +23,7 @@ from open_inwoner.openklant.models import (
     ContactFormSubject,
     ESuiteKlantConfig,
     KlantContactMomentAnswer,
+    KlantenSysteemConfig,
 )
 from open_inwoner.openklant.services import eSuiteVragenService
 from open_inwoner.openklant.tests.data import MockAPIReadData
@@ -72,9 +73,6 @@ class ContactMomentViewsTestCase(
             esuite_subject_code="e_suite_subject_code",
             esuite_config=self.klant_config,
         )
-
-        from open_inwoner.openklant.constants import KlantenServiceType
-        from open_inwoner.openklant.models import KlantenSysteemConfig
 
         self.config = KlantenSysteemConfig.get_solo()
         self.config.primary_backend = KlantenServiceType.ESUITE.value
@@ -939,3 +937,64 @@ class ContactMomentViewsTestCase(
                 )
                 response = self.app.get(url)
                 self.assertRedirects(response, f"{reverse('login')}?next={url}")
+
+    def test_contactmoment_list_accessible_without_contact_registration(
+        self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
+    ):
+        """
+        The contactmomenten list must return 200 even when contact registration
+        is fully disabled. Before the fix, ContactFormView.dispatch() raised
+        Http404 in this configuration.
+        """
+        config = KlantenSysteemConfig.get_solo()
+        config.primary_backend = ""
+        config.register_contact_email = ""
+        config.save()
+
+        self.assertFalse(config.contact_registration_enabled)
+
+        response = self.app.get(reverse("cases:contactmoment_list"), user=self.user)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_contactmoment_list_contact_form_visibility(
+        self, m, mock_openklant2_service, mock_get_kcm_answer_mapping
+    ):
+        """
+        The contact form is shown only when both the site toggle and contact
+        registration are enabled.
+        """
+        siteconfig = SiteConfiguration.get_solo()
+        siteconfig.contactmoment_contact_form_enabled = True
+        siteconfig.save()
+
+        config = KlantenSysteemConfig.get_solo()
+        list_url = reverse("cases:contactmoment_list")
+
+        cases = [
+            (
+                "no registration",
+                {"primary_backend": "", "register_contact_email": ""},
+                False,
+            ),
+            (
+                "email registration",
+                {"primary_backend": "", "register_contact_email": "test@example.com"},
+                True,
+            ),
+        ]
+        for label, config_values, expect_form in cases:
+            with self.subTest(label):
+                for attr, value in config_values.items():
+                    setattr(config, attr, value)
+                config.save()
+
+                response = self.app.get(list_url, user=self.user)
+
+                self.assertEqual(
+                    response.context["contactmoment_contact_form_enabled"], expect_form
+                )
+                if expect_form:
+                    self.assertContains(response, "question-form")
+                else:
+                    self.assertNotContains(response, "question-form")

--- a/src/open_inwoner/openklant/views/contactform.py
+++ b/src/open_inwoner/openklant/views/contactform.py
@@ -70,10 +70,7 @@ class ContactFormView(
                 logger.info("No klanten/vragen service configured for contactform")
 
     def dispatch(self, request, *args, **kwargs):
-        if not (
-            self.klanten_config.contact_registration_enabled
-            or request.path == reverse("cases:contactmoment_list")
-        ):
+        if not self.klanten_config.contact_registration_enabled:
             raise Http404("Contact form is not configured")
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

'Mijn Vragen' raised `404` if the contactform was not configured. The PR fixes this by skipping the `dispatch` from the `ContactFormView` inside the `KlantContactMomentListView`.

## Issue References

Fixes #2600 