### PR TITLE
[#2454] Copy ZGW object configs for duplicates with the same omschrijving

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,10 @@ Nieuwe features
   zijn gekoppeld als contactpersoon.
 * [:gh:`2470`]: Support van lijsten toegevoegd aan veelgestelde vragen en vragenlijststappen.
 * [:gh:`2468`]: Support van lijsten toegevoegd aan geen resultaten tekst op zoekpagina.
+* [:gh:`2454`]: De synchronisatie van ZGW-configuratieobjecten is aangepast,
+  zodat duplicaten die door OpenZaak worden aangemaakt (vermeldingen met dezelfde
+  'omschrijving' als bestaande vermeldingen) automatisch worden ingevuld met de
+  configuratiewaarden van bestaande vermeldingen in OIP.
 
 Bugfixes
 --------

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports.py
@@ -1252,6 +1252,98 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
         self.assertIn("Database lock timeout", excluded.error_message)
         self.assertEqual(excluded.extra_context["zaaktype_identificatie"], "ZAAK-001")
 
+    def test_import_informatieobjecttype_configs_copies_config_from_duplicate(self, m):
+        """
+        When OpenZaak creates a new informatieobjecttype with the same omschrijving,
+        OIP config fields are copied from the existing entry to the new one.
+        """
+        root = self.roots[0]
+        api_group = self.api_groups[0]
+
+        catalogus_url = f"{root}catalogussen/1234-5678"
+        catalogus = CatalogusConfigFactory.create(
+            url=catalogus_url,
+            domein="TEST",
+            rsin="12345",
+            service=api_group.ztc_service,
+        )
+        zaaktype_config = ZaakTypeConfig.objects.create(
+            identificatie="ZAAK-001",
+            omschrijving="Test Zaaktype",
+            catalogus=catalogus,
+            urls=[f"{root}zaaktypen/zt-001"],
+        )
+
+        # Existing config with configured OIP fields and the old informatieobjecttype URL
+        old_iot_url = f"{root}informatieobjecttypen/iot-old"
+        ZaakTypeInformatieObjectTypeConfig.objects.create(
+            zaaktype_config=zaaktype_config,
+            informatieobjecttype_url=old_iot_url,
+            omschrijving="Besluit",
+            zaaktype_uuids=[],
+            document_upload_enabled=True,
+            document_notification_enabled=True,
+        )
+
+        # OpenZaak has created a new informatieobjecttype URL for the same omschrijving
+        new_iot_url = f"{root}informatieobjecttypen/iot-new"
+        zaaktype_uuid = "7092140f-a0fe-4092-a1f8-293d03d2b053"
+
+        m.get(
+            f"{root}zaaktypen?identificatie=ZAAK-001",
+            json=paginated_response(
+                [
+                    generate_oas_component_cached(
+                        "ztc",
+                        "schemas/ZaakType",
+                        uuid=zaaktype_uuid,
+                        url=f"{root}zaaktypen/{zaaktype_uuid}",
+                        identificatie="ZAAK-001",
+                        omschrijving="Test Zaaktype",
+                        catalogus=catalogus_url,
+                        indicatieInternOfExtern="extern",
+                        informatieobjecttypen=[old_iot_url, new_iot_url],
+                        statustypen=[],
+                        resultaattypen=[],
+                    )
+                ]
+            ),
+        )
+        m.get(
+            old_iot_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/InformatieObjectType",
+                url=old_iot_url,
+                omschrijving="Besluit",
+            ),
+        )
+        m.get(
+            new_iot_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/InformatieObjectType",
+                url=new_iot_url,
+                omschrijving="Besluit",
+            ),
+        )
+
+        importer = ZGWCatalogusImporter(api_group)
+        result = importer.import_informatieobjecttype_configs_for_zaaktype(
+            zaaktype_config
+        )
+
+        self.assertEqual(len(result.created), 1)
+        self.assertEqual(len(result.updated), 1)
+        self.assertEqual(len(result.excluded), 0)
+
+        new_config = result.created[0]
+        self.assertEqual(new_config.informatieobjecttype_url, new_iot_url)
+        self.assertEqual(new_config.omschrijving, "Besluit")
+        # OIP config fields copied from the existing entry
+        self.assertTrue(new_config.document_upload_enabled)
+        self.assertTrue(new_config.document_notification_enabled)
+
     def test_import_statustype_configs_create_new(self, m):
         """Test importing a new statustype config for a zaaktype"""
         # Setup: create catalogus and zaaktype
