### PR TITLE
[#2661] Pass KVK + vestigingsnummer combination to eSuite klanten API

### DIFF
--- a/src/open_inwoner/openklant/clients.py
+++ b/src/open_inwoner/openklant/clients.py
@@ -72,13 +72,11 @@ class KlantenClient(KlantAPIClient):
     def retrieve_klanten_for_kvk_or_rsin(
         self, user_kvk_or_rsin: str, *, vestigingsnummer: str | None = None
     ) -> list[Klant]:
-        params = (
-            {
-                "subjectVestiging__vestigingsNummer": vestigingsnummer,
-            }
-            if vestigingsnummer
-            else {"subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin}
-        )
+        params = {}
+        if vestigingsnummer:
+            params["subjectVestiging__vestigingsNummer"] = vestigingsnummer
+        if user_kvk_or_rsin:
+            params["subjectNietNatuurlijkPersoon__innNnpId"] = user_kvk_or_rsin
         response = self.get("klanten", params=params)
         self.raise_for_status(response)
         raw_json_data = self.parse_json(response)

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -244,15 +244,12 @@ class eSuiteKlantenService(
     def _retrieve_klanten_for_kvk_or_rsin(
         self, user_kvk_or_rsin: str, *, vestigingsnummer=None
     ) -> list[Klant]:
-        params = (
-            {
-                "subjectVestiging__vestigingsNummer": vestigingsnummer,
-            }
-            if vestigingsnummer
-            else {
-                "subjectNietNatuurlijkPersoon__innNnpId": user_kvk_or_rsin,
-            }
-        )
+        params = {}
+        if vestigingsnummer:
+            params["subjectVestiging__vestigingsNummer"] = vestigingsnummer
+        if user_kvk_or_rsin:
+            params["subjectNietNatuurlijkPersoon__innNnpId"] = user_kvk_or_rsin
+
         response = self.client.get("klanten", params=params)
         self.client.raise_for_status(response)
         data = self.client.parse_json(response)
@@ -287,15 +284,12 @@ class eSuiteKlantenService(
         if user_bsn:
             payload = payload | {"subjectIdentificatie": {"inpBsn": user_bsn}}
         elif user_kvk_or_rsin:
+            identificatie = {"subjectIdentificatie": {"innNnpId": user_kvk_or_rsin}}
             if vestigingsnummer:
-                payload = payload | {
-                    "subjectIdentificatie": {"vestigingsNummer": vestigingsnummer}
-                }
-
-            else:
-                payload = payload | {
-                    "subjectIdentificatie": {"innNnpId": user_kvk_or_rsin}
-                }
+                identificatie["subjectIdentificatie"]["vestigingsNummer"] = (
+                    vestigingsnummer
+                )
+            payload = payload | identificatie
 
         response = self.client.post("klanten", json=payload)
         self.client.raise_for_status(response)

--- a/src/open_inwoner/openklant/tests/test_esuite_service.py
+++ b/src/open_inwoner/openklant/tests/test_esuite_service.py
@@ -132,8 +132,7 @@ class eSuiteServiceTestCase(TestCase, DisableRequestLogMixin):
             m.request_history[0].json(),
             {
                 "subjectIdentificatie": {
-                    # Note: the innNnpId is not sent for vestiging, it's either innNnpId
-                    # or vestigingsNummer
+                    "innNnpId": "87654321",
                     "vestigingsNummer": "123456789000",
                 }
             },


### PR DESCRIPTION
eSuite requires both `innNnpId` and `vestigingsNummer` to uniquely identify a vestiging klant. Previously OIP sent only one or the other, causing eSuite to store KvkNummer as null and return `409` when multiple vestigingen with the same vestigingsnummer were present.

Fixes #2661 
