### PR TITLE
[#2581] Handle empty status indicators due to missing ZaakTypeStatusTypeConfig

### DIFF
--- a/src/open_inwoner/cms/cases/views/status.py
+++ b/src/open_inwoner/cms/cases/views/status.py
@@ -216,13 +216,24 @@ class InnerCaseDetailView(
                 logger.warning("Failed to build eSuiteVragenService")
 
     def store_statustype_mapping(self, zaaktype_identificatie):
-        # Filter on ZaakType identificatie to avoid eSuite situation where one statustype
-        # is linked to multiple zaaktypes
-        self.statustype_config_mapping = {
-            zaaktype_statustype.statustype_url: zaaktype_statustype
-            for zaaktype_statustype in ZaakTypeStatusTypeConfig.objects.filter(
-                zaaktype_config__identificatie=zaaktype_identificatie
+        # Filter on ZaakType identificatie: one statustype can be linked to multiple zaaktypes
+        # Filter on catalogus service: a zaak could be imported + viewed with different
+        # api groups, causing a mismatch in `ZaakTypeStatusTypeConfig.statustype_url`
+        configs = list(
+            ZaakTypeStatusTypeConfig.objects.filter(
+                zaaktype_config__identificatie=zaaktype_identificatie,
+                zaaktype_config__catalogus__service=self.api_group.ztc_service,
             )
+        )
+        if not configs:
+            logger.warning(
+                "No ZaakTypeStatusTypeConfig found for zaaktype - run zgw_import_data",
+                zaaktype_identificatie=zaaktype_identificatie,
+                api_group=self.api_group.name,
+            )
+
+        self.statustype_config_mapping = {
+            config.statustype_url: config for config in configs
         }
 
     @cached_property
@@ -578,50 +589,65 @@ class InnerCaseDetailView(
     @staticmethod
     def get_statuses_data(
         statuses: list[Status],
-        statustype_config_mapping: dict | None = None,
+        statustype_config_mapping: dict,
     ) -> list[dict]:
-        return [
-            {
-                "date": s.datum_status_gezet,
-                "label": glom_multiple(
-                    s,
-                    ("statustype.statustekst", "statustype.omschrijving"),
-                    default=_("Nieuwe aanvraag"),
-                ),
-                "status_indicator": getattr(
-                    statustype_config_mapping.get(s.statustype.url),
-                    "status_indicator",
-                    None,
-                ),
-                "status_indicator_text": getattr(
-                    statustype_config_mapping.get(s.statustype.url),
-                    "status_indicator_text",
-                    None,
-                ),
-                "call_to_action_url": getattr(
-                    statustype_config_mapping.get(s.statustype.url),
-                    "call_to_action_url",
-                    None,
-                ),
-                "call_to_action_text": getattr(
-                    statustype_config_mapping.get(s.statustype.url),
-                    "call_to_action_text",
-                    None,
-                ),
-                "description": (
-                    config.description.html
-                    if (config := statustype_config_mapping.get(s.statustype.url))
-                    and config.description
-                    else ""
-                ),
-                "case_link_text": getattr(
-                    statustype_config_mapping.get(s.statustype.url),
-                    "case_link_text",
-                    _("Bekijk aanvraag"),
-                ),
-            }
-            for s in statuses
-        ]
+        statuses_data = []
+
+        for status in statuses:
+            config = statustype_config_mapping.get(status.statustype.url)
+            if config is None and status.statustype.url:
+                logger.warning(
+                    "No ZaakTypeStatusTypeConfig for statustype URL",
+                    statustype_url=status.statustype.url,
+                )
+
+            statuses_data.append(
+                {
+                    "date": status.datum_status_gezet,
+                    "label": glom_multiple(
+                        status,
+                        ("statustype.statustekst", "statustype.omschrijving"),
+                        default=_("Nieuwe aanvraag"),
+                    ),
+                    "status_indicator": getattr(
+                        statustype_config_mapping.get(status.statustype.url),
+                        "status_indicator",
+                        None,
+                    ),
+                    "status_indicator_text": getattr(
+                        statustype_config_mapping.get(status.statustype.url),
+                        "status_indicator_text",
+                        None,
+                    ),
+                    "call_to_action_url": getattr(
+                        statustype_config_mapping.get(status.statustype.url),
+                        "call_to_action_url",
+                        None,
+                    ),
+                    "call_to_action_text": getattr(
+                        statustype_config_mapping.get(status.statustype.url),
+                        "call_to_action_text",
+                        None,
+                    ),
+                    "description": (
+                        config.description.html
+                        if (
+                            config := statustype_config_mapping.get(
+                                status.statustype.url
+                            )
+                        )
+                        and config.description
+                        else ""
+                    ),
+                    "case_link_text": getattr(
+                        statustype_config_mapping.get(status.statustype.url),
+                        "case_link_text",
+                        _("Bekijk aanvraag"),
+                    ),
+                }
+            )
+
+        return statuses_data
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
+++ b/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
@@ -1,7 +1,8 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from open_inwoner.openzaak.models import ZGWApiGroupConfig
 from open_inwoner.openzaak.zgw_imports import (
+    ExclusionReason,
     ZGWCatalogusImporter,
 )
 
@@ -21,9 +22,18 @@ class Command(BaseCommand):
             for api_group in ZGWApiGroupConfig.objects.all()
         ]
 
-        outputs: list[str] = []
+        results = []
         for importer in importers:
             result = importer.import_all()
-            outputs.append(result.pretty_print())
+            results.append(result)
 
-        self.stdout.write("\n".join(outputs))
+        self.stdout.write("\n".join(result.pretty_print() for result in results))
+
+        has_errors = any(
+            excluded.reason
+            in (ExclusionReason.API_ERROR, ExclusionReason.DATABASE_ERROR)
+            for result in results
+            for excluded in result.all_excluded()
+        )
+        if has_errors:
+            raise CommandError("Import completed with errors")

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
+from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -3396,3 +3396,129 @@ class TestCaseDetailView(
         self.assertEqual(case.statuses[0]["label"], "Registered")
         self.assertEqual(case.statuses[1]["label"], "Modified")
         self.assertEqual(case.statuses[2]["label"], "Finish")
+
+
+class StoreStatustypeMappingTest(TestCase):
+    def _make_view_with_api_group(self, api_group):
+        view = InnerCaseDetailView()
+        view.api_group = api_group
+        return view
+
+    def test_mapping_scoped_to_current_api_group(self):
+        api_group = ZGWApiGroupConfigFactory()
+        catalogus = CatalogusConfigFactory(service=api_group.ztc_service)
+        ztc = ZaakTypeConfigFactory(catalogus=catalogus, identificatie="ZT-001")
+        config = ZaakTypeStatusTypeConfigFactory(
+            zaaktype_config=ztc,
+            statustype_url=f"{api_group.ztc_service.api_root}statustypen/abc",
+        )
+
+        view = self._make_view_with_api_group(api_group)
+        view.store_statustype_mapping("ZT-001")
+
+        self.assertEqual(
+            view.statustype_config_mapping,
+            {config.statustype_url: config},
+        )
+
+    def test_mapping_excludes_other_api_group(self):
+        api_group = ZGWApiGroupConfigFactory()
+        other_api_group = ZGWApiGroupConfigFactory()
+
+        catalogus = CatalogusConfigFactory(service=api_group.ztc_service)
+        ztc = ZaakTypeConfigFactory(catalogus=catalogus, identificatie="ZT-001")
+        ZaakTypeStatusTypeConfigFactory(
+            zaaktype_config=ztc,
+            statustype_url=f"{api_group.ztc_service.api_root}statustypen/abc",
+        )
+
+        other_catalogus = CatalogusConfigFactory(service=other_api_group.ztc_service)
+        other_ztc = ZaakTypeConfigFactory(
+            catalogus=other_catalogus, identificatie="ZT-001"
+        )
+        ZaakTypeStatusTypeConfigFactory(
+            zaaktype_config=other_ztc,
+            statustype_url=f"{other_api_group.ztc_service.api_root}statustypen/abc",
+        )
+
+        view = self._make_view_with_api_group(api_group)
+        view.store_statustype_mapping("ZT-001")
+
+        self.assertEqual(
+            list(view.statustype_config_mapping.keys()),
+            [f"{api_group.ztc_service.api_root}statustypen/abc"],
+        )
+
+    def test_empty_mapping_logs_warning(self):
+        api_group = ZGWApiGroupConfigFactory()
+        view = self._make_view_with_api_group(api_group)
+
+        with self.assertLogs(
+            "open_inwoner.cms.cases.views.status", level="WARNING"
+        ) as cm:
+            view.store_statustype_mapping("ZT-UNKNOWN")
+
+        self.assertTrue(
+            any("No ZaakTypeStatusTypeConfig found" in msg for msg in cm.output)
+        )
+        self.assertEqual(view.statustype_config_mapping, {})
+
+
+class GetStatusesDataTest(TestCase):
+    def _make_status(self, statustype_url, label="Test status"):
+        statustype = StatusType(
+            url=statustype_url,
+            zaaktype="https://ztc.example.com/zaaktypen/1",
+            omschrijving=label,
+            volgnummer=1,
+        )
+        status = Status(
+            url="https://zrc.example.com/statussen/1",
+            zaak="https://zrc.example.com/zaken/1",
+            statustype=statustype,
+            datum_status_gezet=datetime.datetime(2024, 1, 1),
+        )
+        return status
+
+    def test_returns_list_for_multiple_statuses(self):
+        status_a = self._make_status(
+            "https://ztc.example.com/statustypen/a", "Status A"
+        )
+        status_b = self._make_status(
+            "https://ztc.example.com/statustypen/b", "Status B"
+        )
+
+        result = InnerCaseDetailView.get_statuses_data([status_a, status_b], {})
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_uses_config_when_url_matches(self):
+        url = "https://ztc.example.com/statustypen/abc"
+        status = self._make_status(url)
+        config = ZaakTypeStatusTypeConfigFactory.build(
+            statustype_url=url,
+            status_indicator=StatusIndicators.warning,
+            status_indicator_text="Let op",
+        )
+
+        result = InnerCaseDetailView.get_statuses_data([status], {url: config})
+
+        self.assertEqual(result[0]["status_indicator"], StatusIndicators.warning)
+        self.assertEqual(result[0]["status_indicator_text"], "Let op")
+
+    def test_logs_warning_when_url_not_in_mapping(self):
+        url = "https://ztc.example.com/statustypen/missing"
+        status = self._make_status(url)
+
+        with self.assertLogs(
+            "open_inwoner.cms.cases.views.status", level="WARNING"
+        ) as cm:
+            InnerCaseDetailView.get_statuses_data([status], {})
+
+        self.assertTrue(
+            any(
+                "No ZaakTypeStatusTypeConfig for statustype URL" in msg
+                for msg in cm.output
+            )
+        )

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports.py
@@ -21,7 +21,11 @@ from open_inwoner.openzaak.tests.factories import (
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import ANOTHER_CATALOGI_ROOT, CATALOGI_ROOT
 from open_inwoner.openzaak.zgw_imports import (
+    ExcludedObject,
     ExclusionReason,
+    FullImportResult,
+    ImportResult,
+    ZaakTypeRelatedImportResult,
     ZGWCatalogusImporter,
 )
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
@@ -2987,3 +2991,56 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
                 f"ZaakType {zt.identificatie} from API group 2 should not be affected "
                 f"by API group 1's import",
             )
+
+
+class FullImportResultAllExcludedTest(TestCase):
+    def _make_excluded(
+        self, object_type="StatusType", reason=ExclusionReason.API_ERROR
+    ):
+        return ExcludedObject(
+            object_type=object_type, url="https://example.com", reason=reason
+        )
+
+    def test_all_excluded_empty_when_no_exclusions(self):
+        api_group = ZGWApiGroupConfigFactory()
+        result = FullImportResult(api_group=api_group)
+        self.assertEqual(result.all_excluded(), [])
+
+    def test_all_excluded_collects_from_catalogi_and_zaaktypen(self):
+        api_group = ZGWApiGroupConfigFactory()
+        exc_catalogus = self._make_excluded("Catalogus")
+        exc_zaaktype = self._make_excluded("ZaakType")
+        result = FullImportResult(
+            api_group=api_group,
+            catalogi=ImportResult(excluded=[exc_catalogus]),
+            zaaktypen=ImportResult(excluded=[exc_zaaktype]),
+        )
+        self.assertEqual(result.all_excluded(), [exc_catalogus, exc_zaaktype])
+
+    def test_all_excluded_collects_from_per_zaaktype_results(self):
+        api_group = ZGWApiGroupConfigFactory()
+        exc_statustype = self._make_excluded("StatusType")
+        exc_resultaattype = self._make_excluded("ResultaatType")
+        exc_iot = self._make_excluded("InformatieObjectType")
+        result = FullImportResult(
+            api_group=api_group,
+            statustypen=[ZaakTypeRelatedImportResult(excluded=[exc_statustype])],
+            resultaattypen=[ZaakTypeRelatedImportResult(excluded=[exc_resultaattype])],
+            informatieobjecttypen=[ZaakTypeRelatedImportResult(excluded=[exc_iot])],
+        )
+        self.assertCountEqual(
+            result.all_excluded(), [exc_statustype, exc_resultaattype, exc_iot]
+        )
+
+    def test_all_excluded_returns_flat_list_across_multiple_zaaktypen(self):
+        api_group = ZGWApiGroupConfigFactory()
+        exc_a = self._make_excluded("StatusType")
+        exc_b = self._make_excluded("StatusType")
+        result = FullImportResult(
+            api_group=api_group,
+            statustypen=[
+                ZaakTypeRelatedImportResult(excluded=[exc_a]),
+                ZaakTypeRelatedImportResult(excluded=[exc_b]),
+            ],
+        )
+        self.assertEqual(result.all_excluded(), [exc_a, exc_b])

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
@@ -2,6 +2,7 @@ from io import StringIO
 from unittest import mock
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 
 import requests_mock
@@ -18,6 +19,12 @@ from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import ANOTHER_CATALOGI_ROOT, CATALOGI_ROOT
 from open_inwoner.openzaak.tests.test_zgw_imports import CatalogMockData
+from open_inwoner.openzaak.zgw_imports import (
+    ExcludedObject,
+    ExclusionReason,
+    FullImportResult,
+    ImportResult,
+)
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 
@@ -471,3 +478,54 @@ class ZGWImportCommandWithoutConfigTest(TestCase):
         )
         # Verify the importer was never instantiated
         mock_importer.assert_not_called()
+
+
+class ZGWImportCommandErrorHandlingTest(TestCase):
+    def _make_result_with_exclusion(self, reason):
+        api_group = ZGWApiGroupConfigFactory()
+        return FullImportResult(
+            api_group=api_group,
+            zaaktypen=ImportResult(
+                excluded=[
+                    ExcludedObject(
+                        object_type="ZaakType",
+                        url="https://ztc.example.com/zaaktypen/1",
+                        reason=reason,
+                    )
+                ]
+            ),
+        )
+
+    @mock.patch(
+        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
+    )
+    def test_command_raises_on_api_error(self, mock_importer_cls):
+        result = self._make_result_with_exclusion(ExclusionReason.API_ERROR)
+        mock_importer_cls.return_value.import_all.return_value = result
+        # ZGWApiGroupConfig.objects.all() must return something for importers to be built
+        ZGWApiGroupConfigFactory()
+
+        with self.assertRaises(CommandError):
+            call_command("zgw_import_data", stdout=StringIO())
+
+    @mock.patch(
+        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
+    )
+    def test_command_raises_on_database_error(self, mock_importer_cls):
+        result = self._make_result_with_exclusion(ExclusionReason.DATABASE_ERROR)
+        mock_importer_cls.return_value.import_all.return_value = result
+        ZGWApiGroupConfigFactory()
+
+        with self.assertRaises(CommandError):
+            call_command("zgw_import_data", stdout=StringIO())
+
+    @mock.patch(
+        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
+    )
+    def test_command_does_not_raise_for_filtered_internal(self, mock_importer_cls):
+        result = self._make_result_with_exclusion(ExclusionReason.FILTERED_INTERNAL)
+        mock_importer_cls.return_value.import_all.return_value = result
+        ZGWApiGroupConfigFactory()
+
+        # Should not raise
+        call_command("zgw_import_data", stdout=StringIO())

--- a/src/open_inwoner/openzaak/zgw_imports.py
+++ b/src/open_inwoner/openzaak/zgw_imports.py
@@ -119,6 +119,18 @@ class FullImportResult:
         field(default_factory=list)
     )
 
+    def all_excluded(self) -> list[ExcludedObject]:
+        excluded = []
+        excluded.extend(self.catalogi.excluded)
+        excluded.extend(self.zaaktypen.excluded)
+        for obj in self.informatieobjecttypen:
+            excluded.extend(obj.excluded)
+        for obj in self.statustypen:
+            excluded.extend(obj.excluded)
+        for obj in self.resultaattypen:
+            excluded.extend(obj.excluded)
+        return excluded
+
     def pretty_print(self) -> str:
         """
         Generate a human-readable summary of the import results.


### PR DESCRIPTION
Some zaak statuses are missing a status indicator due to the following causes:

1. Missing `ZaakTypeConfig`: when a new zaaktype is created but the data is not synced via `zgw_import_data`, no config is created for the zaaktype, hence none is created for the zaaktype's statustypes. We log a warning to alert that `zgw_import_data` needs to be run.

2. `ZaakTypeConfig` exists, `ZaakTypeStatusTypeConfig` missing: partial API failures lead to the situation where a `ZaakTypeConfig` exists but the `ZaakTypeStatusTypeConfig` count is less then expected. We log a warning for each statustype that lacks a config.

3. API group mismatch: `ZaakTypeStatusTypeConfig.statustype_url` is determined by the api_root of the `zgw_api_group.catalogi_client` (= `ZGWApiGroupConfig.ztc_service.api_root`) used during syncing. If the `zgw api_group` which is active when viewing a zaak uses a different ZTC group than the one used during sync, the URLs don't match and the statustype mapping lookup silently returned `None`. The fix is to scope the query to the current api_group's ZTC service.

1 + 2 merely improve observability, 3 fixes a bug in our code that will prevent some cases of missing statustype configs. In addition, `zgw_import_data` now raises `CommandError` when any item was excluded due to an API or database error, so monitoring detects partial sync failures at the source.