### PR TITLE
[#2365] Updating requirements to support Python 3.13

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,7 @@ certifi==2025.11.12
     #   elastic-transport
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.17.1
     # via
     #   cryptography
     #   weasyprint
@@ -534,7 +534,7 @@ phonenumbers==8.13.29
     # via -r requirements/base.in
 phonenumberslite==8.13.29
     # via django-two-factor-auth
-pillow==10.3.0
+pillow==10.4.0
     # via
     #   -r requirements/base.in
     #   easy-thumbnails
@@ -550,7 +550,7 @@ protobuf==6.33.5
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psycopg2==2.9.9
+psycopg2==2.9.12
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi
@@ -720,7 +720,7 @@ urllib3==2.6.3
     #   elastic-transport
     #   requests
     #   sentry-sdk
-uwsgi==2.0.23
+uwsgi==2.0.31
     # via -r requirements/base.in
 vine==5.1.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -90,7 +90,7 @@ certifi==2025.11.12
     #   elastic-transport
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.17.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -947,7 +947,7 @@ phonenumberslite==8.13.29
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-pillow==10.3.0
+pillow==10.4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -980,7 +980,7 @@ protobuf==6.33.5
     #   -r requirements/base.txt
     #   googleapis-common-protos
     #   opentelemetry-proto
-psycopg2==2.9.9
+psycopg2==2.9.12
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1305,7 +1305,7 @@ urllib3==2.6.3
     #   requests
     #   sentry-sdk
     #   vcrpy
-uwsgi==2.0.23
+uwsgi==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -104,7 +104,7 @@ certifi==2025.11.12
     #   geventhttpclient
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -894,7 +894,7 @@ mozilla-django-oidc-db[setup-configuration]==0.23.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-msgpack==1.0.7
+msgpack==1.1.2
     # via locust
 multidict==6.6.4
     # via
@@ -1039,7 +1039,7 @@ phonenumberslite==8.13.29
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-pillow==10.3.0
+pillow==10.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1090,7 +1090,7 @@ protobuf==6.33.5
     #   opentelemetry-proto
 psutil==5.9.7
     # via locust
-psycopg2==2.9.9
+psycopg2==2.9.12
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1226,7 +1226,7 @@ pyyaml==6.0.2
     #   tablib
     #   vcrpy
     #   zgw-consumers-oas
-pyzmq==25.1.2
+pyzmq==27.1.0
     # via locust
 qrcode==6.1
     # via
@@ -1484,7 +1484,7 @@ urllib3==2.6.3
     #   requests
     #   sentry-sdk
     #   vcrpy
-uwsgi==2.0.23
+uwsgi==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
## Summary

Currently Python 3.12 is being used for open-inwoner, which is currently on security-support only (https://endoflife.date/python).

I've updated the requirements as a first step to support Python 3.13, I did encounter problems with zope when running management commands so this PR is mainly a first step to go to 3.13