### PR TITLE
[#2514] Cache ZGW objects with Celery on user login

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Nieuwe features
 * [:gh:`2203`, :oip-nlds:`41`, :oip-nlds:`42` :oip-nlds:`43`]: Alle 'utrecht' paragrafen
   vervangen door 'nl' paragrafen, als herbruikbaar web component, waardoor hun huisstijl
   overschrijfbaar wordt met de nieuwe candidate NL design-tokens.
+* [:gh:`2514`]: De ZGW-cache wordt bij het inloggen op de achtergrond voorgeladen via een
+  Celery-taak, zodat de zakenlijst en zaakdetailpagina's bij het eerste bezoek al vanuit
+  de cache worden bediend.
 
 Bugfixes
 --------

--- a/src/open_inwoner/accounts/apps.py
+++ b/src/open_inwoner/accounts/apps.py
@@ -67,7 +67,7 @@ class AccountsConfig(AppConfig):
 
     def ready(self):
         # Register the signals upon app init
-        from .signals import log_user_login, log_user_logout, on_bsn_change  # noqa:F401
+        from . import signals  # noqa: F401
 
         if self._has_run:
             return

--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -17,6 +17,10 @@ import requests
 import structlog
 from axes.signals import user_locked_out
 
+from open_inwoner.accounts.user_identification import (
+    BSNIdentification,
+    KVKIdentification,
+)
 from open_inwoner.haalcentraal.clients import BRPClient
 from open_inwoner.kvk.client import KvKClient
 from open_inwoner.kvk.exceptions import KVKAPIException
@@ -24,6 +28,7 @@ from open_inwoner.openklant.constants import KlantenServiceType
 from open_inwoner.openklant.exceptions import KlantAPIError
 from open_inwoner.openklant.models import KlantenSysteemConfig
 from open_inwoner.openklant.services import OpenKlant2Service, eSuiteKlantenService
+from open_inwoner.openzaak.tasks import warm_cache_for_user
 from open_inwoner.utils.logentry import system_action, user_action
 
 from .metrics import login_failures, logins, logouts, user_lockouts
@@ -253,6 +258,32 @@ def increment_logins_counter(
             "http_target": request.path if request else "",
         },
     )
+
+
+@receiver(user_logged_in, dispatch_uid="user_logged_in.warm_zgw_cache")
+def warm_zgw_cache_on_login(
+    sender: type[User], request: HttpRequest | None, user: User, **kwargs
+) -> None:
+    try:
+        match user.identification:
+            case BSNIdentification(bsn=bsn):
+                warm_cache_for_user.delay(
+                    user_bsn=bsn,
+                    user_kvk=None,
+                    user_rsin=None,
+                    user_vestigingsnummer=None,
+                )
+            case KVKIdentification(
+                kvk=kvk, rsin=rsin, vestigingsnummer=vestigingsnummer
+            ):
+                warm_cache_for_user.delay(
+                    user_bsn=None,
+                    user_kvk=kvk,
+                    user_rsin=rsin,
+                    user_vestigingsnummer=vestigingsnummer,
+                )
+    except Exception:
+        logger.warning("Failed to dispatch ZGW cache warm-up task", exc_info=True)
 
 
 @receiver(user_logged_out, dispatch_uid="user_logged_out.increment_counter")

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -126,7 +126,7 @@ SOLO_CACHE = "local"  # Avoid Redis overhead
 
 # ZGW API caches
 CACHE_ZGW_CATALOGI_TIMEOUT = config("CACHE_ZGW_CATALOGI_TIMEOUT", default=60 * 60 * 24)
-CACHE_ZGW_ZAKEN_TIMEOUT = config("CACHE_ZGW_ZAKEN_TIMEOUT", default=60 * 1)
+CACHE_ZGW_ZAKEN_TIMEOUT = config("CACHE_ZGW_ZAKEN_TIMEOUT", default=60 * 5)
 
 # Maximum number of pagination requests to follow when fetching zaken from ZGW APIs
 ZGW_MAX_REQUESTS = config("ZGW_MAX_REQUESTS", default=8)
