### PR TITLE
fix: enable lazy-apps in uWSGI to fix Python 3.13 segfaults

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -73,5 +73,6 @@ export UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-65535}
 exec uwsgi \
     --show-config \
     --strict \
+    --lazy-apps \
     --static-map /static=/app/static \
     --static-map /media=/app/media


### PR DESCRIPTION
After upgrading to Python 3.13, uWSGI workers were segfaulting in _PyParkingLot_Unpark, the new internal mutex primitive used by threading and GC. The crashes happen because uWSGI's default prefork model imports the app in the master and forks workers, which leaves 3.13's internal lock state inconsistent across the fork boundary. With threads = 8 per worker, this is hit frequently.

Setting lazy-apps = 1 makes each worker import the application after forking, so no interpreter state crosses fork(). Trade-off is slightly higher memory usage since modules are no longer shared copy-on-write between master and workers.
