### PR TITLE
fix: [#2573] missing prosemirror filter on some paragraphs

### DIFF
--- a/src/open_inwoner/accounts/templates/registration/login.html
+++ b/src/open_inwoner/accounts/templates/registration/login.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n static utils grid_tags card_tags form_tags link_tags button_tags icon_tags solo_tags cms_tags djangocms_alias_tags %}
+{% load i18n static utils grid_tags card_tags form_tags link_tags button_tags icon_tags solo_tags render_tags cms_tags djangocms_alias_tags %}
 
 
 {% block header_image %}
@@ -9,7 +9,7 @@
 {% block content %}
     <h1 class="utrecht-heading-1">{% trans 'Welkom' %}</h1>
     {% if login_text.html %}
-        <div class="wysiwyg">{{ login_text.html|safe }}</div>
+        <div class="wysiwyg">{{ login_text.html|prosemirror_content|safe }}</div>
     {% endif %}
 
     {# Tab panels Start #}

--- a/src/open_inwoner/components/templates/components/Header/WarningHeader.html
+++ b/src/open_inwoner/components/templates/components/Header/WarningHeader.html
@@ -1,4 +1,4 @@
-{% load i18n icon_tags link_tags static %}
+{% load i18n icon_tags link_tags static render_tags %}
 
 <style nonce="{{ request.csp_nonce }}">
   .warning-header {
@@ -13,7 +13,7 @@
       >{% icon icon="error_outlined" outlined=True %}</span
     >
     <span class="warning-header__text"
-      >{{ warning_banner_text.html|safe }}</span
+      >{{ warning_banner_text.html|prosemirror_content|safe }}</span
     >
   </div>
 </div>

--- a/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
+++ b/src/open_inwoner/scss/components/SearchResults/SearchResults.scss
@@ -56,7 +56,7 @@
         padding-inline-start: 0;
       }
 
-      nl-paragraph,
+      .nl-paragraph,
       .ul .li {
         color: var(--color-info-darker);
       }

--- a/src/open_inwoner/templates/cms/plugins/links/external-links.html
+++ b/src/open_inwoner/templates/cms/plugins/links/external-links.html
@@ -1,4 +1,4 @@
-{% load i18n icon_tags %}
+{% load i18n icon_tags render_tags %}
 
 {% if link_plugin and link_plugin.child_plugin_instances %}
     <section class="plugin external-links">
@@ -10,7 +10,7 @@
                     <span class="external-link__custom-icon">
                     {% icon icon=link.icon outlined=True %}
                     </span>
-                    <span class="external-link__content">{{ link.name.html|safe }}</span>
+                    <span class="external-link__content">{{ link.name.html|prosemirror_content|safe }}</span>
                     <span class="external-link__arrow">
                     {% icon icon="east" icon_position="after" primary=True outlined=True %}
                     </span>

--- a/src/open_inwoner/templates/cms/plugins/links/link.html
+++ b/src/open_inwoner/templates/cms/plugins/links/link.html
@@ -1,6 +1,6 @@
-{% load cms_tags %}{% spaceless %}
+{% load render_tags cms_tags %}{% spaceless %}
 {# this needs to be in one line for rendering purpose #}
-{% endspaceless %}<a href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name.html|safe }}{% endfor %}</a>
+{% endspaceless %}<a href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name.html|prosemirror_content|safe }}{% endfor %}</a>
 
 {% comment %}
 # Modified from djangocms_link/default/link.html to support ProsemirrorModelField

--- a/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
+++ b/src/open_inwoner/templates/export/questionnaire/questionnaire_export.html
@@ -10,7 +10,7 @@
                 <h4>{% trans "Question:" %}</h4>
                 <nl-paragraph>{{ step.question }}</nl-paragraph>
                 <h4>{% trans "Answer:" %}</h4>
-                <nl-paragraph>{{ step.answer }}</nl-paragraph>
+                <p>{{ step.answer }}</p>
             </li>
             {% endfor %}
         </ol>
@@ -18,14 +18,14 @@
 
     <div class="qa_results">
         <h4 class="utrecht-heading-4">{{ last_step.question }}</h4>
