### PR TITLE
chore: bump django-admin-index to 4.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Onderhoud
 ---------
 
 * [:gh:`2414`]: ClamAV Python-client (``clamd``) toegevoegd.
+* [:gh:`2455`]: ``django-admin-index`` bijgewerkt naar versie ``4.0.0``.
 
 2.2.0 (2026-04-20)
 ==================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -162,7 +162,7 @@ django==4.2.30
     #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
-django-admin-index==3.1.0
+django-admin-index==4.0.0
     # via -r requirements/base.in
 django-appconf==1.0.5
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -246,7 +246,7 @@ django==4.2.30
     #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
-django-admin-index==3.1.0
+django-admin-index==4.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -279,7 +279,7 @@ django==4.2.30
     #   sentry-sdk
     #   zgw-consumers
     #   zgw-consumers-oas
-django-admin-index==3.1.0
+django-admin-index==4.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

`django-admin-index` updated to `4.0.0`

## Checklist

- [x] CHANGELOG.rst updated
