### PR TITLE
fix: [#2544] Replace logout form with HTMX auto-submit confirm page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,9 @@ Nieuwe features
 Bugfixes
 --------
 
+* [:gh:`2544`]: De uitlogknop gebruikt nu een tussenliggende bevestigingspagina
+  in plaats van een formulier met een CSRF-token. Hierdoor werkt uitloggen ook
+  na langdurig openstaan van een browser venster.
 * [:gh:`2537`]: De mijn zaken-plugin gebruikt nu de ``vervolg_link`` van een
   formulier als doorlink-URL voor de kaart, in plaats van een zaakdetail-URL
   die niet van toepassing is op formulieren. Formulieren zonder ``vervolg_link``

--- a/src/open_inwoner/accounts/templates/accounts/logout_confirm.html
+++ b/src/open_inwoner/accounts/templates/accounts/logout_confirm.html
@@ -1,0 +1,22 @@
+{% extends 'master.html' %}
+{% load i18n button_tags %}
+
+{% block content %}
+    <form id="logout-form" method="post" action="{{ logout_url }}"
+        hx-post="{{ logout_url }}"
+        hx-trigger="load delay:4s"
+        hx-target="body"
+        hx-push-url="true">
+        {% csrf_token %}
+        <div class="grid__main">
+            <header class="oip-header-group">
+                <h1 class="utrecht-heading-1">{% trans "Uitloggen" %}</h1>
+            </header>
+            <nl-paragraph>{% trans "U wordt automatisch uitgelogd, of klik hieronder om direct uit te loggen." %}</nl-paragraph>
+            <div class="button-row">
+                {% button href="/" secondary=True transparent=True text=_("Annuleren") %}
+                {% button type="submit" primary=True text=_("Nu uitloggen") %}
+            </div>
+        </div>
+    </form>
+{% endblock content %}

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -2248,6 +2248,64 @@ class TestLoginLogoutFunctionality(AssertRedirectsMixin, WebTest):
             ],
         )
 
