### PR TITLE
[#2613] PP-427: Sync digital addresses with eSuite

### DIFF
--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -461,7 +461,7 @@ class EditProfileView(
         update_data = {
             api_name: user_form_data[local_name]
             for api_name, local_name in field_mapping.items()
-            if user_form_data.get(local_name)
+            if local_name in user_form_data
         }
 
         try:

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -302,77 +302,99 @@ class eSuiteKlantenService(
         response_data = self.client.parse_json(response)
         return self.client.factory(Klant, response_data)
 
-    @transaction.atomic
     def update_user_from_klant(self, klant: Klant, user: User):
         changed_fields: list[str] = []
 
-        if (
-            klant.emailadres
-            and klant.emailadres != user.email
-            and (not User.objects.filter(email__iexact=klant.emailadres).exists())
-        ):
-            user.update_email(klant.emailadres)
-            changed_fields.append("email")
-
-        config = SiteConfiguration.get_solo()
-        if config.enable_notification_channel_choice:
+        with transaction.atomic():
             if (
-                klant.toestemming_zaak_notificaties_alleen_digitaal is True
-                and user.case_notification_channel
-                != NotificationChannelChoice.digital_only
+                klant.emailadres
+                and klant.emailadres != user.email
+                and (not User.objects.filter(email__iexact=klant.emailadres).exists())
             ):
-                user.case_notification_channel = NotificationChannelChoice.digital_only
-                user.save(update_fields=["case_notification_channel"])
-                changed_fields.append("case_notification_channel")
-            elif (
-                klant.toestemming_zaak_notificaties_alleen_digitaal is False
-                and user.case_notification_channel
-                != NotificationChannelChoice.digital_and_post
-            ):
-                user.case_notification_channel = (
-                    NotificationChannelChoice.digital_and_post
-                )
-                user.save(update_fields=["case_notification_channel"])
-                changed_fields.append("case_notification_channel")
-            else:
-                # This is a guard against the scenario where a deployment is
-                # configured to use an older version of the klanten backend (that
-                # is, one that lacks the toestemmingZaakNotificatiesAlleenDigitaal
-                # field). In such a scenario, the enable_notification_channel_choice
-                # flag really shouldn't be set until the update has completed, but
-                # we suspect this is rare. But to validate that assumption, we log
-                # an error so we can remedy this in case we're wrong.
-                logger.error(
-                    "SiteConfig.enable_notification_channel_choice should not be set if"
-                    " toestemmingZaakNotificatiesAlleenDigitaal is not available from the klanten backend"
-                )
+                user.update_email(klant.emailadres)
+                changed_fields.append("email")
 
-        phone_primary = klant.telefoonnummer
-        phone_alternative = klant.telefoonnummer_alternatief
+            config = SiteConfiguration.get_solo()
+            if config.enable_notification_channel_choice:
+                if (
+                    klant.toestemming_zaak_notificaties_alleen_digitaal is True
+                    and user.case_notification_channel
+                    != NotificationChannelChoice.digital_only
+                ):
+                    user.case_notification_channel = (
+                        NotificationChannelChoice.digital_only
+                    )
+                    user.save(update_fields=["case_notification_channel"])
+                    changed_fields.append("case_notification_channel")
+                elif (
+                    klant.toestemming_zaak_notificaties_alleen_digitaal is False
+                    and user.case_notification_channel
+                    != NotificationChannelChoice.digital_and_post
+                ):
+                    user.case_notification_channel = (
+                        NotificationChannelChoice.digital_and_post
+                    )
+                    user.save(update_fields=["case_notification_channel"])
+                    changed_fields.append("case_notification_channel")
+                else:
+                    # This is a guard against the scenario where a deployment is
+                    # configured to use an older version of the klanten backend (that
+                    # is, one that lacks the toestemmingZaakNotificatiesAlleenDigitaal
+                    # field). In such a scenario, the enable_notification_channel_choice
+                    # flag really shouldn't be set until the update has completed, but
+                    # we suspect this is rare. But to validate that assumption, we log
+                    # an error so we can remedy this in case we're wrong.
+                    logger.error(
+                        "SiteConfig.enable_notification_channel_choice should not be set if"
+                        " toestemmingZaakNotificatiesAlleenDigitaal is not available from the klanten backend"
+                    )
 
-        if phone_primary and phone_primary != user.phonenumber:
-            user.update_phonenumber(phone_primary)
-            changed_fields.append("phonenumber")
+            phone_primary = klant.telefoonnummer
+            phone_alternative = klant.telefoonnummer_alternatief
 
-        if (
-            phone_alternative
-            and phone_alternative != user.phonenumber_alternative
-            # Skip when alternative equals primary to avoid storing duplicates.
-            and phone_alternative != phone_primary
-        ):
-            DigitalAddress.objects.update_or_create(
-                user=user,
-                type=DigitalAddressType.phone,
-                is_standard_for_type=False,
-                defaults={"value": phone_alternative, "login_type": user.login_type},
+            if phone_primary and phone_primary != user.phonenumber:
+                user.update_phonenumber(phone_primary)
+                changed_fields.append("phonenumber")
+
+            # eSuite supports at most one alternative phone number. Reconcile the
+            # local non-standard phone DA to match: create, replace, or delete.
+            desired_alternative = (
+                phone_alternative
+                if phone_alternative and phone_alternative != phone_primary
+                else ""
             )
-            changed_fields.append("phonenumber_alternative")
+            if desired_alternative != user.phonenumber_alternative:
+                user.digital_addresses.filter(
+                    type=DigitalAddressType.phone, is_standard_for_type=False
+                ).delete()
+                if desired_alternative:
+                    user.digital_addresses.create(
+                        type=DigitalAddressType.phone,
+                        value=desired_alternative,
+                        login_type=user.login_type,
+                        is_standard_for_type=False,
+                    )
+                changed_fields.append("phonenumber_alternative")
 
-        if changed_fields:
-            system_action(
-                f"updated user from klant API with fields: {', '.join(sorted(changed_fields))}",
-                content_object=user,
-            )
+            if changed_fields:
+                system_action(
+                    f"updated user from klant API with fields: {', '.join(sorted(changed_fields))}",
+                    content_object=user,
+                )
+
+        # Push-back: if eSuite has no email, push the local standard email DA there
+        if not klant.emailadres:
+            local_standard_email = user.digital_addresses.filter(
+                type=DigitalAddressType.email, is_standard_for_type=True
+            ).first()
+            if local_standard_email:
+                self.partial_update_klant(
+                    klant, {"emailadres": local_standard_email.value}
+                )
+                system_action(
+                    "pushed standard email to eSuite klant",
+                    content_object=user,
+                )
 
     def partial_update_klant(self, klant: Klant, update_data) -> Klant:
         response = self.client.patch(url=klant.url, json=update_data)

--- a/src/open_inwoner/openklant/tests/test_esuite_service.py
+++ b/src/open_inwoner/openklant/tests/test_esuite_service.py
@@ -1,10 +1,15 @@
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 
 from django.test import TestCase
 
 import requests_mock
 
-from open_inwoner.accounts.tests.factories import DigidUserFactory, UserFactory
+from open_inwoner.accounts.choices import DigitalAddressType
+from open_inwoner.accounts.tests.factories import (
+    DigidUserFactory,
+    DigitalAddressFactory,
+    UserFactory,
+)
 from open_inwoner.openklant.api_models import Klant
 from open_inwoner.openklant.services import eSuiteKlantenService
 from open_inwoner.openklant.tests.data import KLANTEN_ROOT, MockAPIReadData
@@ -207,40 +212,54 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
             phonenumber_alternative="",
         )
 
-        @dataclass
-        class Klant:
-            bronorganisatie: str
-            klantnummer: str
-            subjectIdentificatie: str
-            url: str
-            emailadres: str
-            telefoonnummer: str
-            telefoonnummer_alternatief: str
-            toestemmingZaakNotificatiesAlleenDigitaal: str
-
         klant = Klant(
+            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             bronorganisatie="123456789",
             klantnummer="12345678",
-            subjectIdentificatie={
-                "inpBsn": "123456789",
-            },
-            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             emailadres="old@example.com",
             telefoonnummer="0100000000",
             telefoonnummer_alternatief="0687654321",
-            toestemmingZaakNotificatiesAlleenDigitaal=False,
         )
 
         with requests_mock.mock() as m:
             m.patch(klant.url, json=asdict(klant))
 
-            klant = self.service.update_klant_from_user(
+            self.service.update_klant_from_user(
                 klant,
                 user,
                 update_fields=["telefoonnummer", "telefoonnummerAlternatief"],
             )
 
-            self.assertEqual(klant.telefoonnummer_alternatief, "0687654321")
+            self.assertIsNone(m.last_request.json()["telefoonnummerAlternatief"])
+
+    def test_update_klant_from_user_sends_alternative_phone_from_digital_address(self):
+        user = DigidUserFactory(
+            phonenumber="0611111111",
+            phonenumber_alternative="0655555555",
+        )
+
+        klant = Klant(
+            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            bronorganisatie="123456789",
+            klantnummer="12345678",
+            emailadres=user.email,
+            telefoonnummer="0611111111",
+            telefoonnummer_alternatief="0622222222",
+        )
+
+        with requests_mock.mock() as m:
+            m.patch(klant.url, json=asdict(klant))
+
+            self.service.update_klant_from_user(
+                klant,
+                user,
+                update_fields=["telefoonnummerAlternatief"],
+            )
+
+            self.assertEqual(
+                m.request_history[0].json()["telefoonnummerAlternatief"],
+                "0655555555",
+            )
 
     def _make_klant(self, telefoonnummer="", telefoonnummer_alternatief=""):
         return Klant(
@@ -284,3 +303,120 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
         user.refresh_from_db()
         self.assertEqual(user.phonenumber, "0611111111")
         self.assertEqual(user.phonenumber_alternative, "")
+
+
+class UpdateUserFromKlantDigitalAddressTestCase(TestCase, DisableRequestLogMixin):
+    def setUp(self):
+        super().setUp()
+        self.data = MockAPIReadData()
+        self.data.setUpServices()
+        self.service = eSuiteKlantenService()
+
+    def _make_klant(
+        self, emailadres="", telefoonnummer="", telefoonnummer_alternatief=""
+    ):
+        return Klant(
+            url=f"{KLANTEN_ROOT}klant/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            bronorganisatie="123456789",
+            klantnummer="12345678",
+            emailadres=emailadres,
+            telefoonnummer=telefoonnummer,
+            telefoonnummer_alternatief=telefoonnummer_alternatief,
+        )
+
+    def test_inbound_email_creates_standard_digital_address(self):
+        user = DigidUserFactory(email="old@example.com")
+        klant = self._make_klant(emailadres="new@example.com")
+
+        self.service.update_user_from_klant(klant, user)
+
+        da = user.digital_addresses.get(type=DigitalAddressType.email)
+        self.assertEqual(da.value, "new@example.com")
+        self.assertTrue(da.is_standard_for_type)
+
+    def test_inbound_primary_phone_creates_standard_digital_address(self):
+        user = DigidUserFactory(phonenumber="0600000000")
+        klant = self._make_klant(telefoonnummer="0611111111")
+
+        self.service.update_user_from_klant(klant, user)
+
+        da = user.digital_addresses.get(
+            type=DigitalAddressType.phone, is_standard_for_type=True
+        )
+        self.assertEqual(da.value, "0611111111")
+
+    def test_inbound_alternative_phone_creates_non_standard_digital_address(self):
+        user = DigidUserFactory(phonenumber="0611111111", phonenumber_alternative="")
+        klant = self._make_klant(
+            telefoonnummer="0611111111",
+            telefoonnummer_alternatief="0622222222",
+        )
+
+        self.service.update_user_from_klant(klant, user)
+
+        da = user.digital_addresses.get(
+            type=DigitalAddressType.phone, is_standard_for_type=False
+        )
+        self.assertEqual(da.value, "0622222222")
+
+    def test_inbound_alternative_phone_deleted_when_esuite_removes_it(self):
+        user = DigidUserFactory(
+            phonenumber="0611111111", phonenumber_alternative="0622222222"
+        )
+        klant = self._make_klant(
+            telefoonnummer="0611111111",
+            telefoonnummer_alternatief="",
+        )
+
+        self.service.update_user_from_klant(klant, user)
+
+        self.assertFalse(
+            user.digital_addresses.filter(
+                type=DigitalAddressType.phone, is_standard_for_type=False
+            ).exists()
+        )
+
+    def test_inbound_alternative_phone_replaced_when_esuite_changes_it(self):
+        user = DigidUserFactory(
+            phonenumber="0611111111", phonenumber_alternative="0622222222"
+        )
+        klant = self._make_klant(
+            telefoonnummer="0611111111",
+            telefoonnummer_alternatief="0633333333",
+        )
+
+        self.service.update_user_from_klant(klant, user)
+
+        alts = list(
+            user.digital_addresses.filter(
+                type=DigitalAddressType.phone, is_standard_for_type=False
+            ).values_list("value", flat=True)
+        )
+        self.assertEqual(alts, ["0633333333"])
+
+    def test_push_back_standard_email_when_esuite_has_no_email(self):
+        user = DigidUserFactory(email="user@example.com")
+        DigitalAddressFactory(
+            user=user,
+            type=DigitalAddressType.email,
+            value="user@example.com",
+            is_standard_for_type=True,
+        )
+        klant = self._make_klant(emailadres="")
+
+        with requests_mock.mock() as m:
+            m.patch(klant.url, json=self.data.klant_bsn)
+            self.service.update_user_from_klant(klant, user)
+
+        self.assertEqual(len(m.request_history), 1)
+        self.assertEqual(m.request_history[0].json()["emailadres"], "user@example.com")
+
+    def test_no_push_back_when_esuite_has_email(self):
+        user = DigidUserFactory(email="user@example.com")
+        klant = self._make_klant(emailadres="user@example.com")
+
+        with requests_mock.mock() as m:
+            m.patch(klant.url, json=self.data.klant_bsn)
+            self.service.update_user_from_klant(klant, user)
+
+        self.assertEqual(len(m.request_history), 0)


### PR DESCRIPTION
## Summary
Replace the old `update_or_create` logic for alternative phone in `update_user_from_klant` with a delete-and-recreate reconcile: compute desired_alternative (empty when eSuite sends none or the same value as primary), then clear all non-standard phone DAs and create a fresh one only when needed. This avoids `MultipleObjectsReturned` on repeated syncs and correctly handles removal.

## Issue References

Closes #2613 