@@ -1735,6 +1827,135 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
         self.assertIn("Save failed", excluded.error_message)
         self.assertIn("Database lock timeout", excluded.error_message)
         self.assertEqual(excluded.extra_context["zaaktype_identificatie"], "ZAAK-001")
+
+    def test_import_statustype_configs_copies_config_from_duplicate(self, m):
+        """
+        When OpenZaak creates a new statustype with the same omschrijving,
+        OIP config fields are copied from the existing entry to the new one.
+        """
+        root = self.roots[0]
+        api_group = self.api_groups[0]
+
+        catalogus_url = f"{root}catalogussen/1234-5678"
+        catalogus = CatalogusConfigFactory.create(
+            url=catalogus_url,
+            domein="TEST",
+            rsin="12345",
+            service=api_group.ztc_service,
+        )
+        zaaktype_config = ZaakTypeConfig.objects.create(
+            identificatie="ZAAK-001",
+            omschrijving="Test Zaaktype",
+            catalogus=catalogus,
+            urls=[f"{root}zaaktypen/zt-001"],
+        )
+
+        # Existing config with configured OIP fields and the old statustype URL
+        old_statustype_url = f"{root}statustypen/st-old"
+        description_doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Status beschrijving"}],
+                }
+            ],
+        }
+        doc_upload_description_doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Upload instructies"}],
+                }
+            ],
+        }
+        ZaakTypeStatusTypeConfig.objects.create(
+            zaaktype_config=zaaktype_config,
+            statustype_url=old_statustype_url,
+            omschrijving="In behandeling",
+            statustekst="Uw zaak wordt behandeld",
+            zaaktype_uuids=[],
+            status_indicator="warning",
+            status_indicator_text="Let op",
+            notify_status_change=False,
+            action_required=True,
+            document_upload_enabled=False,
+            description=description_doc,
+            document_upload_description=doc_upload_description_doc,
+            call_to_action_url="https://example.com",
+            call_to_action_text="Actie vereist",
+            case_link_text="Bekijk zaak",
+        )
+
+        # OpenZaak has created a new statustype URL for the same omschrijving
+        new_statustype_url = f"{root}statustypen/st-new"
+        zaaktype_uuid = "7092140f-a0fe-4092-a1f8-293d03d2b053"
+
+        m.get(
+            f"{root}zaaktypen?identificatie=ZAAK-001",
+            json=paginated_response(
+                [
+                    generate_oas_component_cached(
+                        "ztc",
+                        "schemas/ZaakType",
+                        uuid=zaaktype_uuid,
+                        url=f"{root}zaaktypen/{zaaktype_uuid}",
+                        identificatie="ZAAK-001",
+                        omschrijving="Test Zaaktype",
+                        catalogus=catalogus_url,
+                        indicatieInternOfExtern="extern",
+                        informatieobjecttypen=[],
+                        statustypen=[old_statustype_url, new_statustype_url],
+                        resultaattypen=[],
+                    )
+                ]
+            ),
+        )
+        m.get(
+            old_statustype_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/StatusType",
+                url=old_statustype_url,
+                omschrijving="In behandeling",
+                statustekst="Uw zaak wordt behandeld",
+            ),
+        )
+        m.get(
+            new_statustype_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/StatusType",
+                url=new_statustype_url,
+                omschrijving="In behandeling",
+                statustekst="Uw zaak wordt behandeld",
+            ),
+        )
+
+        importer = ZGWCatalogusImporter(api_group)
+        result = importer.import_statustype_configs_for_zaaktype(zaaktype_config)
+
+        self.assertEqual(len(result.created), 1)
+        self.assertEqual(len(result.updated), 1)
+        self.assertEqual(len(result.excluded), 0)
+
+        new_config = result.created[0]
+        self.assertEqual(new_config.statustype_url, new_statustype_url)
+        self.assertEqual(new_config.omschrijving, "In behandeling")
+        # OIP config fields copied from the existing entry
+        self.assertEqual(new_config.status_indicator, "warning")
+        self.assertEqual(new_config.status_indicator_text, "Let op")
+        self.assertFalse(new_config.notify_status_change)
+        self.assertTrue(new_config.action_required)
+        self.assertFalse(new_config.document_upload_enabled)
+        self.assertEqual(new_config.description.raw_data, description_doc)
+        self.assertEqual(
+            new_config.document_upload_description.raw_data, doc_upload_description_doc
+        )
+        self.assertEqual(new_config.call_to_action_url, "https://example.com")
+        self.assertEqual(new_config.call_to_action_text, "Actie vereist")
+        self.assertEqual(new_config.case_link_text, "Bekijk zaak")
 
     def test_import_resultaattype_configs_create_new(self, m):
         """Test importing a new resultaattype config for a zaaktype"""
