### PR TITLE
ci: replace pre-commit/action with direct invocation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -72,9 +72,12 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: 'pyproject.toml'
+      - name: Install pre-commit
+        run: grep "^pre-commit" requirements/dev.txt | xargs pip install
       - name: npm install
         run: npm install
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
   ruff-version-check:
     name: Check ruff version consistency


### PR DESCRIPTION
pre-commit/action is not in the org's allowed actions allowlist. Install pre-commit from the pinned version in requirements/dev.txt and invoke it directly instead.

