### PR TITLE
feat: [#2615] sync phonenumber and email with DigitalAddress

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -114,7 +114,6 @@ class CustomRegistrationForm(RegistrationForm):
             "infix",
             "last_name",
             "phonenumber",
-            "phonenumber_alternative",
             "password1",
             "password2",
             "invite",
@@ -123,11 +122,9 @@ class CustomRegistrationForm(RegistrationForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # make phonenumber required when 2fa-sms login is enabled
         config = SiteConfiguration.get_solo()
         if not config.login_2fa_sms:
             del self.fields["phonenumber"]
-            del self.fields["phonenumber_alternative"]
         else:
             self.fields["phonenumber"].required = True
 
@@ -139,7 +136,6 @@ class BaseUserForm(forms.ModelForm):
             "first_name",
             "email",
             "phonenumber",
-            "phonenumber_alternative",
             "image",
             "cropping",
         )
@@ -165,7 +161,6 @@ class UserForm(ErrorMessageMixin, BaseUserForm):
             "last_name",
             "email",
             "phonenumber",
-            "phonenumber_alternative",
             "street",
             "housenumber",
             "postcode",

--- a/src/open_inwoner/accounts/migrations/0094_remove_phonenumber_backfill_digital_addresses.py
+++ b/src/open_inwoner/accounts/migrations/0094_remove_phonenumber_backfill_digital_addresses.py
@@ -1,0 +1,57 @@
+from django.db import migrations
+
+
+def backfill_phone_digital_addresses(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    DigitalAddress = apps.get_model("accounts", "DigitalAddress")
+
+    # Establish the initial DA state that mirrors the current field values:
+    # standard DA for phonenumber, non-standard DA for phonenumber_alternative.
+    # phonenumber_alternative is about to be dropped; phonenumber stays as a field.
+    for user in User.objects.filter(phonenumber__gt=""):
+        DigitalAddress.objects.create(
+            user=user,
+            type="phone",
+            value=user.phonenumber,
+            login_type=user.login_type,
+            is_standard_for_type=True,
+        )
+        if (
+            user.phonenumber_alternative
+            and user.phonenumber_alternative != user.phonenumber
+        ):
+            DigitalAddress.objects.create(
+                user=user,
+                type="phone",
+                value=user.phonenumber_alternative,
+                login_type=user.login_type,
+                is_standard_for_type=False,
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "accounts",
+            "0093_add_digitaladdress_and_preferred_address",
+        ),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="user",
+            name="phonenumber_alt_requires_phonenumber_primary",
+        ),
+        migrations.RemoveConstraint(
+            model_name="user",
+            name="check_alternative_phonenumber_differs_from_primary_phonenumber",
+        ),
+        migrations.RunPython(
+            backfill_phone_digital_addresses,
+            migrations.RunPython.noop,
+        ),
+        migrations.RemoveField(
+            model_name="user",
+            name="phonenumber_alternative",
+        ),
+    ]

