### PR TITLE
[#2494] Use POST request for logout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,6 +84,7 @@ Onderhoud
   geïmporteerd in openzaak-modules die deze klasse nodig hebben. Andere sites moeten in plaats
   daarvan de nieuwe ZGWService gebruiken. Verbeterde testdekking door het toevoegen van tests
   voor ZGWService.
+* [:gh:`2494`]: Uitloglink vervangen door een formulierknop (POST) conform Django 5-vereisten.
 
 2.2.0 (2026-04-20)
 ==================

--- a/src/open_inwoner/accounts/tests/test_commands.py
+++ b/src/open_inwoner/accounts/tests/test_commands.py
@@ -41,8 +41,10 @@ class DeleteContactInvitationsTest(AssertTimelineLogMixin, TestCase):
             self.assertIn("total 2 timelinelogs", log_dump)
 
             self.assertIn(
-                f'deleted_invitations=["{invite1.invitee_email} (invited on 2023-09-26)", "{invite2.invitee_email} (invited on 2023-09-26)"',
-                log_dump,
+                f'"{invite1.invitee_email} (invited on 2023-09-26)"', log_dump
+            )
+            self.assertIn(
+                f'"{invite2.invitee_email} (invited on 2023-09-26)"', log_dump
             )
             self.assertIn(
                 f'deleted_invitations=["{invite3.invitee_email} (invited on 2023-09-26)"',

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -3209,13 +3209,10 @@ class EIDASOIDCFlowTests(WebTest):
 class GenericOIDCLogoutViewTests(WebTest):
     """Tests for the generic OIDC logout view (for staff/admin users)."""
 
-    def test_generic_oidc_logout_accepts_get_request_for_oidc_users(self):
+    def test_generic_oidc_logout_accepts_post_request_for_oidc_users(self):
         """
-        Test that the generic OIDC logout view accepts GET requests for users
+        Test that the generic OIDC logout view accepts POST requests for users
         with login_type=oidc.
-
-        Needed because staff users who log in via OIDC need to be able to log
-        out using a simple link (GET request), not a form POST.
         """
         user = UserFactory.create(login_type=LoginTypeChoices.oidc)
         self.client.force_login(user)
@@ -3225,8 +3222,8 @@ class GenericOIDCLogoutViewTests(WebTest):
         # Verify user is logged in
         self.assertTrue(self.client.session.get("_auth_user_id"))
 
-        # Perform logout via GET request
-        response = self.client.get(logout_url)
+        # Perform logout via POST request
+        response = self.client.post(logout_url)
 
         # Should redirect to logout redirect URL
         self.assertRedirects(
@@ -3293,7 +3290,7 @@ class GenericOIDCLogoutViewTests(WebTest):
                 self.client.force_login(user)
 
                 # User with non-OIDC login_type tries to use generic OIDC logout
-                response = self.client.get(reverse("oidc_logout"))
+                response = self.client.post(reverse("oidc_logout"))
 
                 # Should redirect to the correct logout URL for their login type
                 expected_logout_url = user.get_logout_url()

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -97,10 +97,10 @@ class ProfileViewTests(WebTest):
     def test_show_correct_logout_button_for_login_type_default(self):
         response = self.app.get(self.url, user=self.user)
 
-        logout_title = _("Logout")
-        logout_link = response.pyquery.find(f"[title='{logout_title}']")
+        logout_url = reverse("logout")
+        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
 
-        self.assertEqual(logout_link.attr("href"), reverse("logout"))
+        self.assertEqual(logout_form.attr["action"], logout_url)
 
     @patch("open_inwoner.accounts.models.OpenIDDigiDConfig.get_solo")
     def test_show_correct_logout_button_for_login_type_digid(self, mock_solo):
@@ -114,10 +114,9 @@ class ProfileViewTests(WebTest):
 
                 response = self.app.get(self.url, user=self.digid_user)
 
-                logout_title = _("Logout")
-                logout_link = response.pyquery.find(f"[title='{logout_title}']")
+                logout_form = response.pyquery.find(f"form[action='{logout_url}']")
 
-                self.assertEqual(logout_link.attr("href"), logout_url)
+                self.assertEqual(logout_form.attr["action"], logout_url)
 
     def test_show_correct_logout_button_for_login_type_eherkenning(self):
         """eHerkenning always uses OIDC logout"""
@@ -125,10 +124,9 @@ class ProfileViewTests(WebTest):
 
         response = self.app.get(self.url, user=self.eherkenning_user)
 
-        logout_title = _("Logout")
-        logout_link = response.pyquery.find(f"[title='{logout_title}']")
+        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
 
-        self.assertEqual(logout_link.attr("href"), logout_url)
+        self.assertEqual(logout_form.attr["action"], logout_url)
 
     def test_show_correct_logout_button_for_login_type_eidas(self):
         """eIDAS always uses OIDC logout"""
@@ -142,10 +140,9 @@ class ProfileViewTests(WebTest):
 
         response = self.app.get(self.url, user=eidas_user)
 
-        logout_title = _("Logout")
-        logout_link = response.pyquery.find(f"[title='{logout_title}']")
+        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
 
-        self.assertEqual(logout_link.attr("href"), logout_url)
+        self.assertEqual(logout_form.attr["action"], logout_url)
 
     @patch(
         "open_inwoner.cms.utils.page_display.inbox_page_is_published", return_value=True

--- a/src/open_inwoner/accounts/views/auth_oidc.py
+++ b/src/open_inwoner/accounts/views/auth_oidc.py
@@ -175,6 +175,9 @@ class GenericOIDCLogoutView(OIDCLogoutView):
         auth.logout(request)
         return HttpResponseRedirect(self.get_success_url())
 
+    # Implement POST logout similar to the GET to prevent status 405 on log-out.
+    post = get
+
 
 generic_oidc_logout = GenericOIDCLogoutView.as_view()
 

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -91,15 +91,13 @@
                                 {% endif %}
                             {% endif %}
                             <li class="header__list-item">
-                            {% with logout_url=request.user.get_logout_url %}
-                                <form method="post" action="{{ logout_url }}">
+                                <form method="post" action="{{ request.user.get_logout_url }}">
                                     {% csrf_token %}
                                     <button type="submit" class="link link--primary link--icon link--icon-position-before">
                                         <span class="link__text">{% trans "Uitloggen" %}</span>
                                         {% icon icon="logout" %}
                                     </button>
                                 </form>
-                            {% endwith %}
                             </li>
                         </ul>
                     {% elif config.login_show %}

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -91,7 +91,15 @@
                                 {% endif %}
                             {% endif %}
                             <li class="header__list-item">
-                                {% link text=_("Logout") href=request.user.get_logout_url icon="login" icon_position="before" primary=True icon_outlined=True %}
+                            {% with logout_url=request.user.get_logout_url %}
+                                <form method="post" action="{{ logout_url }}">
+                                    {% csrf_token %}
+                                    <button type="submit" class="link link--primary link--icon link--icon-position-before">
+                                        <span class="link__text">{% trans "Uitloggen" %}</span>
+                                        {% icon icon="logout" %}
+                                    </button>
+                                </form>
+                            {% endwith %}
                             </li>
                         </ul>
                     {% elif config.login_show %}

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -32,7 +32,15 @@
                         {% endif %}
                     {% endif %}
                     <li class="primary-navigation__list-item primary-navigation__list-item--always-visible">
-                        {% link text=_("Logout") href=request.user.get_logout_url icon="logout" icon_position="before" primary=True %}
+                        {% with logout_url=request.user.get_logout_url %}
+                            <form method="post" action="{{ logout_url }}">
+                                {% csrf_token %}
+                                <button type="submit" class="link link--primary link--icon link--icon-position-before">
+                                    <span class="link__text">{% trans "Uitloggen" %}</span>
+                                    {% icon icon="logout" %}
+                                </button>
+                            </form>
+                        {% endwith %}
                     </li>
                 </ul>
             </li>

--- a/src/open_inwoner/pdc/tests/test_category_admin.py
+++ b/src/open_inwoner/pdc/tests/test_category_admin.py
@@ -174,8 +174,8 @@ class TestAdminCategoryForm(WebTest):
             ),
             user=group_user,
         )
-        self.assertIn("name", response.forms[1].fields)
-        self.assertNotIn("access_groups", response.forms[1].fields)
+        self.assertIn("name", response.forms["category_form"].fields)
+        self.assertNotIn("access_groups", response.forms["category_form"].fields)
 
     @patch("open_inwoner.openzaak.models.OpenZaakConfig.get_solo")
     def test_user_can_link_zaaktypen_if_category_filtering_with_zaken_feature_flag_enabled(
@@ -191,7 +191,7 @@ class TestAdminCategoryForm(WebTest):
             user=self.user,
         )
 
-        form = response_get.form
+        form = response_get.forms[1]
 
         # Fix inline formsets - set TOTAL_FORMS to INITIAL_FORMS to prevent validation errors
         # on empty inline forms (QuestionInline has required fields)
@@ -225,7 +225,7 @@ class TestAdminCategoryForm(WebTest):
             user=self.user,
         )
 
-        form = response_get.form
+        form = response_get.forms[1]
 
         # Fix inline formsets - set TOTAL_FORMS to INITIAL_FORMS to prevent validation errors
         # on empty inline forms (QuestionInline has required fields)

--- a/src/open_inwoner/pdc/tests/test_category_admin.py
+++ b/src/open_inwoner/pdc/tests/test_category_admin.py
@@ -174,8 +174,8 @@ class TestAdminCategoryForm(WebTest):
             ),
             user=group_user,
         )
