### PR TITLE
:accessibility: [#2273] Change 'Dyslexie'/'Normaal lettertype' button texts to comply with wcag

### DIFF
--- a/src/open_inwoner/components/templates/components/Header/AccessibilityHeader.html
+++ b/src/open_inwoner/components/templates/components/Header/AccessibilityHeader.html
@@ -15,8 +15,8 @@
         </li>
 
         <li class="accessibility-header__list-item">
-            {% trans "Dyslexie" as link_text %}
-            {% trans "Normaal lettertype" as alt_link_text %}
+            {% trans "Dyslexie lettertype" as link_text %}
+            {% trans "Standaard lettertype" as alt_link_text %}
             {% if desktop %}
                 {% link href="#" icon="font_download" text=link_text extra_classes="accessibility--change-font" data_text=link_text data_alt_text=alt_link_text %}
             {% else %}


### PR DESCRIPTION
## Summary

Change 'Dyslexie'/'Normaal lettertype' button texts to comply with wcag

## Issue References

- Github Issue: #2273
- Github Parent Issue: #2268

## Checklist

- [x] CHANGELOG.rst updated main issue for #2268