### PR TITLE
[#2586] Remove .html access on mijn_uitkeringen_text in SSD template

### DIFF
--- a/src/open_inwoner/templates/pages/ssd/reports_base.html
+++ b/src/open_inwoner/templates/pages/ssd/reports_base.html
@@ -12,7 +12,7 @@
                 {{ page_title }}
             </h1>
             <p>
-                {% blocktrans with mijn_uitkeringen_text=client.config.mijn_uitkeringen_text.html|safe %}
+                {% blocktrans with mijn_uitkeringen_text=client.config.mijn_uitkeringen_text|safe %}
                     {{ mijn_uitkeringen_text }}
                 {% endblocktrans %}
             <p>


### PR DESCRIPTION
SSDConfig.mijn_uitkeringen_text is a models.TextField, but the base template for the SSD attempted config.mijn_uitkeringen_text.html|, which rendered as "".