-        self.assertIn("name", response.form.fields)
-        self.assertNotIn("access_groups", response.form.fields)
+        self.assertIn("name", response.forms[1].fields)
+        self.assertNotIn("access_groups", response.forms[1].fields)
 
     @patch("open_inwoner.openzaak.models.OpenZaakConfig.get_solo")
     def test_user_can_link_zaaktypen_if_category_filtering_with_zaken_feature_flag_enabled(

--- a/src/open_inwoner/pdc/tests/test_logging.py
+++ b/src/open_inwoner/pdc/tests/test_logging.py
@@ -107,7 +107,7 @@ class TestProductLogging(WebTest):
             reverse("admin:pdc_product_delete", kwargs={"object_id": self.product.id}),
             user=self.user,
         )
-        form = response.forms[0]
+        form = response.forms[1]
         form.submit()
         products = Product.objects.all().count()
 
@@ -142,10 +142,10 @@ class TestProductLogging(WebTest):
         )
         byte_data = str.encode(dataset.export("csv"))
         response = self.app.get(reverse("admin:pdc_product_import"), user=self.user)
-        form = response.forms[0]
+        form = next(f for f in response.forms.values() if "import_file" in f.fields)
         form["import_file"] = Upload("products.csv", byte_data, "text/csv")
         form["input_format"] = 1