--- a/src/open_inwoner/accounts/migrations/0095_sync_primary_email_phonenumber_digital_addresses.py
+++ b/src/open_inwoner/accounts/migrations/0095_sync_primary_email_phonenumber_digital_addresses.py
@@ -1,0 +1,59 @@
+from django.db import migrations
+
+
+def sync_primary_digital_addresses(apps, schema_editor):
+    """
+    Ensure every user has standard DigitalAddress records mirroring their
+    primary email and phonenumber fields. Uses update_or_create so it is safe
+    to run on a database that already has partial DA coverage (e.g. from
+    migration 0094 or from update_email/update_phonenumber calls).
+    """
+    User = apps.get_model("accounts", "User")
+    DigitalAddress = apps.get_model("accounts", "DigitalAddress")
+
+    for user in User.objects.filter(email__gt=""):
+        # Before creating the standard email DA, remove any non-standard DA
+        # that already holds this value to avoid violating
+        # unique_digital_address_per_user_type_value.
+        DigitalAddress.objects.filter(
+            user=user,
+            type="email",
+            is_standard_for_type=False,
+            value=user.email,
+        ).delete()
+        DigitalAddress.objects.update_or_create(
+            user=user,
+            type="email",
+            is_standard_for_type=True,
+            defaults={"value": user.email, "login_type": user.login_type},
+        )
+
+    for user in User.objects.filter(phonenumber__gt=""):
+        DigitalAddress.objects.filter(
+            user=user,
+            type="phone",
+            is_standard_for_type=False,
+            value=user.phonenumber,
+        ).delete()
+        DigitalAddress.objects.update_or_create(
+            user=user,
+            type="phone",
+            is_standard_for_type=True,
+            defaults={"value": user.phonenumber, "login_type": user.login_type},
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "accounts",
+            "0094_remove_phonenumber_backfill_digital_addresses",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            sync_primary_digital_addresses,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/src/open_inwoner/accounts/models.py
+++ b/src/open_inwoner/accounts/models.py
@@ -11,7 +11,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import models, transaction
-from django.db.models import F, Q, UniqueConstraint
+from django.db.models import Q, UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -374,20 +374,6 @@ class User(AbstractBaseUser, PermissionsMixin):
     def has_verified_email(self):
         return self.verified_email != "" and self.email == self.verified_email
 
-    phonenumber = models.CharField(
-        verbose_name=_("Phonenumber"),
-        blank=True,
-        default="",
-        max_length=15,
-        validators=[DutchPhoneNumberValidator()],
-    )
-    phonenumber_alternative = models.CharField(
-        verbose_name=_("Alternative phonenumber"),
-        blank=True,
-        default="",
-        max_length=15,
-        validators=[DutchPhoneNumberValidator()],
-    )
     preferred_address = models.ForeignKey(
         "accounts.DigitalAddress",
         on_delete=models.SET_NULL,
@@ -396,6 +382,72 @@ class User(AbstractBaseUser, PermissionsMixin):
         related_name="+",
         verbose_name=_("Preferred digital address"),
     )
+    phonenumber = models.CharField(
+        verbose_name=_("Phonenumber"),
+        blank=True,
+        default="",
+        max_length=15,
+        validators=[DutchPhoneNumberValidator()],
+    )
+
+    @property
+    def phonenumber_alternative(self) -> str:
+        da = (
+            self.digital_addresses.filter(
+                type=DigitalAddressType.phone,
+                is_standard_for_type=False,
+            )
+            .values_list("value", flat=True)
+            .first()
+        )
+        return da or ""
+
+    @transaction.atomic
+    def update_email(self, value: str) -> None:
+        """Update email field and keep the standard email DigitalAddress in sync."""
+        # Remove any non-standard email DA with this value first to avoid
+        # violating unique_digital_address_per_user_type_value.
+        self.digital_addresses.filter(
+            type=DigitalAddressType.email,
+            is_standard_for_type=False,
+            value=value,
+        ).delete()
+        self.email = value
+        self.save(update_fields=["email"])
+        DigitalAddress.objects.update_or_create(
+            user=self,
+            type=DigitalAddressType.email,
+            is_standard_for_type=True,
+            defaults={"value": value, "login_type": self.login_type},
+        )
+
+    @transaction.atomic
+    def update_phonenumber(self, value: str) -> None:
+        """Update phonenumber field and keep the standard phone DigitalAddress in sync."""
+        if value:
+            # Remove any non-standard phone DA with this value first to avoid
+            # violating unique_digital_address_per_user_type_value.
+            self.digital_addresses.filter(
+                type=DigitalAddressType.phone,
+                is_standard_for_type=False,
+                value=value,
+            ).delete()
+            self.phonenumber = value
+            self.save(update_fields=["phonenumber"])
+            DigitalAddress.objects.update_or_create(
+                user=self,
+                type=DigitalAddressType.phone,
+                is_standard_for_type=True,
+                defaults={"value": value, "login_type": self.login_type},
+            )
+        else:
+            self.phonenumber = ""
+            self.save(update_fields=["phonenumber"])
+            self.digital_addresses.filter(
+                type=DigitalAddressType.phone,
+                is_standard_for_type=True,
+            ).delete()
+
     image = ImageCropField(
         verbose_name=_("Image"),
         null=True,
@@ -589,22 +641,6 @@ class User(AbstractBaseUser, PermissionsMixin):
                 fields=["email"],
                 condition=Q(login_type=LoginTypeChoices.default),
                 name="unique_email_for_regular_users",
-            ),
-            models.CheckConstraint(
-                check=~Q(phonenumber__exact="") | Q(phonenumber_alternative__exact=""),
-                name="phonenumber_alt_requires_phonenumber_primary",
-                violation_error_message=_(
-                    "A primary phone number is required for setting an alternative "
-                    "phone number"
-                ),
-            ),
-            models.CheckConstraint(
-                check=~Q(phonenumber=F("phonenumber_alternative"))
-                | Q(phonenumber__exact=""),
-                name="check_alternative_phonenumber_differs_from_primary_phonenumber",
-                violation_error_message=_(
-                    "Primary and secondary phone numbers cannot be the same"
-                ),
             ),
             models.CheckConstraint(
                 check=~Q(kvk__exact="", login_type=LoginTypeChoices.eherkenning),

--- a/src/open_inwoner/accounts/tests/factories.py
+++ b/src/open_inwoner/accounts/tests/factories.py
@@ -53,6 +53,18 @@ class UserFactory(factory.django.DjangoModelFactory):
     kvk = ""
     vestiging = ""
 
+    @factory.post_generation
+    def phonenumber_alternative(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        DigitalAddressFactory.create(
+            user=self,
+            type=DigitalAddressType.phone,
+            value=extracted,
+            login_type=self.login_type,
+            is_standard_for_type=False,
+        )
+
 
 class DigidUserFactory(UserFactory):
     login_type = LoginTypeChoices.digid

--- a/src/open_inwoner/accounts/tests/test_auth.py
+++ b/src/open_inwoner/accounts/tests/test_auth.py
@@ -1212,42 +1212,6 @@ class EmailPasswordRegistrationTest(WebTest):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("pages-root"))
 
-    def test_registration_succeeds_with_2fa_sms_and_phonenumber(self):
-        self.config.login_2fa_sms = True
-        self.config.save()
-
-        register_page = self.app.get(reverse("django_registration_register"))
-        form = register_page.forms["registration-form"]
-        form["email"] = self.user.email
-        form["first_name"] = self.user.first_name
-        form["last_name"] = self.user.last_name
-        form["phonenumber"] = self.user.phonenumber
-        form["password1"] = self.user.password
-        form["password2"] = self.user.password
-        form.submit()
-        # Verify the registered user.
-        registered_user = User.objects.get(email=self.user.email)
-        self.assertEqual(registered_user.email, self.user.email)
-        self.assertTrue(registered_user.check_password(self.user.password))
-
-    def test_registration_fails_with_2fa_sms_and_no_phonenumber(self):
-        self.config.login_2fa_sms = True
-        self.config.save()
-
-        register_page = self.app.get(reverse("django_registration_register"))
-        form = register_page.forms["registration-form"]
-        form["email"] = self.user.email
-        form["first_name"] = self.user.first_name
-        form["last_name"] = self.user.last_name
-        form["password1"] = self.user.password
-        form["password2"] = self.user.password
-        response = form.submit()
-
-        self.assertEqual(
-            response.context["form"].errors,
-            {"phonenumber": [_("Dit veld is vereist.")]},
-        )
-
 
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class DuplicateEmailRegistrationTest(WebTest):
@@ -1849,7 +1813,6 @@ class TestRegistrationNecessary(ClearCachesMixin, WebTest):
             first_name="",
             last_name="",
             email="old@example.com",
-            phonenumber="",
             login_type=LoginTypeChoices.digid,
         )
 

--- a/src/open_inwoner/accounts/tests/test_auth_2fa_sms.py
+++ b/src/open_inwoner/accounts/tests/test_auth_2fa_sms.py
@@ -27,7 +27,9 @@ signer = TimestampSigner()
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 class TestSMSVerificationLogin(WebTest):
     def setUp(self):
-        self.user = UserFactory(email="ex@example.com", password="secret")
+        self.user = UserFactory(
+            email="ex@example.com", password="secret", phonenumber="0612345678"
+        )
 
         self.config = SiteConfiguration.get_solo()
         self.config.login_2fa_sms = True
@@ -202,7 +204,11 @@ class TestSMSVerificationLogin(WebTest):
 
             # check a new user can log in
             frozen_time.tick(delta=datetime.timedelta(minutes=-1))
-            other_user = UserFactory(email="ex2@example.com", password="secret2")
+            other_user = UserFactory(
+                email="ex2@example.com",
+                password="secret2",
+                phonenumber="0687654321",
+            )
 
             response = self.app.get(reverse("login"))
             login_form = response.forms["login-form"]
@@ -384,7 +390,7 @@ class TestSMSVerificationLogin(WebTest):
     @patch("open_inwoner.accounts.gateways.gateway.send")
     def test_login_by_adding_phone_number_succeeds(self, mock_gateway_send):
         self.user.phonenumber = ""
-        self.user.save()
+        self.user.save(update_fields=["phonenumber"])
 
         response = self.app.get(reverse("login"))
         mock_gateway_send.assert_not_called()
@@ -422,7 +428,7 @@ class TestSMSVerificationLogin(WebTest):
     @patch("open_inwoner.accounts.gateways.gateway.send")
     def test_login_fails_with_different_phonenumbers(self, mock_gateway_send):
         self.user.phonenumber = ""
-        self.user.save()
+        self.user.save(update_fields=["phonenumber"])
 
         response = self.app.get(reverse("login"))
         mock_gateway_send.assert_not_called()

--- a/src/open_inwoner/accounts/tests/test_contact_views.py
+++ b/src/open_inwoner/accounts/tests/test_contact_views.py
@@ -457,7 +457,6 @@ class ContactViewTests(WebTest):
             first_name="Luke",
             last_name="Skywalker",
             email="ex@example.com",
-            phonenumber="06988989898",
         )
         self.user.contacts_for_approval.add(existing_user)
 
