### PR TITLE
ci: fix false positive linkcheck fail on packaging.python.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ linkcheck_ignore = [
     # 403s when running on github actions:
     r"https?://stackoverflow\.com/.*",
     r"https?://www\.npmjs\.com/.*",
+    r"https://packaging\.python\.org/.*",  # anchor detection fails in CI
 ]
 
 extlinks = {


### PR DESCRIPTION


<!-- readthedocs-preview open-inwoner start -->
----
📚 Documentation preview 📚: https://open-inwoner--2488.org.readthedocs.build/en/2488/

<!-- readthedocs-preview open-inwoner end -->