### PR TITLE
feat: [#2567] allow logout confirm page for users with incomplete nec…

### DIFF
--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1646,6 +1646,12 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
 
                 self.assertRedirects(response, redirect.url)
 
+    def test_logout_confirm_not_blocked_by_necessary_fields(self):
+        user = NewDigidUserFactory()
+        self.assertTrue(user.require_necessary_fields())
+        response = self.app.get(reverse("logout_confirm"), user=user)
+        self.assertEqual(response.status_code, 200)
+
     def test_submit_without_invite(self):
         config = SiteConfiguration.get_solo()
         config.notifications_cases_enabled = True

--- a/src/open_inwoner/utils/middleware.py
+++ b/src/open_inwoner/utils/middleware.py
@@ -17,6 +17,7 @@ def get_always_pass_prefixes() -> tuple[str, ...]:
         reverse("login"),
         reverse("logout"),
         reverse("kvk:branches"),
+        reverse("logout_confirm"),
         # prefixes from urls.py
         "/admin/",
         "/csp/",


### PR DESCRIPTION
…essary fields

Add `logout_confirm` to the always-pass prefixes in `get_always_pass_prefixes()` so that the `NecessaryFieldsMiddleware` does not intercept users who have not yet completed required registration fields.

Without this, those users were caught in a redirect loop: the middleware redirected them away from `logout_confirm` before they could log out.

Closes: #2567
