### PR TITLE
feat: [#2539] add low-latency Celery worker for ZGW cache warm-up on …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,54 +14,55 @@
 version: '3.4'
 
 x-app-env: &x-app-env
-  - LOG_STDOUT=true
-  - DJANGO_SETTINGS_MODULE=open_inwoner.conf.docker
-  - SECRET_KEY=${SECRET_KEY:-7bk)w=_%lnm#68rc!c)h@gy&5+%^fl=okq17bv!)yv!l0udu2y}
-  - ALLOWED_HOSTS=*
-  - CORS_ALLOW_ALL_ORIGINS=${CORS_ALLOW_ALL_ORIGINS:-true}
-  - CSRF_TRUSTED_ORIGINS='http://localhost:9000'
-  - CACHE_DEFAULT=redis:6379/0
-  - CACHE_AXES=redis:6379/0
-  - CACHE_OIDC=redis:6379/0
-  - CACHE_PORTALOCKER=redis:6379/0
-  - CELERY_BROKER_URL=redis://redis:6379/0
-  - CELERY_RESULT_BACKEND=redis://redis:6379/0
-  - CELERY_LOGLEVEL=DEBUG
-  - ES_HOST=http://elasticsearch:9200
-  - ES_USERNAME=${ES_USERNAME:-elastic}
-  - ES_PASSWORD=${ES_PASSWORD:-elastic}
-  - OIDC_FRONTEND_LOGOUT_WITH_HINTS=true
+  LOG_STDOUT: 'true'
+  DJANGO_SETTINGS_MODULE: open_inwoner.conf.docker
+  SECRET_KEY: ${SECRET_KEY:-7bk)w=_%lnm#68rc!c)h@gy&5+%^fl=okq17bv!)yv!l0udu2y}
+  ALLOWED_HOSTS: '*'
+  CORS_ALLOW_ALL_ORIGINS: ${CORS_ALLOW_ALL_ORIGINS:-true}
+  CSRF_TRUSTED_ORIGINS: "'http://localhost:9000'"
+  CACHE_DEFAULT: redis:6379/0
+  CACHE_AXES: redis:6379/0
+  CACHE_OIDC: redis:6379/0
+  CACHE_PORTALOCKER: redis:6379/0
+  CACHE_SEEDING_QUEUE: low-latency
+  CELERY_BROKER_URL: redis://redis:6379/0
+  CELERY_RESULT_BACKEND: redis://redis:6379/0
+  CELERY_LOGLEVEL: DEBUG
+  ES_HOST: http://elasticsearch:9200
+  ES_USERNAME: ${ES_USERNAME:-elastic}
+  ES_PASSWORD: ${ES_PASSWORD:-elastic}
+  OIDC_FRONTEND_LOGOUT_WITH_HINTS: 'true'
   # Needed for Celery Flower to match the TIME_ZONE configured in the
   # settings used by workers and beat containers.
-  - TZ=Europe/Amsterdam
+  TZ: Europe/Amsterdam
   # WARNING: Strictly for development!
-  - DISABLE_2FA=${DISABLE_2FA:-True}
-  - DEBUG=True
-  - IS_HTTPS=no
-  - ALLOW_CUSTOM_JS=False
+  DISABLE_2FA: ${DISABLE_2FA:-True}
+  DEBUG: 'True'
+  IS_HTTPS: 'no'
+  ALLOW_CUSTOM_JS: 'False'
   # Overridable uwsgi settings
-  - UWSGI_PROCESSES
-  - UWSGI_THREADS
-  - PORT
-  - UWSGI_HTTP_KEEPALIVE
-  - UWSGI_HTTP_TIMEOUT
-  - UWSGI_HARAKIRI
-  - UWSGI_MAX_REQUESTS
-  - UWSGI_POST_BUFFERING
-  - UWSGI_BUFFER_SIZE
+  UWSGI_PROCESSES:
+  UWSGI_THREADS:
+  PORT:
+  UWSGI_HTTP_KEEPALIVE:
+  UWSGI_HTTP_TIMEOUT:
+  UWSGI_HARAKIRI:
+  UWSGI_MAX_REQUESTS:
+  UWSGI_POST_BUFFERING:
+  UWSGI_BUFFER_SIZE:
   # Overridable ZGW API settings
-  - ZGW_MAX_REQUESTS
-  - STATIC_ROOT_VOLUME=/srv/static
+  ZGW_MAX_REQUESTS:
+  STATIC_ROOT_VOLUME: /srv/static
   # Enabling Open Telemetry requires the services in docker/docker-compose.observability.yml
   # to be up and running.
-  - OTEL_SDK_DISABLED=${OTEL_SDK_DISABLED:-true}
-  - OTEL_RESOURCE_ATTRIBUTES=oip.target=docker-compose
-  - OTEL_METRIC_EXPORT_INTERVAL=${OTEL_METRIC_EXPORT_INTERVAL:-60000}
-  - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317} # gRPC
+  OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-true}
+  OTEL_RESOURCE_ATTRIBUTES: oip.target=docker-compose
+  OTEL_METRIC_EXPORT_INTERVAL: ${OTEL_METRIC_EXPORT_INTERVAL:-60000}
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317} # gRPC
   # otel:supersecret, escape spaces and = with percent encoding
