### PR TITLE
ci: enforce strict conventional commits, reject fixup/squash commits

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -122,7 +122,7 @@ jobs:
         run: pip install commitizen==4.16.3
       - name: Check commit messages
         run: |
-          cz check --rev-range origin/${GITHUB_BASE_REF}..${{ github.sha }}
+          cz check --rev-range origin/${GITHUB_BASE_REF}..${{ github.event.pull_request.head.sha }}
 
   zizmor:
     name: GitHub Actions Security Analysis with zizmor 🌈

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,4 @@ repos:
       - id: commitizen
         stages: [commit-msg]
         args:
-          - --allow-abort
-          - --allowed-prefixes
-          - Merge
-          - Revert
-          - Pull request
-          - fixup!
-          - squash!
-          - amend!
           - --commit-msg-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,8 @@ tag_format = "v$version"
 version_scheme = "semver2"
 version_provider = "pep621"
 update_changelog_on_bump = true
+allow_abort = true
+allowed_prefixes = []
 pre_bump_hooks = [
     "sed -i \"s/releaseDate: '.*'/releaseDate: '$(date +%Y-%m-%d)'/\" publiccode.yaml",
     "uv lock",


### PR DESCRIPTION
Removes fixup!, squash!, and amend! from the commitizen allowed prefixes
and consolidates hook config into pyproject.toml so both local pre-commit
and CI share the same rules. Drops allowed_prefixes entirely since the
rebase-merge workflow means no auto-generated commit messages appear in
PR branches.

Also make sure we check the commits with reference to the PR's head commit, not the head of the merge commit (which has the default git "Merge X into Y" message, which would fail).