-        response_form = form.submit().forms[0]
+        response_form = form.submit().forms[1]
         response_form.submit()
         log_entry = TimelineLog.objects.last()
         product = Product.objects.first()
@@ -166,7 +166,7 @@ class TestProductLogging(WebTest):
     def test_export_is_logged(self):
         ProductFactory(categories=(self.category,))
         response = self.app.get(reverse("admin:pdc_product_export"), user=self.user)
-        form = response.forms[0]
+        form = next(f for f in response.forms.values() if "file_format" in f.fields)
         form["file_format"] = 1
         form.submit()
         log_entry = TimelineLog.objects.last()
@@ -278,7 +278,7 @@ class TestCategoryLogging(WebTest):
             reverse("admin:pdc_category_delete", kwargs={"object_id": category.id}),
             user=self.user,
         )
-        form = response.forms[0]
+        form = response.forms[1]
         form.submit()
         categories = Category.objects.all().count()
 
@@ -300,10 +300,10 @@ class TestCategoryLogging(WebTest):
         )
         byte_data = str.encode(dataset.export("csv"))
         response = self.app.get(reverse("admin:pdc_category_import"), user=self.user)
-        form = response.forms[0]
+        form = next(f for f in response.forms.values() if "import_file" in f.fields)
         form["import_file"] = Upload("categories.csv", byte_data, "text/csv")
         form["input_format"] = 1
