### PR TITLE
fix: [#2250] fix vertical-align on inline-flex buttons (Mijn Profiel)

### DIFF
--- a/src/open_inwoner/scss/components/Button/Button.scss
+++ b/src/open_inwoner/scss/components/Button/Button.scss
@@ -25,6 +25,7 @@
   outline-width: 1px;
   outline-offset: 1px;
   border: 0;
+  vertical-align: middle;
   white-space: nowrap;
 
   &:focus,


### PR DESCRIPTION
inline-flex elements align on text baseline by default; adding vertical-align: middle to .button ensures consistent alignment when multiple buttons appear side by side

## Summary

Bugfix for profile button (and other buttons)

---

<img width="806" height="182" alt="alignment-profilebewerk" src="https://github.com/user-attachments/assets/49c0137f-c468-4c83-8d19-5f0bbd654aa5" />

---

## Checklist

n.a.
