### PR TITLE
fix: delete remote digital addresses by UUID

### DIFF
--- a/src/open_inwoner/accounts/tests/test_profile_views.py
+++ b/src/open_inwoner/accounts/tests/test_profile_views.py
@@ -29,7 +29,7 @@ from open_inwoner.accounts.forms import (
     PhoneDigitalAddressFormSet,
     UserForm,
 )
-from open_inwoner.accounts.models import User
+from open_inwoner.accounts.models import DigitalAddress, User
 from open_inwoner.cms.cases.cms_apps import CasesApphook
 from open_inwoner.cms.collaborate.cms_apps import CollaborateApphook
 from open_inwoner.cms.inbox.cms_apps import InboxApphook
@@ -42,7 +42,10 @@ from open_inwoner.haalcentraal.tests.mixins import HaalCentraalMixin
 from open_inwoner.laposta.models import LapostaConfig
 from open_inwoner.laposta.tests.factories import LapostaListFactory, MemberFactory
 from open_inwoner.openklant.constants import KlantenServiceType
-from open_inwoner.openklant.models import ESuiteKlantConfig
+from open_inwoner.openklant.models import (
+    DigitaalAdresOpenKlantMapping,
+    ESuiteKlantConfig,
+)
 from open_inwoner.openklant.tests.data import MockAPIReadPatchData
 from open_inwoner.openklant.tests.factories import DigitaalAdresOpenKlantMappingFactory
 from open_inwoner.pdc.tests.factories import CategoryFactory
@@ -971,6 +974,126 @@ class EditProfileTests(AssertTimelineLogMixin, WebTest):
             if r.method == "POST" and "digitaleadressen" in r.path
         ]
         self.assertEqual(len(post_requests), 0)