-        <nl-paragraph>{{ last_step.content.html|safe}}</nl-paragraph>
+        <p>{{ last_step.content.html|safe}}</p>
         {% if related_products.exists %}
             <h4>{% trans "Related products:" %}</h4>
             <ol>
                 {% for product in related_products %}
                 <li>
                     <h4>{{ product.name }}</h4>
-                    <nl-paragraph>{{ product.summary }}</nl-paragraph>
+                    <p>{{ product.summary }}</p>
                 </li>
                 {% endfor %}
             </ol>

--- a/src/open_inwoner/templates/pages/product/detail.html
+++ b/src/open_inwoner/templates/pages/product/detail.html
@@ -47,6 +47,7 @@
         <div class="readmore__content" id="readmore__content" data-toggle-readmore="{{ readmore|lower }}">
             <div class="readmore__inner-content {% if object.content_is_collapsable %}readmore__content--hidden{% endif %}">
                 {{ object|product_rendered_content|safe }}
+                {# Styled with 'beautifulsoup' instead of prosemirror_content #}
             </div>
         </div>
     </div>

--- a/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
+++ b/src/open_inwoner/templates/pages/questionnaire/questionnaire-step.html
@@ -43,7 +43,7 @@
                 {% csrf_token %}
 
                 {% if form.instance.content %}
-                    {{ form.instance.content|safe }}
+                    {{ form.instance.content|prosemirror_content|safe }}
                 {% endif %}
 
                 {% if questionnaire_files %}

--- a/src/open_inwoner/templates/pages/search.html
+++ b/src/open_inwoner/templates/pages/search.html
@@ -1,5 +1,5 @@
 {% extends 'master.html' %}
-{% load i18n form_tags icon_tags grid_tags pagination_tags filter_tags %}
+{% load i18n form_tags icon_tags grid_tags pagination_tags render_tags cms_tags filter_tags %}
 
 {% block main_inner %}
     {#  search term section #}
@@ -98,7 +98,7 @@
                             {% trans "We konden geen zoekresultaten vinden" %}
                         </h2>
                         {% if configurable_text.search_page.search_zero_results_text.html %}
-                            {{ configurable_text.search_page.search_zero_results_text.html|safe }}
+                            {{ configurable_text.search_page.search_zero_results_text.html|prosemirror_content|safe }}
                         {% else %}
                             <nl-paragraph>{% trans "Probeer het nog eens met deze tips:" %}</nl-paragraph>
                             <ul class="ul">

--- a/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
+++ b/src/open_inwoner/templates/pages/ssd/monthly_reports_list.html
@@ -15,7 +15,7 @@
                 {# Setting class to 'tab__contents' instead of 'tab__content' is a quick-fix #}
                     <div id="maandspecificaties" class="tab__contents active">
                         <div class="wysiwyg">
-                            {% blocktrans with display_text=client.config.maandspecificatie_display_text.html|safe %}
+                            {% blocktrans with display_text=client.config.maandspecificatie_display_text.html|prosemirror_content|safe %}
                                 {{ display_text }}
                             {% endblocktrans %}
                         </div>

--- a/src/open_inwoner/templates/pages/ssd/yearly_reports_list.html
+++ b/src/open_inwoner/templates/pages/ssd/yearly_reports_list.html
@@ -16,7 +16,7 @@
                     {# Setting class to 'tab__contents' instead of 'tab__content' is a quick-fix #}
                         <div id="maandspecificaties" class="tab__contents active">
                             <div class="wysiwyg">
-                                {% blocktrans with jaaropgave_text=client.config.jaaropgave_display_text.html|safe %}
+                                {% blocktrans with jaaropgave_text=client.config.jaaropgave_display_text.html|prosemirror_content|safe %}
                                     {{ jaaropgave_text }}
                                 {% endblocktrans %}
                             </div>


### PR DESCRIPTION
 add prosemirror filter so nlds css class is applied to paragraphs

some pages were missing correct render_tags and cms_tags

## Issue References

Additional bugfix for issue #2203 and #2394 that were closed. 

## Checklist

- [ ] 