### PR TITLE
[#2673] Enforce document ownership in InboxStartView and MessageFileInputWidget

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -675,6 +675,7 @@ class ActionForm(forms.ModelForm):
 
 class MessageFileInputWidget(forms.ClearableFileInput):
     template_name = "utils/widgets/message_file_input.html"
+    user = None  # set by InboxForm.__init__ to enforce ownership
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -695,8 +696,8 @@ class MessageFileInputWidget(forms.ClearableFileInput):
 
         # check if there is initial file
         init_value = forms.TextInput().value_from_datadict(data, files, name + "-init")
-        if init_value:
-            document = Document.objects.filter(uuid=init_value).first()
+        if init_value and self.user is not None:
+            document = Document.objects.filter(uuid=init_value, owner=self.user).first()
             if document:
                 return document.file
 
@@ -740,6 +741,8 @@ class InboxForm(forms.ModelForm):
 
         if not self.config.allow_messages_file_sharing:
             del self.fields["file"]
+        else:
+            self.fields["file"].widget.user = user
 
     def clean(self):
         cleaned_data = super().clean()

--- a/src/open_inwoner/accounts/tests/test_inbox_start_page.py
+++ b/src/open_inwoner/accounts/tests/test_inbox_start_page.py
@@ -149,6 +149,35 @@ class InboxPageTests(WebTest):
         self.assertEqual(message.receiver, contact)
         self.assertEqual(message.file, document.file)
 
+    @temp_private_root()
+    def test_get_with_other_users_document_returns_404(self):
+        other_user = UserFactory()
+        document = DocumentFactory.create(owner=other_user)
+        url = furl(self.url).add({"file": document.uuid}).url
+
+        self.app.get(url, status=404)
+
+    @temp_private_root()
+    def test_post_with_other_users_document_init_does_not_attach_file(self):
+        contact = UserFactory()
+        self.user.user_contacts.add(contact)
+        other_user = UserFactory()
+        document = DocumentFactory.create(owner=other_user)
+
+        response = self.app.get(self.url)
+        form = response.forms["start-message-form"]
+        form["receiver"] = str(contact.uuid)
+        form["content"] = "hello"
+        # simulate an attacker injecting another user's document UUID
+        form["file-init"] = str(document.uuid)
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Message.objects.count(), 1)
+        message = Message.objects.get()
+        self.assertFalse(message.file)
+
     def test_send_empty_message_with_sharing_disabled(self):
         contact = UserFactory()
         self.user.user_contacts.add(contact)

--- a/src/open_inwoner/accounts/views/inbox.py
+++ b/src/open_inwoner/accounts/views/inbox.py
@@ -230,7 +230,9 @@ class InboxStartView(LogMixin, LoginRequiredMixin, CommonPageMixin, FormView):
         if not document_uuid:
             return
 
-        document = get_object_or_404(Document, uuid=document_uuid)
+        document = get_object_or_404(
+            Document, uuid=document_uuid, owner=self.request.user
+        )
 
         return document.file
 


### PR DESCRIPTION
GET now returns 404 if the document is not owned by the requesting user. POST with a crafted file-init UUID is ignored if the document owner does not match the authenticated user (fail when user is unset for some reason).
