### PR TITLE
Use correct test for request.path when fetching menu items

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,7 @@ Bugfixes
   uitlogpagina.
 * [:gh:`2426`]: De zaakstatus feedmelding toont de statusomschrijving nu tussen dubbele aanhalingstekens
   (bijv. ``"Aanvraag is in behandeling"``) in plaats van een HTML ``<span>``-element.
+* Correctie aangebracht in de controle van 'request.path' bij het ophalen van menu-items voor de 'SideMenu'.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/components/templatetags/menu.py
+++ b/src/open_inwoner/components/templatetags/menu.py
@@ -389,25 +389,21 @@ class SideNavMenuData:
         return complete_menu
 
     def get_extra_menu_items(self) -> List[MenuItem]:
-        extra_items: List[MenuItem] = []
         request = self.context.get("request")
-        if not request and hasattr(request, "path"):
-            return extra_items
+        if not request or not hasattr(request, "path"):
+            return []
 
         if not self.context.get("has_general_faq_questions", False):
-            return extra_items
-
-        # FAQ item
-        is_current = False
+            return []
 
         try:
             faq_url = reverse("general_faq")
             is_current = request.path.startswith(faq_url)
         except NoReverseMatch:
             logger.warning("Could not add FAQ menu item", exc_info=True)
-            return extra_items
+            return []
 
-        extra_items.append(
+        extra_items: List[MenuItem] = [
             {
                 "href": faq_url,
                 "label": str(_("Veelgestelde vragen")),
@@ -415,7 +411,7 @@ class SideNavMenuData:
                 "current": is_current,
                 "counter": None,
             }
-        )
+        ]
 
         logger.debug("Generated extra menu items", count=len(extra_items))
         return extra_items

--- a/src/open_inwoner/components/tests/test_menu_tags.py
+++ b/src/open_inwoner/components/tests/test_menu_tags.py
@@ -524,6 +524,14 @@ class TestExtraMenuItemGeneration(TestCase):
         with self.assertRaises(ValueError):
             SideNavMenuData(context).get_extra_menu_items()
 
+    def test_no_extra_items_when_request_has_no_path_attribute(self):
+        request = object()  # no .path attribute
+        context = Context({"request": request, "has_general_faq_questions": True})
+
+        extra_items = SideNavMenuData(context).get_extra_menu_items()
+
+        self.assertEqual(extra_items, [])
+
     def test_url_reverse_failures_are_handled_gracefully(self):
         context = Context(
             {"request": self.factory.get("/"), "has_general_faq_questions": True}


### PR DESCRIPTION
## Summary

`SideNavMenuData.get_extra_menu_items()` had a bug (`if not request and not request.hasattr(...)`) which is fixed.

## Checklist

- [x] CHANGELOG.rst updated
