### PR TITLE
:bug: [#2438] Wrap file names in notification for case documents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Bugfixes
   te voorkomen.
 * [:gh:`2449`]: Het ‘formaat' van een bestand wordt ingesteld op het inhoudstype van de
   upload wanneer het naar een zaak wordt geüpload, zodat er een voorbeeld beschikbaar komt.
+* [:gh:`2438`]: Lange bestandsnamen in notificaties worden nu correct afgebroken zodat ze niet
+  buiten de notificatie vallen.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/scss/components/Notification/_Notification.scss
+++ b/src/open_inwoner/scss/components/Notification/_Notification.scss
@@ -100,6 +100,7 @@
 
   & &__content {
     margin-top: var(--spacing-tiny);
+    overflow-wrap: anywhere;
 
     &:focus,
     &:focus-visible {


### PR DESCRIPTION
## Summary

Wrap file names in notification for case documents

## Issue References

- Github Issue: #2438 

## Checklist

- [x] CHANGELOG.rst updated