### PR TITLE
fix: [#2443] fetch roles for all betrokkene typen in zaak notificatio…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,10 +54,16 @@ Bugfixes
   die mogelijk beschadigd zijn.
 * [:gh:`2450`]: De ProseMirror-migraties zijn aangepast om directe toewijzing van niet-JSON-inhoud
   te voorkomen.
-* [:gh:`2449`]: Het ‘formaat' van een bestand wordt ingesteld op het inhoudstype van de
+* [:gh:`2449`]: Het ‘formaat’ van een bestand wordt ingesteld op het inhoudstype van de
   upload wanneer het naar een zaak wordt geüpload, zodat er een voorbeeld beschikbaar komt.
 * [:gh:`2438`]: Lange bestandsnamen in notificaties worden nu correct afgebroken zodat ze niet
   buiten de notificatie vallen.
+* [:gh:`2443`]: De zaaknotificatie-handler hield geen rekening met de instelling
+  ``Rollen ophalen per betrokkene type``. Wanneer deze instelling actief is, worden
+  rollen nu ook bij het verwerken van zaaknotificaties apart opgevraagd per betrokkene
+  type (natuurlijk persoon, niet-natuurlijk persoon, vestiging), zodat backends die
+  verzoeken voor interne typen (medewerker, organisatorische eenheid) afwijzen geen
+  problemen meer veroorzaken.
 
 Onderhoud
 ---------

--- a/src/open_inwoner/openzaak/notifications.py
+++ b/src/open_inwoner/openzaak/notifications.py
@@ -81,7 +81,24 @@ def handle_zaken_notification(notification: Notification):
     zaken_client = api_group.zaken_client
 
     # check if we have users that need to be informed about this case
-    if not (roles := zaken_client.fetch_zaak_roles(zaak_url)):
+    if zaken_client.fetch_rollen_with_betrokkene_type:
+        # Only query types that can map to a user account; medewerker and
+        # organisatorische_eenheid are internal government roles and some
+        # backends (e.g. iConnect/Decos) reject those types with a 400.
+        available_user_betrokkene_types = (
+            RolTypes.natuurlijk_persoon,
+            RolTypes.niet_natuurlijk_persoon,
+            RolTypes.vestiging,
+        )
+        roles = []
+        for betrokkene_type in available_user_betrokkene_types:
+            roles += zaken_client.fetch_zaak_roles(
+                zaak_url, betrokkene_type=betrokkene_type
+            )
+    else:
+        roles = zaken_client.fetch_zaak_roles(zaak_url)
+
+    if not roles:
         log_system_action(
             f"ignored {r} notification: cannot retrieve rollen for zaak {zaak_url}",
             # NOTE this used to be logging.ERROR, but as this is also our first call

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_infoobject.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 import requests_mock
 from freezegun import freeze_time
 from zgw_consumers.api_models.base import factory
-from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+from zgw_consumers.api_models.constants import RolTypes, VertrouwelijkheidsAanduidingen
 
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.openzaak.api_models import (
@@ -24,10 +24,11 @@ from open_inwoner.openzaak.tests.factories import (
     NotificationFactory,
     ZaakTypeInformatieObjectTypeConfigFactory,
 )
-from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
 
 from .helpers import copy_with_new_uuid
+from .shared import ZAKEN_ROOT
 from .test_notification_data import MockAPIData, MockAPIDataAlt
 
 
@@ -174,6 +175,69 @@ class ZaakInformatieObjectNotificationHandlerTestCase(
     def test_zio_bails_when_no_roles_found_for_case(self, m, mock_handle: Mock):
         data = MockAPIData()
         data.install_mocks(m, res404=["case_roles"])
+
+        handle_zaken_notification(data.zio_notification)
+
+        mock_handle.assert_not_called()
+        self.assertTimelineLog(
+            "ignored zaakinformatieobject notification: cannot retrieve rollen for zaak https://",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )
+
+    def test_handle_zaak_zio_notifications_with_betrokkene_type_flag(
+        self, m, mock_handle: Mock
+    ):
+        """
+        Happy path when fetch_rollen_with_betrokkene_type=True: roles are fetched per
+        betrokkene type and the handler correctly finds users and proceeds.
+        """
+        MockAPIData.api_group.fetch_rollen_with_betrokkene_type = True
+        MockAPIData.api_group.save()
+
+        data = MockAPIData().install_mocks(m)
+        zaak_url = data.zaak["url"]
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.natuurlijk_persoon}",
+            json=paginated_response(data.case_roles),
+        )
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.niet_natuurlijk_persoon}",
+            json=paginated_response([]),
+        )
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.vestiging}",
+            json=paginated_response([]),
+        )
+
+        ZaakTypeInformatieObjectTypeConfigFactory.from_case_type_info_object_dicts(
+            data.zaak_type, data.informatie_object, document_notification_enabled=True
+        )
+
+        handle_zaken_notification(data.zio_notification)
+
+        mock_handle.assert_called_once()
+        args = mock_handle.call_args.args
+        self.assertEqual(args[1], data.user_initiator)
+        self.assertEqual(args[2].url, data.zaak["url"])
+
+    def test_zio_bails_when_no_roles_found_with_betrokkene_type_flag(
+        self, m, mock_handle: Mock
+    ):
+        """
+        When fetch_rollen_with_betrokkene_type=True, empty results across all betrokkene
+        type queries cause the handler to bail.
+        """
+        MockAPIData.api_group.fetch_rollen_with_betrokkene_type = True
+        MockAPIData.api_group.save()
+
+        data = MockAPIData().install_mocks(m)
+        zaak_url = data.zaak["url"]
+        for betrokkene_type in RolTypes:
+            m.get(
+                f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={betrokkene_type}",
+                json=paginated_response([]),
+            )
 
         handle_zaken_notification(data.zio_notification)
 

