### PR TITLE
:bug: [#2465] Reimplement CKEditor configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,10 @@ Bugfixes
 * [:gh:`2445`]: Ongeldige inhoud in TextPlugin-velden (lege of platte tekst opgeslagen
   als JSON-string) wordt nu automatisch hersteld via een datamigatie. De CMS-wizard
   vult het tekstveld niet langer voor, zodat nieuwe corruptie wordt voorkomen.
+* [:gh:`2465`]: CKEDITOR_CONFIGS aan de configuratie is toegevoegd om te voorkomen dat de
+  opmaak van e-mailsjablonen verloren gaat bij het opslaan. Het beheeropdracht
+  'find_modified_mail_templates' is toegevoegd om e-mailsjablonen op te sporen en te melden
+  die mogelijk beschadigd zijn.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -1141,6 +1141,32 @@ else:
 
 MAIL_EDITOR_BASE_HOST = BASE_URL
 
+CKEDITOR_CONFIGS = {
+    "default": {
+        "allowedContent": True,
+        "toolbar": "Custom",
+        "toolbar_Custom": [
+            ["Format"],  # Headings
+            ["Bold", "Italic", "Underline"],
+            ["NumberedList", "BulletedList"],
+            ["Link", "Unlink"],
+            ["Table", "HorizontalRule"],
+            ["RemoveFormat", "Source"],
+            ["Undo", "Redo"],
+        ],
+        "removeButtons": "TextColor,BGColor",  # Remove color-styling
+        "versionCheck": False,
+        "width": 600,
+    },
+    "mail_editor": {
+        "allowedContent": True,
+        "contentsCss": [
+            "/static/mailcss/email.css"
+        ],  # Enter the css file used to style the email.
+        "height": 600,  # This is optional
+        "entities": False,  # This is added because CKEDITOR escapes the ' when you do an if statement
+    },
+}
 
 #
 # django-setup-configuration

--- a/src/open_inwoner/configurations/management/commands/find_modified_mail_templates.py
+++ b/src/open_inwoner/configurations/management/commands/find_modified_mail_templates.py
@@ -79,6 +79,8 @@ class Command(BaseCommand):
             if template.language:
                 label += f" ({template.language})"
 
+            path = reverse("admin:mail_editor_mailtemplate_change", args=[template.pk])
+
             self.stdout.write(self.style.SUCCESS(label))
             self.stdout.write(f"  Subject : {template.subject}")
             self.stdout.write(
@@ -86,9 +88,10 @@ class Command(BaseCommand):
                 f"by {last_save.user}"
             )
             self.stdout.write(f"  Saves since cutoff : {len(saves)}")
+            self.stdout.write(f"  Admin URL : {path}")
             self.stdout.write("")
 
-            blocks.append((label, template))
+            blocks.append((label, template, path))
 
         email_address = options["email"]
         if not email_address:
@@ -98,8 +101,7 @@ class Command(BaseCommand):
         lines = []
         list_items = []
 
-        for label, template in blocks:
-            path = reverse("admin:mail_editor_mailtemplate_change", args=[template.pk])
+        for label, template, path in blocks:
             url = f"https://{domain}{path}"
             lines.append(f"{label}: {url}")
             list_items.append(f'<li><a href="{url}">{label}</a></li>')

--- a/src/open_inwoner/configurations/management/commands/find_modified_mail_templates.py
+++ b/src/open_inwoner/configurations/management/commands/find_modified_mail_templates.py
@@ -1,0 +1,123 @@
+from datetime import date
+
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail import EmailMultiAlternatives
+from django.core.management.base import BaseCommand, CommandError
+from django.urls import reverse
+
+from mail_editor.models import MailTemplate
+
+DEFAULT_CUTOFF = date(2026, 3, 4)
+
+
+class Command(BaseCommand):
+    help = (
+        "List mail templates saved on or after a given date (default: 2026-03-04), "
+        "when CKEditor was re-added without CKEDITOR_CONFIGS, which may have stripped "
+        "CSS classes from the body. Pass --email to receive the full template bodies "
+        "at that address."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--since",
+            type=date.fromisoformat,
+            default=DEFAULT_CUTOFF,
+            metavar="YYYY-MM-DD",
+            help=f"Only report templates saved on or after this date (default: {DEFAULT_CUTOFF}).",
+        )
+        parser.add_argument(
+            "--email",
+            help="Send the affected templates to this address.",
+        )
+
+    def handle(self, *args, **options):
+        since = options["since"]
+        ct = ContentType.objects.get_for_model(MailTemplate)
+
+        log_entries = (
+            LogEntry.objects.filter(
+                content_type=ct,
+                action_time__date__gte=since,
+                action_flag__in=[ADDITION, CHANGE],
+            )
+            .select_related("user")
+            .order_by("object_id", "action_time")
+        )
+
+        if not log_entries.exists():
+            self.stdout.write(f"No mail templates were saved on or after {since}.")
+            return
+
+        # LogEntry.object_id is a CharField; cast to int to avoid a type mismatch in Postgre
+        affected_pks = [
+            int(pk) for pk in log_entries.values_list("object_id", flat=True).distinct()
+        ]
+        templates = MailTemplate.objects.filter(pk__in=affected_pks).order_by(
+            "template_type", "language"
+        )
+        entries_by_pk = {}
+        for entry in log_entries:
+            entries_by_pk.setdefault(entry.object_id, []).append(entry)
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"Found {templates.count()} mail template(s) saved on or after {since}:"
+            )
+        )
+        self.stdout.write("")
+
+        blocks = []
+        for template in templates:
+            pk_str = str(template.pk)
+            saves = entries_by_pk.get(pk_str, [])
+            last_save = saves[-1]
+
+            label = template.template_type
+            if template.language:
+                label += f" ({template.language})"
+
+            self.stdout.write(self.style.SUCCESS(label))
+            self.stdout.write(f"  Subject : {template.subject}")
+            self.stdout.write(
+                f"  Last saved : {last_save.action_time:%Y-%m-%d %H:%M} "
+                f"by {last_save.user}"
+            )
+            self.stdout.write(f"  Saves since cutoff : {len(saves)}")
+            self.stdout.write("")
+
+            blocks.append((label, template))
+
+        email_address = options["email"]
+        if not email_address:
+            return
+
+        domain = get_current_site(None).domain
+        lines = []
+        list_items = []
+
+        for label, template in blocks:
+            path = reverse("admin:mail_editor_mailtemplate_change", args=[template.pk])
+            url = f"https://{domain}{path}"
+            lines.append(f"{label}: {url}")
+            list_items.append(f'<li><a href="{url}">{label}</a></li>')
+
+        subject = f"Mail templates saved on or after {since}"
+        plain_body = "\n".join(lines)
+        html_body = f"<ul>{''.join(list_items)}</ul>"
+
+        message = EmailMultiAlternatives(
+            subject=subject,
+            body=plain_body,
+            to=[email_address],
+        )
+        message.attach_alternative(html_body, "text/html")
+
+        try:
+            message.send()
+        except Exception as exc:
+            raise CommandError(f"Failed to send email: {exc}") from exc
+
+        self.stdout.write(self.style.SUCCESS(f"Sent to {email_address}."))


