### PR TITLE
fix: [#2447] align fetch_single_status cache timeout with CACHE_ZGW_Z…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,11 @@ Nieuwe features
 Bugfixes
 --------
 
-* ...
+* [:gh:`2447`]: De status van een zaak wordt nu correct bijgewerkt in de zakenlijst
+  wanneer een ZGW-backend (bijv. eSuite) een bestaand statusobject aanpast zonder
+  het URL te wijzigen. De cache-timeout van ``fetch_single_status`` is gelijkgesteld
+  aan ``CACHE_ZGW_ZAKEN_TIMEOUT`` (standaard 60 seconden), zodat de zakenlijst
+  dezelfde versheid garandeert als de zaakdetailpagina.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -350,7 +350,10 @@ class ZakenClient(ZgwAPIClient):
     def fetch_status_history(self, zaak_url: str) -> list[Status]:
         return self.fetch_status_history_no_cache(zaak_url)
 
-    @cache_result("{self.base_url}:status:{status_url}", timeout=60 * 60)
+    @cache_result(
+        "{self.base_url}:status:{status_url}",
+        timeout=settings.CACHE_ZGW_ZAKEN_TIMEOUT,
+    )
     def fetch_single_status(self, status_url: str) -> Status | None:
         try:
             response = self.get(url=status_url)


### PR DESCRIPTION
`fetch_single_status` was hardcoded to a 1-hour cache timeout while all other zaak-related fetches use `settings.CACHE_ZGW_ZAKEN_TIMEOUT` (default: 60 seconds). When a ZGW backend (e.g. eSuite) updates a Status object in-place without changing its URL, the case list would serve stale status text for up to an hour while the detail page, which uses `fetch_status_history` (keyed by zaak URL, 60s TTL), showed the correct updated status.

Closes: #2447

