### PR TITLE
feat: [#2363] add contact approval notifications via service methods

### DIFF
--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -750,6 +750,67 @@ class User(AbstractBaseUser, PermissionsMixin):
     def has_contact(self, user):
         return self.user_contacts.filter(id=user.id).exists()
 
+    @transaction.atomic
+    def _send_contact_accepted_notifications(self, other_user: "User") -> None:
+        """
+        Send notification emails to both users about an accepted contact relationship.
+        Uses the 'contact_invitation_accepted' email template.
+        """
+        contacts_url = settings.BASE_URL + reverse("profile:contact_list")
+        template = find_template("contact_invitation_accepted")
+
+        # Send email to self
+        template.send_email(
+            [self.email],
+            {
+                "contact_name": other_user.get_full_name(),
+                "email": self.email,
+                "contacts_link": contacts_url,
+            },
+        )
+
+        # Send email to other user
+        template.send_email(
+            [other_user.email],
+            {
+                "contact_name": self.get_full_name(),
+                "email": other_user.email,
+                "contacts_link": contacts_url,
+            },
+        )
+
+    @transaction.atomic
+    def approve_contact(self, sender: "User") -> bool:
+        """
+        Approve a pending contact request from another user (the sender).
+        The sender had previously added the receiver (self) to their contacts_for_approval.
+        Establishes bidirectional contact relationship and sends notifications to both parties.
+
+        Returns True if the relationship was newly created, False if it already existed.
+        """
+        # Check if this is a new relationship
+        is_new = not self.has_contact(sender)
+
+        # Remove the receiver (self) from the sender's pending approvals list
+        sender.contacts_for_approval.remove(self)
+
+        # Add to contacts (bidirectional)
+        if is_new:
+            self.user_contacts.add(sender)
+
+        # Send notifications to both parties
+        if is_new:
+            self._send_contact_accepted_notifications(sender)
+
+        return is_new
+
+    def reject_contact_request(self, sender: "User") -> None:
+        """
+        Reject a pending contact request from another user (the sender).
+        Removes the receiver (self) from the sender's pending approvals list.
+        """
+        sender.contacts_for_approval.remove(self)
+
     def get_plan_contact_new_count(self):
         return (
             PlanContact.objects.filter(user=self, notify_new=True)
@@ -1183,24 +1244,7 @@ class Invite(models.Model):
     # atomic, but it can't hurt to have an extra savepoint.
     @transaction.atomic
     def send_accepted_emails(self):
-        contacts_url = settings.BASE_URL + reverse("profile:contact_list")
-        template = find_template("contact_invitation_accepted")
-        template.send_email(
-            [self.inviter.email],
-            {
-                "contact_name": self.invitee.get_full_name(),
-                "email": self.inviter.email,
-                "contacts_link": contacts_url,
-            },
-        )
-        template.send_email(
-            [self.invitee.email],
-            {
-                "contact_name": self.inviter.get_full_name(),
-                "email": self.invitee.email,
-                "contacts_link": contacts_url,
-            },
-        )
+        self.inviter._send_contact_accepted_notifications(self.invitee)
 
     def get_absolute_url(self) -> str:
         return reverse("profile:invite_accept", kwargs={"key": self.key})

--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -430,6 +430,22 @@ class ContactViewTests(WebTest):
         response = form.submit("contact_approve")
         self.assertRedirects(response, reverse("profile:contact_list"))
 
+    def test_approve_contact_sends_notifications_to_both_parties(self):
+        existing_user = UserFactory(
+            first_name="Luke", last_name="Skywalker", email="ex@example.com"
+        )
+        self.user.contacts_for_approval.add(existing_user)
+
+        mail.outbox.clear()
+
+        response = self.app.get(self.list_url, user=existing_user)
+        form = response.forms["approval_form"]
+        form.submit("contact_approve")
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(self.user.email, recipients)
+        self.assertIn(existing_user.email, recipients)
+
     def test_user_cannot_approve_other_users_contact(self):
         other_user = UserFactory()
         contact = UserFactory()

--- a/src/open_inwoner/accounts/tests/test_models.py
+++ b/src/open_inwoner/accounts/tests/test_models.py
@@ -48,3 +48,56 @@ class InviteAcceptTests(TestCase):
         invite.accept(invitee)
 
         self.assertEqual(len(mail.outbox), count_after_first)
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class UserApproveContactTests(TestCase):
+    def test_approve_contact_establishes_relationship(self):
+        sender = UserFactory()
+        receiver = UserFactory()
+        sender.contacts_for_approval.add(receiver)
+
+        result = receiver.approve_contact(sender)
+
+        self.assertTrue(result)
+        self.assertIn(sender, receiver.user_contacts.all())
+        self.assertIn(receiver, sender.user_contacts.all())
+        self.assertNotIn(receiver, sender.contacts_for_approval.all())
+
+    def test_approve_contact_sends_notifications_to_both_parties(self):
+        sender = UserFactory()
+        receiver = UserFactory()
+        sender.contacts_for_approval.add(receiver)
+
+        mail.outbox.clear()
+
+        receiver.approve_contact(sender)
+
+        recipients = {m.to[0] for m in mail.outbox}
+        self.assertIn(sender.email, recipients)
+        self.assertIn(receiver.email, recipients)
+
+    def test_approve_contact_returns_false_when_already_approved(self):
+        sender = UserFactory()
+        receiver = UserFactory()
+        sender.contacts_for_approval.add(receiver)
+
+        receiver.approve_contact(sender)
+        mail.outbox.clear()
+
+        result = receiver.approve_contact(sender)
+
+        self.assertFalse(result)
+        # No new emails should be sent
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_reject_contact_request_removes_from_pending(self):
+        sender = UserFactory()
+        receiver = UserFactory()
+        sender.contacts_for_approval.add(receiver)
+
+        receiver.reject_contact_request(sender)
+
+        self.assertNotIn(receiver, sender.contacts_for_approval.all())
+        self.assertNotIn(sender, receiver.user_contacts.all())
+        self.assertNotIn(receiver, sender.user_contacts.all())

--- a/src/open_inwoner/accounts/views/contacts.py
+++ b/src/open_inwoner/accounts/views/contacts.py
@@ -183,10 +183,9 @@ class ContactApprovalView(LogMixin, LoginRequiredMixin, SingleObjectMixin, View)
 
     def update_contact(self, sender, receiver, type_of_approval):
         if type_of_approval == "approve":
-            sender.contacts_for_approval.remove(receiver)
-            sender.user_contacts.add(receiver)
+            receiver.approve_contact(sender)
             self.log_change(sender, _("contact was approved"))
 
         elif type_of_approval == "reject":
-            sender.contacts_for_approval.remove(receiver)
+            receiver.reject_contact_request(sender)
             self.log_change(sender, _("contact was rejected"))


### PR DESCRIPTION
Refactored contact management to use proper service methods that ensure notifications are sent consistently across all contact acceptance paths.

Changes:
- Added User.approve_contact() service method to handle contact approval logic, ensuring notifications are sent to both parties
- Added User.reject_contact_request() service method for rejecting requests
- Added User._send_contact_accepted_notifications() private helper method to centralize notification logic
- Refactored Invite.send_accepted_emails() to use the shared notification helper, ensuring consistent behavior between invite and approval flows
- Updated ContactApprovalView to use new service methods instead of direct M2M manipulation
- Added comprehensive tests to verify notifications are sent in both paths (invite acceptance and contact approval)

This ensures that when users approve contact requests from the contacts overview page, both parties receive notification emails, matching the behavior of the invite acceptance flow.

Closes #2363
