### PR TITLE
fix: [#2520] show non 200 response error on case detail page

### DIFF
--- a/src/open_inwoner/templates/pages/cases/status_outer.html
+++ b/src/open_inwoner/templates/pages/cases/status_outer.html
@@ -7,6 +7,8 @@
 {% endblock notifications %}
 
 {% block content %}
+    <div class="case-detail" id="any-error" data-error-message="{% trans 'We kunnen op dit moment de gegevens niet ophalen, probeer het later opnieuw.' %}"></div>
+
     <div class="case-detail" id="cases-detail-content">
         <oip-loading-spinner
             loading-text="{% trans 'Gegevens laden...' %}"


### PR DESCRIPTION
## Summary

htmx logic on case detail page did not display a user-facing error on non 200 res ponses

## Issue References

- Github Issue: #2520 