+
+    @requests_mock.Mocker()
+    def test_delete_with_openklant_mapping_sends_remote_delete(self, m):
+        MockAPIReadPatchData.setUpServices(
+            klanten_service_type=KlantenServiceType.OPENKLANT2
+        )
+        data = MockAPIReadPatchData().install_mocks_openklant(m)
+
+        REMOTE_UUID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        email_addr = DigitalAddressFactory(
+            user=data.digid_user,
+            type=DigitalAddressType.email,
+            value=data.digid_user.email,
+            login_type=LoginTypeChoices.digid,
+            is_standard_for_type=True,
+        )
+        DigitaalAdresOpenKlantMappingFactory(
+            digital_address=email_addr, ok_uuid=REMOTE_UUID
+        )
+        delete_matcher = m.delete(
+            f"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/{REMOTE_UUID}",
+            status_code=204,
+        )
+
+        self.client.force_login(data.digid_user)
+
+        post_data = self._da_formset_data(
+            "email_addresses",
+            [(email_addr.value, True)],
+            initial_pks=[email_addr.pk],
+        )
+        post_data["email_addresses-0-DELETE"] = "on"
+        post_data.update(self._da_formset_data("phone_addresses", []))
+
+        response = self.client.post(self.url, data=post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(delete_matcher.called)
+        self.assertFalse(DigitalAddress.objects.filter(pk=email_addr.pk).exists())
+
+    @requests_mock.Mocker()
+    def test_delete_with_openklant_mapping_api_error_rolls_back_local_deletion(self, m):
+        MockAPIReadPatchData.setUpServices(
+            klanten_service_type=KlantenServiceType.OPENKLANT2
+        )
+        data = MockAPIReadPatchData().install_mocks_openklant(m)
+
+        REMOTE_UUID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        email_addr = DigitalAddressFactory(
+            user=data.digid_user,
+            type=DigitalAddressType.email,
+            value=data.digid_user.email,
+            login_type=LoginTypeChoices.digid,
+            is_standard_for_type=True,
+        )
+        DigitaalAdresOpenKlantMappingFactory(
+            digital_address=email_addr, ok_uuid=REMOTE_UUID
+        )
+
+        self.client.force_login(data.digid_user)
+
+        post_data = {}
+        post_data.update(
+            self._da_formset_data(
+                "email_addresses",
+                [(email_addr.value, True)],
+                initial_pks=[email_addr.pk],
+            )
+        )
+        post_data["email_addresses-0-DELETE"] = "on"
+        post_data.update(self._da_formset_data("phone_addresses", []))
+
+        with patch(
+            "open_inwoner.openklant.services.OpenKlant2Service.delete_remote_digitaal_adressen",
+            side_effect=Exception("remote API unavailable"),
+        ):
+            response = self.client.post(self.url, data=post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(DigitalAddress.objects.filter(pk=email_addr.pk).exists())
+        self.assertTrue(
+            DigitaalAdresOpenKlantMapping.objects.filter(
+                digital_address=email_addr
+            ).exists()
+        )
+
+    @requests_mock.Mocker()
+    def test_delete_without_openklant_mapping_no_remote_delete(self, m):
+        MockAPIReadPatchData.setUpServices(
+            klanten_service_type=KlantenServiceType.OPENKLANT2
+        )
+        user = DigidUserFactory()
+        email_addr = DigitalAddressFactory(
+            user=user,
+            type=DigitalAddressType.email,
+            value=user.email,
+            login_type=LoginTypeChoices.digid,
+            is_standard_for_type=True,
+        )
+        # No DigitaalAdresOpenKlantMapping — nothing to delete remotely.
+
+        self.client.force_login(user)
+
+        post_data = {}
+        post_data.update(
+            self._da_formset_data(
+                "email_addresses",
+                [(email_addr.value, True)],
+                initial_pks=[email_addr.pk],
+            )
+        )
+        post_data["email_addresses-0-DELETE"] = "on"
+        post_data.update(self._da_formset_data("phone_addresses", []))
+
+        response = self.client.post(self.url, data=post_data)
+
+        self.assertEqual(response.status_code, 302)
+        delete_requests = [r for r in m.request_history if r.method == "DELETE"]
+        self.assertEqual(delete_requests, [])
+        self.assertFalse(DigitalAddress.objects.filter(pk=email_addr.pk).exists())
 
 
 class TestForm(ErrorMessageMixin, forms.Form):

--- a/src/open_inwoner/accounts/views/profile.py
+++ b/src/open_inwoner/accounts/views/profile.py
@@ -1,10 +1,11 @@
+import contextlib
 from collections.abc import Generator
 from datetime import date
 from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
@@ -315,6 +316,18 @@ class EditProfileView(
 
         with transaction.atomic():
             form.save()
+
+            # Collect OpenKlant mapping UUIDs for addresses about to be deleted,
+            # before _save_digital_address_formset cascade-deletes the mappings.
+            ok_uuids_to_delete = []
+            for formset in (email_formset, phone_formset):
+                for da_form in formset.deleted_forms:
+                    if da_form.instance.pk:
+                        with contextlib.suppress(ObjectDoesNotExist):
+                            ok_uuids_to_delete.append(
+                                da_form.instance.openklant_mapping.ok_uuid
+                            )
+
             self._save_digital_address_formset(
                 email_formset, user, DigitalAddressType.email
             )
@@ -332,7 +345,7 @@ class EditProfileView(
             if new_alt != old_phonenumber_alternative:
                 changed_data["phonenumber_alternative"] = new_alt
 
-            if changed_data:
+            if changed_data or ok_uuids_to_delete:
                 # Sync address changes to external APIs. API calls run inside
                 # the transaction so that a failure rolls back the DB writes
                 # too, keeping local state consistent with the remote. The
@@ -341,7 +354,9 @@ class EditProfileView(
                 # endpoint.
                 klanten_config = KlantenSysteemConfig.get_solo()
 
-                if klanten_config.has_api_service_configured(KlantenServiceType.ESUITE):
+                if changed_data and klanten_config.has_api_service_configured(
+                    KlantenServiceType.ESUITE
+                ):
                     try:
                         self.update_klant_via_esuite(changed_data, user)
                     except Exception:
@@ -354,7 +369,9 @@ class EditProfileView(
                     KlantenServiceType.OPENKLANT2
                 ):
                     try:
-                        self.update_klant_via_openklant(changed_data, user)
+                        self.update_klant_via_openklant(
+                            changed_data, user, ok_uuids_to_delete
+                        )
                     except Exception:
                         logger.exception(
                             "OpenKlant failed during profile update", user=user
@@ -435,7 +452,12 @@ class EditProfileView(
             if not has_remaining and formset.initial_form_count() > 0:
                 user.update_phonenumber("")
 
-    def update_klant_via_openklant(self, user_form_data: dict, user: User) -> bool:
+    def update_klant_via_openklant(
+        self,
+        user_form_data: dict,
+        user: User,
+        ok_uuids_to_delete: list | None = None,
+    ) -> bool:
         try:
             service = OpenKlant2Service()
         except Exception:
@@ -446,6 +468,12 @@ class EditProfileView(
 
         if not partij:
             return False
+
+        if ok_uuids_to_delete:
+            service.delete_remote_digitaal_adressen(ok_uuids_to_delete)
+
+        if not user_form_data:
+            return True
 
         return service.update_partij_from_user_data(
             partij_uuid=partij["uuid"],

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -1724,15 +1724,11 @@ class OpenKlant2Service(
 
         return updated_fields
 
-    def delete_remote_digitaal_adres_for_local(self, local_address) -> bool:
-        """Delete the remote digitaal adres corresponding to a local DigitalAddress."""
-        try:
-            mapping = local_address.openklant_mapping
-        except DigitaalAdresOpenKlantMapping.DoesNotExist:
-            return False
-        with contextlib.suppress(OK2NotFound):
-            self.client.digitaal_adres.delete(str(mapping.ok_uuid))
-        return True
+    def delete_remote_digitaal_adressen(self, ok_uuids: Iterable) -> None:
+        """Delete remote digitaal adressen by their OpenKlant UUIDs."""
+        for ok_uuid in ok_uuids:
+            with contextlib.suppress(OK2NotFound):
+                self.client.digitaal_adres.delete(str(ok_uuid))
 
     def _create_klantcontact(
         self,


### PR DESCRIPTION
### Issue
When a user deletes a digital address via the profile formset, `_save_digital_address_formset` calls `form.instance.delete()`, which cascade-deletes the `DigitaalAdresOpenKlantMapping`. By the time the OpenKlant sync runs, the mapping UUID is gone, so the remote digitaal adres was never deleted from OpenKlant. On the next inbound sync, the remote address would be re-adopted locally, silently reversing the deletion.

A secondary issue: if a remote deletion API call were to fail, the exception would propagate outside the `try/except` blocks in form_valid, causing a `500` instead of a graceful rollback.

### Solution
Before `_save_digital_address_formset` runs, collect the OpenKlant mapping UUIDs for all addresses marked for deletion (while the mappings still exist in the DB). After the local formset saves, call the new `delete_remote_digitaal_adressen` service method with those UUIDs inside the existing OpenKlant `try/except` block. An API failure now follows the same path as any other sync error: set_rollback(True) rolls back the local deletion and the user sees the standard error message.

 The eSuite call guard is tightened to if changed_data only, since eSuite has no per-address remote deletion concept.