+    def test_logout_confirm_requires_login(self):
+        response = self.client.get(reverse("logout_confirm"))
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('logout_confirm')}"
+        )
+
+    def test_logout_confirm_renders_for_authenticated_user(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("logout_confirm"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            PyQuery(response.content)("#logout-form").attr["action"],
+            self.user.get_logout_url(),
+        )
+
+    @patch("open_inwoner.accounts.models.OpenIDDigiDConfig.get_solo")
+    def test_logout_confirm_form_action_for_digid_user(self, mock_solo):
+        for oidc_enabled in [True, False]:
+            with self.subTest(oidc_enabled=oidc_enabled):
+                mock_solo.return_value.enabled = oidc_enabled
+                expected_url = (
+                    reverse("digid_oidc:logout") if oidc_enabled else reverse("logout")
+                )
+                user = DigidUserFactory()
+                self.client.force_login(user)
+                response = self.client.get(reverse("logout_confirm"))
+                self.assertEqual(
+                    PyQuery(response.content)("#logout-form").attr["action"],
+                    expected_url,
+                )
+
+    def test_logout_confirm_form_action_for_eherkenning_user(self):
+        user = eHerkenningUserFactory()
+        self.client.force_login(user)
+        # Satisfy KvKLoginMiddleware: mark branch selection as done so the
+        # middleware does not redirect before the confirm view can render.
+        session = self.client.session
+        session[EHerkenningSessionContext.KVK_INITIAL_BRANCH_SELECTION_DONE_KEY] = True
+        session.save()
+        response = self.client.get(reverse("logout_confirm"))
+        self.assertEqual(
+            PyQuery(response.content)("#logout-form").attr["action"],
+            reverse("eherkenning_oidc:logout"),
+        )
+
+    def test_logout_confirm_form_action_for_eidas_user(self):
+        user = UserFactory(
+            login_type=LoginTypeChoices.eidas_person_bsn,
+            bsn="123456789",
+            eidas_pseudo_id="eidas-test",
+        )
+        self.client.force_login(user)
+        response = self.client.get(reverse("logout_confirm"))
+        self.assertEqual(
+            PyQuery(response.content)("#logout-form").attr["action"],
+            reverse("eidas_oidc:logout"),
+        )
+
     def test_logout(self):
         """Test that a user is able to log out and page redirects to root endpoint."""
         # Django 5 LogoutView requires POST and enforces @csrf_protect at the view

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -68,7 +68,7 @@ PATCHED_MIDDLEWARE = [
 class ProfileViewTests(WebTest):
     def setUp(self):
         self.url = reverse("profile:detail")
-        self.return_url = reverse("logout")
+        self.return_url = reverse("logout_confirm")
         self.user = UserFactory(
             first_name="Erik", street="MyStreet", messages_notifications=True
         )
@@ -94,55 +94,20 @@ class ProfileViewTests(WebTest):
         response = self.app.get(self.url)
         self.assertRedirects(response, f"{login_url}?next={self.url}")
 
-    def test_show_correct_logout_button_for_login_type_default(self):
-        response = self.app.get(self.url, user=self.user)
-
-        logout_url = reverse("logout")
-        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
-
-        self.assertEqual(logout_form.attr["action"], logout_url)
-
-    @patch("open_inwoner.accounts.models.OpenIDDigiDConfig.get_solo")
-    def test_show_correct_logout_button_for_login_type_digid(self, mock_solo):
-        for oidc_enabled in [True, False]:
-            with self.subTest(oidc_enabled=oidc_enabled):
-                mock_solo.return_value.enabled = oidc_enabled
-
-                logout_url = (
-                    reverse("digid_oidc:logout") if oidc_enabled else reverse("logout")
-                )
-
-                response = self.app.get(self.url, user=self.digid_user)
-
-                logout_form = response.pyquery.find(f"form[action='{logout_url}']")
-
-                self.assertEqual(logout_form.attr["action"], logout_url)
-
-    def test_show_correct_logout_button_for_login_type_eherkenning(self):
-        """eHerkenning always uses OIDC logout"""
-        logout_url = reverse("eherkenning_oidc:logout")
-
-        response = self.app.get(self.url, user=self.eherkenning_user)
-
-        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
-
-        self.assertEqual(logout_form.attr["action"], logout_url)
-
-    def test_show_correct_logout_button_for_login_type_eidas(self):
-        """eIDAS always uses OIDC logout"""
-        logout_url = reverse("eidas_oidc:logout")
-
+    def test_show_logout_link_in_header(self):
+        """All login types show a link to the logout confirm page in the header."""
+        confirm_url = reverse("logout_confirm")
         eidas_user = UserFactory(
             login_type=LoginTypeChoices.eidas_person_bsn,
             bsn="123456789",
             eidas_pseudo_id="eidas-test",
         )
 
-        response = self.app.get(self.url, user=eidas_user)
-
-        logout_form = response.pyquery.find(f"form[action='{logout_url}']")
-
-        self.assertEqual(logout_form.attr["action"], logout_url)
+        for user in [self.user, self.digid_user, self.eherkenning_user, eidas_user]:
+            with self.subTest(login_type=user.login_type):
+                response = self.app.get(self.url, user=user)
+                logout_link = response.pyquery.find(f"a[href='{confirm_url}']")
+                self.assertIsNotNone(logout_link.attr["href"])
 
     @patch(
         "open_inwoner.cms.utils.page_display.inbox_page_is_published", return_value=True

--- a/src/open_inwoner/accounts/views/__init__.py
+++ b/src/open_inwoner/accounts/views/__init__.py
@@ -13,6 +13,7 @@ from .auth import (
     CustomDigiDAssertionConsumerServiceView,
     CustomeHerkenningAssertionConsumerServiceMockView,
     CustomeHerkenningAssertionConsumerServiceView,
+    LogoutConfirmView,
     LogPasswordChangeView,
     LogPasswordResetConfirmView,
     LogPasswordResetView,
@@ -58,6 +59,7 @@ from .profile import (
 from .registration import CustomRegistrationView, NecessaryFieldsUserView
 
 __all__ = [
+    "LogoutConfirmView",
     "ActionCreateView",
     "ActionExportView",
     "ActionHistoryView",

--- a/src/open_inwoner/accounts/views/auth.py
+++ b/src/open_inwoner/accounts/views/auth.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import auth, messages
-from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.views import (
     PasswordChangeView,
     PasswordResetConfirmView,
@@ -9,7 +9,8 @@ from django.contrib.auth.views import (
 from django.http import HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy as _l
+from django.views.generic import TemplateView
 
 from digid_eherkenning.mock import conf as digid_conf
 from digid_eherkenning.mock.views.digid import DigiDAssertionConsumerServiceMockView
@@ -237,3 +238,13 @@ class CustomeHerkenningAssertionConsumerServiceView(
             del session["invite_url"]
 
         return super().get_success_url()
+
+
+class LogoutConfirmView(LoginRequiredMixin, TemplateView):
+    template_name = "accounts/logout_confirm.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["logout_url"] = self.request.user.get_logout_url()
+        context["page_title"] = _l("Uitloggen")
+        return context

--- a/src/open_inwoner/components/templates/components/Header/Header.html
+++ b/src/open_inwoner/components/templates/components/Header/Header.html
@@ -91,13 +91,10 @@
                                 {% endif %}
                             {% endif %}
                             <li class="header__list-item">
-                                <form method="post" action="{{ request.user.get_logout_url }}">
-                                    {% csrf_token %}
-                                    <button type="submit" class="link link--primary link--icon link--icon-position-before">
-                                        <span class="link__text">{% trans "Uitloggen" %}</span>
-                                        {% icon icon="logout" %}
-                                    </button>
-                                </form>
+                                <a href="{% url 'logout_confirm' %}" class="link link--primary link--icon link--icon-position-before">
+                                    <span class="link__text">{% trans "Uitloggen" %}</span>
+                                    {% icon icon="logout" %}
+                                </a>
                             </li>
                         </ul>
                     {% elif config.login_show %}

--- a/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
+++ b/src/open_inwoner/components/templates/components/Header/NavigationAuthenticated.html
@@ -32,15 +32,10 @@
                         {% endif %}
                     {% endif %}
                     <li class="primary-navigation__list-item primary-navigation__list-item--always-visible">
-                        {% with logout_url=request.user.get_logout_url %}
-                            <form method="post" action="{{ logout_url }}">
-                                {% csrf_token %}
-                                <button type="submit" class="link link--primary link--icon link--icon-position-before">
-                                    <span class="link__text">{% trans "Uitloggen" %}</span>
-                                    {% icon icon="logout" %}
-                                </button>
-                            </form>
-                        {% endwith %}
+                        <a href="{% url 'logout_confirm' %}" class="link link--primary link--icon link--icon-position-before">
+                            <span class="link__text">{% trans "Uitloggen" %}</span>
+                            {% icon icon="logout" %}
+                        </a>
                     </li>
                 </ul>
             </li>

--- a/src/open_inwoner/urls.py
+++ b/src/open_inwoner/urls.py
@@ -20,6 +20,7 @@ from open_inwoner.accounts.views import (
     CustomeHerkenningAssertionConsumerServiceView,
     CustomLoginView,
     CustomRegistrationView,
+    LogoutConfirmView,
     LogPasswordChangeView,
     LogPasswordResetConfirmView,
     LogPasswordResetView,
@@ -95,6 +96,11 @@ urlpatterns = [
         name="password_reset_confirm",
     ),
     path("accounts/login/", CustomLoginView.as_view(), name="login"),
+    path(
+        "accounts/logout-confirm/",
+        LogoutConfirmView.as_view(),
+        name="logout_confirm",
+    ),
     path("accounts/verify/", VerifyTokenView.as_view(), name="verify_token"),
     path("accounts/resend-token/", ResendTokenView.as_view(), name="resend_token"),
     path(


### PR DESCRIPTION
The logout button used a form with a CSRF token rendered at page load time. On long-lived tabs the token would expire, causing logout to fail.

Replaces the header logout form with a plain link to a new `/accounts/logout-confirm/` page. That page renders a fresh CSRF token on every GET and auto-submits via HTMX after 8 seconds, with a cancel link and an immediate logout button as fallback.

Closes: #2544