-        response_form = form.submit().forms[0]
+        response_form = form.submit().forms[1]
         response_form.submit()
         log_entry = TimelineLog.objects.last()
         category = Category.objects.first()
@@ -324,7 +324,7 @@ class TestCategoryLogging(WebTest):
     def test_export_is_logged(self):
         CategoryFactory()
         response = self.app.get(reverse("admin:pdc_category_export"), user=self.user)
-        form = response.forms[0]
+        form = next(f for f in response.forms.values() if "file_format" in f.fields)
         form["file_format"] = 1
         form.submit()
         log_entry = TimelineLog.objects.last()

--- a/src/open_inwoner/pdc/tests/test_organization_location.py
+++ b/src/open_inwoner/pdc/tests/test_organization_location.py
@@ -21,7 +21,7 @@ class TestLocationFormInput(WebTest):
         user = UserFactory(is_superuser=True, is_staff=True)
 
         response = self.app.get(reverse("admin:pdc_organization_add"), user=user)
-        form = response.forms[1]
+        form = response.forms["organization_form"]
         form["name"] = organization.name
         form["slug"] = "a-slug-example"
         form["type"] = organization.type.pk

--- a/src/open_inwoner/pdc/tests/test_organization_location.py
+++ b/src/open_inwoner/pdc/tests/test_organization_location.py
@@ -21,7 +21,7 @@ class TestLocationFormInput(WebTest):
         user = UserFactory(is_superuser=True, is_staff=True)
 
         response = self.app.get(reverse("admin:pdc_organization_add"), user=user)
-        form = response.form
+        form = response.forms[1]
         form["name"] = organization.name
         form["slug"] = "a-slug-example"
         form["type"] = organization.type.pk

--- a/src/open_inwoner/pdc/tests/test_product_admin.py
+++ b/src/open_inwoner/pdc/tests/test_product_admin.py
@@ -107,13 +107,15 @@ class TestAdminProductForm(WebTest):
             response = self.app.get(url, user=super_user)
 
             # all categories visible
-            self.assertEqual(len(response.form["categories"].options), 3)
             self.assertEqual(
-                set(response.form["categories"].value),
+                len(response.forms["product_form"]["categories"].options), 3
+            )
+            self.assertEqual(
+                set(response.forms["product_form"]["categories"].value),
                 {str(category_general.id), str(category_grouped.id)},
             )
-            fix_inline_formsets(response.form)
-            response = response.form.submit("_continue").follow()
+            fix_inline_formsets(response.forms["product_form"])
+            response = response.forms["product_form"].submit("_continue").follow()
 
             # no changes on resubmit
             self.assertEqual(
@@ -121,19 +123,21 @@ class TestAdminProductForm(WebTest):
             )
 
             # sanity check with different combinations
