### PR TITLE
fix: [#2588] ensure Site exists before uWSGI starts on fresh deployments

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -21,7 +21,11 @@ ${SCRIPTPATH}/wait_for_db.sh
 
 # Apply database migrations
 >&2 echo "Apply database migrations"
-python src/manage.py migrate
+python src/manage.py migrate --skip-checks
+
+# Run system checks now that the database is populated
+>&2 echo "Running system checks"
+python src/manage.py check
 
 # Ensure all mail-editor templates exist in the database
 >&2 echo "Loading mail templates"


### PR DESCRIPTION
Django CMS loads urls.py at module import time and calls Site.objects.get_current(), which requires a Site row to exist. On fresh deployments, Django's system check framework (which runs URL validation) is triggered by the migrate command before any migrations have been applied, causing the container to crash with Site.DoesNotExist before the database is even populated.

Add --skip-checks to the migrate call in docker_start.sh so URL validation is deferred until after migrations complete, at which point Django's post_migrate signal creates the default Site. System checks are then run explicitly before starting the application server.

Closes: #2588