@@ -2225,6 +2446,96 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
         self.assertIn("Save failed", excluded.error_message)
         self.assertIn("Database lock timeout", excluded.error_message)
         self.assertEqual(excluded.extra_context["zaaktype_identificatie"], "ZAAK-001")
+
+    def test_import_resultaattype_configs_copies_config_from_duplicate(self, m):
+        """
+        When OpenZaak creates a new resultaattype with the same omschrijving,
+        OIP config fields are copied from the existing entry to the new one.
+        """
+        root = self.roots[0]
+        api_group = self.api_groups[0]
+
+        catalogus_url = f"{root}catalogussen/1234-5678"
+        catalogus = CatalogusConfigFactory.create(
+            url=catalogus_url,
+            domein="TEST",
+            rsin="12345",
+            service=api_group.ztc_service,
+        )
+        zaaktype_config = ZaakTypeConfig.objects.create(
+            identificatie="ZAAK-001",
+            omschrijving="Test Zaaktype",
+            catalogus=catalogus,
+            urls=[f"{root}zaaktypen/zt-001"],
+        )
+
+        # Existing config with a configured description and the old resultaattype URL
+        old_resultaattype_url = f"{root}resultaattypen/rt-old"
+        ZaakTypeResultaatTypeConfig.objects.create(
+            zaaktype_config=zaaktype_config,
+            resultaattype_url=old_resultaattype_url,
+            omschrijving="Toegewezen",
+            zaaktype_uuids=[],
+            description="De zaak is toegewezen aan een behandelaar.",
+        )
+
+        # OpenZaak has created a new resultaattype URL for the same omschrijving
+        new_resultaattype_url = f"{root}resultaattypen/rt-new"
+        zaaktype_uuid = "7092140f-a0fe-4092-a1f8-293d03d2b053"
+
+        m.get(
+            f"{root}zaaktypen?identificatie=ZAAK-001",
+            json=paginated_response(
+                [
+                    generate_oas_component_cached(
+                        "ztc",
+                        "schemas/ZaakType",
+                        uuid=zaaktype_uuid,
+                        url=f"{root}zaaktypen/{zaaktype_uuid}",
+                        identificatie="ZAAK-001",
+                        omschrijving="Test Zaaktype",
+                        catalogus=catalogus_url,
+                        indicatieInternOfExtern="extern",
+                        informatieobjecttypen=[],
+                        statustypen=[],
+                        resultaattypen=[old_resultaattype_url, new_resultaattype_url],
+                    )
+                ]
+            ),
+        )
+        m.get(
+            old_resultaattype_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/ResultaatType",
+                url=old_resultaattype_url,
+                omschrijving="Toegewezen",
+            ),
+        )
+        m.get(
+            new_resultaattype_url,
+            json=generate_oas_component_cached(
+                "ztc",
+                "schemas/ResultaatType",
+                url=new_resultaattype_url,
+                omschrijving="Toegewezen",
+            ),
+        )
+
+        importer = ZGWCatalogusImporter(api_group)
+        result = importer.import_resultaattype_configs_for_zaaktype(zaaktype_config)
+
+        self.assertEqual(len(result.created), 1)
+        self.assertEqual(len(result.updated), 1)
+        self.assertEqual(len(result.excluded), 0)
+
+        new_config = result.created[0]
+        self.assertEqual(new_config.resultaattype_url, new_resultaattype_url)
+        self.assertEqual(new_config.omschrijving, "Toegewezen")
+        # OIP config field copied from the existing entry
+        self.assertEqual(
+            new_config.description, "De zaak is toegewezen aan een behandelaar."
+        )
 
     def test_full_zaaktype_import_integration(self, m):
         """Integration test: full import with creates, updates, and exclusions"""