-  - OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic b3RlbDpzdXBlcnNlY3JldA==
-  - OTEL_EXPORTER_OTLP_METRICS_INSECURE=${OTEL_EXPORTER_OTLP_METRICS_INSECURE:-true}
-  - _OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR=true
+  OTEL_EXPORTER_OTLP_HEADERS: Authorization=Basic b3RlbDpzdXBlcnNlY3JldA==
+  OTEL_EXPORTER_OTLP_METRICS_INSECURE: ${OTEL_EXPORTER_OTLP_METRICS_INSECURE:-true}
+  _OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR: 'true'
 
 services:
   db:
@@ -190,6 +191,29 @@ services:
         # pending, the database also needs to be ready for Celery itself. We
         # therefore have the health check here, and make Celery beat and
         # monitor containers depend on the celery container.
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - openinwoner-dev
+
+  celery-low-latency:
+    build: *web_build
+    image: maykinmedia/open-inwoner:${TAG:-latest}
+    environment:
+      <<: *x-app-env
+      CELERY_WORKER_QUEUE: ${CELERY_WORKER_QUEUE:-low-latency}
+      CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_CONCURRENCY:-10}
+    command: /celery_worker.sh
+    healthcheck:
+      test: ['CMD', 'python', '/app/bin/check_celery_worker_liveness.py']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    volumes: *web_volumes
+    depends_on:
+      web:
         condition: service_healthy
       redis:
         condition: service_started

--- a/src/open_inwoner/accounts/signals.py
+++ b/src/open_inwoner/accounts/signals.py
@@ -1,5 +1,7 @@
+import functools
 from typing import Literal
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.signals import (
     user_logged_in,
@@ -264,23 +266,30 @@ def increment_logins_counter(
 def warm_zgw_cache_on_login(
     sender: type[User], request: HttpRequest | None, user: User, **kwargs
 ) -> None:
+    dispatch = functools.partial(
+        warm_cache_for_user.apply_async, queue=settings.CACHE_SEEDING_QUEUE
+    )
     try:
         match user.identification:
             case BSNIdentification(bsn=bsn):
-                warm_cache_for_user.delay(
-                    user_bsn=bsn,
-                    user_kvk=None,
-                    user_rsin=None,
-                    user_vestigingsnummer=None,
+                dispatch(
+                    kwargs={
+                        "user_bsn": bsn,
+                        "user_kvk": None,
+                        "user_rsin": None,
+                        "user_vestigingsnummer": None,
+                    }
                 )
             case KVKIdentification(
                 kvk=kvk, rsin=rsin, vestigingsnummer=vestigingsnummer
             ):
-                warm_cache_for_user.delay(
-                    user_bsn=None,
-                    user_kvk=kvk,
-                    user_rsin=rsin,
-                    user_vestigingsnummer=vestigingsnummer,
+                dispatch(
+                    kwargs={
+                        "user_bsn": None,
+                        "user_kvk": kvk,
+                        "user_rsin": rsin,
+                        "user_vestigingsnummer": vestigingsnummer,
+                    }
                 )
     except Exception:
         logger.warning("Failed to dispatch ZGW cache warm-up task", exc_info=True)

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -1069,6 +1069,12 @@ ZGW_CASE_LIST_FETCH_TIMEOUT = config("ZGW_CASE_LIST_FETCH_TIMEOUT", default=25)
 # status history, roles, and documents on top of what the list view resolves.
 ZGW_CACHE_WARMUP_TIMEOUT = config("ZGW_CACHE_WARMUP_TIMEOUT", default=120)
 
+# Celery queue to use for cache-seeding tasks (IO-bound, latency-sensitive).
+# Operators may dedicate a separate high-priority queue/worker pool for these.
+# Defaults to Celery's built-in default queue so no extra infrastructure is
+# needed out of the box.
+CACHE_SEEDING_QUEUE = config("CACHE_SEEDING_QUEUE", default="celery")
+
 # notifications
 ZGW_LIMIT_NOTIFICATIONS_FREQUENCY = config(
     "ZGW_LIMIT_NOTIFICATIONS_FREQUENCY", default=60 * 15

--- a/src/open_inwoner/openzaak/tests/test_tasks.py
+++ b/src/open_inwoner/openzaak/tests/test_tasks.py
@@ -205,7 +205,11 @@ class ZgwCachingIntegrationTest(ClearCachesMixin, TestCase):
         request.user = user
 
         with patch.object(
-            warm_cache_for_user, "delay", side_effect=warm_cache_for_user.run
+            warm_cache_for_user,
+            "apply_async",
+            side_effect=lambda *args, **kwargs: warm_cache_for_user.run(
+                **kwargs["kwargs"]
+            ),
         ):
             user_logged_in.send(sender=None, request=request, user=user)
 


### PR DESCRIPTION
…login

On login, dispatch ZGW cache warm-up tasks to a dedicated "low-latency" queue via apply_async so the queue is configurable (CACHE_SEEDING_QUEUE).

Add a celery-low-latency docker-compose service that runs the existing generic celery_worker.sh, parametrized via CELERY_WORKER_QUEUE (default: low-latency) and CELERY_WORKER_CONCURRENCY (default: 10). The higher concurrency suits the IO-bound, latency-sensitive nature of these tasks.

Also convert the x-app-env anchor from a YAML sequence to a mapping so per-service env overrides can be expressed with <<: merge keys.

Closes: #2539