--- a/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
+++ b/src/open_inwoner/openzaak/tests/test_notification_zaak_status.py
@@ -6,7 +6,7 @@ from django.test import RequestFactory, TestCase, override_settings
 import requests_mock
 from freezegun import freeze_time
 from zgw_consumers.api_models.base import factory
-from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+from zgw_consumers.api_models.constants import RolTypes, VertrouwelijkheidsAanduidingen
 
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
@@ -17,7 +17,7 @@ from open_inwoner.openzaak.notifications import (
     _handle_status_update,
     handle_zaken_notification,
 )
-from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 from open_inwoner.utils.tests.helpers import AssertTimelineLogMixin, Lookups
 
 from .factories import (
@@ -26,6 +26,7 @@ from .factories import (
     ZaakTypeStatusTypeConfigFactory,
 )
 from .helpers import copy_with_new_uuid
+from .shared import ZAKEN_ROOT
 from .test_notification_data import MockAPIData, MockAPIDataAlt
 
 
@@ -200,6 +201,75 @@ class StatusNotificationHandlerTestCase(
     def test_status_bails_when_no_roles_found_for_case(self, m, mock_handle: Mock):
         data = MockAPIData()
         data.install_mocks(m, res404=["case_roles"])
+
+        handle_zaken_notification(data.status_notification)
+
+        mock_handle.assert_not_called()
+        self.assertTimelineLog(
+            "ignored status notification: cannot retrieve rollen for zaak https://",
+            lookup=Lookups.startswith,
+            level=logging.INFO,
+        )
+
+    def test_handle_zaak_status_notifications_with_betrokkene_type_flag(
+        self, m, mock_handle: Mock
+    ):
+        """
+        Happy path when fetch_rollen_with_betrokkene_type=True: roles are fetched per
+        betrokkene type and the handler correctly finds users and proceeds.
+        """
+        MockAPIData.api_group.fetch_rollen_with_betrokkene_type = True
+        MockAPIData.api_group.save()
+
+        data = MockAPIData().install_mocks(m)
+        zaak_url = data.zaak["url"]
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.natuurlijk_persoon}",
+            json=paginated_response(data.case_roles),
+        )
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.niet_natuurlijk_persoon}",
+            json=paginated_response([]),
+        )
+        m.get(
+            f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={RolTypes.vestiging}",
+            json=paginated_response([]),
+        )
+
+        ztc = ZaakTypeConfigFactory.create(
+            catalogus__url=data.zaak_type["catalogus"],
+            identificatie=data.zaak_type["identificatie"],
+        )
+        ZaakTypeStatusTypeConfigFactory.create(
+            zaaktype_config=ztc,
+            omschrijving=data.status_type_final["omschrijving"],
+            statustype_url=data.status_type_final["url"],
+        )
+
+        handle_zaken_notification(data.status_notification)
+
+        mock_handle.assert_called_once()
+        args = mock_handle.call_args.args
+        self.assertEqual(args[1], data.user_initiator)
+        self.assertEqual(args[2].url, data.zaak["url"])
+
+    def test_status_bails_when_no_roles_found_with_betrokkene_type_flag(
+        self, m, mock_handle: Mock
+    ):
+        """
+        When fetch_rollen_with_betrokkene_type=True, empty results across all betrokkene
+        type queries cause the handler to bail.
+        """
+        MockAPIData.api_group.fetch_rollen_with_betrokkene_type = True
+        MockAPIData.api_group.save()
+
+        data = MockAPIData().install_mocks(m)
+        zaak_url = data.zaak["url"]
+        for betrokkene_type in RolTypes:
+            m.get(
+                f"{ZAKEN_ROOT}rollen?zaak={zaak_url}&betrokkeneType={betrokkene_type}",
+                json=paginated_response([]),
+            )
 
         handle_zaken_notification(data.status_notification)
 


### PR DESCRIPTION
…n handler

We forgot to honor the flag to split out /rollen fetch queries per betrokkene_type in the notification permission flag. This did not affect any production users: the only user which uses this flag is not in production using notifications.

Closes: #2443