-            response.form["categories"].select_multiple(
+            response.forms["product_form"]["categories"].select_multiple(
                 value=[str(category_general.id), str(category_extra.id)]
             )
-            fix_inline_formsets(response.form)
-            response = response.form.submit("_continue").follow()
+            fix_inline_formsets(response.forms["product_form"])
+            response = response.forms["product_form"].submit("_continue").follow()
             self.assertEqual(
                 set(product.categories.all()), {category_general, category_extra}
             )
 
             # sanity check with different combinations
-            response.form["categories"].select_multiple(value=[str(category_extra.id)])
-            fix_inline_formsets(response.form)
-            response = response.form.submit("_continue").follow()
+            response.forms["product_form"]["categories"].select_multiple(
+                value=[str(category_extra.id)]
+            )
+            fix_inline_formsets(response.forms["product_form"])
+            response = response.forms["product_form"].submit("_continue").follow()
             self.assertEqual(set(product.categories.all()), {category_extra})
 
         product.categories.set([category_general, category_grouped])
@@ -142,22 +146,26 @@ class TestAdminProductForm(WebTest):
             response = self.app.get(url, user=group_user)
 
             # only our restricted
-            self.assertEqual(len(response.form["categories"].options), 2)
             self.assertEqual(
-                set(response.form["categories"].value),
+                len(response.forms["product_form"]["categories"].options), 2
+            )
+            self.assertEqual(
+                set(response.forms["product_form"]["categories"].value),
                 {str(category_grouped.id)},
             )
-            fix_inline_formsets(response.form)
-            response = response.form.submit("_continue").follow()
+            fix_inline_formsets(response.forms["product_form"])
+            response = response.forms["product_form"].submit("_continue").follow()
 
             # on resubmit the non-group category is still there
             self.assertEqual(
                 set(product.categories.all()), {category_general, category_grouped}
             )
             # select different category
-            response.form["categories"].select_multiple(value=[str(category_extra.id)])
-            fix_inline_formsets(response.form)
-            response.form.submit().follow()
+            response.forms["product_form"]["categories"].select_multiple(
+                value=[str(category_extra.id)]
+            )
+            fix_inline_formsets(response.forms["product_form"])
+            response.forms["product_form"].submit().follow()
 
             # swapped different category but the non-group category is still there
             self.assertEqual(
@@ -165,9 +173,9 @@ class TestAdminProductForm(WebTest):
             )
 
             # requires at least one category
-            response.form["categories"].select_multiple(value=[])
-            fix_inline_formsets(response.form)
-            response = response.form.submit()
+            response.forms["product_form"]["categories"].select_multiple(value=[])
+            fix_inline_formsets(response.forms["product_form"])
+            response = response.forms["product_form"].submit()
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.context["errors"][0][0],

--- a/src/open_inwoner/pdc/tests/test_product_location.py
+++ b/src/open_inwoner/pdc/tests/test_product_location.py
@@ -230,7 +230,7 @@ class TestLocationFormInput(WebTest):
         user = UserFactory(is_superuser=True, is_staff=True)
 
         response = self.app.get(reverse("admin:pdc_productlocation_add"), user=user)
-        form = response.forms[1]
+        form = response.forms["productlocation_form"]
         form_response = form.submit("_save")
 
         self.assertListEqual(

--- a/src/open_inwoner/pdc/tests/test_product_location.py
+++ b/src/open_inwoner/pdc/tests/test_product_location.py
@@ -230,7 +230,7 @@ class TestLocationFormInput(WebTest):
         user = UserFactory(is_superuser=True, is_staff=True)
 
         response = self.app.get(reverse("admin:pdc_productlocation_add"), user=user)
-        form = response.form
+        form = response.forms[1]
         form_response = form.submit("_save")
 
         self.assertListEqual(

--- a/src/open_inwoner/scss/admin/_admin_theme.scss
+++ b/src/open_inwoner/scss/admin/_admin_theme.scss
@@ -38,13 +38,29 @@ a:hover {
   }
 }
 
-#user-tools a {
+#user-tools a,
+#user-tools button {
   border-bottom: none;
   text-decoration: underline;
 
   &:focus,
   &:hover {
     color: $color_darkest;
+  }
+}
+
+#user-tools button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  // font: inherit;
+  color: inherit;
+
+  &:focus,
+  &:hover {
+    background: none;
+    text-decoration: none;
   }
 }
 

--- a/src/open_inwoner/scss/admin/_admin_theme.scss
+++ b/src/open_inwoner/scss/admin/_admin_theme.scss
@@ -49,18 +49,10 @@ a:hover {
   }
 }
 
-#user-tools button {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  // font: inherit;
-  color: inherit;
-
-  &:focus,
-  &:hover {
-    background: none;
-    text-decoration: none;
+#logout-form button {
+  &:hover,
+  &:active {
+    margin-bottom: 0;
   }
 }
 

--- a/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
+++ b/src/open_inwoner/scss/components/Header/PrimaryNavigation.scss
@@ -355,6 +355,18 @@
     }
   }
 
+  // Logout form
+  form[action] {
+    display: contents;
+
+    button.link {
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+    }
+  }
+
   /// Mobile nested list.
 
   @media (max-width: 767px) {

--- a/src/open_inwoner/scss/components/Typography/Link.scss
+++ b/src/open_inwoner/scss/components/Typography/Link.scss
@@ -97,3 +97,10 @@
     transform: scale(1);
   }
 }