@@ -882,6 +882,7 @@ CELERY_BEAT_SCHEDULE = {
 # *should* have the same effect...
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
+
 #
 # SENTRY - error monitoring
 #
@@ -1056,6 +1057,11 @@ ZGW_CASE_LIST_NUM_WORKERS = (
 # cases on the "Mijn Zaken" page. Should be set to slightly less than the overall
 # timeout.
 ZGW_CASE_LIST_FETCH_TIMEOUT = config("ZGW_CASE_LIST_FETCH_TIMEOUT", default=25)
+
+# Timeout in seconds for the login cache warm-up task per API group.
+# Needs to be longer than ZGW_CASE_LIST_FETCH_TIMEOUT because the warm-up fetches
+# status history, roles, and documents on top of what the list view resolves.
+ZGW_CACHE_WARMUP_TIMEOUT = config("ZGW_CACHE_WARMUP_TIMEOUT", default=120)
 
 # notifications
 ZGW_LIMIT_NOTIFICATIONS_FREQUENCY = config(

--- a/src/open_inwoner/conf/dev.py
+++ b/src/open_inwoner/conf/dev.py
@@ -75,7 +75,11 @@ LOGGING["loggers"].update(
 # in memory cache and django-axes don't get along.
 # https://django-axes.readthedocs.io/en/latest/configuration.html#known-configuration-problems
 CACHES = {
-    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/0",
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    },
     "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
 }
 
@@ -99,6 +103,10 @@ if "test" in sys.argv:
     ELASTICSEARCH_DSL_AUTO_REFRESH = False
     ELASTICSEARCH_DSL_AUTOSYNC = False
     ES_INDEX_PRODUCTS = "products_test"
+    CACHES = {
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+    }
 
 # Django debug toolbar
 INSTALLED_APPS += ["django_extensions"]

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -77,17 +77,23 @@ class ZgwAPIClient(BaseAPIClient):
 class ZakenClient(ZgwAPIClient):
     use_openzaak_120_params: bool
     fetch_rollen_with_betrokkene_type: bool
+    zaak_max_confidentiality: str
+    limit_user_visible_cases_to_role: str | None
 
     def __init__(
         self,
         *args,
         use_openzaak_120_params: bool,
         fetch_rollen_with_betrokkene_type: bool,
+        zaak_max_confidentiality: str,
+        limit_user_visible_cases_to_role: str | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.use_openzaak_120_params = use_openzaak_120_params
         self.fetch_rollen_with_betrokkene_type = fetch_rollen_with_betrokkene_type
+        self.zaak_max_confidentiality = zaak_max_confidentiality
+        self.limit_user_visible_cases_to_role = limit_user_visible_cases_to_role
 
     def fetch_zaken(
         self,
@@ -141,17 +147,15 @@ class ZakenClient(ZgwAPIClient):
         :param:max_requests - used to limit the number of requests to list_zaken resource.
         :param:identificatie - used to filter the zaken by a specific identification
         """
-        config = OpenZaakConfig.get_solo()
-
         params = {
             "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": user_bsn,
-            "maximaleVertrouwelijkheidaanduiding": config.zaak_max_confidentiality,
+            "maximaleVertrouwelijkheidaanduiding": self.zaak_max_confidentiality,
         }
         if identificatie:
             params.update({"identificatie": identificatie})
-        if config.limit_user_visible_cases_to_role:
+        if self.limit_user_visible_cases_to_role:
             params.update(
-                {"rol__omschrijvingGeneriek": config.limit_user_visible_cases_to_role}
+                {"rol__omschrijvingGeneriek": self.limit_user_visible_cases_to_role}
             )
 
         response = self.get(
@@ -196,10 +200,8 @@ class ZakenClient(ZgwAPIClient):
                 "You must set either a `kvk_or_rsin` or `vestigingsnummer`"
             )
 
-        config = OpenZaakConfig.get_solo()
-
         params = {
-            "maximaleVertrouwelijkheidaanduiding": config.zaak_max_confidentiality,
+            "maximaleVertrouwelijkheidaanduiding": self.zaak_max_confidentiality,
         }
 
         vestigingsnummer_param = (
@@ -224,9 +226,9 @@ class ZakenClient(ZgwAPIClient):
         if zaak_identificatie:
             params.update({"identificatie": zaak_identificatie})
 
-        if config.limit_user_visible_cases_to_role:
+        if self.limit_user_visible_cases_to_role:
             params.update(
-                {"rol__omschrijvingGeneriek": config.limit_user_visible_cases_to_role}
+                {"rol__omschrijvingGeneriek": self.limit_user_visible_cases_to_role}
             )
 
         response = self.get(
@@ -875,6 +877,8 @@ def _build_all_zgw_clients_for_type(
                 client_init_kwargs = {
                     "use_openzaak_120_params": api_group.fetch_eherkenning_zaken_with_openzaak_120_params,
                     "fetch_rollen_with_betrokkene_type": api_group.fetch_rollen_with_betrokkene_type,
+                    "zaak_max_confidentiality": config.zaak_max_confidentiality,
+                    "limit_user_visible_cases_to_role": config.limit_user_visible_cases_to_role,
                 }
 
             client = build_zgw_client_from_service(service, **client_init_kwargs)

--- a/src/open_inwoner/openzaak/services.py
+++ b/src/open_inwoner/openzaak/services.py
@@ -510,6 +510,7 @@ class ZGWService:
 
         resolved_zaken.sort(
             key=lambda c: (
+                # negate ordinal for descending order: date has no __neg__.
                 -c.zaak.startdatum.toordinal(),
                 all_api_groups.index(c.api_group),
             )

--- a/src/open_inwoner/openzaak/services.py
+++ b/src/open_inwoner/openzaak/services.py
@@ -148,13 +148,19 @@ class ZGWService:
         )
 
     @staticmethod
-    def _zaken_client_factory(group: ZGWApiGroupConfig) -> ZakenClient:
+    def _zaken_client_factory(
+        group: ZGWApiGroupConfig, config: OpenZaakConfig | None = None
+    ) -> ZakenClient:
+        if config is None:
+            config = OpenZaakConfig.get_solo()
         return cast(
             ZakenClient,
             build_zgw_client_from_service(
                 group.zrc_service,
                 use_openzaak_120_params=group.fetch_eherkenning_zaken_with_openzaak_120_params,
                 fetch_rollen_with_betrokkene_type=group.fetch_rollen_with_betrokkene_type,
+                zaak_max_confidentiality=config.zaak_max_confidentiality,
+                limit_user_visible_cases_to_role=config.limit_user_visible_cases_to_role,
             ),
         )
 
@@ -355,11 +361,13 @@ class ZGWService:
         self,
         group: ZGWApiGroupConfig,
         user_identification: UserIdentification,
+        zaken_client: ZakenClient,
+        use_rsin: bool,
         zaak_identificatie: str | None = None,
     ) -> list[ZaakWithApiGroup]:
-        raw_zaken = group.zaken_client.fetch_zaken(
+        raw_zaken = zaken_client.fetch_zaken(
             user_identification,
-            use_rsin=group.fetch_eherkenning_zaken_with_rsin,
+            use_rsin=use_rsin,
             identificatie=zaak_identificatie,
         )
         return [
@@ -375,6 +383,11 @@ class ZGWService:
         zaak_identificatie: str | None = None,
     ) -> list[ZaakWithApiGroup]:
         """Fetch zaken without resolution. For PDC and cache seeding."""
+
+        # Each thread gets its own zaken client because requests.Session is not
+        # thread-safe. Pre-fetch OpenZaakConfig to avoid additional DB calls.
+        config = OpenZaakConfig.get_solo()
+
         all_api_groups = list(
             ZGWApiGroupConfig.objects.select_related("zrc_service").all()
         )
@@ -386,6 +399,8 @@ class ZGWService:
                     self._get_raw_zaken_for_api_group,
                     group,
                     user_identification,
+                    self._zaken_client_factory(group, config),
+                    group.fetch_eherkenning_zaken_with_rsin,
                     zaak_identificatie,
                 )
                 for group in all_api_groups
@@ -408,14 +423,20 @@ class ZGWService:
     def search_zaken(
         self, user_identification: UserIdentification, zaak_identificatie: str
     ) -> list[ZaakWithApiGroup]:
-        """Search for a zaak by zaak_identificatie across all API groups. Returns visible matches."""
+        """
+        Search for a zaak by zaak_identificatie across all API groups.
+        Returns visible matches.
+        """
         visible_zaken = []
         for zaak_with_group in self.get_raw_zaken(
             user_identification, zaak_identificatie
         ):
             try:
                 # TODO: could be done in parallel
-                self._resolve_zaak_type(zaak_with_group)
+                catalogi_client = self._catalogi_client_factory(
+                    zaak_with_group.api_group
+                )
+                self._resolve_zaak_type(zaak_with_group, catalogi_client)
             except (ZgwAPIError, ResolveCaseException):
                 logger.warning(
                     "Unable to resolve zaaktype for search result",
@@ -449,11 +470,19 @@ class ZGWService:
             ).all()
         )
 
+        # Each thread gets its own zaken client because requests.Session is not
+        # thread-safe. Pre-fetch OpenZaakConfig to avoid additional DB calls.
+        config = OpenZaakConfig.get_solo()
+
         fetched_zaken: list[ZaakWithApiGroup] = []
         with parallel(max_workers=self._max_workers) as executor:
             futures: list[concurrent.futures.Future[list[ZaakWithApiGroup]]] = [
                 executor.submit(
-                    self._get_raw_zaken_for_api_group, group, user_identification
+                    self._get_raw_zaken_for_api_group,
+                    group,
+                    user_identification,
+                    self._zaken_client_factory(group, config),
+                    group.fetch_eherkenning_zaken_with_rsin,
                 )
                 for group in all_api_groups
             ]
@@ -474,17 +503,32 @@ class ZGWService:
             defaultdict(list)
         )
 
-        resolver_functions = [
-            self._resolve_resultaat_and_resultaat_type,
-            self._resolve_status_and_status_type,
-            self._resolve_zaak_type,
-        ]
-
         with parallel(max_workers=self._max_workers) as executor:
             for zaak_with_group in fetched_zaken:
-                for func in resolver_functions:
-                    future = executor.submit(func, zaak_with_group)
-                    zaak_futures[zaak_with_group].append(future)
+                group = zaak_with_group.api_group
+                zaak_futures[zaak_with_group].append(
+                    executor.submit(
+                        self._resolve_zaak_type,
+                        zaak_with_group,
+                        self._catalogi_client_factory(group),
+                    )
+                )
+                zaak_futures[zaak_with_group].append(
+                    executor.submit(
+                        self._resolve_status_and_status_type,
+                        zaak_with_group,
+                        self._zaken_client_factory(group, config),
+                        self._catalogi_client_factory(group),
+                    )
+                )
+                zaak_futures[zaak_with_group].append(
+                    executor.submit(
+                        self._resolve_resultaat_and_resultaat_type,
+                        zaak_with_group,
+                        self._zaken_client_factory(group, config),
+                        self._catalogi_client_factory(group),
+                    )
+                )
 
         # TODO add wait call or refactor: we want either all futures to complete or timeout
         resolved_zaken: list[ZaakWithApiGroup] = []
@@ -553,8 +597,11 @@ class ZGWService:
 
         return zaak_with_api_group
 
-    def _resolve_zaak_type(self, zaak_with_group: ZaakWithApiGroup) -> None:
-        client = ZGWService._catalogi_client_factory(zaak_with_group.api_group)
+    def _resolve_zaak_type(
+        self,
+        zaak_with_group: ZaakWithApiGroup,
+        catalogi_client: CatalogiClient,
+    ) -> None:
         if not isinstance(zaak_with_group.zaak.zaaktype, str):
             logger.debug(
                 "Case %s already has a resolved zaaktype",
@@ -562,17 +609,17 @@ class ZGWService:
             )
             return
 
-        zaaktype = client.fetch_single_zaaktype(zaak_with_group.zaak.zaaktype)
+        zaaktype = catalogi_client.fetch_single_zaaktype(zaak_with_group.zaak.zaaktype)
 
         with self._zaak_update_lock:
             zaak_with_group.zaak.zaaktype = zaaktype
 
     def _resolve_status_and_status_type(
-        self, zaak_with_group: ZaakWithApiGroup
+        self,
+        zaak_with_group: ZaakWithApiGroup,
+        zaken_client: ZakenClient,
+        catalogi_client: CatalogiClient,
     ) -> None:
-        zaken_client = ZGWService._zaken_client_factory(zaak_with_group.api_group)
-        catalogi_client = ZGWService._catalogi_client_factory(zaak_with_group.api_group)
-
         if not isinstance(zaak_with_group.zaak.status, str):
             raise ResolveCaseException(
                 f"`case.status` for case {zaak_with_group.zaak.identificatie} "
@@ -587,13 +634,13 @@ class ZGWService:
             zaak_with_group.zaak.status.statustype = status_type
 
     def _resolve_resultaat_and_resultaat_type(
-        self, zaak_with_group: ZaakWithApiGroup
+        self,
+        zaak_with_group: ZaakWithApiGroup,
+        zaken_client: ZakenClient,
+        catalogi_client: CatalogiClient,
     ) -> None:
         if zaak_with_group.zaak.resultaat is None:
             return
-
-        zaken_client = ZGWService._zaken_client_factory(zaak_with_group.api_group)
-        catalogi_client = ZGWService._catalogi_client_factory(zaak_with_group.api_group)
 
         if not isinstance(zaak_with_group.zaak.resultaat, str):
             raise ResolveCaseException(
@@ -651,9 +698,9 @@ class ZGWService:
         api_group: ZGWApiGroupConfig,
     ) -> list[ZaakDocumentData]:
         """Fetch zaak documents filtered by visibility. Sorted newest-first."""
-        case_info_objects = api_group.zaken_client.fetch_zaak_information_objects(
-            zaak.url
-        )
+        case_info_objects = self._zaken_client_factory(
+            api_group
+        ).fetch_zaak_information_objects(zaak.url)
 
         config = OpenZaakConfig.get_solo()
         documents = []
@@ -694,7 +741,7 @@ class ZGWService:
         api_group: ZGWApiGroupConfig,
         user_identification: UserIdentification,
     ) -> str:
-        zaken_client = api_group.zaken_client
+        zaken_client = self._zaken_client_factory(api_group)
 
         if not api_group.fetch_rollen_with_betrokkene_type:
             roles = zaken_client.fetch_zaak_roles(

--- a/src/open_inwoner/openzaak/tasks.py
+++ b/src/open_inwoner/openzaak/tasks.py
@@ -1,13 +1,24 @@
+import concurrent.futures
 import io
 
+from django.conf import settings
 from django.core.management import call_command
 
 import structlog
+from celery_once import QueueOnce
 from zgw_consumers.api_models.base import factory
+from zgw_consumers.concurrent import parallel
 
+from open_inwoner.accounts.user_identification import (
+    BSNIdentification,
+    KVKIdentification,
+    UserIdentification,
+)
 from open_inwoner.celery import app
-from open_inwoner.openzaak.api_models import Notification
+from open_inwoner.openzaak.api_models import Notification, Zaak
+from open_inwoner.openzaak.clients import CatalogiClient, ZakenClient
 from open_inwoner.openzaak.notifications import handle_zaken_notification
+from open_inwoner.openzaak.services import ZGWService
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -30,3 +41,118 @@ def process_zaken_notification(notification_data: dict):
     logger.info("Started process_zaken_notification() task")
     notification = factory(Notification, notification_data)
     handle_zaken_notification(notification)
+
+
+@app.task(
+    base=QueueOnce,
+    once={
+        "keys": ["user_bsn", "user_kvk", "user_rsin", "user_vestigingsnummer"],
+        "graceful": True,
+    },
+)
+def warm_cache_for_user(
+    user_bsn: str | None = None,
+    user_kvk: str | None = None,
+    user_rsin: str | None = None,
+    user_vestigingsnummer: str | None = None,
+):
+    """
+    Warm the ZGW cache for a user on login.
+
+    Calls the same @cache_result-decorated client methods that the case list and
+    detail views use, so those pages get cache hits instead of API round-trips.
+    Supports both BSN (DigiD) and KVK (eHerkenning) users.
+    """
+    if user_bsn:
+        identification = BSNIdentification(bsn=user_bsn)
+    elif user_kvk:
+        identification = KVKIdentification(
+            kvk=user_kvk,
+            rsin=user_rsin,
+            vestigingsnummer=user_vestigingsnummer,
+        )
+    else:
+        return
+
+    logger.info("Starting ZGW cache warm-up")
+
+    service = ZGWService()
+
+    # get_raw_zaken handles multi-group concurrency and timeouts; populates fetch_zaken_by_bsn cache
+    raw_zaken = service.get_raw_zaken(identification)
+    if not raw_zaken:
+        logger.info("Finished ZGW cache warm-up: no zaken found")
+        return
+
+    # Pre-build clients per api_group in the main thread so spawned threads only
+    # do HTTP requests and never open Django DB connections.
+    clients_per_group: dict[int, tuple[ZakenClient, CatalogiClient, bool]] = {}
+    for zaak_with_group in raw_zaken:
+        group = zaak_with_group.api_group
+        if group.pk not in clients_per_group:
+            clients_per_group[group.pk] = (
+                ZGWService._zaken_client_factory(group),
+                ZGWService._catalogi_client_factory(group),
+                group.fetch_eherkenning_zaken_with_rsin,
+            )
+
+    with parallel(max_workers=10) as executor:
+        futures = {
+            executor.submit(
+                _warm_single_zaak,
+                zaak_with_group.zaak,
+                *clients_per_group[zaak_with_group.api_group.pk],
+                identification,
+            ): zaak_with_group
+            for zaak_with_group in raw_zaken
+        }
+        done, timed_out = concurrent.futures.wait(
+            futures, timeout=settings.ZGW_CACHE_WARMUP_TIMEOUT
+        )
+
+    for future in timed_out:
+        zaak_with_group = futures[future]
+        logger.warning(
+            "ZGW cache warm-up timed out for zaak",
+            zaak_url=zaak_with_group.zaak.url,
+        )
+
+    for future in done:
+        if exc := future.exception():
+            zaak_with_group = futures[future]
+            logger.warning(
+                "ZGW cache warm-up failed for zaak",
+                zaak_url=zaak_with_group.zaak.url,
+                exc_info=exc,
+            )
+
+    logger.info("Finished ZGW cache warm-up")
+
+
+def _warm_single_zaak(
+    zaak: Zaak,
+    zaken_client: ZakenClient,
+    catalogi_client: CatalogiClient,
+    use_rsin: bool,
+    identification: UserIdentification,
+) -> None:
+    # Case list: zaaktype
+    if isinstance(zaak.zaaktype, str):
+        catalogi_client.fetch_single_zaaktype(zaak.zaaktype)
+
+    # Case list: status + statustype
+    if isinstance(zaak.status, str):
+        status = zaken_client.fetch_single_status(zaak.status)
+        catalogi_client.fetch_single_status_type(status.statustype)
+
+    # Case list: resultaat + resultaattype
+    if isinstance(zaak.resultaat, str):
+        resultaat = zaken_client.fetch_single_result(zaak.resultaat)
+        catalogi_client.fetch_single_resultaat_type(resultaat.resultaattype)
+
+    # Case detail: access check (fetch_single_zaak + fetch_zaak_roles via fetch_rollen_for_user)
+    zaken_client.fetch_single_zaak(str(zaak.uuid))
+    zaken_client.fetch_rollen_for_user(zaak.url, identification, use_rsin=use_rsin)
+
+    # Case detail: status history
+    zaken_client.fetch_status_history(zaak.url)

--- a/src/open_inwoner/openzaak/tasks.py
+++ b/src/open_inwoner/openzaak/tasks.py
@@ -17,6 +17,7 @@ from open_inwoner.accounts.user_identification import (
 from open_inwoner.celery import app
 from open_inwoner.openzaak.api_models import Notification, Zaak
 from open_inwoner.openzaak.clients import CatalogiClient, ZakenClient
+from open_inwoner.openzaak.models import OpenZaakConfig
 from open_inwoner.openzaak.notifications import handle_zaken_notification
 from open_inwoner.openzaak.services import ZGWService
 
@@ -84,24 +85,18 @@ def warm_cache_for_user(
         logger.info("Finished ZGW cache warm-up: no zaken found")
         return
 
-    # Pre-build clients per api_group in the main thread so spawned threads only
-    # do HTTP requests and never open Django DB connections.
-    clients_per_group: dict[int, tuple[ZakenClient, CatalogiClient, bool]] = {}
-    for zaak_with_group in raw_zaken:
-        group = zaak_with_group.api_group
-        if group.pk not in clients_per_group:
-            clients_per_group[group.pk] = (
-                ZGWService._zaken_client_factory(group),
-                ZGWService._catalogi_client_factory(group),
-                group.fetch_eherkenning_zaken_with_rsin,
-            )
+    # Each thread gets its own zaken client because requests.Session is not
+    # thread-safe. Pre-fetch OpenZaakConfig to avoid additional DB calls.
+    config = OpenZaakConfig.get_solo()
 
     with parallel(max_workers=10) as executor:
         futures = {
             executor.submit(
                 _warm_single_zaak,
                 zaak_with_group.zaak,
-                *clients_per_group[zaak_with_group.api_group.pk],
+                ZGWService._zaken_client_factory(zaak_with_group.api_group, config),
+                ZGWService._catalogi_client_factory(zaak_with_group.api_group),
+                zaak_with_group.api_group.fetch_eherkenning_zaken_with_rsin,
                 identification,
             ): zaak_with_group
             for zaak_with_group in raw_zaken

--- a/src/open_inwoner/openzaak/tests/test_clients.py
+++ b/src/open_inwoner/openzaak/tests/test_clients.py
@@ -151,6 +151,7 @@ class ZGWApiGroupConfigFilterTests(TestCase):
                     client_init_kwargs = {
                         "use_openzaak_120_params": group.fetch_eherkenning_zaken_with_openzaak_120_params,
                         "fetch_rollen_with_betrokkene_type": group.fetch_rollen_with_betrokkene_type,
+                        "zaak_max_confidentiality": VertrouwelijkheidsAanduidingen.openbaar,
                     }
                 client = build_zgw_client_from_service(service, **client_init_kwargs)
                 url = service.api_root
@@ -244,6 +245,7 @@ class ZGWApiGroupConfigFilterTests(TestCase):
             api_group.zrc_service,
             use_openzaak_120_params=False,
             fetch_rollen_with_betrokkene_type=api_group.fetch_rollen_with_betrokkene_type,
+            zaak_max_confidentiality=VertrouwelijkheidsAanduidingen.openbaar,
         )
 
         case_url_1 = f"{ZAKEN_ROOT}zaken/12345678-1234-1234-1234-123456789012"
@@ -338,6 +340,7 @@ class ZGWApiGroupConfigFilterTests(TestCase):
             api_group.zrc_service,
             use_openzaak_120_params=False,
             fetch_rollen_with_betrokkene_type=api_group.fetch_rollen_with_betrokkene_type,
+            zaak_max_confidentiality=VertrouwelijkheidsAanduidingen.openbaar,
         )
 
         case_url = f"{ZAKEN_ROOT}zaken/12345678-1234-1234-1234-123456789012"
@@ -597,16 +600,17 @@ class FetchZakenForCompanyTests(TestCase):
         self.api_group = ZGWApiGroupConfigFactory(
             zrc_service__api_root=ZAKEN_ROOT,
         )
-        self.zaken_client = build_zgw_client_from_service(
-            self.api_group.zrc_service,
-            use_openzaak_120_params=False,
-            fetch_rollen_with_betrokkene_type=False,
-        )
         config = OpenZaakConfig.get_solo()
         config.zaak_max_confidentiality = (
             VertrouwelijkheidsAanduidingen.beperkt_openbaar
         )
         config.save()
+        self.zaken_client = build_zgw_client_from_service(
+            self.api_group.zrc_service,
+            use_openzaak_120_params=False,
+            fetch_rollen_with_betrokkene_type=False,
+            zaak_max_confidentiality=config.zaak_max_confidentiality,
+        )
 
     def test_raises_value_error_when_neither_kvk_nor_vestigingsnummer_given(self, m):
         with self.assertRaises(ValueError):

--- a/src/open_inwoner/openzaak/tests/test_tasks.py
+++ b/src/open_inwoner/openzaak/tests/test_tasks.py
@@ -1,0 +1,228 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.auth.signals import user_logged_in
+from django.test import RequestFactory, TestCase, TransactionTestCase
+
+import requests_mock as requests_mock_module
+from zgw_consumers.api_models.base import factory as zgw_factory
+from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+
+from open_inwoner.accounts.tests.factories import DigidUserFactory
+from open_inwoner.accounts.user_identification import BSNIdentification
+from open_inwoner.openzaak.api_models import Zaak
+from open_inwoner.openzaak.models import OpenZaakConfig
+from open_inwoner.openzaak.services import ZGWService
+from open_inwoner.openzaak.tasks import _warm_single_zaak, warm_cache_for_user
+from open_inwoner.utils.test import ClearCachesMixin, paginated_response
+
+from .factories import ZGWApiGroupConfigFactory
+from .helpers import generate_oas_component_cached
+from .shared import CATALOGI_ROOT, ZAKEN_ROOT
+
+BSN = "900222086"
+IDENTIFICATION = BSNIdentification(bsn=BSN)
+
+ZAAK_UUID = "a8c8bc90-defa-4cf4-9c9a-1b3b8af8f0d1"
+ZAAK_URL = f"{ZAKEN_ROOT}zaken/{ZAAK_UUID}"
+STATUS_URL = f"{ZAKEN_ROOT}statussen/1e5e8af8-8f0d-4cf4-9c9a-a8c8bc90defa"
+ZAAKTYPE_URL = f"{CATALOGI_ROOT}zaaktypen/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+STATUSTYPE_URL = f"{CATALOGI_ROOT}statustypen/11111111-2222-3333-4444-555555555555"
+
+ZAAK_UUID_2 = "b9d9cd91-efab-5d07-ad0b-c2c9cf001e2f"
+ZAAK_URL_2 = f"{ZAKEN_ROOT}zaken/{ZAAK_UUID_2}"
+STATUS_URL_2 = f"{ZAKEN_ROOT}statussen/2f6f9bf9-9f1e-5df5-0d0b-b9d9cd91efab"
+
+
+def _make_zaak_dict(zaak_url, zaak_uuid, status_url):
+    return generate_oas_component_cached(
+        "zrc",
+        "schemas/Zaak",
+        url=zaak_url,
+        uuid=zaak_uuid,
+        zaaktype=ZAAKTYPE_URL,
+        status=status_url,
+        resultaat=None,
+        einddatum=None,
+        vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+    )
+
+
+def _make_status_dict(status_url, zaak_url):
+    return generate_oas_component_cached(
+        "zrc",
+        "schemas/Status",
+        url=status_url,
+        zaak=zaak_url,
+        statustype=STATUSTYPE_URL,
+        datumStatusGezet="2024-01-01",
+    )
+
+
+def _register_zaak_resources(m, zaak_dict, status_dict):
+    zaaktype = generate_oas_component_cached(
+        "ztc", "schemas/ZaakType", url=ZAAKTYPE_URL
+    )
+    statustype = generate_oas_component_cached(
+        "ztc", "schemas/StatusType", url=STATUSTYPE_URL, zaaktype=ZAAKTYPE_URL
+    )
+    m.get(ZAAKTYPE_URL, json=zaaktype)
+    m.get(STATUSTYPE_URL, json=statustype)
+    m.get(zaak_dict["status"], json=status_dict)
+    m.get(zaak_dict["url"], json=zaak_dict)
+    m.get(f"{ZAKEN_ROOT}rollen?zaak={zaak_dict['url']}", json=paginated_response([]))
+    m.get(
+        f"{ZAKEN_ROOT}statussen?zaak={zaak_dict['url']}",
+        json={"results": [status_dict]},
+    )
+
+
+class ZgwCachingUnitTest(ClearCachesMixin, TestCase):
+    """
+    Tests for _warm_single_zaak called synchronously (no threading).
+
+    Verifies that all per-zaak resources are fetched via HTTP on the first call,
+    and that a second call for the same zaak makes no further HTTP requests
+    because all results are now cached.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.api_group = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ZAKEN_ROOT,
+            ztc_service__api_root=CATALOGI_ROOT,
+        )
+        config = OpenZaakConfig.get_solo()
+        config.zaak_max_confidentiality = VertrouwelijkheidsAanduidingen.openbaar
+        config.save()
+        self.zaken_client = ZGWService._zaken_client_factory(self.api_group)
+        self.catalogi_client = ZGWService._catalogi_client_factory(self.api_group)
+        self.use_rsin = self.api_group.fetch_eherkenning_zaken_with_rsin
+
+    def _warm(self, zaak_dict):
+        zaak = zgw_factory(Zaak, zaak_dict)
+        _warm_single_zaak(
+            zaak,
+            self.zaken_client,
+            self.catalogi_client,
+            self.use_rsin,
+            IDENTIFICATION,
+        )
+
+    @requests_mock_module.Mocker()
+    def test_per_zaak_resources_are_cached_after_warm(self, m):
+        zaak_dict = _make_zaak_dict(ZAAK_URL, ZAAK_UUID, STATUS_URL)
+        status_dict = _make_status_dict(STATUS_URL, ZAAK_URL)
+        _register_zaak_resources(m, zaak_dict, status_dict)
+
+        self._warm(zaak_dict)
+
+        calls_after_warmup = len(m.request_history)
+        self.assertGreater(calls_after_warmup, 0)
+
+        # Second call must make zero new HTTP requests: everything is cached
+        self._warm(zaak_dict)
+
+        self.assertEqual(len(m.request_history), calls_after_warmup)
+
+    @requests_mock_module.Mocker()
+    def test_shared_zaaktype_fetched_once_for_two_zaken(self, m):
+        zaak1_dict = _make_zaak_dict(ZAAK_URL, ZAAK_UUID, STATUS_URL)
+        zaak2_dict = _make_zaak_dict(ZAAK_URL_2, ZAAK_UUID_2, STATUS_URL_2)
+        status1_dict = _make_status_dict(STATUS_URL, ZAAK_URL)
+        status2_dict = _make_status_dict(STATUS_URL_2, ZAAK_URL_2)
+        _register_zaak_resources(m, zaak1_dict, status1_dict)
+        _register_zaak_resources(m, zaak2_dict, status2_dict)
+
+        self._warm(zaak1_dict)
+        self._warm(zaak2_dict)
+
+        zaaktype_calls = [r for r in m.request_history if r.url == ZAAKTYPE_URL]
+        self.assertEqual(
+            len(zaaktype_calls), 1, "zaaktype should be fetched once and cached"
+        )
+
+    @requests_mock_module.Mocker()
+    def test_zaken_list_cached_with_correct_key(self, m):
+        """
+        Verify that fetch_zaken_by_bsn is cached using the same max_requests value
+        that get_zaken (called by the case list view) passes through fetch_zaken.
+        A second call with the same arguments must make no new HTTP requests.
+        """
+        zaak_dict = _make_zaak_dict(ZAAK_URL, ZAAK_UUID, STATUS_URL)
+        m.get(
+            f"{ZAKEN_ROOT}zaken"
+            f"?rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn={BSN}"
+            f"&maximaleVertrouwelijkheidaanduiding={OpenZaakConfig.get_solo().zaak_max_confidentiality}",
+            json=paginated_response([zaak_dict]),
+        )
+
+        zaken_client = ZGWService._zaken_client_factory(self.api_group)
+        zaken_client.fetch_zaken_by_bsn(BSN, max_requests=settings.ZGW_MAX_REQUESTS)
+
+        calls_after_first = len(m.request_history)
+        self.assertGreater(calls_after_first, 0)
+
+        zaken_client.fetch_zaken_by_bsn(BSN, max_requests=settings.ZGW_MAX_REQUESTS)
+
+        self.assertEqual(len(m.request_history), calls_after_first)
+
+
+class ZgwCachingIntegrationTest(ClearCachesMixin, TransactionTestCase):
+    """
+    Integration test covering the full signal -> task -> cache chain.
+
+    Uses TransactionTestCase so that DB rows committed by setUp are visible to
+    threads spawned by get_raw_zaken -> parallel(). warm_cache_for_user.delay is
+    patched to call the underlying run() directly, bypassing QueueOnce (which
+    requires Redis) while still exercising the full task body.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.api_group = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ZAKEN_ROOT,
+            ztc_service__api_root=CATALOGI_ROOT,
+        )
+        config = OpenZaakConfig.get_solo()
+        config.zaak_max_confidentiality = VertrouwelijkheidsAanduidingen.openbaar
+        config.save()
+
+    @requests_mock_module.Mocker()
+    def test_login_seeds_zgw_cache_for_bsn_user(self, m):
+        zaak_dict = _make_zaak_dict(ZAAK_URL, ZAAK_UUID, STATUS_URL)
+        status_dict = _make_status_dict(STATUS_URL, ZAAK_URL)
+        _register_zaak_resources(m, zaak_dict, status_dict)
+        m.get(
+            f"{ZAKEN_ROOT}zaken"
+            f"?rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn={BSN}"
+            f"&maximaleVertrouwelijkheidaanduiding={OpenZaakConfig.get_solo().zaak_max_confidentiality}",
+            json=paginated_response([zaak_dict]),
+        )
+
+        user = DigidUserFactory(bsn=BSN)
+        request = RequestFactory().get("/")
+        request.user = user
+
+        with patch.object(
+            warm_cache_for_user, "delay", side_effect=warm_cache_for_user.run
+        ):
+            user_logged_in.send(sender=None, request=request, user=user)
+
+        calls_after_login = len(m.request_history)
+        self.assertGreater(calls_after_login, 0, "no HTTP calls made during warm-up")
+
+        # Client calls that the case list view makes must now be served from cache
+        zaken_client = ZGWService._zaken_client_factory(self.api_group)
+        catalogi_client = ZGWService._catalogi_client_factory(self.api_group)
+
+        zaken_client.fetch_zaken_by_bsn(BSN, max_requests=settings.ZGW_MAX_REQUESTS)
+        status = zaken_client.fetch_single_status(STATUS_URL)
+        catalogi_client.fetch_single_zaaktype(ZAAKTYPE_URL)
+        catalogi_client.fetch_single_status_type(status.statustype)
+
+        self.assertEqual(
+            len(m.request_history),
+            calls_after_login,
+            "client methods made HTTP requests that should have been cached after login",
+        )

--- a/src/open_inwoner/openzaak/tests/test_tasks.py
+++ b/src/open_inwoner/openzaak/tests/test_tasks.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
-from django.test import RequestFactory, TestCase, TransactionTestCase
+from django.test import RequestFactory, TestCase
 
 import requests_mock as requests_mock_module
 from zgw_consumers.api_models.base import factory as zgw_factory
@@ -168,14 +168,14 @@ class ZgwCachingUnitTest(ClearCachesMixin, TestCase):
         self.assertEqual(len(m.request_history), calls_after_first)
 
 
-class ZgwCachingIntegrationTest(ClearCachesMixin, TransactionTestCase):
+class ZgwCachingIntegrationTest(ClearCachesMixin, TestCase):
     """
     Integration test covering the full signal -> task -> cache chain.
 
-    Uses TransactionTestCase so that DB rows committed by setUp are visible to
-    threads spawned by get_raw_zaken -> parallel(). warm_cache_for_user.delay is
-    patched to call the underlying run() directly, bypassing QueueOnce (which
-    requires Redis) while still exercising the full task body.
+    warm_cache_for_user.delay is patched to call the underlying run() directly,
+    bypassing QueueOnce (which requires Redis) while still exercising the full
+    task body. Threads spawned by parallel() make no DB queries (clients are
+    pre-built in the main thread), so TestCase is sufficient.
     """
 
     def setUp(self):


### PR DESCRIPTION
## Summary

The ZGW cache is preloaded in the background via a Celery task when a user logs in, so that the case list and case detail pages are served from the cache on the first visit.

## Issue References

Closes #2514 

## Checklist

- [x] CHANGELOG.rst updated
