### PR TITLE
feat: [#2582] bump django prosemirror to 0.8.0 to fix inline admin

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -455,7 +455,7 @@ maykin-2fa==1.0.2
     # via -r requirements/base.in
 maykin-common[cli, docs, health-checks, otel]==0.19.0
     # via -r requirements/base.in
-maykin-django-prosemirror[images]==0.7.0
+maykin-django-prosemirror[images]==0.8.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -796,7 +796,7 @@ maykin-common[cli, docs, health-checks, otel]==0.19.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-django-prosemirror[images]==0.7.0
+maykin-django-prosemirror[images]==0.8.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -883,7 +883,7 @@ maykin-common[cli, docs, health-checks, otel]==0.19.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-django-prosemirror[images]==0.7.0
+maykin-django-prosemirror[images]==0.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
The latest version of django prosemirror ensures that the editor is properly initialized on Django admin pages that use Django formsets. Previously, dynamically added rows would not have a properly bound prosemirror instance, leading to errors when submitting the form. The new version listens for the relevant DOM events to bind on new formset rows as they're inserted into the DOM.

Closes: #2582
