### PR TITLE
[#2449] Set bestandsformaat to upload content type when uploaded to a zaak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ Bugfixes
   die mogelijk beschadigd zijn.
 * [:gh:`2450`]: De ProseMirror-migraties zijn aangepast om directe toewijzing van niet-JSON-inhoud
   te voorkomen.
+* [:gh:`2449`]: Het ‘formaat' van een bestand wordt ingesteld op het inhoudstype van de
+  upload wanneer het naar een zaak wordt geüpload, zodat er een voorbeeld beschikbaar komt.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -751,6 +751,8 @@ class DocumentenClient(ZgwAPIClient):
             "taal": "dut",
             "informatieobjecttype": informatieobjecttype_url,
         }
+        if file.content_type:
+            document_body["formaat"] = file.content_type
 
         try:
             response = self.post("enkelvoudiginformatieobjecten", json=document_body)

--- a/src/open_inwoner/openzaak/tests/test_documents.py
+++ b/src/open_inwoner/openzaak/tests/test_documents.py
@@ -639,6 +639,9 @@ class TestDocumentDownloadUpload(ClearCachesMixin, TransactionWebTest):
 
         self.assertEqual(created_document, self.informatie_object)
 
+        post_body = m.last_request.json()
+        self.assertEqual(post_body["formaat"], file.content_type)
+
     def test_document_upload_multiple_backends(self, m):
         self._setUpMocks(m)
         self._setUpAdditionalMocks(m)


### PR DESCRIPTION

## Summary

Without bestandsformaat (mime type), external services could not determine whether a preview could be rendered for a given file.


## Issue References

Fixes #2449

## Checklist

- [x] CHANGELOG.rst updated
  - [ ] Deployment notes added
        <!--e.g. because of migrations, config flags, etc. -->
  - [ ] Breaking changes flagged
        <!-- e.g. removed endpoints/commands, deprecated support -->
- [ ] Documentation updated <!-- If the PR changes admin/config pages-->
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created
      <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
- [ ] Updated the `docker-compose.yml` environment variables
  - [ ] Created an issue in https://github.com/maykinmedia/charts/ for new
        environment variables
