### PR TITLE
fix: [#2535] Defensively handle malformed _expand in klantcontacten_f…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,10 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:gh:`2535`]: ``klantcontacten_for_partij`` in de OpenKlant2-service verwerkt
+  nu robuust klantcontacten waarbij ``_expand.hadBetrokkenen`` ontbreekt of een
+  onverwachte structuur heeft. Dergelijke items worden overgeslagen (met een
+  waarschuwing in de log) in plaats van dat er helemaal niets getoond wordt.
 * [:gh:`2447`]: De status van een zaak wordt nu correct bijgewerkt in de zakenlijst
   wanneer een ZGW-backend (bijv. eSuite) een bestaand statusobject aanpast zonder
   het URL te wijzigen. De cache-timeout van ``fetch_single_status`` is gelijkgesteld

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1625,29 +1625,42 @@ class OpenKlant2Service(
             "kanaal": kanaal or self.config.mijn_vragen_kanaal,
         }
         klantcontacten = self.client.klant_contact.list_iter(params=params)
-        klantcontacten_for_partij = filter(
-            lambda row: partij_uuid
-            in glom.glom(
-                row,
-                (
-                    "_expand.hadBetrokkenen",
-                    [(glom.Coalesce("wasPartij.uuid", default=glom.SKIP),)],
-                ),
-            ),
-            klantcontacten,
-        )
 
-        # only show questions initiated by the current user
-        klantcontacten_for_initiator = filter(
-            lambda row: True
-            in glom.glom(
-                row,
-                ("_expand.hadBetrokkenen", ["initiator"]),
-            ),
-            klantcontacten_for_partij,
-        )
+        def _has_partij_uuid(row) -> bool:
+            try:
+                uuids = glom.glom(
+                    row,
+                    (
+                        glom.Coalesce("_expand.hadBetrokkenen", default=[]),
+                        [(glom.Coalesce("wasPartij.uuid", default=glom.SKIP),)],
+                    ),
+                )
+                return partij_uuid in uuids
+            except glom.GlomError:
+                logger.warning(
+                    "klantcontact_partij_filter_error",
+                    klantcontact_uuid=row.get("uuid"),
+                )
+                return False
 
-        return klantcontacten_for_initiator
+        def _has_initiator(row) -> bool:
+            try:
+                initiators = glom.glom(
+                    row,
+                    (
+                        glom.Coalesce("_expand.hadBetrokkenen", default=[]),
+                        ["initiator"],
+                    ),
+                )
+                return True in initiators
+            except glom.GlomError:
+                logger.warning(
+                    "klantcontact_initiator_filter_error",
+                    klantcontact_uuid=row.get("uuid"),
+                )
+                return False
+
+        return filter(_has_initiator, filter(_has_partij_uuid, klantcontacten))
 
     def questions_for_partij(self, partij_uuid: str) -> list[OpenKlant2Question]:
         """

--- a/src/open_inwoner/openklant/tests/test_openklant2_service.py
+++ b/src/open_inwoner/openklant/tests/test_openklant2_service.py
@@ -1056,3 +1056,106 @@ class UpdatePartijFromUserDataTestCase(TestCase):
         mock_client.digitaal_adres.list.assert_called_once()
         mock_client.digitaal_adres.create.assert_called_once()
         self.assertEqual(result, ["digitaleAddresen.telefoonnummer"])
+
+
+@patch("open_inwoner.openklant.services.OpenKlantClient")
+class KlantcontactenForPartijTestCase(TestCase):
+    PARTIJ_UUID = "partij-uuid-1234"
+
+    def setUp(self):
+        self.config = OpenKlant2ConfigFactory()
+
+    def _make_kc(self, uuid, partij_uuid=None, initiator=True, expand_key="_expand"):
+        betrokkene = {"initiator": initiator}
+        if partij_uuid is not None:
+            betrokkene["wasPartij"] = {"uuid": partij_uuid}
+        else:
+            betrokkene["wasPartij"] = None
+        return {
+            "uuid": uuid,
+            expand_key: {"hadBetrokkenen": [betrokkene]},
+        }
+
+    def test_matching_klantcontact_is_returned(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        kc = self._make_kc("kc-1", partij_uuid=self.PARTIJ_UUID, initiator=True)
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [kc])
+
+    def test_different_partij_uuid_is_excluded(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        kc = self._make_kc("kc-1", partij_uuid="other-partij-uuid", initiator=True)
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [])
+
+    def test_non_initiator_is_excluded(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        kc = self._make_kc("kc-1", partij_uuid=self.PARTIJ_UUID, initiator=False)
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [])
+
+    def test_missing_expand_key_is_excluded_without_exception(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        kc = {"uuid": "kc-bad"}  # no _expand key at all
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [])
+
+    def test_missing_had_betrokkenen_in_expand_is_excluded_without_exception(
+        self, mock_client_class
+    ):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        kc = {"uuid": "kc-bad", "_expand": {}}  # hadBetrokkenen absent
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [])
+
+    def test_null_was_partij_is_excluded_without_exception(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        # wasPartij is null — the betrokkene belongs to no partij
+        kc = self._make_kc("kc-1", partij_uuid=None, initiator=True)
+        mock_client.klant_contact.list_iter.return_value = iter([kc])
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [])
+
+    def test_malformed_items_excluded_valid_items_returned(self, mock_client_class):
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        good = self._make_kc("kc-good", partij_uuid=self.PARTIJ_UUID, initiator=True)
+        bad_no_expand = {"uuid": "kc-bad-1"}
+        bad_empty_expand = {"uuid": "kc-bad-2", "_expand": {}}
+        mock_client.klant_contact.list_iter.return_value = iter(
+            [bad_no_expand, bad_empty_expand, good]
+        )
+
+        service = OpenKlant2Service(config=self.config)
+        result = list(service.klantcontacten_for_partij(self.PARTIJ_UUID))
+
+        self.assertEqual(result, [good])


### PR DESCRIPTION
…or_partij

Klantcontacten where `_expand.hadBetrokkenen` is absent or has an unexpected structure caused a glom PathAccessError and broke the whole filter. Extract the two filter predicates into named helpers with try/except around glom calls so malformed items are skipped with a warning rather than crashing. Also apply the same Coalesce guard to the initiator filter.

Add KlantcontactenForPartijTestCase covering matching, non-matching, non-initiator, missing _expand, missing hadBetrokkenen, null wasPartij, and mixed-item scenarios.

Closes: #2535