+
+button.link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/src/open_inwoner/scss/components/Typography/Link.scss
+++ b/src/open_inwoner/scss/components/Typography/Link.scss
@@ -97,10 +97,3 @@
     transform: scale(1);
   }
 }
-
-button.link {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}

--- a/src/open_inwoner/templates/admin/base_site.html
+++ b/src/open_inwoner/templates/admin/base_site.html
@@ -37,7 +37,10 @@
     {% if user.has_usable_password %}
     <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
     {% endif %}
-    <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+    <form method="post" action="{% url 'admin:logout' %}" style="display: inline;">
+        {% csrf_token %}
+        <button type="submit">{% trans 'UITLOGGEN' %}</button>
+    </form>
 {% endblock %}
 
 {% block nav-global %}

--- a/src/open_inwoner/templates/admin/base_site.html
+++ b/src/open_inwoner/templates/admin/base_site.html
@@ -37,9 +37,9 @@
     {% if user.has_usable_password %}
     <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
     {% endif %}
-    <form method="post" action="{% url 'admin:logout' %}" style="display: inline;">
+    <form method="post" action="{% url 'admin:logout' %}" id="logout-form">
         {% csrf_token %}
-        <button type="submit">{% trans 'UITLOGGEN' %}</button>
+        <button type="submit">{% trans 'Log out' %}</button>
     </form>
 {% endblock %}
 

--- a/src/open_inwoner/utils/tests/test_timeline_logger.py
+++ b/src/open_inwoner/utils/tests/test_timeline_logger.py
@@ -81,7 +81,7 @@ class TestAdminTimelineLogging(WebTest):
     def test_deleted_object_is_logged(self):
         plan = PlanFactory(created_by=self.user)
         url = reverse("admin:plans_plan_delete", kwargs={"object_id": plan.id})
-        delete_form = self.app.get(url, user=self.user).forms[0]
+        delete_form = self.app.get(url, user=self.user).forms[1]
         delete_form.submit()
 
         log_entry = TimelineLog.objects.last()
@@ -173,7 +173,7 @@ class TestAdminTimelineLogging(WebTest):
     def test_get_action_returns_delete_when_object_is_deleted(self):
         plan = PlanFactory()
         url = reverse("admin:plans_plan_delete", kwargs={"object_id": plan.id})
-        form = self.app.get(url, user=self.user).forms[0]
+        form = self.app.get(url, user=self.user).forms[1]
         form.submit()
 
         log_entry = TimelineLog.objects.last()
@@ -206,9 +206,9 @@ class TestTimelineLogExport(WebTest):
     @freeze_time("2021-10-18 13:00:00")
     def test_proper_data_is_exported(self):
         user = UserFactory(is_superuser=True, is_staff=True)
-        form = self.app.get(
-            reverse("admin:timeline_logger_timelinelog_export"), user=user
-        ).forms[0]
+        export_url = reverse("admin:timeline_logger_timelinelog_export")
+        response = self.app.get(export_url, user=user)
+        form = next(f for f in response.forms.values() if "file_format" in f.fields)
 
         # csv format chosen
         form["file_format"] = "0"


### PR DESCRIPTION
## Summary

Logout via GET is no longer allowed in Django 5. The PR replaces logout via GET with logout via POST.

## Issue References

Closes #2494


## Checklist

- [ ] CHANGELOG.rst updated
  - [ ] Deployment notes added
        <!--e.g. because of migrations, config flags, etc. -->
  - [ ] Breaking changes flagged
        <!-- e.g. removed endpoints/commands, deprecated support -->
- [ ] Documentation updated <!-- If the PR changes admin/config pages-->
- [ ] Codecov report reviewed for untested lines
- [ ] Storybook component updated/created
      <!-- If the PR react component changes -->
- [ ] Vitest tests added/updated <!-- If the PR has typescript changes -->
- [ ] Updated the `docker-compose.yml` environment variables
  - [ ] Created an issue in https://github.com/maykinmedia/charts/ for new
        environment variables
