### PR TITLE
[#2583] Fix ssd error handling

### DIFF
--- a/src/open_inwoner/ssd/client.py
+++ b/src/open_inwoner/ssd/client.py
@@ -85,8 +85,7 @@ class SSDBaseClient(ABC):
                 **auth_kwargs,
             )
             response.raise_for_status()
-        except (requests.HTTPError, requests.RequestException) as exc:
-            logger.exception("Requests error from SSD client")
+        except requests.RequestException as exc:
             raise SSDClientException from exc
 
         return response
@@ -145,9 +144,6 @@ class JaaropgaveClient(SSDBaseClient):
     def get_reports(self, bsn: str, report_date: str, request_url: str) -> bytes | None:
         response = self.templated_request(bsn=bsn, dienstjaar=report_date)
 
-        if not response or response.status_code != 200:
-            return None
-
         jaaropgaven = get_jaaropgaven(response)
 
         if not jaaropgaven:
@@ -197,9 +193,6 @@ class UitkeringClient(SSDBaseClient):
 
     def get_reports(self, bsn: str, report_date: str, request_url: str) -> bytes | None:
         response = self.templated_request(bsn=bsn, period=report_date)
-
-        if not response or response.status_code != 200:
-            return None
 
         uitkeringen = get_uitkeringen(response)
 

--- a/src/open_inwoner/ssd/tests/test_client.py
+++ b/src/open_inwoner/ssd/tests/test_client.py
@@ -157,18 +157,7 @@ class UitkeringClientTest(TestCase):
             service__url="https://example.com/soap-service/",
         )
 
-        mock_request.post(
-            "https://example.com/soap-service/maandspecificatie/",
-            status_code=300,
-        )
-        res = ssd_client.get_reports(
-            bsn="12345",
-            report_date="198507",
-            request_url="https://dummy.com",
-        )
-        self.assertIsNone(res)
-
-        for code in [400, 500]:
+        for code in [300, 400, 500]:
             with self.subTest(code=code):
                 mock_request.post(
                     "https://example.com/soap-service/maandspecificatie/",
@@ -227,18 +216,7 @@ class JaaropgaveClientTest(TestCase):
             service__url="https://example.com/soap-service/",
         )
 
-        mock_request.post(
-            "https://example.com/soap-service/jaaropgave/",
-            status_code=300,
-        )
-        res = ssd_client.get_reports(
-            bsn="12345",
-            report_date="198507",
-            request_url="https://dummy.com",
-        )
-        self.assertIsNone(res)
-
-        for code in [400, 500]:
+        for code in [300, 400, 500]:
             with self.subTest(code=code):
                 mock_request.post(
                     "https://example.com/soap-service/jaaropgave/",

--- a/src/open_inwoner/ssd/tests/test_views.py
+++ b/src/open_inwoner/ssd/tests/test_views.py
@@ -135,7 +135,13 @@ class TestMonthlyBenefitsFormView(TestCase):
         response = self.client.post(url, data={"report_date": "1985-12-25"})
 
         messages = [str(m) for m in get_messages(response.wsgi_request)]
-        self.assertTrue(any("Probeer het later nog eens" in m for m in messages))
+        self.assertTrue(
+            any(
+                _("Your report(s) could not be retrieved due to technical problems.")
+                in m
+                for m in messages
+            )
+        )
 
     @patch(
         "open_inwoner.ssd.client.UitkeringClient.get_reports",
@@ -154,7 +160,13 @@ class TestMonthlyBenefitsFormView(TestCase):
         response = self.client.post(url, data={"report_date": "1985-12-25"})
 
         messages = [str(m) for m in get_messages(response.wsgi_request)]
-        self.assertTrue(any("contact op met de gemeente" in m for m in messages))
+        self.assertTrue(
+            any(
+                _("Your report(s) could not be retrieved due to technical problems.")
+                in m
+                for m in messages
+            )
+        )
 
     @patch("open_inwoner.ssd.models.SSDConfig.get_solo")
     def test_uitkering_get_reports_not_enabled(self, mock_solo):

--- a/src/open_inwoner/ssd/views.py
+++ b/src/open_inwoner/ssd/views.py
@@ -55,30 +55,21 @@ class BenefitsFormView(
             report_date = ssd_client.format_report_date(form.data["report_date"])
             request_url = request.build_absolute_uri()
 
+            user_msg = _(
+                "Your report(s) could not be retrieved due to technical problems."
+            )
             try:
                 pdf_content = ssd_client.get_reports(bsn, report_date, request_url)
-            except (ImproperlyConfigured, SSDServiceFaultException) as exc:
+            except SSDServiceFaultException as exc:
                 logger.warning(
                     "SSD service fault",
                     meldingen=[m.tekst for m in exc.meldingen],
                 )
-                messages.error(
-                    request=request,
-                    message=_(
-                        "Your report(s) could not be retrieved due to technical problems. "
-                        "Please contact the municipality."
-                    ),
-                )
+                messages.error(request=request, message=user_msg)
                 pdf_content = None
-            except SSDClientException:
+            except (ImproperlyConfigured, SSDClientException):
                 logger.exception("SSD client error")
-                messages.error(
-                    request=request,
-                    message=_(
-                        "Your report(s) could not be retrieved due to technical problems. "
-                        "Please try again later."
-                    ),
-                )
+                messages.error(request=request, message=user_msg)
                 pdf_content = None
 
             if not pdf_content:

--- a/src/open_inwoner/ssd/xml.py
+++ b/src/open_inwoner/ssd/xml.py
@@ -58,7 +58,7 @@ def _get_report_info(
 
     if not (info_node := tree.find(info_response_node)):
         raise SSDClientException(
-            "XML node %s not found in response", info_response_node
+            f"XML node {info_response_node!r} not found in response"
         )
 
     parser = XmlParser(context=XmlContext(), handler=LxmlEventHandler)
@@ -66,7 +66,7 @@ def _get_report_info(
     try:
         info_response = parser.parse(info_node, info_type)
     except ParserError as exc:
-        raise SSDClientException("failed to parse XML for %s", info_response) from exc
+        raise SSDClientException("failed to parse XML response") from exc
 
     # fout, waarschuwing, informatie
     if info_response.fwi:


### PR DESCRIPTION
## Summary

- `SSDServiceFaultException` and `(ImproperlyConfigured, SSDClientException)` are now handled separately.
- Two constructions of `SSDClientException` in `ssd/xml.py` passed the wrong arguments (probably due to copy/pasting from a logging call site)