--- a/src/open_inwoner/openzaak/zgw_imports.py
+++ b/src/open_inwoner/openzaak/zgw_imports.py
@@ -789,10 +789,16 @@ class ZGWCatalogusImporter:
             for url in zaak_type.informatieobjecttypen:
                 info_queue[url].append(zaak_type)
 
-        # Map existing config records by url
+        # Map existing config records by url and by omschrijving (natural key).
+        # The omschrijving lookup is used to copy OIP config fields onto newly
+        # created entries when OpenZaak produces a duplicate information object type
+        # (same omschrijving, new URL) after a zaaktype edit.
+        all_existing_iots = list(ztc.zaaktypeinformatieobjecttypeconfig_set.all())
         existing_map = {
-            ztiotc.informatieobjecttype_url: ztiotc
-            for ztiotc in ztc.zaaktypeinformatieobjecttypeconfig_set.all()
+            ztiotc.informatieobjecttype_url: ztiotc for ztiotc in all_existing_iots
+        }
+        existing_iot_by_omschrijving = {
+            ztiotc.omschrijving: ztiotc for ztiotc in all_existing_iots
         }
 
         iot_urls_seen = set()
@@ -878,7 +884,12 @@ class ZGWCatalogusImporter:
                                 )
                             )
                 else:
-                    # Create new
+                    # Create new: if an existing entry with the same omschrijving
+                    # exists, copy its OIP config fields so the admin does not have
+                    # to reconfigure after OpenZaak duplicates an information object type.
+                    config_source = existing_iot_by_omschrijving.get(
+                        info_type.omschrijving
+                    )
                     ztiotc = ZaakTypeInformatieObjectTypeConfig(
                         zaaktype_config=ztc,
                         informatieobjecttype_url=info_type.url,
@@ -886,6 +897,19 @@ class ZGWCatalogusImporter:
                         zaaktype_uuids=[zt.uuid for zt in using_zaak_types],
                         found_in_api=True,
                     )
+                    if config_source is not None:
+                        logger.info(
+                            "Copying OIP config from existing information object type with matching omschrijving",
+                            new_informatieobjecttype_url=info_type.url,
+                            source_informatieobjecttype_url=config_source.informatieobjecttype_url,
+                            omschrijving=info_type.omschrijving,
+                        )
+                        ztiotc.document_upload_enabled = (
+                            config_source.document_upload_enabled
+                        )
+                        ztiotc.document_notification_enabled = (
+                            config_source.document_notification_enabled
+                        )
                     try:
                         ztiotc.save()
                         result.created.append(ztiotc)
@@ -952,10 +976,16 @@ class ZGWCatalogusImporter:
             for url in zaak_type.statustypen:
                 status_queue[url].append(zaak_type)
 
-        # Map existing config records by url
+        # Map existing config records by url and by omschrijving (natural key).
+        # The omschrijving lookup is used to copy OIP config fields onto newly
+        # created entries when OpenZaak produces a duplicate status type (same
+        # omschrijving, new URL) after a zaaktype edit.
+        all_existing_statustypes = list(ztc.zaaktypestatustypeconfig_set.all())
         existing_map = {
-            ztstc.statustype_url: ztstc
-            for ztstc in ztc.zaaktypestatustypeconfig_set.all()
+            ztstc.statustype_url: ztstc for ztstc in all_existing_statustypes
+        }
+        existing_statustype_by_omschrijving = {
+            ztstc.omschrijving: ztstc for ztstc in all_existing_statustypes
         }
 
         statustype_urls_seen = set()
@@ -1043,7 +1073,9 @@ class ZGWCatalogusImporter:
                                 )
                             )
                 else:
