### PR TITLE
fix: [#2508] normalize phone/email before digitale adressen deduplica…

### DIFF
--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
@@ -31,6 +32,7 @@ from openklant_client.types.resources.betrokkene import (
 from openklant_client.types.resources.digitaal_adres import (
     DigitaalAdres,
     DigitaalAdresCreateData,
+    DigitaalAdresPartialUpdateData,
 )
 from openklant_client.types.resources.interne_taak import InterneTaak
 from openklant_client.types.resources.klant_contact import (
@@ -85,6 +87,18 @@ from open_inwoner.utils.time import instance_is_new
 from open_inwoner.utils.views import LogMixin
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+def _normalize_phone(phone: str) -> str:
+    """Strip formatting; convert leading '+' to '00' (API requires 00-prefix, not +)."""
+    stripped = re.sub(r"[^0-9+]", "", phone.strip())
+    if stripped.startswith("+"):
+        stripped = "00" + stripped[1:]
+    return stripped
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
 
 
 class BsnFetchParam(TypedDict):
@@ -1251,9 +1265,18 @@ class OpenKlant2Service(
         uuid: str,
         soort_adres: Literal["email", "telefoonnummer"],
         adres: str,
-        is_standaard_adres: bool = False,
+        is_standaard_adres: bool | None = None,
         adressen: list[DigitaalAdres] | None = None,
     ) -> tuple[DigitaalAdres, bool]:
+        match soort_adres:
+            case "telefoonnummer":
+                normalize = _normalize_phone
+            case "email":
+                normalize = _normalize_email
+            case _:
+                assert_never(soort_adres)
+        adres = normalize(adres)
+
         digitale_adressen = self._filter_digitale_addressen(
             subject_type=subject_type,
             uuid=uuid,
@@ -1261,17 +1284,23 @@ class OpenKlant2Service(
             adressen=adressen,
         )
         for digitaal_adres in digitale_adressen:
-            if (
-                digitaal_adres["adres"] == adres
-                and digitaal_adres["isStandaardAdres"] == is_standaard_adres
-            ):
+            if normalize(digitaal_adres["adres"]) == adres:
+                if (
+                    is_standaard_adres is True
+                    and not digitaal_adres["isStandaardAdres"]
+                ):
+                    updated = self.client.digitaal_adres.partial_update(
+                        digitaal_adres["uuid"],
+                        data=DigitaalAdresPartialUpdateData(isStandaardAdres=True),
+                    )
+                    return updated, False
                 return digitaal_adres, False
 
         if subject_type == "partij":
             adres_data = DigitaalAdresCreateData(
                 adres=adres,
                 soortDigitaalAdres=soort_adres,
-                isStandaardAdres=is_standaard_adres,
+                isStandaardAdres=is_standaard_adres or False,
                 omschrijving="OIP profiel",
                 verstrektDoorPartij={"uuid": uuid},
                 verstrektDoorBetrokkene=None,
@@ -1280,7 +1309,7 @@ class OpenKlant2Service(
             adres_data = DigitaalAdresCreateData(
                 adres=adres,
                 soortDigitaalAdres=soort_adres,
-                isStandaardAdres=is_standaard_adres,
+                isStandaardAdres=is_standaard_adres or False,
                 omschrijving="OIP profiel",
                 verstrektDoorBetrokkene={"uuid": uuid},
                 verstrektDoorPartij=None,
@@ -1293,7 +1322,7 @@ class OpenKlant2Service(
         partij_uuid: str,
         soort_adres: Literal["email", "telefoonnummer"],
         adres: str,
-        is_standaard_adres: bool = False,
+        is_standaard_adres: bool | None = None,
         adressen: list[DigitaalAdres] | None = None,
     ) -> tuple[DigitaalAdres, bool]:
         return self._get_or_create_digitaal_adres(
@@ -1310,7 +1339,7 @@ class OpenKlant2Service(
         betrokkene_uuid: str,
         soort_adres: Literal["email", "telefoonnummer"],
         adres: str,
-        is_standaard_adres: bool = False,
+        is_standaard_adres: bool | None = None,
         adressen: list[DigitaalAdres] | None = None,
     ) -> tuple[DigitaalAdres, bool]:
         return self._get_or_create_digitaal_adres(

--- a/src/open_inwoner/openklant/tests/data.py
+++ b/src/open_inwoner/openklant/tests/data.py
@@ -278,16 +278,6 @@ class MockAPIReadPatchData(MockAPIData):
                 "results": [],
             },
         )
-        m.post(
-            f"{OPENKLANT2_ROOT}/digitaleadressen",
-            headers={"Content-Type": "application/json"},
-            json={
-                "count": 1,
-                "next": None,
-                "previous": None,
-                "results": [],
-            },
-        )
         m.get(
             f"http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorPartij__uuid={self.partij_uuid}",
             json={
@@ -363,17 +353,25 @@ class MockAPIReadPatchData(MockAPIData):
             },
         )
 
-        # Mock for creating new digital addresses
+        # Mock for creating new digital addresses: echo back the request body so the
+        # returned soortDigitaalAdres matches what was sent (prevents false cache hits).
+        def _create_digitaal_adres(request, context):
+            body = request.json()
+            return {
+                "uuid": "new-adres-uuid",
+                "adres": body["adres"],
+                "soortDigitaalAdres": body["soortDigitaalAdres"],
+                "isStandaardAdres": body.get("isStandaardAdres", False),
+                "verstrektDoorPartij": body.get("verstrektDoorPartij")
+                or {"uuid": self.partij_uuid},
+                "verstrektDoorBetrokkene": body.get("verstrektDoorBetrokkene"),
+                "omschrijving": body.get("omschrijving", ""),
+            }
+
         m.post(
             "http://localhost:8338/klantinteracties/api/v1/digitaleadressen",
             headers={"Content-Type": "application/json"},
-            json={
-                "uuid": "new-email-uuid",
-                "adres": "new@example.com",
-                "soortDigitaalAdres": "email",
-                "isStandaardAdres": True,
-                "verstrektDoorPartij": {"uuid": self.partij_uuid},
-            },
+            json=_create_digitaal_adres,
         )
 
         klantcontact = {

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -8,6 +8,8 @@ from open_inwoner.openklant.services import (
     OpenKlant2Answer,
     OpenKlant2Question,
     OpenKlant2Service,
+    _normalize_email,
+    _normalize_phone,
 )
 from open_inwoner.openklant.tests.factories import OpenKlant2ConfigFactory
 
@@ -868,6 +870,219 @@ class OpenKlant2QuestionAnswerTestCase(TestCase):
         self.assertEqual(q3.question, "Question 3?")
         self.assertEqual(len(q3.answers), 1)
         self.assertEqual(q3.answers[0].answer, "Second answer to Q3")
+
+
+class NormalizeHelpersTestCase(TestCase):
+    def test_normalize(self):
+        cases = [
+            (_normalize_phone, "06-12 345 678", "0612345678"),
+            (_normalize_phone, "+31 6 12 34 56 78", "0031612345678"),
+            (_normalize_phone, "  0612345678  ", "0612345678"),
+            (_normalize_email, "User@Example.COM", "user@example.com"),
+            (_normalize_email, "  user@example.com  ", "user@example.com"),
+        ]
+        for fn, value, expected in cases:
+            with self.subTest(fn=fn.__name__, value=value):
+                self.assertEqual(fn(value), expected, f"{fn.__name__}({value!r})")
+
+
+def _make_digitaal_adres(adres, soort, is_standaard=True, uuid_str="addr-uuid"):
+    return {
+        "uuid": uuid_str,
+        "soortDigitaalAdres": soort,
+        "adres": adres,
+        "isStandaardAdres": is_standaard,
+        "omschrijving": "OIP profiel",
+        "verstrektDoorPartij": {"uuid": "partij-uuid"},
+        "verstrektDoorBetrokkene": None,
+    }
+
+
+@patch("open_inwoner.openklant.services.OpenKlantClient")
+class GetOrCreateDigitaalAdresNormalizationTestCase(TestCase):
+    """Deduplication must survive formatting differences in stored vs incoming values."""
+
+    def setUp(self):
+        self.config = OpenKlant2ConfigFactory()
+
+    def _service_with_existing(self, mock_client_class, existing_adres):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.digitaal_adres.list.return_value = {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [existing_adres],
+        }
+        return OpenKlant2Service(config=self.config), mock_client
+
+    def test_phone_not_duplicated_when_formatting_differs(self, mock_client_class):
+        existing = _make_digitaal_adres("06-12 345 678", "telefoonnummer")
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="0612345678",
+            is_standaard_adres=True,
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+
+    def test_phone_not_duplicated_when_international_format_differs(
+        self, mock_client_class
+    ):
+        existing = _make_digitaal_adres("+31 6 12345678", "telefoonnummer")
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="+31612345678",
+            is_standaard_adres=True,
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+
+    def test_email_not_duplicated_when_case_differs(self, mock_client_class):
+        existing = _make_digitaal_adres("User@Example.COM", "email", is_standaard=False)
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="email",
+            adres="user@example.com",
+            is_standaard_adres=False,
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+
+    def test_phone_created_normalized_when_no_existing(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.digitaal_adres.list.return_value = {
+            "count": 0,
+            "next": None,
+            "previous": None,
+            "results": [],
+        }
+        mock_client.digitaal_adres.create.return_value = _make_digitaal_adres(
+            "0612345678", "telefoonnummer"
+        )
+
+        service = OpenKlant2Service(config=self.config)
+        service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="06-12 345 678",
+            is_standaard_adres=True,
+        )
+
+        create_call = mock_client.digitaal_adres.create.call_args
+        self.assertEqual(create_call[1]["data"]["adres"], "0612345678")
+
+    def test_email_created_normalized_when_no_existing(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.digitaal_adres.list.return_value = {
+            "count": 0,
+            "next": None,
+            "previous": None,
+            "results": [],
+        }
+        mock_client.digitaal_adres.create.return_value = _make_digitaal_adres(
+            "user@example.com", "email", is_standaard=False
+        )
+
+        service = OpenKlant2Service(config=self.config)
+        service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="email",
+            adres="  User@Example.COM  ",
+            is_standaard_adres=False,
+        )
+
+        create_call = mock_client.digitaal_adres.create.call_args
+        self.assertEqual(create_call[1]["data"]["adres"], "user@example.com")
+
+    def test_different_phone_still_creates_new(self, mock_client_class):
+        existing = _make_digitaal_adres("0612345678", "telefoonnummer")
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+        mock_client.digitaal_adres.create.return_value = _make_digitaal_adres(
+            "0687654321", "telefoonnummer", uuid_str="new-uuid"
+        )
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="0687654321",
+            is_standaard_adres=True,
+        )
+
+        self.assertTrue(created)
+        mock_client.digitaal_adres.create.assert_called_once()
+
+    def test_not_duplicated_when_only_is_standaard_differs(self, mock_client_class):
+        existing = _make_digitaal_adres(
+            "0612345678", "telefoonnummer", is_standaard=True
+        )
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="0612345678",
+            is_standaard_adres=False,
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+        mock_client.digitaal_adres.partial_update.assert_not_called()
+
+    def test_not_duplicated_when_is_standaard_adres_is_none(self, mock_client_class):
+        existing = _make_digitaal_adres(
+            "0612345678", "telefoonnummer", is_standaard=True
+        )
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+
+        _, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="0612345678",
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+        mock_client.digitaal_adres.partial_update.assert_not_called()
+
+    def test_patches_is_standaard_when_existing_is_not_standaard(
+        self, mock_client_class
+    ):
+        existing = _make_digitaal_adres(
+            "0612345678", "telefoonnummer", is_standaard=False
+        )
+        service, mock_client = self._service_with_existing(mock_client_class, existing)
+        patched = _make_digitaal_adres(
+            "0612345678", "telefoonnummer", is_standaard=True
+        )
+        mock_client.digitaal_adres.partial_update.return_value = patched
+
+        result, created = service.get_or_create_digitaal_adres_for_partij(
+            partij_uuid="partij-uuid",
+            soort_adres="telefoonnummer",
+            adres="0612345678",
+            is_standaard_adres=True,
+        )
+
+        self.assertFalse(created)
+        mock_client.digitaal_adres.create.assert_not_called()
+        mock_client.digitaal_adres.partial_update.assert_called_once_with(
+            "addr-uuid", data={"isStandaardAdres": True}
+        )
+        self.assertEqual(result, patched)
 
 
 @patch("open_inwoner.openklant.services.OpenKlantClient")


### PR DESCRIPTION
…tion

Digital addresses, especially phone numbers, would be duplicated due to missing normalization (e.g. spaces, parentheses). This commit ensure in both reading and writing that emails and and phone numbers are normalized.

Closes: #2508