@@ -466,7 +465,6 @@ class ContactViewTests(WebTest):
         self.assertContains(response, existing_user.email)
         self.assertNotContains(response, existing_user.first_name)
         self.assertNotContains(response, existing_user.last_name)
-        self.assertNotContains(response, existing_user.phonenumber)
 
     def test_accepted_contact_appears_in_both_contact_lists(self):
         existing_user = UserFactory(

--- a/src/open_inwoner/accounts/tests/test_migrations.py
+++ b/src/open_inwoner/accounts/tests/test_migrations.py
@@ -1,0 +1,74 @@
+from django.test import tag
+
+from open_inwoner.utils.tests.test_migrations import TestSuccessfulMigrations
+
+
+@tag("migrations")
+class TestPhoneNumberBackfill(TestSuccessfulMigrations):
+    """
+    Phone numbers on User are backfilled as DigitalAddress records.
+
+    Three scenarios are covered in a single migration pass:
+    - user with only a primary phonenumber
+    - user with primary and alternative phonenumber
+    - user with no phonenumber
+    """
+
+    app = "accounts"
+    migrate_from = "0093_add_digitaladdress_and_preferred_address"
+    migrate_to = "0094_remove_phonenumber_backfill_digital_addresses"
+
+    def setUpBeforeMigration(self, apps):
+        User = apps.get_model("accounts", "User")
+
+        primary_only = User.objects.create(
+            email="primary@example.com",
+            phonenumber="0612345678",
+        )
+        self.primary_only_pk = primary_only.pk
+
+        both = User.objects.create(
+            email="both@example.com",
+            phonenumber="0612345678",
+            phonenumber_alternative="0687654321",
+        )
+        self.both_pk = both.pk
+
+        no_phone = User.objects.create(email="nophone@example.com")
+        self.no_phone_pk = no_phone.pk
+
+    def test_primary_only_gets_single_standard_address(self):
+        DigitalAddress = self.apps.get_model("accounts", "DigitalAddress")
+        addresses = DigitalAddress.objects.filter(
+            user_id=self.primary_only_pk, type="phone"
+        )
+        self.assertEqual(addresses.count(), 1)
+        self.assertEqual(addresses.get().value, "0612345678")
+        self.assertTrue(addresses.get().is_standard_for_type)
+
+    def test_both_numbers_get_two_addresses(self):
+        DigitalAddress = self.apps.get_model("accounts", "DigitalAddress")
+        addresses = DigitalAddress.objects.filter(user_id=self.both_pk, type="phone")
+        self.assertEqual(addresses.count(), 2)
+
+    def test_primary_is_standard(self):
+        DigitalAddress = self.apps.get_model("accounts", "DigitalAddress")
+        standard = DigitalAddress.objects.get(
+            user_id=self.both_pk, type="phone", is_standard_for_type=True
+        )
+        self.assertEqual(standard.value, "0612345678")
+
+    def test_alternative_is_not_standard(self):
+        DigitalAddress = self.apps.get_model("accounts", "DigitalAddress")
+        alternative = DigitalAddress.objects.get(
+            user_id=self.both_pk, type="phone", is_standard_for_type=False
+        )
+        self.assertEqual(alternative.value, "0687654321")
+
+    def test_no_phone_gets_no_addresses(self):
+        DigitalAddress = self.apps.get_model("accounts", "DigitalAddress")
+        self.assertFalse(
+            DigitalAddress.objects.filter(
+                user_id=self.no_phone_pk, type="phone"
+            ).exists()
+        )

--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -119,7 +119,6 @@ class ProfileViewTests(WebTest):
         self.assertContains(response, f"Welkom, {self.user.display_name}")
         self.assertContains(response, f"{self.user.infix} {self.user.last_name}")
         self.assertContains(response, self.user.email)
-        self.assertContains(response, self.user.phonenumber)
         self.assertContains(response, self.user.street)
         self.assertContains(response, self.user.housenumber)
         self.assertContains(response, self.user.city)
@@ -324,8 +323,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         form["first_name"] = ""
         form["last_name"] = ""
         form["email"] = ""
-        form["phonenumber"] = ""
-        form["phonenumber_alternative"] = ""
         form["street"] = ""
         form["housenumber"] = ""
         form["postcode"] = ""
@@ -351,8 +348,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         form["first_name"] = "First name"
         form["last_name"] = "Last name"
         form["email"] = "user@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
         form["street"] = "Keizersgracht"
         form["housenumber"] = "17 d"
         form["postcode"] = "1013 RM"
@@ -367,8 +362,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         self.assertEqual(self.user.last_name, "Last name")
         self.assertEqual(self.user.display_name, "First name")
         self.assertEqual(self.user.email, "user@example.com")
-        self.assertEqual(self.user.phonenumber, "0612345678")
-        self.assertEqual(self.user.phonenumber_alternative, "0687654321")
         self.assertEqual(self.user.street, "Keizersgracht")
         self.assertEqual(self.user.housenumber, "17 d")
         self.assertEqual(self.user.postcode, "1013 RM")
@@ -428,15 +421,11 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
         response = self.app.get(self.url, user=eherkenning_user)
         form = response.forms["profile-edit"]
         form["email"] = "user@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
         response = form.submit()
 
         eherkenning_user.refresh_from_db()
         self.assertEqual(response.url, self.return_url)
         self.assertEqual(eherkenning_user.email, "user@example.com")
-        self.assertEqual(eherkenning_user.phonenumber, "0612345678")
-        self.assertEqual(eherkenning_user.phonenumber_alternative, "0687654321")
 
     @patch(
         "open_inwoner.accounts.views.profile.EditProfileView.update_klant_via_esuite"
@@ -478,8 +467,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
             form["first_name"] = "test"
 
         form["email"] = "user@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
         response = form.submit()
 
         self.assertEqual(response.url, self.return_url)
@@ -488,8 +475,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertEqual(user.display_name, "name")
         self.assertEqual(user.email, "user@example.com")
-        self.assertEqual(user.phonenumber, "0612345678")
-        self.assertEqual(user.phonenumber_alternative, "0687654321")
 
     def test_expected_form_is_rendered(self):
         # regular user
@@ -609,7 +594,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
                     form = response.forms["profile-edit"]
                     form["email"] = "new@example.com"
-                    form["phonenumber"] = "0612345678"
                     form.submit()
 
                     # user data tested in other cases
@@ -619,12 +603,11 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
                         klant_patch_data,
                         {
                             "emailadres": "new@example.com",
-                            "telefoonnummer": "0612345678",
                         },
                     )
                     self.assertTimelineLog("retrieved klant for user")
                     self.assertTimelineLog(
-                        "patched klant from user profile edit with fields: emailadres, telefoonnummer"
+                        "patched klant from user profile edit with fields: emailadres"
                     )
 
     @requests_mock.Mocker()
@@ -645,70 +628,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         self.assertFalse(data.matchers[0].called)
         self.assertFalse(data.matchers[1].called)
-
-    @requests_mock.Mocker()
-    def test_modify_phone_and_email_updates_klant_api(self, m):
-        MockAPIReadPatchData.setUpServices()
-        data = MockAPIReadPatchData().install_mocks(m)
-
-        response = self.app.get(self.url, user=data.user)
-
-        # reset noise from signals
-        m.reset_mock()
-        self.clearTimelineLogs()
-
-        form = response.forms["profile-edit"]
-        form["email"] = "new@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
-        form.submit()
-
-        # user data tested in other cases
-
-        self.assertTrue(data.matchers[0].called)
-        klant_patch_data = data.matchers[1].request_history[0].json()
-        self.assertEqual(
-            klant_patch_data,
-            {
-                "emailadres": "new@example.com",
-                "telefoonnummer": "0612345678",
-                "telefoonnummerAlternatief": "0687654321",
-            },
-        )
-        self.assertTimelineLog("retrieved klant for user")
-        self.assertTimelineLog(
-            "patched klant from user profile edit with fields: emailadres, telefoonnummer, telefoonnummerAlternatief"
-        )
-
-    @requests_mock.Mocker()
-    def test_modify_phone_updates_klant_api_but_skip_unchanged_email(self, m):
-        MockAPIReadPatchData.setUpServices()
-        data = MockAPIReadPatchData().install_mocks(m)
-
-        response = self.app.get(self.url, user=data.user)
-
-        # reset noise from signals
-        m.reset_mock()
-        self.clearTimelineLogs()
-
-        form = response.forms["profile-edit"]
-        form["phonenumber"] = "0612345678"
-        form.submit()
-
-        # user data tested in other cases
-
-        self.assertTrue(data.matchers[0].called)
-        klant_patch_data = data.matchers[1].request_history[0].json()
-        self.assertEqual(
-            klant_patch_data,
-            {
-                "telefoonnummer": "0612345678",
-            },
-        )
-        self.assertTimelineLog("retrieved klant for user")
-        self.assertTimelineLog(
-            "patched klant from user profile edit with fields: telefoonnummer"
-        )
 
     @requests_mock.Mocker()
     def test_modify_email_updates_klant_api_but_skip_unchanged_phone(self, m):
@@ -755,8 +674,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
 
         form = response.forms["profile-edit"]
         form["email"] = "new@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
         response = form.submit()
 
         self.assertEqual(response.status_code, 302)
@@ -767,7 +684,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
             if "digitaleadressen" in response.path
         ]
 