-                    # Create new
+                    # Create new: if an existing entry with the same omschrijving
+                    # exists, copy its OIP config fields so the admin does not have
+                    # to reconfigure after OpenZaak duplicates a status type.
                     ztstc = ZaakTypeStatusTypeConfig(
                         zaaktype_config=ztc,
                         statustype_url=status_type.url,
@@ -1052,6 +1084,32 @@ class ZGWCatalogusImporter:
                         zaaktype_uuids=[zt.uuid for zt in using_zaak_types],
                         found_in_api=True,
                     )
+                    config_source = existing_statustype_by_omschrijving.get(
+                        status_type.omschrijving
+                    )
+                    if config_source is not None:
+                        logger.info(
+                            "Copying OIP config from existing statustype with matching omschrijving",
+                            new_statustype_url=status_type.url,
+                            source_statustype_url=config_source.statustype_url,
+                            omschrijving=status_type.omschrijving,
+                        )
+                        ztstc.status_indicator = config_source.status_indicator
+                        ztstc.status_indicator_text = (
+                            config_source.status_indicator_text
+                        )
+                        ztstc.document_upload_description = (
+                            config_source.document_upload_description
+                        )
+                        ztstc.description = config_source.description
+                        ztstc.notify_status_change = config_source.notify_status_change
+                        ztstc.action_required = config_source.action_required
+                        ztstc.document_upload_enabled = (
+                            config_source.document_upload_enabled
+                        )
+                        ztstc.call_to_action_url = config_source.call_to_action_url
+                        ztstc.call_to_action_text = config_source.call_to_action_text
+                        ztstc.case_link_text = config_source.case_link_text
                     try:
                         ztstc.save()
                         result.created.append(ztstc)
@@ -1113,10 +1171,16 @@ class ZGWCatalogusImporter:
 
         zaak_types = self.get_api_zaaktypen_for_saved_ztc(ztc)
 
-        # Map existing config records by url
+        # Map existing config records by url and by omschrijving (natural key).
+        # The omschrijving lookup is used to copy OIP config fields onto newly
+        # created entries when OpenZaak produces a duplicate result type (same
+        # omschrijving, new URL) after a zaaktype edit.
+        all_existing_resultaattypes = list(ztc.zaaktyperesultaattypeconfig_set.all())
         existing_map = {
-            ztrtc.resultaattype_url: ztrtc
-            for ztrtc in ztc.zaaktyperesultaattypeconfig_set.all()
+            ztrtc.resultaattype_url: ztrtc for ztrtc in all_existing_resultaattypes
+        }
+        existing_resultaattype_by_omschrijving = {
+            ztrtc.omschrijving: ztrtc for ztrtc in all_existing_resultaattypes
         }
 
         # Collect and implicitly de-duplicate resultaattype urls
@@ -1206,7 +1270,12 @@ class ZGWCatalogusImporter:
                                 )
                             )
                 else:
-                    # Create new
+                    # Create new: if an existing entry with the same omschrijving
+                    # exists, copy its OIP config fields so the admin does not have
+                    # to reconfigure after OpenZaak duplicates a result type.
+                    config_source = existing_resultaattype_by_omschrijving.get(
+                        resultaat_type.omschrijving
+                    )
                     ztrtc = ZaakTypeResultaatTypeConfig(
                         zaaktype_config=ztc,
                         resultaattype_url=resultaat_type.url,
@@ -1214,6 +1283,14 @@ class ZGWCatalogusImporter:
                         zaaktype_uuids=[zt.uuid for zt in using_zaak_types],
                         found_in_api=True,
                     )
+                    if config_source is not None:
+                        logger.info(
+                            "Copying OIP config from existing resultaattype with matching omschrijving",
+                            new_resultaattype_url=resultaat_type.url,
+                            source_resultaattype_url=config_source.resultaattype_url,
+                            omschrijving=resultaat_type.omschrijving,
+                        )
+                        ztrtc.description = config_source.description
                     try:
                         ztrtc.save()
                         result.created.append(ztrtc)


### PR DESCRIPTION

## Summary

The configuration for existing ZGW objects (status type, resultaat type) is copied to newly created (by OpenZaak) entries with the same 'omschrijving', which are duplicates from a user-perspective.

## Issue References

Closes #2454 

## Checklist

- [x] CHANGELOG.rst updated
