### PR TITLE
[#2623] Escape user-controlled fields in QuestionnaireStepAdmin list display

### DIFF
--- a/src/open_inwoner/questionnaire/admin.py
+++ b/src/open_inwoner/questionnaire/admin.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.forms import BaseModelFormSet
+from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
 from treebeard.admin import TreeAdmin
@@ -102,16 +103,14 @@ class QuestionnaireStepAdmin(TreeAdmin):
     def display_question_answer(self, obj):
         redirect = ""
         if obj.redirect_to:
-            redirect = " - doorsturen -> {} - {}".format(
-                obj.redirect_to.question, obj.redirect_to.id
+            redirect = format_html(
+                " - doorsturen -> {} - {}", obj.redirect_to.question, obj.redirect_to.id
             )
 
-        postfix = " <small>({} - {}{})</small>".format(obj.id, obj.code, redirect)
+        postfix = format_html(" <small>({} - {}{})</small>", obj.id, obj.code, redirect)
         if not obj.parent_answer:
-            return obj.question + postfix
-        return "{} -> {}".format(obj.parent_answer, obj.question) + postfix
-
-    display_question_answer.allow_tags = True
+            return format_html("{}{}", obj.question, postfix)
+        return format_html("{} -> {}{}", obj.parent_answer, obj.question, postfix)
 
     def get_changelist_formset(self, request, **kwargs):
         kwargs["formset"] = QuestionnaireStepAdminFormSet


### PR DESCRIPTION
`display_question_answer` used `allow_tags = True` with plain string formatting, allowing a stored XSS payload in the `question` field to execute in the admin changelist. Replace with `format_html` which escapes all interpolated values.

Closes: #2623
