### PR TITLE
[#2665] Include role and confidentiality config in zaken cache keys

### DIFF
--- a/src/open_inwoner/openzaak/clients.py
+++ b/src/open_inwoner/openzaak/clients.py
@@ -135,7 +135,7 @@ class ZakenClient(ZgwAPIClient):
                 )
 
     @cache_result(
-        "{self.base_url}:zaken:{user_bsn}:{max_requests}:{identificatie}",
+        "{self.base_url}:zaken:{user_bsn}:{max_requests}:{identificatie}:{self.zaak_max_confidentiality}:{self.limit_user_visible_cases_to_role}",
         timeout=lambda self: self.cache_zaken_timeout,
     )
     def fetch_zaken_by_bsn(
@@ -179,7 +179,7 @@ class ZakenClient(ZgwAPIClient):
         return self.factory(Zaak, all_data)
 
     @cache_result(
-        "{self.base_url}:zaken:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}",
+        "{self.base_url}:zaken:{kvk_or_rsin}:{vestigingsnummer}:{max_requests}:{zaak_identificatie}:{self.zaak_max_confidentiality}:{self.limit_user_visible_cases_to_role}",
         timeout=lambda self: self.cache_zaken_timeout,
     )
     def fetch_zaken_for_company(


### PR DESCRIPTION
`fetch_zaken_by_bsn()` and `fetch_zaken_for_company()` filter requests by `zaak_max_confidentiality` and `limit_user_visible_cases_to_role`, but neither field was part of the cache key. Changing either config value would serve stale results until the cache expired.

Fixes #2665 