### PR TITLE
PP-400: Fix corrupted ProseMirror contents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ Bugfixes
   dezelfde versheid garandeert als de zaakdetailpagina.
 * [:gh:`2289`] Validate content-length in ZGW document downloads to prevent broken downloads
   when the backend returns error messages instead of file content.
+* [:gh:`2445`]: Ongeldige inhoud in TextPlugin-velden (lege of platte tekst opgeslagen
+  als JSON-string) wordt nu automatisch hersteld via een datamigatie. De CMS-wizard
+  vult het tekstveld niet langer voor, zodat nieuwe corruptie wordt voorkomen.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/cms/plugins/migrations/0015_fix_legacy_text_plugin_body.py
+++ b/src/open_inwoner/cms/plugins/migrations/0015_fix_legacy_text_plugin_body.py
@@ -1,0 +1,130 @@
+import json
+
+from django.db import migrations
+
+import structlog
+from django_prosemirror.config import ProsemirrorConfig
+from django_prosemirror.constants import EMPTY_DOC
+from django_prosemirror.schema import MarkType, NodeType
+from django_prosemirror.serde import html_to_doc
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+def fix_legacy_text_plugin_body(apps, schema_editor):
+    """
+    Fix Text plugin body fields that contain legacy or invalid data.
+
+    After replacing djangocms_text_ckeditor with the Prosemirror-based TextPlugin,
+    the body column may contain JSON strings (not dicts) from the old plugin:
+
+    - Empty string JSON values ("") -> set to EMPTY_DOC (body column is NOT NULL)
+    - Non-empty legacy HTML strings -> convert to Prosemirror JSON via html_to_doc;
+      fall back to EMPTY_DOC if conversion fails
+
+    Raw SQL is required because the ProsemirrorModelField descriptor raises
+    ValidationError when Django tries to instantiate models with string body values,
+    making it impossible to load the corrupt rows via the ORM.
+    """
+
+    # Mirror the schema from 0008_add_text_plugin
+    config = ProsemirrorConfig(
+        allowed_node_types=[
+            NodeType.PARAGRAPH,
+            NodeType.BLOCKQUOTE,
+            NodeType.HORIZONTAL_RULE,
+            NodeType.HEADING,
+            NodeType.HARD_BREAK,
+            NodeType.CODE_BLOCK,
+            NodeType.BULLET_LIST,
+            NodeType.ORDERED_LIST,
+            NodeType.LIST_ITEM,
+            NodeType.TABLE,
+            NodeType.TABLE_ROW,
+            NodeType.TABLE_CELL,
+            NodeType.TABLE_HEADER,
+        ],
+        allowed_mark_types=[
+            MarkType.STRONG,
+            MarkType.ITALIC,
+            MarkType.LINK,
+            MarkType.CODE,
+            MarkType.UNDERLINE,
+            MarkType.STRIKETHROUGH,
+        ],
+    )
+
+    fixed_empty = 0
+    converted = 0
+    failed = 0
+
+    with schema_editor.connection.cursor() as cursor:
+        # Cast to text so we get the raw JSON string regardless of whether the
+        # psycopg2 JSONB adapter is active; we parse it ourselves below.
+        cursor.execute("SELECT cmsplugin_ptr_id, body::text FROM plugins_text")
+        rows = cursor.fetchall()
+
+    for plugin_id, raw_text in rows:
+        if raw_text is None:
+            continue  # SQL NULL — skip
+        raw_value = json.loads(raw_text)
+        if raw_value is None or isinstance(raw_value, dict):
+            continue  # JSONB null or valid Prosemirror dict — skip
+
+        if raw_value == "":
+            logger.info(
+                "Fixing empty string in Text.body",
+                plugin_id=plugin_id,
+            )
+            with schema_editor.connection.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE plugins_text SET body = %s::jsonb WHERE cmsplugin_ptr_id = %s",
+                    (json.dumps(EMPTY_DOC), plugin_id),
+                )
+            fixed_empty += 1
+        elif isinstance(raw_value, str):
+            try:
+                doc = html_to_doc(raw_value, schema=config.schema)
+                with schema_editor.connection.cursor() as cursor:
+                    cursor.execute(
+                        "UPDATE plugins_text SET body = %s::jsonb WHERE cmsplugin_ptr_id = %s",
+                        (json.dumps(doc), plugin_id),
+                    )
+                converted += 1
+                logger.info(
+                    "Converted legacy HTML in Text.body to Prosemirror JSON",
+                    plugin_id=plugin_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Could not convert legacy Text.body, setting to EMPTY_DOC",
+                    plugin_id=plugin_id,
+                    raw_value=raw_value[:100],
+                    exc_info=True,
+                )
+                with schema_editor.connection.cursor() as cursor:
+                    cursor.execute(
+                        "UPDATE plugins_text SET body = %s::jsonb WHERE cmsplugin_ptr_id = %s",
+                        (json.dumps(EMPTY_DOC), plugin_id),
+                    )
+                failed += 1
+
+    logger.info(
+        "Completed fixing Text plugin body fields",
+        fixed_empty=fixed_empty,
+        converted=converted,
+        failed=failed,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("plugins", "0014_alter_extendedcmslink_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=fix_legacy_text_plugin_body,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/src/open_inwoner/cms/plugins/tests/test_migrations.py
+++ b/src/open_inwoner/cms/plugins/tests/test_migrations.py
@@ -5,6 +5,107 @@ from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
 
 
 @tag("migrations")
+class FixLegacyTextPluginBodyMigrationTest(TestSuccessfulMigrations):
+    """
+    Test the data migration that fixes Text plugin body fields containing
+    legacy plain strings (stored as JSON strings in JSONB) instead of
+    Prosemirror JSON documents.
+
+    Scenarios:
+    - Empty JSON string ("") → EMPTY_DOC (body is NOT NULL)
+    - HTML string → Prosemirror JSON dict
+    - Plain text string → Prosemirror JSON dict (wrapped in paragraph)
+    - None → unchanged
+    - Valid Prosemirror dict → unchanged
+    """
+
+    migrate_from = "0014_alter_extendedcmslink_name"
+    migrate_to = "0015_fix_legacy_text_plugin_body"
+    app = "plugins"
+
+    def setUpBeforeMigration(self, apps):
+        CMSPlugin = apps.get_model("cms", "CMSPlugin")
+        Placeholder = apps.get_model("cms", "Placeholder")
+
+        placeholder = Placeholder.objects.create(slot="content")
+
+        def make_plugin(position, path):
+            return CMSPlugin.objects.create(
+                language="nl",
+                plugin_type="TextPlugin",
+                placeholder=placeholder,
+                position=position,
+                path=path,
+                depth=1,
+                numchild=0,
+            )
+
+        self.plugin_empty = make_plugin(0, "0001")
+        self.plugin_html = make_plugin(1, "0002")
+        self.plugin_plain = make_plugin(2, "0003")
+        self.plugin_none = make_plugin(3, "0004")
+        self.plugin_valid = make_plugin(4, "0005")
+
+        with connection.cursor() as cursor:
+            # Empty string stored as JSON-encoded empty string (the wizard bug)
+            cursor.execute(
+                "INSERT INTO plugins_text (cmsplugin_ptr_id, body) VALUES (%s, %s::jsonb)",
+                (self.plugin_empty.id, '""'),
+            )
+            # Legacy HTML content stored as a JSON string
+            cursor.execute(
+                "INSERT INTO plugins_text (cmsplugin_ptr_id, body) VALUES (%s, %s::jsonb)",
+                (self.plugin_html.id, '"<p>Hello <strong>world</strong></p>"'),
+            )
+            # Plain text stored as a JSON string
+            cursor.execute(
+                "INSERT INTO plugins_text (cmsplugin_ptr_id, body) VALUES (%s, %s::jsonb)",
+                (self.plugin_plain.id, '"plain text"'),
+            )
+            # JSON null — should be left alone (NOT NULL column can still store 'null'::jsonb)
+            cursor.execute(
+                "INSERT INTO plugins_text (cmsplugin_ptr_id, body) VALUES (%s, 'null'::jsonb)",
+                (self.plugin_none.id,),
+            )
+            # Already a valid Prosemirror JSON object — should be left alone
+            cursor.execute(
+                "INSERT INTO plugins_text (cmsplugin_ptr_id, body) VALUES (%s, %s::jsonb)",
+                (
+                    self.plugin_valid.id,
+                    '{"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Valid"}]}]}',
+                ),
+            )
+
+    def test_empty_string_becomes_empty_doc(self):
+        Text = self.apps.get_model("plugins", "Text")
+        text = Text.objects.get(cmsplugin_ptr_id=self.plugin_empty.id)
+        self.assertEqual(text.body.raw_data, {"type": "doc", "content": []})
+
+    def test_html_string_converted_to_prosemirror(self):
+        Text = self.apps.get_model("plugins", "Text")
+        text = Text.objects.get(cmsplugin_ptr_id=self.plugin_html.id)
+        self.assertIsInstance(text.body.raw_data, dict)
+        self.assertEqual(text.body.raw_data.get("type"), "doc")
+
+    def test_plain_text_converted_to_prosemirror(self):
+        Text = self.apps.get_model("plugins", "Text")
+        text = Text.objects.get(cmsplugin_ptr_id=self.plugin_plain.id)
+        self.assertIsInstance(text.body.raw_data, dict)
+        self.assertEqual(text.body.raw_data.get("type"), "doc")
+
+    def test_none_remains_none(self):
+        Text = self.apps.get_model("plugins", "Text")
+        text = Text.objects.get(cmsplugin_ptr_id=self.plugin_none.id)
+        self.assertIsNone(text.body.raw_data)
+
+    def test_valid_prosemirror_dict_unchanged(self):
+        Text = self.apps.get_model("plugins", "Text")
+        text = Text.objects.get(cmsplugin_ptr_id=self.plugin_valid.id)
+        self.assertIsInstance(text.body.raw_data, dict)
+        self.assertEqual(text.body.raw_data.get("type"), "doc")
+
+
+@tag("migrations")
 class SwapTasksObjectTypeFieldsMigrationTest(TestSuccessfulMigrations):
     """
     Test the data migration that swaps object_type_dimpact and

--- a/src/open_inwoner/cms/plugins/tests/test_wizard.py
+++ b/src/open_inwoner/cms/plugins/tests/test_wizard.py
@@ -1,0 +1,49 @@
+from django.test import TestCase, override_settings
+
+from cms.forms.wizards import CreateCMSPageForm
+from cms.wizards.forms import WizardStep2BaseForm, step2_form_factory
+
+from open_inwoner.accounts.tests.factories import UserFactory
+from open_inwoner.cms.plugins.models import Text
+
+CreateCMSPageForm = step2_form_factory(
+    mixin_cls=WizardStep2BaseForm,
+    entry_form_class=CreateCMSPageForm,
+)
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class CMSPageWizardTextPluginTest(TestCase):
+    """
+    Tests that the CMS page creation wizard does not corrupt Prosemirror body
+    fields. CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY = "" disables the wizard's
+    plain-text content pre-fill, preventing raw strings from reaching the body column.
+    """
+
+    def setUp(self):
+        self.superuser = UserFactory.create(is_superuser=True, is_staff=True)
+
+    def _make_form(self, content="some content"):
+        return CreateCMSPageForm(
+            data={
+                "title": "Test page",
+                "slug": "test-page",
+                "page_type": None,
+                "content": content,
+            },
+            wizard_page=None,
+            wizard_user=self.superuser,
+            wizard_language="nl",
+        )
+
+    def test_wizard_does_not_create_text_plugin_with_plain_string_body(self):
+        """With CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY = "" no Text plugin is created."""
+        form = self._make_form()
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.assertEqual(
+            Text.objects.count(),
+            0,
+            "Wizard must not create a Text plugin when CONTENT_PLUGIN_BODY is disabled.",
+        )

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -659,6 +659,13 @@ CMS_PAGE_CACHE = False
 CMS_PLACEHOLDER_CACHE = False
 CMS_PLUGIN_CACHE = False
 
+# The page creation wizard defaults to creating a TextPlugin pre-filled with
+# the wizard's content field. The content field is a plain textarea (we no
+# longer use djangocms_text_ckeditor), so the raw string would be stored
+# directly as the Prosemirror body field, bypassing JSON serialisation.
+# Disabling the body field prevents the wizard from creating a broken plugin.
+CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY = ""
+
 CMS_TEMPLATES = [
     ("cms/fullwidth.html", "Home page template"),
     ("cms/cms_flatpage_template.html", "CMS Flatpage Template"),


### PR DESCRIPTION
## Summary

The CMS page creation wizard used a plain Textarea widget for its content field (since `djangocms_text_ckeditor` was removed). When a user typed into the wizard, the raw string was passed directly to `add_plugin(body=<text>`), bypassing `ProsemirrorFormField` entirely. The string was stored as a JSON string in DB and read back as a Python `str`, causing `json.loads` to crash whenever the plugin content was rendered.

  Fixes:

  - ~`get_product_rendered_content` guard: added the same try/except that get_rendered_content already had, so malformed body data doesn't produce a `500` when rendering product pages.~
  - Data migration: converts existing Text plugins whose body is a plain string: empty strings become null, legacy HTML/text is converted to Prosemirror JSON via `html_to_doc`, failures fall back to null. Cleans up data already corrupted
  before the wizard fix.
  - Disable CMS wizard body field: sets `CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY = ""` so the wizard no longer pre-populates the Text plugin body. Prevents new corruption; users add content through the Prosemirror editor after page creation.

Note: the changes to `get_product_rendered_content` are no longer needed; they are fixed in the library.

## Issue References

Fixes #2445 

## Checklist

- [x] CHANGELOG.rst updated