### PR DESCRIPTION
## Summary
CKEditor has a feature called Advanced Content Filter (ACF) that is enabled by default. When ACF is active, CKEditor silently strips any HTML elements, attributes, or CSS classes it doesn't recognise as "safe" on every save. Setting `allowedContent: True` disables ACF entirely and tells CKEditor to preserve whatever HTML is present verbatim.

 When CKEditor was added without `CKEDITOR_CONFIGS["mail_editor"]` in commit [69b176f44d0333271fc8abf1f7f825b0b6f69101](https://github.com/maykinmedia/open-inwoner/commit/69b176f44d0333271fc8abf1f7f825b0b6f69101) the widget fell back to CKEditor's default config - ACF enabled, with restrictive allowlist.

Mail templates saved after 2026-03-04, the date of release `2.1.0`, would have lost their styling do to this ACF mechanism.

The PR adds `CKEDITOR_CONFIGS` back. A management command `find_modified_mail_templates` is added to find and report mail templates which might have been corrupted.

## Issue References
Fixes #2465 

## Checklist

- [x] CHANGELOG.rst updated
  - [ ] Deployment notes added
        <!--e.g. because of migrations, config flags, etc. -->
  - [ ] Breaking changes flagged
        <!-- e.g. removed endpoints/commands, deprecated support -->
- [ ] Documentation updated <!-- If the PR changes admin/config pages-->
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created
      <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
- [ ] Updated the `docker-compose.yml` environment variables
  - [ ] Created an issue in https://github.com/maykinmedia/charts/ for new
        environment variables