-        # 1. email update
         email_requests = [
             response
             for response in digitale_adressen_requests
@@ -784,96 +700,6 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
             email_req.json()["verstrektDoorPartij"],
             {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
         )
-
-        # 2. phone number updates
-        phone_requests = [
-            response
-            for response in digitale_adressen_requests
-            if response.method in ["POST"]
-            and response.json()
-            and response.json().get("soortDigitaalAdres") == "telefoonnummer"
-        ]
-        self.assertEqual(len(phone_requests), 2)
-
-        phone_numbers = [response.json() for response in phone_requests]
-        standard_number = next(num for num in phone_numbers if num["isStandaardAdres"])
-        self.assertEqual(
-            standard_number,
-            {
-                "adres": "0612345678",
-                "soortDigitaalAdres": "telefoonnummer",
-                "isStandaardAdres": True,
-                "verstrektDoorPartij": {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
-                "verstrektDoorBetrokkene": None,
-                "omschrijving": "OIP profiel",
-            },
-        )
-
-        alt_number = next(num for num in phone_numbers if not num["isStandaardAdres"])
-        self.assertEqual(
-            alt_number,
-            {
-                "adres": "0687654321",
-                "soortDigitaalAdres": "telefoonnummer",
-                "isStandaardAdres": False,
-                "verstrektDoorPartij": {"uuid": "7260ea01-12c0-4750-8fd1-dfa777818837"},
-                "verstrektDoorBetrokkene": None,
-                "omschrijving": "OIP profiel",
-            },
-        )
-
-    @requests_mock.Mocker()
-    def test_update_via_openklant_cleans_up_old_contact_info(self, m):
-        """Test that old contact information is deleted from OpenKlant when updating"""
-        MockAPIReadPatchData.setUpServices(
-            klanten_service_type=KlantenServiceType.OPENKLANT2
-        )
-        MockAPIReadPatchData().install_mocks_openklant(m)
-
-        User.objects.all().delete()
-        digid_user = DigidUserFactory()
-
-        digid_user.email = "old@example.com"
-        digid_user.phonenumber = "0600000000"
-        digid_user.phonenumber_alternative = "0611111111"
-        digid_user.save()
-
-        # Mock DELETE requests for old contact info
-        delete_email_matcher = m.delete(
-            "http://localhost:8338/klantinteracties/api/v1/digitaleadressen/email-uuid-123",
-            status_code=204,
-        )
-        delete_phone_matcher = m.delete(
-            "http://localhost:8338/klantinteracties/api/v1/digitaleadressen/phone-uuid-123",
-            status_code=204,
-        )
-        delete_phone_alt_matcher = m.delete(
-            "http://localhost:8338/klantinteracties/api/v1/digitaleadressen/phone-alt-uuid-123",
-            status_code=204,
-        )
-
-        response = self.app.get(self.url, user=digid_user)
-
-        form = response.forms["profile-edit"]
-        form["email"] = "new@example.com"
-        form["phonenumber"] = "0612345678"
-        form["phonenumber_alternative"] = "0687654321"
-        response = form.submit()
-
-        self.assertEqual(response.status_code, 302)
-
-        # Verify DELETE requests were made for old contact info
-        self.assertTrue(delete_email_matcher.called_once)
-        self.assertTrue(delete_phone_matcher.called_once)
-        self.assertTrue(delete_phone_alt_matcher.called_once)
-
-        # Verify POST requests were made for new contact info
-        post_requests = [
-            req
-            for req in m.request_history
-            if req.method == "POST" and "digitaleadressen" in req.path
-        ]
-        self.assertEqual(len(post_requests), 3)  # email + 2 phone numbers
 
 
 class TestForm(ErrorMessageMixin, forms.Form):
@@ -1050,7 +876,6 @@ class MyDataTests(AssertTimelineLogMixin, HaalCentraalMixin, WebTest):
             self.expected_response.city,
             self.user.bsn,
             self.user.email,
-            self.user.phonenumber,
         ]
         self.clearTimelineLogs()
 

--- a/src/open_inwoner/accounts/tests/test_user.py
+++ b/src/open_inwoner/accounts/tests/test_user.py
@@ -128,27 +128,6 @@ class UserTests(TestCase):
         user.clear_plan_contact_new_count()
         self.assertEqual(0, user.get_plan_contact_new_count())
 
-    def test_phonenumber_alternative_requires_primary_phonenumber(self):
-        user = UserFactory(phonenumber="")
-
-        with self.assertRaises(IntegrityError):
-            user.phonenumber_alternative = "0612345678"
-            user.save()
-
-    def test_phonenumber_alternative_differs_from_non_empty_primary_phonenumber(self):
-        user = UserFactory(phonenumber="612345678")
-
-        with self.assertRaises(IntegrityError):
-            user.phonenumber_alternative = user.phonenumber
-            user.save()
-
-    def test_allow_both_phonenumbers_empty(self):
-        user = UserFactory()
-
-        user.phonenumber = ""
-        user.phonenumber_alternative = ""
-        user.save()
-
     def test_eherkenning_user_requires_kvk(self):
         with self.assertRaises(IntegrityError):
             UserFactory(login_type=LoginTypeChoices.eherkenning, kvk="")

--- a/src/open_inwoner/accounts/views/login.py
+++ b/src/open_inwoner/accounts/views/login.py
@@ -348,15 +348,14 @@ class AddPhoneNumberWizardView(LogMixin, SessionWizardView):
 
     def done(self, form_list, **kwargs):
         phonenumber = self.get_cleaned_data_for_step("phonenumber")["phonenumber_1"]
-        self.user_cache.phonenumber = phonenumber
+
+        self.user_cache.update_phonenumber(phonenumber)
 
         self.request.user = self.user_cache
         self.log_change(
             self.user_cache,
             "Telefoonnummer gewijzigd: {}".format(phonenumber),
         )
-
-        self.user_cache.save()
 
         # security check complete, log the user in
         auth_login(self.request, self.user_cache)

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -16,6 +16,7 @@ from typing import (
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -51,8 +52,8 @@ from zgw_consumers.client import build_client as build_zgw_client
 from zgw_consumers.models.services import Service as ServiceConfig
 from zgw_consumers.utils import pagination_helper
 
-from open_inwoner.accounts.choices import NotificationChannelChoice
-from open_inwoner.accounts.models import User
+from open_inwoner.accounts.choices import DigitalAddressType, NotificationChannelChoice
+from open_inwoner.accounts.models import DigitalAddress, User
 from open_inwoner.configurations.models import SiteConfiguration
 from open_inwoner.openklant.api_models import (
     ContactMoment,
@@ -99,21 +100,6 @@ def _normalize_phone(phone: str) -> str:
 
 def _normalize_email(email: str) -> str:
     return email.strip().lower()
-
-
-def _resolve_phonenumber_update(user: "User", update_data: dict) -> None:
-    """Clear alternative phonenumber from update_data if it would violate model constraints."""
-    if (
-        "phonenumber" not in update_data
-        and "phonenumber_alternative" not in update_data
-    ):
-        return
-    primary = update_data.get("phonenumber", user.phonenumber)
-    alternative = update_data.get(
-        "phonenumber_alternative", user.phonenumber_alternative
-    )
-    if alternative and (not primary or primary == alternative):
-        update_data["phonenumber_alternative"] = ""
 
 
 class BsnFetchParam(TypedDict):
@@ -311,24 +297,17 @@ class eSuiteKlantenService(
         response_data = self.client.parse_json(response)
         return self.client.factory(Klant, response_data)
 
+    @transaction.atomic
     def update_user_from_klant(self, klant: Klant, user: User):
-        update_data = {}
+        changed_fields: list[str] = []
 
         if (
             klant.emailadres
             and klant.emailadres != user.email
             and (not User.objects.filter(email__iexact=klant.emailadres).exists())
         ):
-            update_data["email"] = klant.emailadres
-
-        if klant.telefoonnummer and klant.telefoonnummer != user.phonenumber:
-            update_data["phonenumber"] = klant.telefoonnummer
-
-        if (
-            klant.telefoonnummer_alternatief
-            and klant.telefoonnummer_alternatief != user.phonenumber_alternative
-        ):
-            update_data["phonenumber_alternative"] = klant.telefoonnummer_alternatief
+            user.update_email(klant.emailadres)
+            changed_fields.append("email")
 
         config = SiteConfiguration.get_solo()
         if config.enable_notification_channel_choice:
@@ -337,18 +316,19 @@ class eSuiteKlantenService(
                 and user.case_notification_channel
                 != NotificationChannelChoice.digital_only
             ):
-                update_data["case_notification_channel"] = (
-                    NotificationChannelChoice.digital_only
-                )
-
+                user.case_notification_channel = NotificationChannelChoice.digital_only
+                user.save(update_fields=["case_notification_channel"])
+                changed_fields.append("case_notification_channel")
             elif (
                 klant.toestemming_zaak_notificaties_alleen_digitaal is False
                 and user.case_notification_channel
                 != NotificationChannelChoice.digital_and_post
             ):
-                update_data["case_notification_channel"] = (
+                user.case_notification_channel = (
                     NotificationChannelChoice.digital_and_post
                 )
+                user.save(update_fields=["case_notification_channel"])
+                changed_fields.append("case_notification_channel")
             else:
                 # This is a guard against the scenario where a deployment is
                 # configured to use an older version of the klanten backend (that
@@ -362,13 +342,30 @@ class eSuiteKlantenService(
                     " toestemmingZaakNotificatiesAlleenDigitaal is not available from the klanten backend"
                 )
 
-        if update_data:
-            _resolve_phonenumber_update(user, update_data)
-            for attr, value in update_data.items():
-                setattr(user, attr, value)
-            user.save(update_fields=update_data.keys())
+        phone_primary = klant.telefoonnummer
+        phone_alternative = klant.telefoonnummer_alternatief
+
+        if phone_primary and phone_primary != user.phonenumber:
+            user.update_phonenumber(phone_primary)
+            changed_fields.append("phonenumber")
+
+        if (
+            phone_alternative
+            and phone_alternative != user.phonenumber_alternative
+            # Skip when alternative equals primary to avoid storing duplicates.
+            and phone_alternative != phone_primary
+        ):
+            DigitalAddress.objects.update_or_create(
+                user=user,
+                type=DigitalAddressType.phone,
+                is_standard_for_type=False,
+                defaults={"value": phone_alternative, "login_type": user.login_type},
+            )
+            changed_fields.append("phonenumber_alternative")
+
+        if changed_fields:
             system_action(
-                f"updated user from klant API with fields: {', '.join(sorted(update_data.keys()))}",
+                f"updated user from klant API with fields: {', '.join(sorted(changed_fields))}",
                 content_object=user,
             )
 
@@ -1361,6 +1358,7 @@ class OpenKlant2Service(
             adressen=adressen,
         )
 
+    @transaction.atomic
     def update_user_from_partij(self, partij_uuid: str, user: User):
         update_data = {}
 
@@ -1373,15 +1371,10 @@ class OpenKlant2Service(
             if not User.objects.filter(email__iexact=email).exists():
                 update_data["email"] = email
 
-        if phone_adressen := self.filter_digitale_addressen_for_partij(
+        phone_adressen = self.filter_digitale_addressen_for_partij(
             partij_uuid, soort_digital_adres="telefoonnummer", adressen=adressen
-        ):
-            for adres in phone_adressen:
-                if adres["isStandaardAdres"]:
-                    update_data["phonenumber"] = adres["adres"]
-                else:
-                    update_data["phonenumber_alternative"] = adres["adres"]
-
+        )
+        if phone_adressen:
             # we currently only support two phone numbers: primary + secondary
             # the following edge case cannot happen through OIP, but we cannot
             # exclude that it happens through some external service. In this case,
@@ -1392,15 +1385,41 @@ class OpenKlant2Service(
                     partij_uuid=partij_uuid,
                 )
 
-        if update_data:
-            _resolve_phonenumber_update(user, update_data)
-            for attr, value in update_data.items():
-                setattr(user, attr, value)
-            user.save(update_fields=update_data.keys())
-            system_action(
-                f"updated user from klant API with fields: {', '.join(sorted(update_data.keys()))}",
-                content_object=user,
+            primary_value = next(
+                (a["adres"] for a in phone_adressen if a["isStandaardAdres"]), None
             )
+            if primary_value:
+                update_data["phonenumber"] = primary_value
+                alternative_value = next(
+                    (a["adres"] for a in phone_adressen if not a["isStandaardAdres"]),
+                    None,
+                )
+                # Skip alternative when it equals the primary to avoid
+                # violating unique_digital_address_per_user_type_value.
+                if alternative_value and alternative_value != primary_value:
+                    update_data["phonenumber_alternative"] = alternative_value
+
+        if not update_data:
+            return
+
+        if email := update_data.get("email"):
+            user.update_email(email)
+
+        if phonenumber := update_data.get("phonenumber"):
+            user.update_phonenumber(phonenumber)
+
+        if alternative := update_data.get("phonenumber_alternative"):
+            DigitalAddress.objects.update_or_create(
+                user=user,
+                type=DigitalAddressType.phone,
+                is_standard_for_type=False,
+                defaults={"value": alternative, "login_type": user.login_type},
+            )
+
+        system_action(
+            f"updated user from klant API with fields: {', '.join(sorted(update_data.keys()))}",
+            content_object=user,
+        )
 
     def update_partij_from_user_data(
         self,

--- a/src/open_inwoner/openklant/tests/test_signal.py
+++ b/src/open_inwoner/openklant/tests/test_signal.py
@@ -5,7 +5,11 @@ from django.test.testcases import SerializeMixin
 import requests_mock
 from django_webtest import WebTest
 
-from open_inwoner.accounts.choices import LoginTypeChoices, NotificationChannelChoice
+from open_inwoner.accounts.choices import (
+    DigitalAddressType,
+    LoginTypeChoices,
+    NotificationChannelChoice,
+)
 from open_inwoner.accounts.models import User
 from open_inwoner.accounts.tests.factories import UserFactory, eHerkenningUserFactory
 from open_inwoner.configurations.models import SiteConfiguration
@@ -184,8 +188,10 @@ class UpdateUserFromLoginSignalAPITestCase(
             ):
                 user.email = "old@example.com"
                 user.phonenumber = "0123456789"
-                user.phonenumber_alternative = ""
-                user.save()
+                user.save(update_fields=["email", "phonenumber"])
+                user.digital_addresses.filter(
+                    type=DigitalAddressType.phone, is_standard_for_type=False
+                ).delete()
                 self.clearTimelineLogs()
 
                 config = ESuiteKlantConfig.get_solo()


### PR DESCRIPTION
Remove phonenumber_alternative from User and replace it with a
non-standard phone DigitalAddress. Keep phonenumber and email as real
DB fields for auth and 2FA performance, but introduce update_email()
and update_phonenumber() model methods that write both the field and
the corresponding standard DigitalAddress atomically.

Add two data migrations: one backfills existing phone numbers into
DigitalAddress, another ensures every user's primary email and phone
have a matching standard DA. Update openklant services to use the new
sync methods.

Closes: #2615