### PR TITLE
[#2663] Link question onderwerpobject to zaak by UUID

### DIFF
--- a/bin/record_openklant2_fixtures.sh
+++ b/bin/record_openklant2_fixtures.sh
@@ -25,7 +25,7 @@ else
     exit 0
 fi
 
-export OPEN_KLANT_IMAGE_TAG="2.7.0"
+export OPEN_KLANT_IMAGE_TAG="2.15.0"
 echo "Using Open Klant image version $OPEN_KLANT_IMAGE_TAG"
 set -x
 RECORD_OPENKLANT_CASSETTES=1 python src/manage.py test src/open_inwoner --tag openklant2

--- a/docker/docker-compose.openklant.yml
+++ b/docker/docker-compose.openklant.yml
@@ -3,10 +3,11 @@ version: '3'
 
 services:
   openklant-db:
-    image: postgis/postgis:12-2.5
+    image: postgis/postgis:${PG_VERSION:-14-master}
     environment:
       - POSTGRES_USER=${DB_USER:-open_klant}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-open_klant}
+      - POSTGRES_DB=${DB_NAME:-open_klant}
     volumes:
       - db_data:/var/lib/postgresql/data
     networks:
@@ -22,20 +23,20 @@ services:
           - openklant.local
 
   openklant-web:
-    image: maykinmedia/open-klant:0.5-pre
+    image: maykinmedia/open-klant:${OPEN_KLANT_IMAGE_TAG:-2.15.0}
     environment:
       - DJANGO_SETTINGS_MODULE=openklant.conf.docker
       - SECRET_KEY=${SECRET_KEY:-a8s@b*ds4t84-q_2#c0j0506@!l2q6r5_pq5e!vm^_9c*#^66b}
       - DB_HOST=openklant-db
+      - DB_NAME=${DB_NAME:-open_klant}
       - DB_USER=${DB_USER:-open_klant}
       - DB_PASSWORD=${DB_PASSWORD:-open_klant}
       - ALLOWED_HOSTS=*
       - CACHE_DEFAULT=openklant-redis:6379/0
       - CACHE_AXES=openklant-redis:6379/0
       - NOTIFICATIONS_DISABLED=1
-      - UWSGI_PORT=8001
     ports:
-      - 8001:8001
+      - 8338:8000
     depends_on:
       - openklant-db
       - openklant-redis

--- a/src/open_inwoner/cms/cases/tests/test_contactform.py
+++ b/src/open_inwoner/cms/cases/tests/test_contactform.py
@@ -408,7 +408,7 @@ class CasesContactFormTestCase(AssertMockMatchersMixin, ClearCachesMixin, WebTes
         }
         KlantContactValidator.validate_python(klantcontact)
         m.get(
-            f"{OPENKLANT2_ROOT}klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=ZAAK-2022-0000000024",
+            f"{OPENKLANT2_ROOT}klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d",
             headers={"Content-Type": "application/json"},
             json={
                 "count": 123,

--- a/src/open_inwoner/openklant/services.py
+++ b/src/open_inwoner/openklant/services.py
@@ -90,6 +90,7 @@ from open_inwoner.openzaak.models import ZGWApiGroupConfig
 from open_inwoner.openzaak.services import ZGWService
 from open_inwoner.utils.logentry import system_action
 from open_inwoner.utils.time import instance_is_new
+from open_inwoner.utils.url import uuid_from_url
 from open_inwoner.utils.views import LogMixin
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -1865,10 +1866,10 @@ class OpenKlant2Service(
                 "klantcontact": {"uuid": ok2_question.question_kcm_uuid},
                 "wasKlantcontact": None,
                 "onderwerpobjectidentificator": {
-                    "objectId": zaak.identificatie,
-                    "codeObjecttype": "zaak",
+                    "objectId": str(uuid_from_url(zaak.url)),
+                    "codeObjecttype": "zgw-Zaak",
                     "codeRegister": "openzaak",
-                    "codeSoortObjectId": "identificatie",
+                    "codeSoortObjectId": "uuid",
                 },
             }
         )
@@ -2125,27 +2126,14 @@ class OpenKlant2Service(
         onderwerp_object = onderwerp_objecten[0]
 
         # find the unique zaak + relevant api group for the question
-        identificatie = onderwerp_object["onderwerpobjectidentificator"]["objectId"]
-        results = ZGWService().search_zaken(
-            user.identification, zaak_identificatie=identificatie
-        )
+        zaak_uuid = onderwerp_object["onderwerpobjectidentificator"]["objectId"]
+        zaak_with_api_group = ZGWService().get_zaak_by_uuid(zaak_uuid)
 
-        if not results:
+        if not zaak_with_api_group:
             logger.info(
                 "Unable to find matched contactmomenten zaak with OpenKlant2 backend"
             )
             return self._build_question_dto(question_ok2=question, user=user), None
-
-        if len(results) > 1:
-            logger.error(
-                "More than one zaak found for question",
-                question_kcm_uuid=question.question_kcm_uuid,
-            )
-            return self._build_question_dto(question_ok2=question, user=user), None
-
-        zaak_with_api_group = ZaakWithApiGroup(
-            zaak=results[0].zaak, api_group=results[0].api_group
-        )
 
         return (
             self._build_question_dto(question_ok2=question, user=user),
@@ -2206,7 +2194,9 @@ class OpenKlant2Service(
         user: User,
     ) -> list[Question]:
         params: ListKlantContactParams = {
-            "onderwerpobject__onderwerpobjectidentificatorObjectId": zaak.identificatie,
+            "onderwerpobject__onderwerpobjectidentificatorObjectId": str(
+                uuid_from_url(zaak.url)
+            ),
             "expand": ["hadBetrokkenen"],
         }
         klantcontacten_for_zaak = self.client.klant_contact.list_iter(params=params)

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_with_vestiging.yaml
@@ -1,0 +1,1206 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "organisatie",
+        "partijIdentificatie": {"naam": ""}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '265'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '901'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "28b509a0-a2ea-4003-b523-517a85b8f521"}, "partijIdentificator":
+        {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
+        "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '225'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '532'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "28b509a0-a2ea-4003-b523-517a85b8f521"}, "subIdentificatorVan": {"uuid":
+        "402102b2-9459-42ed-b4b4-1002afd93971"}, "partijIdentificator":
+        {"codeObjecttype": "vestiging", "codeSoortObjectId": "vestigingsnummer",
+        "objectId": "123456789123", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '294'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '685'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2184'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}},{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1270'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '737'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521
+    response:
+      body:
+        string: '{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '2119'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2184'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"d141c097-50c1-4ad0-b4ca-bef2f03f53fd","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/d141c097-50c1-4ad0-b4ca-bef2f03f53fd","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971"}},{"uuid":"402102b2-9459-42ed-b4b4-1002afd93971","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/402102b2-9459-42ed-b4b4-1002afd93971","identificeerdePartij":{"uuid":"28b509a0-a2ea-4003-b523-517a85b8f521","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28b509a0-a2ea-4003-b523-517a85b8f521"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1270'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "organisatie",
+        "partijIdentificatie": {"naam": ""}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '265'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '901'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "4450a445-e858-479d-92a1-371f34319e75"}, "partijIdentificator":
+        {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
+        "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '225'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '532'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "4450a445-e858-479d-92a1-371f34319e75"}, "subIdentificatorVan": {"uuid":
+        "34dba496-1fb1-405a-8294-d564686ea18a"}, "partijIdentificator":
+        {"codeObjecttype": "vestiging", "codeSoortObjectId": "vestigingsnummer",
+        "objectId": "123456789123", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '294'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '685'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2184'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}},{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1270'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=vestigingsnummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=vestiging&partijIdentificatorObjectId=123456789123
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '737'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75
+    response:
+      body:
+        string: '{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '2119'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null},{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2184'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":2,"next":null,"previous":null,"results":[{"uuid":"da278228-ef12-4f62-93e6-4f96a74a3073","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/da278228-ef12-4f62-93e6-4f96a74a3073","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"vestiging","codeSoortObjectId":"vestigingsnummer","objectId":"123456789123","codeRegister":"hr"},"subIdentificatorVan":{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a"}},{"uuid":"34dba496-1fb1-405a-8294-d564686ea18a","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/34dba496-1fb1-405a-8294-d564686ea18a","identificeerdePartij":{"uuid":"4450a445-e858-479d-92a1-371f34319e75","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4450a445-e858-479d-92a1-371f34319e75"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1270'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_organisatie_without_vestiging.yaml
@@ -1,0 +1,956 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "organisatie",
+        "partijIdentificatie": {"naam": ""}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '265'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '901'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "639186d3-c7a6-43fb-ba2f-32157223885a"}, "partijIdentificator":
+        {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
+        "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '225'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '532'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1498'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a
+    response:
+      body:
+        string: '{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '1433'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1498'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"3cc16cf0-d130-48d3-8005-d36162837838","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/3cc16cf0-d130-48d3-8005-d36162837838","identificeerdePartij":{"uuid":"639186d3-c7a6-43fb-ba2f-32157223885a","url":"http://localhost:8338/klantinteracties/api/v1/partijen/639186d3-c7a6-43fb-ba2f-32157223885a"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "organisatie",
+        "partijIdentificatie": {"naam": ""}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '265'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '901'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"identificeerdePartij": {"uuid":
+        "c56a8f64-e110-4958-b83a-6e82716d7ed7"}, "partijIdentificator":
+        {"codeObjecttype": "niet_natuurlijk_persoon", "codeSoortObjectId":
+        "kvk_nummer", "objectId": "12345678", "codeRegister": "hr"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '225'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '532'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1498'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren?partijIdentificatorCodeSoortObjectId=kvk_nummer&partijIdentificatorCodeRegister=hr&partijIdentificatorCodeObjecttype=niet_natuurlijk_persoon&partijIdentificatorObjectId=12345678
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7
+    response:
+      body:
+        string: '{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '1433'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}],"soortPartij":"organisatie","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"naam":""},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1498'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0b0b2d07-ee04-41e4-8fe7-e43cd22fab03","identificeerdePartij":{"uuid":"c56a8f64-e110-4958-b83a-6e82716d7ed7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c56a8f64-e110-4958-b83a-6e82716d7ed7"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"niet_natuurlijk_persoon","codeSoortObjectId":"kvk_nummer","objectId":"12345678","codeRegister":"hr"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '584'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_partij_for_user_without_bsn_kvk.yaml
@@ -1,0 +1,600 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Jane", "achternaam": "Anonymous",
+        "voorletters": "", "voorvoegselAchternaam": ""}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '361'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"5fb1114c-1901-4782-959c-26153bcd3fc9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5fb1114c-1901-4782-959c-26153bcd3fc9","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1023'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/5fb1114c-1901-4782-959c-26153bcd3fc9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"5fb1114c-1901-4782-959c-26153bcd3fc9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5fb1114c-1901-4782-959c-26153bcd3fc9","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1088'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Jane", "achternaam": "Anonymous",
+        "voorletters": "", "voorvoegselAchternaam": ""}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '361'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"cdec693e-09e1-4d51-9261-35721a356623","url":"http://localhost:8338/klantinteracties/api/v1/partijen/cdec693e-09e1-4d51-9261-35721a356623","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1023'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/cdec693e-09e1-4d51-9261-35721a356623
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"cdec693e-09e1-4d51-9261-35721a356623","url":"http://localhost:8338/klantinteracties/api/v1/partijen/cdec693e-09e1-4d51-9261-35721a356623","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}},{"uuid":"5fb1114c-1901-4782-959c-26153bcd3fc9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/5fb1114c-1901-4782-959c-26153bcd3fc9","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2125'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Jane", "achternaam": "Anonymous",
+        "voorletters": "", "voorvoegselAchternaam": ""}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '361'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"28ade2a6-8ab3-4568-a74b-35c797f61445","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28ade2a6-8ab3-4568-a74b-35c797f61445","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1023'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/28ade2a6-8ab3-4568-a74b-35c797f61445
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"28ade2a6-8ab3-4568-a74b-35c797f61445","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28ade2a6-8ab3-4568-a74b-35c797f61445","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1088'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Jane", "achternaam": "Anonymous",
+        "voorletters": "", "voorvoegselAchternaam": ""}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '361'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"a4f2a1a1-3ce5-4e18-bd3e-824d3623568e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a4f2a1a1-3ce5-4e18-bd3e-824d3623568e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1023'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/a4f2a1a1-3ce5-4e18-bd3e-824d3623568e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"a4f2a1a1-3ce5-4e18-bd3e-824d3623568e","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a4f2a1a1-3ce5-4e18-bd3e-824d3623568e","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}},{"uuid":"28ade2a6-8ab3-4568-a74b-35c797f61445","url":"http://localhost:8338/klantinteracties/api/v1/partijen/28ade2a6-8ab3-4568-a74b-35c797f61445","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Jane
+          Anonymous"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '2125'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/PartijGetOrCreateTestCase.test_get_or_create_persoon.yaml
@@ -1,0 +1,812 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "John", "achternaam": "Doe", "voorletters":
+        "", "voorvoegselAchternaam": ""}}, "partijIdentificatoren":
+        [{"partijIdentificator": {"codeObjecttype": "natuurlijk_persoon",
+        "codeSoortObjectId": "bsn", "objectId": "521311408", "codeRegister":
+        "brp"}}]}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '525'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1533'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '574'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    response:
+      body:
+        string:
+          '{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{"betrokkenen":[]}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '1562'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"e0544d00-aee3-4086-b9ed-d0326f4409df","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/e0544d00-aee3-4086-b9ed-d0326f4409df","identificeerdePartij":{"uuid":"d015f335-ed5f-476d-8391-7aa5a321a41c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d015f335-ed5f-476d-8391-7aa5a321a41c"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '574'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; frame-src 'self'; script-src 'self'
+            'unsafe-inline'; base-uri 'self'; img-src 'self' data: cdn.redoc.ly;
+            frame-ancestors 'none'; font-src 'self' fonts.gstatic.com;
+            default-src 'self'; form-action 'self'; object-src 'none'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "John", "achternaam": "Doe", "voorletters":
+        "", "voorvoegselAchternaam": ""}}, "partijIdentificatoren":
+        [{"partijIdentificator": {"codeObjecttype": "natuurlijk_persoon",
+        "codeSoortObjectId": "bsn", "objectId": "521311408", "codeRegister":
+        "brp"}}]}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '525'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1533'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '574'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=521311408&soortPartij=persoon
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    response:
+      body:
+        string:
+          '{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{"betrokkenen":[]}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '1562'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Doe"},"volledigeNaam":"John
+          Doe"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1598'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partij-identificatoren
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0c34ae07-5125-41fc-ba48-5497822d67ef","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/0c34ae07-5125-41fc-ba48-5497822d67ef","identificeerdePartij":{"uuid":"36bd8c3b-ee97-4813-b775-28501aae0564","url":"http://localhost:8338/klantinteracties/api/v1/partijen/36bd8c3b-ee97-4813-b775-28501aae0564"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"521311408","codeRegister":"brp"},"subIdentificatorVan":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '574'
+        Content-Security-Policy:
+          - "frame-ancestors 'none'; style-src 'self' 'unsafe-inline'
+            fonts.googleapis.com; form-action 'self'; worker-src 'self' blob:;
+            frame-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; base-uri 'self'; object-src 'none'; img-src
+            'self' data: cdn.redoc.ly; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question.yaml
@@ -1,0 +1,954 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"b4d8534b-80c4-412b-9aed-92e9231866e9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/b4d8534b-80c4-412b-9aed-92e9231866e9","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/b4d8534b-80c4-412b-9aed-92e9231866e9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"18cf6412-8459-4c9e-84dd-fd44fd6af886","url":"http://localhost:8338/klantinteracties/api/v1/partijen/18cf6412-8459-4c9e-84dd-fd44fd6af886","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/18cf6412-8459-4c9e-84dd-fd44fd6af886
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"66978e98-60b1-49ae-97c3-58a8ddea65c0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/66978e98-60b1-49ae-97c3-58a8ddea65c0","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/66978e98-60b1-49ae-97c3-58a8ddea65c0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"05404068-e9c3-4c83-afa4-fd185905a591","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Alice", "onderwerp": "Important
+        questions", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '199'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+          questions","inhoud":"A question asked by
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '511'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "18cf6412-8459-4c9e-84dd-fd44fd6af886"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "11e34ad3-63c3-4a70-b075-c803bf649e97"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"17d669d4-f52b-4ec7-81f5-199676e588d9","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/17d669d4-f52b-4ec7-81f5-199676e588d9","wasPartij":{"uuid":"18cf6412-8459-4c9e-84dd-fd44fd6af886","url":"http://localhost:8338/klantinteracties/api/v1/partijen/18cf6412-8459-4c9e-84dd-fd44fd6af886"},"hadKlantcontact":{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/17d669d4-f52b-4ec7-81f5-199676e588d9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "11e34ad3-63c3-4a70-b075-c803bf649e97"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "05404068-e9c3-4c83-afa4-fd185905a591"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"23b00d7e-fe32-46a4-ad05-d415c046670d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23b00d7e-fe32-46a4-ad05-d415c046670d","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97"},"toegewezenAanActor":{"uuid":"05404068-e9c3-4c83-afa4-fd185905a591","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591"},"toegewezenAanActoren":[{"uuid":"05404068-e9c3-4c83-afa4-fd185905a591","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:41:13.341407Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/23b00d7e-fe32-46a4-ad05-d415c046670d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"17d669d4-f52b-4ec7-81f5-199676e588d9","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/17d669d4-f52b-4ec7-81f5-199676e588d9"}],"leiddeTotInterneTaken":[{"uuid":"23b00d7e-fe32-46a4-ad05-d415c046670d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23b00d7e-fe32-46a4-ad05-d415c046670d"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+          questions","inhoud":"A question asked by
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '877'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"17d669d4-f52b-4ec7-81f5-199676e588d9","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/17d669d4-f52b-4ec7-81f5-199676e588d9","wasPartij":{"uuid":"18cf6412-8459-4c9e-84dd-fd44fd6af886","url":"http://localhost:8338/klantinteracties/api/v1/partijen/18cf6412-8459-4c9e-84dd-fd44fd6af886"},"hadKlantcontact":{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1130'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"23b00d7e-fe32-46a4-ad05-d415c046670d","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/23b00d7e-fe32-46a4-ad05-d415c046670d","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"11e34ad3-63c3-4a70-b075-c803bf649e97","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/11e34ad3-63c3-4a70-b075-c803bf649e97"},"toegewezenAanActor":{"uuid":"05404068-e9c3-4c83-afa4-fd185905a591","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591"},"toegewezenAanActoren":[{"uuid":"05404068-e9c3-4c83-afa4-fd185905a591","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05404068-e9c3-4c83-afa4-fd185905a591"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:41:13.341407Z","afgehandeldOp":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '952'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"f1d48737-a6fc-47fd-b7a7-011b4561138a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f1d48737-a6fc-47fd-b7a7-011b4561138a","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/f1d48737-a6fc-47fd-b7a7-011b4561138a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"3fc6c855-516f-4e87-9f93-6e9a8f350499","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3fc6c855-516f-4e87-9f93-6e9a8f350499","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/3fc6c855-516f-4e87-9f93-6e9a8f350499
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"a942e24b-3c22-49ee-97a4-6f2b403f8931","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a942e24b-3c22-49ee-97a4-6f2b403f8931","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/a942e24b-3c22-49ee-97a4-6f2b403f8931
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"02b76ced-906c-4250-affe-0813f74739ed","url":"http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Alice", "onderwerp": "Important
+        questions", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '199'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+          questions","inhoud":"A question asked by
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '511'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "3fc6c855-516f-4e87-9f93-6e9a8f350499"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "db8cdda9-6a42-4172-a4ba-44b813e7df04"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"8c07a10a-bfc2-4a4d-971e-f39be6dea71e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8c07a10a-bfc2-4a4d-971e-f39be6dea71e","wasPartij":{"uuid":"3fc6c855-516f-4e87-9f93-6e9a8f350499","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3fc6c855-516f-4e87-9f93-6e9a8f350499"},"hadKlantcontact":{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/8c07a10a-bfc2-4a4d-971e-f39be6dea71e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "db8cdda9-6a42-4172-a4ba-44b813e7df04"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "02b76ced-906c-4250-affe-0813f74739ed"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"8c0b76dc-39d4-4424-ad5c-082ef62af627","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/8c0b76dc-39d4-4424-ad5c-082ef62af627","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04"},"toegewezenAanActor":{"uuid":"02b76ced-906c-4250-affe-0813f74739ed","url":"http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed"},"toegewezenAanActoren":[{"uuid":"02b76ced-906c-4250-affe-0813f74739ed","url":"http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:47:07.640380Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/8c0b76dc-39d4-4424-ad5c-082ef62af627
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"8c07a10a-bfc2-4a4d-971e-f39be6dea71e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8c07a10a-bfc2-4a4d-971e-f39be6dea71e"}],"leiddeTotInterneTaken":[{"uuid":"8c0b76dc-39d4-4424-ad5c-082ef62af627","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/8c0b76dc-39d4-4424-ad5c-082ef62af627"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Important
+          questions","inhoud":"A question asked by
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '877'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"8c07a10a-bfc2-4a4d-971e-f39be6dea71e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8c07a10a-bfc2-4a4d-971e-f39be6dea71e","wasPartij":{"uuid":"3fc6c855-516f-4e87-9f93-6e9a8f350499","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3fc6c855-516f-4e87-9f93-6e9a8f350499"},"hadKlantcontact":{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1130'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"8c0b76dc-39d4-4424-ad5c-082ef62af627","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/8c0b76dc-39d4-4424-ad5c-082ef62af627","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"db8cdda9-6a42-4172-a4ba-44b813e7df04","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/db8cdda9-6a42-4172-a4ba-44b813e7df04"},"toegewezenAanActor":{"uuid":"02b76ced-906c-4250-affe-0813f74739ed","url":"http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed"},"toegewezenAanActoren":[{"uuid":"02b76ced-906c-4250-affe-0813f74739ed","url":"http://localhost:8338/klantinteracties/api/v1/actoren/02b76ced-906c-4250-affe-0813f74739ed"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:47:07.640380Z","afgehandeldOp":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '952'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_for_zaak.yaml
@@ -1,0 +1,882 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"e0b8cbf9-884b-47ac-aeb3-9b760dd60989","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e0b8cbf9-884b-47ac-aeb3-9b760dd60989","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/e0b8cbf9-884b-47ac-aeb3-9b760dd60989
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"c97f3724-32c1-4cd5-9ef5-87d4c31fa406","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c97f3724-32c1-4cd5-9ef5-87d4c31fa406","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c97f3724-32c1-4cd5-9ef5-87d4c31fa406
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"e66bdb84-edf2-44e8-b0d3-b9591eb30b3f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/e66bdb84-edf2-44e8-b0d3-b9591eb30b3f","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/e66bdb84-edf2-44e8-b0d3-b9591eb30b3f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"98813e73-e25d-4fa7-a3c8-722cadc54f3b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/98813e73-e25d-4fa7-a3c8-722cadc54f3b","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/98813e73-e25d-4fa7-a3c8-722cadc54f3b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "c97f3724-32c1-4cd5-9ef5-87d4c31fa406"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"5e765429-7dd4-438a-8df5-ae7e0948d4dd","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5e765429-7dd4-438a-8df5-ae7e0948d4dd","wasPartij":{"uuid":"c97f3724-32c1-4cd5-9ef5-87d4c31fa406","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c97f3724-32c1-4cd5-9ef5-87d4c31fa406"},"hadKlantcontact":{"uuid":"0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/5e765429-7dd4-438a-8df5-ae7e0948d4dd
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "98813e73-e25d-4fa7-a3c8-722cadc54f3b"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"3120756d-2779-4883-8471-f31f0fafe1bf","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/3120756d-2779-4883-8471-f31f0fafe1bf","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"},"toegewezenAanActor":{"uuid":"98813e73-e25d-4fa7-a3c8-722cadc54f3b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/98813e73-e25d-4fa7-a3c8-722cadc54f3b"},"toegewezenAanActoren":[{"uuid":"98813e73-e25d-4fa7-a3c8-722cadc54f3b","url":"http://localhost:8338/klantinteracties/api/v1/actoren/98813e73-e25d-4fa7-a3c8-722cadc54f3b"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:41:30.040802Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/3120756d-2779-4883-8471-f31f0fafe1bf
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"0183c25f-7516-4043-956d-c61c611c0c09","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0183c25f-7516-4043-956d-c61c611c0c09","klantcontact":{"uuid":"0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0183c25f-7516-4043-956d-c61c611c0c09
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"0183c25f-7516-4043-956d-c61c611c0c09","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/0183c25f-7516-4043-956d-c61c611c0c09","klantcontact":{"uuid":"0d9010c7-7477-4db0-a2d9-eb9ed0c889c8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/0d9010c7-7477-4db0-a2d9-eb9ed0c889c8"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '564'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"373d268a-60d9-4a03-a45b-1636892e8906","url":"http://localhost:8338/klantinteracties/api/v1/actoren/373d268a-60d9-4a03-a45b-1636892e8906","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/373d268a-60d9-4a03-a45b-1636892e8906
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"ecf8cf03-435a-4dfa-9a3a-833fa40aaee7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ecf8cf03-435a-4dfa-9a3a-833fa40aaee7","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/ecf8cf03-435a-4dfa-9a3a-833fa40aaee7
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"f146392a-406e-4674-b9e3-562f91809bb0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f146392a-406e-4674-b9e3-562f91809bb0","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/f146392a-406e-4674-b9e3-562f91809bb0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"6d72bf6a-4f0b-4031-b40e-79746cff4569","url":"http://localhost:8338/klantinteracties/api/v1/actoren/6d72bf6a-4f0b-4031-b40e-79746cff4569","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/6d72bf6a-4f0b-4031-b40e-79746cff4569
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "ecf8cf03-435a-4dfa-9a3a-833fa40aaee7"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"3de33cc0-d4df-4d54-86c9-b9e35fab57d1","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3de33cc0-d4df-4d54-86c9-b9e35fab57d1","wasPartij":{"uuid":"ecf8cf03-435a-4dfa-9a3a-833fa40aaee7","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ecf8cf03-435a-4dfa-9a3a-833fa40aaee7"},"hadKlantcontact":{"uuid":"f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/3de33cc0-d4df-4d54-86c9-b9e35fab57d1
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "6d72bf6a-4f0b-4031-b40e-79746cff4569"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"35478eee-0873-4806-bcfe-ca9ee55d3086","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/35478eee-0873-4806-bcfe-ca9ee55d3086","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"},"toegewezenAanActor":{"uuid":"6d72bf6a-4f0b-4031-b40e-79746cff4569","url":"http://localhost:8338/klantinteracties/api/v1/actoren/6d72bf6a-4f0b-4031-b40e-79746cff4569"},"toegewezenAanActoren":[{"uuid":"6d72bf6a-4f0b-4031-b40e-79746cff4569","url":"http://localhost:8338/klantinteracties/api/v1/actoren/6d72bf6a-4f0b-4031-b40e-79746cff4569"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:47:25.332817Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/35478eee-0873-4806-bcfe-ca9ee55d3086
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"fd9a47a9-b6aa-42db-9e9d-28c8d9e9b00d","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fd9a47a9-b6aa-42db-9e9d-28c8d9e9b00d","klantcontact":{"uuid":"f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fd9a47a9-b6aa-42db-9e9d-28c8d9e9b00d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"fd9a47a9-b6aa-42db-9e9d-28c8d9e9b00d","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/fd9a47a9-b6aa-42db-9e9d-28c8d9e9b00d","klantcontact":{"uuid":"f9cf5d0c-4e59-4410-b05a-b9801c80d2a5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/f9cf5d0c-4e59-4410-b05a-b9801c80d2a5"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '564'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_raises_on_missing_question.yaml
@@ -1,0 +1,402 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"85e89ec5-f88d-4ae7-a151-0091fd70f184","url":"http://localhost:8338/klantinteracties/api/v1/actoren/85e89ec5-f88d-4ae7-a151-0091fd70f184","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/85e89ec5-f88d-4ae7-a151-0091fd70f184
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"de5d673c-7d55-43f2-a1ee-af9d70392722","url":"http://localhost:8338/klantinteracties/api/v1/partijen/de5d673c-7d55-43f2-a1ee-af9d70392722","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/de5d673c-7d55-43f2-a1ee-af9d70392722
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"59537b25-8fe1-405a-9e4c-2461c785e051","url":"http://localhost:8338/klantinteracties/api/v1/partijen/59537b25-8fe1-405a-9e4c-2461c785e051","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/59537b25-8fe1-405a-9e4c-2461c785e051
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"36e3ffb4-2e6e-43ab-b938-4dbcc3b6e0b9","url":"http://localhost:8338/klantinteracties/api/v1/actoren/36e3ffb4-2e6e-43ab-b938-4dbcc3b6e0b9","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/36e3ffb4-2e6e-43ab-b938-4dbcc3b6e0b9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"47f4adaa-79a2-4fd2-8c61-3a7bb3848294","url":"http://localhost:8338/klantinteracties/api/v1/actoren/47f4adaa-79a2-4fd2-8c61-3a7bb3848294","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/47f4adaa-79a2-4fd2-8c61-3a7bb3848294
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"a3b53026-e219-45a5-aeed-878bcfe49185","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a3b53026-e219-45a5-aeed-878bcfe49185","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/a3b53026-e219-45a5-aeed-878bcfe49185
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"3fe8bc73-f384-46ed-9de5-18813a937e8c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/3fe8bc73-f384-46ed-9de5-18813a937e8c","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/3fe8bc73-f384-46ed-9de5-18813a937e8c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"e4463c03-7012-4f34-bf25-4ecf4220b0fe","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e4463c03-7012-4f34-bf25-4ecf4220b0fe","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/e4463c03-7012-4f34-bf25-4ecf4220b0fe
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene.yaml
@@ -1,0 +1,1396 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"47fd135f-63e6-4419-9bd2-40c31db77b6d","url":"http://localhost:8338/klantinteracties/api/v1/actoren/47fd135f-63e6-4419-9bd2-40c31db77b6d","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/47fd135f-63e6-4419-9bd2-40c31db77b6d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"283ed6f2-6984-466d-af13-87c9e74bd91b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/283ed6f2-6984-466d-af13-87c9e74bd91b","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/283ed6f2-6984-466d-af13-87c9e74bd91b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"8ee3d25f-8cc8-4425-a394-2529faeefa9d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/8ee3d25f-8cc8-4425-a394-2529faeefa9d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/8ee3d25f-8cc8-4425-a394-2529faeefa9d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"a205b177-7679-437d-8312-97a401a685a6","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question from an anonymous user", "onderwerp": "Anonymous
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '205'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"A question from an anonymous
+          user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '517'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "d6ff97b6-8497-46d4-a6d7-2563f604d100"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam":
+        "Hieronymous", "achternaam": "Anonymous"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '238'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde","wasPartij":null,"hadKlantcontact":{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+          Anonymous","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '963'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=86635938-697b-4553-a8c1-311e65193dde
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "hieronymous.anonymous@example.com", "soortDigitaalAdres":
+        "email", "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "86635938-697b-4553-a8c1-311e65193dde"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '241'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"32712f5b-e650-4c31-9697-da2f1e700a3f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/32712f5b-e650-4c31-9697-da2f1e700a3f","verstrektDoorBetrokkene":{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '526'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/32712f5b-e650-4c31-9697-da2f1e700a3f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=86635938-697b-4553-a8c1-311e65193dde
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"32712f5b-e650-4c31-9697-da2f1e700a3f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/32712f5b-e650-4c31-9697-da2f1e700a3f","verstrektDoorBetrokkene":{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '591'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "86635938-697b-4553-a8c1-311e65193dde"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '227'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"5dadb020-8701-429a-a64b-59df30daf314","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5dadb020-8701-429a-a64b-59df30daf314","verstrektDoorBetrokkene":{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5dadb020-8701-429a-a64b-59df30daf314
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "d6ff97b6-8497-46d4-a6d7-2563f604d100"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "a205b177-7679-437d-8312-97a401a685a6"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"5c3ca995-49b9-43fa-956a-83e58b48cbe9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5c3ca995-49b9-43fa-956a-83e58b48cbe9","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100"},"toegewezenAanActor":{"uuid":"a205b177-7679-437d-8312-97a401a685a6","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6"},"toegewezenAanActoren":[{"uuid":"a205b177-7679-437d-8312-97a401a685a6","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:42:05.116419Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/5c3ca995-49b9-43fa-956a-83e58b48cbe9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"}],"leiddeTotInterneTaken":[{"uuid":"5c3ca995-49b9-43fa-956a-83e58b48cbe9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5c3ca995-49b9-43fa-956a-83e58b48cbe9"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"A question from an anonymous
+          user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '883'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde","wasPartij":null,"hadKlantcontact":{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100"},"digitaleAdressen":[{"uuid":"32712f5b-e650-4c31-9697-da2f1e700a3f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/32712f5b-e650-4c31-9697-da2f1e700a3f"},{"uuid":"5dadb020-8701-429a-a64b-59df30daf314","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5dadb020-8701-429a-a64b-59df30daf314"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+          Anonymous","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1339'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"5c3ca995-49b9-43fa-956a-83e58b48cbe9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5c3ca995-49b9-43fa-956a-83e58b48cbe9","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"d6ff97b6-8497-46d4-a6d7-2563f604d100","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d6ff97b6-8497-46d4-a6d7-2563f604d100"},"toegewezenAanActor":{"uuid":"a205b177-7679-437d-8312-97a401a685a6","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6"},"toegewezenAanActoren":[{"uuid":"a205b177-7679-437d-8312-97a401a685a6","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a205b177-7679-437d-8312-97a401a685a6"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:42:05.116419Z","afgehandeldOp":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '952'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=86635938-697b-4553-a8c1-311e65193dde
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"5dadb020-8701-429a-a64b-59df30daf314","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/5dadb020-8701-429a-a64b-59df30daf314","verstrektDoorBetrokkene":{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}},{"uuid":"32712f5b-e650-4c31-9697-da2f1e700a3f","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/32712f5b-e650-4c31-9697-da2f1e700a3f","verstrektDoorBetrokkene":{"uuid":"86635938-697b-4553-a8c1-311e65193dde","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/86635938-697b-4553-a8c1-311e65193dde"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1117'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"f08b7264-642b-4508-96ed-d0c929254589","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f08b7264-642b-4508-96ed-d0c929254589","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/f08b7264-642b-4508-96ed-d0c929254589
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"d20b172e-e7c3-44f4-827a-60324668a743","url":"http://localhost:8338/klantinteracties/api/v1/partijen/d20b172e-e7c3-44f4-827a-60324668a743","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/d20b172e-e7c3-44f4-827a-60324668a743
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"c810b31d-60bd-43f4-a9d2-743f924fdb01","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c810b31d-60bd-43f4-a9d2-743f924fdb01","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c810b31d-60bd-43f4-a9d2-743f924fdb01
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"1a0b19b2-536b-4735-88fe-f36bd59bbea4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question from an anonymous user", "onderwerp": "Anonymous
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '205'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"A question from an anonymous
+          user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '517'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam":
+        "Hieronymous", "achternaam": "Anonymous"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '238'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8","wasPartij":null,"hadKlantcontact":{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+          Anonymous","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '963'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=40fe6542-7a50-4953-afbe-42656e4a27e8
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "hieronymous.anonymous@example.com", "soortDigitaalAdres":
+        "email", "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "40fe6542-7a50-4953-afbe-42656e4a27e8"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '241'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"d3a69450-2505-4c35-9be9-6cc609398ce6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/d3a69450-2505-4c35-9be9-6cc609398ce6","verstrektDoorBetrokkene":{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '526'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/d3a69450-2505-4c35-9be9-6cc609398ce6
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=40fe6542-7a50-4953-afbe-42656e4a27e8
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d3a69450-2505-4c35-9be9-6cc609398ce6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/d3a69450-2505-4c35-9be9-6cc609398ce6","verstrektDoorBetrokkene":{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '591'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "40fe6542-7a50-4953-afbe-42656e4a27e8"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '227'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"96a455f0-57ce-4656-8384-1a7ead4b5d0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/96a455f0-57ce-4656-8384-1a7ead4b5d0d","verstrektDoorBetrokkene":{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/96a455f0-57ce-4656-8384-1a7ead4b5d0d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "1a0b19b2-536b-4735-88fe-f36bd59bbea4"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"},"toegewezenAanActor":{"uuid":"1a0b19b2-536b-4735-88fe-f36bd59bbea4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4"},"toegewezenAanActoren":[{"uuid":"1a0b19b2-536b-4735-88fe-f36bd59bbea4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:48:00.088155Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"}],"leiddeTotInterneTaken":[{"uuid":"b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"A question from an anonymous
+          user","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '883'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8","wasPartij":null,"hadKlantcontact":{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"},"digitaleAdressen":[{"uuid":"d3a69450-2505-4c35-9be9-6cc609398ce6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/d3a69450-2505-4c35-9be9-6cc609398ce6"},{"uuid":"96a455f0-57ce-4656-8384-1a7ead4b5d0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/96a455f0-57ce-4656-8384-1a7ead4b5d0d"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Hieronymous","voorvoegselAchternaam":"","achternaam":"Anonymous"},"volledigeNaam":"Hieronymous
+          Anonymous","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1339'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b67f8bc2-e82e-4fdb-9fc6-10f0df0b7580","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"99875a25-6e77-4cf4-8bb4-e3026cc2d7f8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/99875a25-6e77-4cf4-8bb4-e3026cc2d7f8"},"toegewezenAanActor":{"uuid":"1a0b19b2-536b-4735-88fe-f36bd59bbea4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4"},"toegewezenAanActoren":[{"uuid":"1a0b19b2-536b-4735-88fe-f36bd59bbea4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1a0b19b2-536b-4735-88fe-f36bd59bbea4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:48:00.088155Z","afgehandeldOp":null}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '952'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=40fe6542-7a50-4953-afbe-42656e4a27e8
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"96a455f0-57ce-4656-8384-1a7ead4b5d0d","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/96a455f0-57ce-4656-8384-1a7ead4b5d0d","verstrektDoorBetrokkene":{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}},{"uuid":"d3a69450-2505-4c35-9be9-6cc609398ce6","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/d3a69450-2505-4c35-9be9-6cc609398ce6","verstrektDoorBetrokkene":{"uuid":"40fe6542-7a50-4953-afbe-42656e4a27e8","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/40fe6542-7a50-4953-afbe-42656e4a27e8"},"verstrektDoorPartij":null,"adres":"hieronymous.anonymous@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1117'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_partial_contact_info.yaml
@@ -1,0 +1,1048 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"0f5a6f14-646d-4357-9995-f813ec232823","url":"http://localhost:8338/klantinteracties/api/v1/actoren/0f5a6f14-646d-4357-9995-f813ec232823","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/0f5a6f14-646d-4357-9995-f813ec232823
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"48a55034-ccc7-4409-8cc9-d14d3fc45f81","url":"http://localhost:8338/klantinteracties/api/v1/partijen/48a55034-ccc7-4409-8cc9-d14d3fc45f81","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/48a55034-ccc7-4409-8cc9-d14d3fc45f81
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"578c5d49-cd17-4b6a-a4d3-3f377056e89b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/578c5d49-cd17-4b6a-a4d3-3f377056e89b","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/578c5d49-cd17-4b6a-a4d3-3f377056e89b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"bee81382-9cdd-4140-a560-b1377fd040ac","url":"http://localhost:8338/klantinteracties/api/v1/actoren/bee81382-9cdd-4140-a560-b1377fd040ac","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/bee81382-9cdd-4140-a560-b1377fd040ac
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question with only email", "onderwerp": "Email only
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '199'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"a010578c-cb1f-4ec3-93e1-06db4ecb85c5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a010578c-cb1f-4ec3-93e1-06db4ecb85c5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
+          only inquiry","inhoud":"A question with only
+          email","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '511'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/a010578c-cb1f-4ec3-93e1-06db4ecb85c5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "a010578c-cb1f-4ec3-93e1-06db4ecb85c5"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam": "Bob",
+        "achternaam": "EmailOnly"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '230'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"d839fb39-db56-410f-8f67-977f3b3f1e37","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d839fb39-db56-410f-8f67-977f3b3f1e37","wasPartij":null,"hadKlantcontact":{"uuid":"a010578c-cb1f-4ec3-93e1-06db4ecb85c5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a010578c-cb1f-4ec3-93e1-06db4ecb85c5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+          EmailOnly","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '947'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/d839fb39-db56-410f-8f67-977f3b3f1e37
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=d839fb39-db56-410f-8f67-977f3b3f1e37
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "bob.email@example.com", "soortDigitaalAdres": "email",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "d839fb39-db56-410f-8f67-977f3b3f1e37"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '229'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"b1e00179-3e29-4bc1-8c5e-93bba1133841","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b1e00179-3e29-4bc1-8c5e-93bba1133841","verstrektDoorBetrokkene":{"uuid":"d839fb39-db56-410f-8f67-977f3b3f1e37","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d839fb39-db56-410f-8f67-977f3b3f1e37"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '514'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b1e00179-3e29-4bc1-8c5e-93bba1133841
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "a010578c-cb1f-4ec3-93e1-06db4ecb85c5"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "bee81382-9cdd-4140-a560-b1377fd040ac"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"c87c84ac-e800-484f-aa1a-5a9bf3ce5702","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c87c84ac-e800-484f-aa1a-5a9bf3ce5702","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"a010578c-cb1f-4ec3-93e1-06db4ecb85c5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a010578c-cb1f-4ec3-93e1-06db4ecb85c5"},"toegewezenAanActor":{"uuid":"bee81382-9cdd-4140-a560-b1377fd040ac","url":"http://localhost:8338/klantinteracties/api/v1/actoren/bee81382-9cdd-4140-a560-b1377fd040ac"},"toegewezenAanActoren":[{"uuid":"bee81382-9cdd-4140-a560-b1377fd040ac","url":"http://localhost:8338/klantinteracties/api/v1/actoren/bee81382-9cdd-4140-a560-b1377fd040ac"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:42:22.927557Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/c87c84ac-e800-484f-aa1a-5a9bf3ce5702
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"d839fb39-db56-410f-8f67-977f3b3f1e37","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d839fb39-db56-410f-8f67-977f3b3f1e37","wasPartij":null,"hadKlantcontact":{"uuid":"a010578c-cb1f-4ec3-93e1-06db4ecb85c5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/a010578c-cb1f-4ec3-93e1-06db4ecb85c5"},"digitaleAdressen":[{"uuid":"b1e00179-3e29-4bc1-8c5e-93bba1133841","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b1e00179-3e29-4bc1-8c5e-93bba1133841"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+          EmailOnly","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1167'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=d839fb39-db56-410f-8f67-977f3b3f1e37
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"b1e00179-3e29-4bc1-8c5e-93bba1133841","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/b1e00179-3e29-4bc1-8c5e-93bba1133841","verstrektDoorBetrokkene":{"uuid":"d839fb39-db56-410f-8f67-977f3b3f1e37","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d839fb39-db56-410f-8f67-977f3b3f1e37"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '579'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"ac3b2d40-55bf-40f5-b786-c16f55f7d959","url":"http://localhost:8338/klantinteracties/api/v1/actoren/ac3b2d40-55bf-40f5-b786-c16f55f7d959","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/ac3b2d40-55bf-40f5-b786-c16f55f7d959
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"78309f50-aeda-45ea-957b-b6250430f82b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/78309f50-aeda-45ea-957b-b6250430f82b","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/78309f50-aeda-45ea-957b-b6250430f82b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"6ca22a19-fe80-4b9c-a002-f006ec8909f4","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6ca22a19-fe80-4b9c-a002-f006ec8909f4","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/6ca22a19-fe80-4b9c-a002-f006ec8909f4
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"35866fde-c870-4ed4-ad89-2675e5ea40f0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/35866fde-c870-4ed4-ad89-2675e5ea40f0","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/35866fde-c870-4ed4-ad89-2675e5ea40f0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question with only email", "onderwerp": "Email only
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '199'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"3561a687-33d6-4dca-856a-1b40fa5b29dd","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3561a687-33d6-4dca-856a-1b40fa5b29dd","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Email
+          only inquiry","inhoud":"A question with only
+          email","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '511'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3561a687-33d6-4dca-856a-1b40fa5b29dd
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "3561a687-33d6-4dca-856a-1b40fa5b29dd"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam": "Bob",
+        "achternaam": "EmailOnly"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '230'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","wasPartij":null,"hadKlantcontact":{"uuid":"3561a687-33d6-4dca-856a-1b40fa5b29dd","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3561a687-33d6-4dca-856a-1b40fa5b29dd"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+          EmailOnly","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '947'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/6b1b7d6e-4197-4952-9e9e-fdce767d7c1e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=6b1b7d6e-4197-4952-9e9e-fdce767d7c1e
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "bob.email@example.com", "soortDigitaalAdres": "email",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "6b1b7d6e-4197-4952-9e9e-fdce767d7c1e"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '229'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"90145b10-965f-4758-a552-1c091f01250e","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/90145b10-965f-4758-a552-1c091f01250e","verstrektDoorBetrokkene":{"uuid":"6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6b1b7d6e-4197-4952-9e9e-fdce767d7c1e"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '514'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/90145b10-965f-4758-a552-1c091f01250e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "3561a687-33d6-4dca-856a-1b40fa5b29dd"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "35866fde-c870-4ed4-ad89-2675e5ea40f0"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"a3382e2a-6240-4c1b-9898-58bad5581e10","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a3382e2a-6240-4c1b-9898-58bad5581e10","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"3561a687-33d6-4dca-856a-1b40fa5b29dd","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3561a687-33d6-4dca-856a-1b40fa5b29dd"},"toegewezenAanActor":{"uuid":"35866fde-c870-4ed4-ad89-2675e5ea40f0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/35866fde-c870-4ed4-ad89-2675e5ea40f0"},"toegewezenAanActoren":[{"uuid":"35866fde-c870-4ed4-ad89-2675e5ea40f0","url":"http://localhost:8338/klantinteracties/api/v1/actoren/35866fde-c870-4ed4-ad89-2675e5ea40f0"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:48:17.838356Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/a3382e2a-6240-4c1b-9898-58bad5581e10
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","wasPartij":null,"hadKlantcontact":{"uuid":"3561a687-33d6-4dca-856a-1b40fa5b29dd","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3561a687-33d6-4dca-856a-1b40fa5b29dd"},"digitaleAdressen":[{"uuid":"90145b10-965f-4758-a552-1c091f01250e","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/90145b10-965f-4758-a552-1c091f01250e"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"EmailOnly"},"volledigeNaam":"Bob
+          EmailOnly","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1167'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=6b1b7d6e-4197-4952-9e9e-fdce767d7c1e
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"90145b10-965f-4758-a552-1c091f01250e","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/90145b10-965f-4758-a552-1c091f01250e","verstrektDoorBetrokkene":{"uuid":"6b1b7d6e-4197-4952-9e9e-fdce767d7c1e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/6b1b7d6e-4197-4952-9e9e-fdce767d7c1e"},"verstrektDoorPartij":null,"adres":"bob.email@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '579'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_raises_on_missing_question.yaml
@@ -1,0 +1,402 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"72f52253-70f1-4969-b5ac-7fd3d0c81184","url":"http://localhost:8338/klantinteracties/api/v1/actoren/72f52253-70f1-4969-b5ac-7fd3d0c81184","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/72f52253-70f1-4969-b5ac-7fd3d0c81184
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"c9d0df4c-f51d-46a4-a1d3-a57c53c9276f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c9d0df4c-f51d-46a4-a1d3-a57c53c9276f","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c9d0df4c-f51d-46a4-a1d3-a57c53c9276f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"719832ff-55dc-4f51-84f2-d2084b3b1170","url":"http://localhost:8338/klantinteracties/api/v1/partijen/719832ff-55dc-4f51-84f2-d2084b3b1170","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/719832ff-55dc-4f51-84f2-d2084b3b1170
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"82b92241-ec9a-45e8-8982-183dda273772","url":"http://localhost:8338/klantinteracties/api/v1/actoren/82b92241-ec9a-45e8-8982-183dda273772","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/82b92241-ec9a-45e8-8982-183dda273772
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"d5034db4-a46e-46eb-be6f-000077ab4318","url":"http://localhost:8338/klantinteracties/api/v1/actoren/d5034db4-a46e-46eb-be6f-000077ab4318","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/d5034db4-a46e-46eb-be6f-000077ab4318
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"a0720d4a-8d49-4ba8-9de1-1eaccc521b89","url":"http://localhost:8338/klantinteracties/api/v1/partijen/a0720d4a-8d49-4ba8-9de1-1eaccc521b89","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/a0720d4a-8d49-4ba8-9de1-1eaccc521b89
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"376154fa-b19c-4a90-8ca7-fb87653581f2","url":"http://localhost:8338/klantinteracties/api/v1/partijen/376154fa-b19c-4a90-8ca7-fb87653581f2","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/376154fa-b19c-4a90-8ca7-fb87653581f2
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"6e20ee04-5461-4822-923c-94245407224e","url":"http://localhost:8338/klantinteracties/api/v1/actoren/6e20ee04-5461-4822-923c-94245407224e","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/6e20ee04-5461-4822-923c-94245407224e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_create_question_with_betrokkene_without_contact_info.yaml
@@ -1,0 +1,868 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"9c346e6e-78a1-475b-a6fc-43f29292b774","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9c346e6e-78a1-475b-a6fc-43f29292b774","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/9c346e6e-78a1-475b-a6fc-43f29292b774
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"90a48a22-af86-47ff-b050-aeb1e9637b4d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/90a48a22-af86-47ff-b050-aeb1e9637b4d","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/90a48a22-af86-47ff-b050-aeb1e9637b4d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"35b06302-08be-49b0-a7e1-642ce486b6e8","url":"http://localhost:8338/klantinteracties/api/v1/partijen/35b06302-08be-49b0-a7e1-642ce486b6e8","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/35b06302-08be-49b0-a7e1-642ce486b6e8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"602716b3-f9aa-4526-8c05-9ed0cba8c0c8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/602716b3-f9aa-4526-8c05-9ed0cba8c0c8","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/602716b3-f9aa-4526-8c05-9ed0cba8c0c8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question without contact details", "onderwerp": "Minimal
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '204'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"fcd09846-50da-4e17-9920-86edabc913e5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fcd09846-50da-4e17-9920-86edabc913e5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
+          inquiry","inhoud":"A question without contact
+          details","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '516'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/fcd09846-50da-4e17-9920-86edabc913e5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "fcd09846-50da-4e17-9920-86edabc913e5"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam":
+        "Jane", "achternaam": "Minimal"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '229'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"816fc10a-0f6d-42ec-bca9-319cffbe4fdf","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/816fc10a-0f6d-42ec-bca9-319cffbe4fdf","wasPartij":null,"hadKlantcontact":{"uuid":"fcd09846-50da-4e17-9920-86edabc913e5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fcd09846-50da-4e17-9920-86edabc913e5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+          Minimal","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '945'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/816fc10a-0f6d-42ec-bca9-319cffbe4fdf
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "fcd09846-50da-4e17-9920-86edabc913e5"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "602716b3-f9aa-4526-8c05-9ed0cba8c0c8"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"486fbceb-3783-4367-92c9-e80c7bac4d6a","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/486fbceb-3783-4367-92c9-e80c7bac4d6a","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"fcd09846-50da-4e17-9920-86edabc913e5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fcd09846-50da-4e17-9920-86edabc913e5"},"toegewezenAanActor":{"uuid":"602716b3-f9aa-4526-8c05-9ed0cba8c0c8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/602716b3-f9aa-4526-8c05-9ed0cba8c0c8"},"toegewezenAanActoren":[{"uuid":"602716b3-f9aa-4526-8c05-9ed0cba8c0c8","url":"http://localhost:8338/klantinteracties/api/v1/actoren/602716b3-f9aa-4526-8c05-9ed0cba8c0c8"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:42:58.379501Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/486fbceb-3783-4367-92c9-e80c7bac4d6a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"816fc10a-0f6d-42ec-bca9-319cffbe4fdf","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/816fc10a-0f6d-42ec-bca9-319cffbe4fdf","wasPartij":null,"hadKlantcontact":{"uuid":"fcd09846-50da-4e17-9920-86edabc913e5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/fcd09846-50da-4e17-9920-86edabc913e5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+          Minimal","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1010'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=816fc10a-0f6d-42ec-bca9-319cffbe4fdf
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"771b0dc3-c02b-40c7-9fe6-0f0a2f589070","url":"http://localhost:8338/klantinteracties/api/v1/actoren/771b0dc3-c02b-40c7-9fe6-0f0a2f589070","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/771b0dc3-c02b-40c7-9fe6-0f0a2f589070
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"def3703a-5053-43e3-904d-6ef5babdaf8c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/def3703a-5053-43e3-904d-6ef5babdaf8c","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/def3703a-5053-43e3-904d-6ef5babdaf8c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"c8b544d5-db95-4a28-9214-9169c24b2295","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c8b544d5-db95-4a28-9214-9169c24b2295","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c8b544d5-db95-4a28-9214-9169c24b2295
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"64a61407-f4ac-4588-bed0-45f004b85619","url":"http://localhost:8338/klantinteracties/api/v1/actoren/64a61407-f4ac-4588-bed0-45f004b85619","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/64a61407-f4ac-4588-bed0-45f004b85619
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question without contact details", "onderwerp": "Minimal
+        inquiry", "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk":
+        false, "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '204'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"ae012af9-9e00-43ad-a99b-cf6cee7f45b1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ae012af9-9e00-43ad-a99b-cf6cee7f45b1","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Minimal
+          inquiry","inhoud":"A question without contact
+          details","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '516'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ae012af9-9e00-43ad-a99b-cf6cee7f45b1
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "ae012af9-9e00-43ad-a99b-cf6cee7f45b1"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam":
+        "Jane", "achternaam": "Minimal"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '229'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"da020f09-91d1-4c6d-ba60-4cebe3c37304","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/da020f09-91d1-4c6d-ba60-4cebe3c37304","wasPartij":null,"hadKlantcontact":{"uuid":"ae012af9-9e00-43ad-a99b-cf6cee7f45b1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ae012af9-9e00-43ad-a99b-cf6cee7f45b1"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+          Minimal","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '945'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/da020f09-91d1-4c6d-ba60-4cebe3c37304
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "ae012af9-9e00-43ad-a99b-cf6cee7f45b1"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "64a61407-f4ac-4588-bed0-45f004b85619"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"8170e991-0b4e-41bc-88ab-411472fe2c05","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/8170e991-0b4e-41bc-88ab-411472fe2c05","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"ae012af9-9e00-43ad-a99b-cf6cee7f45b1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ae012af9-9e00-43ad-a99b-cf6cee7f45b1"},"toegewezenAanActor":{"uuid":"64a61407-f4ac-4588-bed0-45f004b85619","url":"http://localhost:8338/klantinteracties/api/v1/actoren/64a61407-f4ac-4588-bed0-45f004b85619"},"toegewezenAanActoren":[{"uuid":"64a61407-f4ac-4588-bed0-45f004b85619","url":"http://localhost:8338/klantinteracties/api/v1/actoren/64a61407-f4ac-4588-bed0-45f004b85619"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:48:52.886477Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/8170e991-0b4e-41bc-88ab-411472fe2c05
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"da020f09-91d1-4c6d-ba60-4cebe3c37304","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/da020f09-91d1-4c6d-ba60-4cebe3c37304","wasPartij":null,"hadKlantcontact":{"uuid":"ae012af9-9e00-43ad-a99b-cf6cee7f45b1","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ae012af9-9e00-43ad-a99b-cf6cee7f45b1"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Jane","voorvoegselAchternaam":"","achternaam":"Minimal"},"volledigeNaam":"Jane
+          Minimal","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1010'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=da020f09-91d1-4c6d-ba60-4cebe3c37304
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_designated_actor_is_required_to_create_question.yaml
@@ -1,0 +1,402 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"e0447d80-21b5-46c8-9d22-1c9c20658012","url":"http://localhost:8338/klantinteracties/api/v1/actoren/e0447d80-21b5-46c8-9d22-1c9c20658012","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/e0447d80-21b5-46c8-9d22-1c9c20658012
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"0b92a85a-e6a2-42b5-8805-fe11bc039b38","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0b92a85a-e6a2-42b5-8805-fe11bc039b38","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/0b92a85a-e6a2-42b5-8805-fe11bc039b38
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"54cf9d32-a937-4e68-b899-97da7f1851fb","url":"http://localhost:8338/klantinteracties/api/v1/partijen/54cf9d32-a937-4e68-b899-97da7f1851fb","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/54cf9d32-a937-4e68-b899-97da7f1851fb
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"f6e566ce-a23a-415d-ae46-c64adf7d3ec7","url":"http://localhost:8338/klantinteracties/api/v1/actoren/f6e566ce-a23a-415d-ae46-c64adf7d3ec7","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/f6e566ce-a23a-415d-ae46-c64adf7d3ec7
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"94266bbc-aca2-43f0-b69f-1429a4c0db1a","url":"http://localhost:8338/klantinteracties/api/v1/actoren/94266bbc-aca2-43f0-b69f-1429a4c0db1a","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/94266bbc-aca2-43f0-b69f-1429a4c0db1a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"c84bf071-5345-4497-b939-c53d49c27612","url":"http://localhost:8338/klantinteracties/api/v1/partijen/c84bf071-5345-4497-b939-c53d49c27612","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/c84bf071-5345-4497-b939-c53d49c27612
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"55cc2149-67bc-487d-b26c-af0efbc35d9d","url":"http://localhost:8338/klantinteracties/api/v1/partijen/55cc2149-67bc-487d-b26c-af0efbc35d9d","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/55cc2149-67bc-487d-b26c-af0efbc35d9d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"05b434be-434a-4046-a76e-58c961c70e12","url":"http://localhost:8338/klantinteracties/api/v1/actoren/05b434be-434a-4046-a76e-58c961c70e12","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/05b434be-434a-4046-a76e-58c961c70e12
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_get_questions.yaml
@@ -1,0 +1,2632 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"1b2bdae5-8486-4f07-87a4-2474681fe949","url":"http://localhost:8338/klantinteracties/api/v1/actoren/1b2bdae5-8486-4f07-87a4-2474681fe949","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/1b2bdae5-8486-4f07-87a4-2474681fe949
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 73cfef09-edfa-4274-99ce-4709bddb8d4b,
+        part 0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          73cfef09-edfa-4274-99ce-4709bddb8d4b, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "73cfef09-edfa-4274-99ce-4709bddb8d4b"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"51104a2b-4ebb-49ab-a041-da93cc388f29","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "c978f943-497e-4255-b39f-8840ea11457c"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"b8cbada8-5203-4e72-9d9e-7a0de13f3efe","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b8cbada8-5203-4e72-9d9e-7a0de13f3efe","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:34.937252Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/b8cbada8-5203-4e72-9d9e-7a0de13f3efe
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 73cfef09-edfa-4274-99ce-4709bddb8d4b,
+        part 1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          73cfef09-edfa-4274-99ce-4709bddb8d4b, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "73cfef09-edfa-4274-99ce-4709bddb8d4b"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "ff9d874f-bb12-43c5-b1ea-e9806445fce0"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"aef9983d-af04-4268-8526-38d0fd2e81a5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/aef9983d-af04-4268-8526-38d0fd2e81a5","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/aef9983d-af04-4268-8526-38d0fd2e81a5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "ff9d874f-bb12-43c5-b1ea-e9806445fce0"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "c978f943-497e-4255-b39f-8840ea11457c"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"758c2a66-cdad-42f9-ad58-0c5b5a655c1c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/758c2a66-cdad-42f9-ad58-0c5b5a655c1c","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:34.980110Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/758c2a66-cdad-42f9-ad58-0c5b5a655c1c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5
+    response:
+      body:
+        string:
+          '{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"51104a2b-4ebb-49ab-a041-da93cc388f29","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29"}],"leiddeTotInterneTaken":[{"uuid":"b8cbada8-5203-4e72-9d9e-7a0de13f3efe","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b8cbada8-5203-4e72-9d9e-7a0de13f3efe"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          73cfef09-edfa-4274-99ce-4709bddb8d4b, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '846'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"inhoud": "The answer is 42", "onderwerp": "Life and stuff", "taal":
+        "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '185'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '497'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"rol": "klant", "hadKlantcontact": {"uuid":
+        "3a66fc19-172d-459d-84de-5e92e9d9a877"}, "initiator": true, "wasPartij":
+        {"uuid": "73cfef09-edfa-4274-99ce-4709bddb8d4b"}, "organisatienaam":
+        "Open Inwoner Platform"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '211'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"466767d3-0958-4028-ae5d-7b113c839a1d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/466767d3-0958-4028-ae5d-7b113c839a1d","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/466767d3-0958-4028-ae5d-7b113c839a1d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "3a66fc19-172d-459d-84de-5e92e9d9a877"},
+        "wasKlantcontact": {"uuid": "844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '135'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"db991daa-b002-4501-a705-7423d87efbb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3","klantcontact":{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877"},"wasKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 6db87f63-6586-494d-9491-5e67cc5c1679,
+        part 0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          6db87f63-6586-494d-9491-5e67cc5c1679, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "6db87f63-6586-494d-9491-5e67cc5c1679"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "d835be57-d185-4e38-9f51-083d011e1a6b"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"d0c2b921-dabb-4b7b-9550-fda949b1964a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "d835be57-d185-4e38-9f51-083d011e1a6b"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "c978f943-497e-4255-b39f-8840ea11457c"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"b504a8b7-1319-4f20-bdf7-4f6651d943e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b504a8b7-1319-4f20-bdf7-4f6651d943e9","nummer":"0000000003","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:35.059532Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/b504a8b7-1319-4f20-bdf7-4f6651d943e9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 6db87f63-6586-494d-9491-5e67cc5c1679,
+        part 1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          6db87f63-6586-494d-9491-5e67cc5c1679, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "6db87f63-6586-494d-9491-5e67cc5c1679"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "8fdb5430-90af-471b-8b83-22c0ab5fd42c"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"3ce1ce4d-f398-407c-8412-70be1f456679","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3ce1ce4d-f398-407c-8412-70be1f456679","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/3ce1ce4d-f398-407c-8412-70be1f456679
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "8fdb5430-90af-471b-8b83-22c0ab5fd42c"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "c978f943-497e-4255-b39f-8840ea11457c"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"7ff3d108-3757-43a2-badd-250821db50ac","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7ff3d108-3757-43a2-badd-250821db50ac","nummer":"0000000004","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:35.101158Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/7ff3d108-3757-43a2-badd-250821db50ac
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b
+    response:
+      body:
+        string:
+          '{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"d0c2b921-dabb-4b7b-9550-fda949b1964a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a"}],"leiddeTotInterneTaken":[{"uuid":"b504a8b7-1319-4f20-bdf7-4f6651d943e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b504a8b7-1319-4f20-bdf7-4f6651d943e9"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          6db87f63-6586-494d-9491-5e67cc5c1679, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '846'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"inhoud": "The answer is 42", "onderwerp": "Life and stuff", "taal":
+        "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '185'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '497'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"rol": "klant", "hadKlantcontact": {"uuid":
+        "d199986a-5f16-4491-bbc3-cf66681afdf8"}, "initiator": true, "wasPartij":
+        {"uuid": "6db87f63-6586-494d-9491-5e67cc5c1679"}, "organisatienaam":
+        "Open Inwoner Platform"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '211'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"a079b2ea-3c49-4ebf-8d25-124e2c24f94f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a079b2ea-3c49-4ebf-8d25-124e2c24f94f","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a079b2ea-3c49-4ebf-8d25-124e2c24f94f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "d199986a-5f16-4491-bbc3-cf66681afdf8"},
+        "wasKlantcontact": {"uuid": "d835be57-d185-4e38-9f51-083d011e1a6b"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '135'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"1f4c6658-a70a-47c4-9d6e-21b1ef31e06f","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/1f4c6658-a70a-47c4-9d6e-21b1ef31e06f","klantcontact":{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8"},"wasKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/1f4c6658-a70a-47c4-9d6e-21b1ef31e06f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
+    response:
+      body:
+        string:
+          '{"count":6,"next":null,"previous":null,"results":[{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8","gingOverOnderwerpobjecten":[{"uuid":"1f4c6658-a70a-47c4-9d6e-21b1ef31e06f","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/1f4c6658-a70a-47c4-9d6e-21b1ef31e06f"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a079b2ea-3c49-4ebf-8d25-124e2c24f94f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a079b2ea-3c49-4ebf-8d25-124e2c24f94f"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"1f4c6658-a70a-47c4-9d6e-21b1ef31e06f","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/1f4c6658-a70a-47c4-9d6e-21b1ef31e06f","klantcontact":{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8"},"wasKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"a079b2ea-3c49-4ebf-8d25-124e2c24f94f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a079b2ea-3c49-4ebf-8d25-124e2c24f94f","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"d199986a-5f16-4491-bbc3-cf66681afdf8","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d199986a-5f16-4491-bbc3-cf66681afdf8"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"d0c2b921-dabb-4b7b-9550-fda949b1964a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a"},{"uuid":"3ce1ce4d-f398-407c-8412-70be1f456679","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3ce1ce4d-f398-407c-8412-70be1f456679"},{"uuid":"a079b2ea-3c49-4ebf-8d25-124e2c24f94f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a079b2ea-3c49-4ebf-8d25-124e2c24f94f"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"3ce1ce4d-f398-407c-8412-70be1f456679","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3ce1ce4d-f398-407c-8412-70be1f456679"}],"leiddeTotInterneTaken":[{"uuid":"7ff3d108-3757-43a2-badd-250821db50ac","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7ff3d108-3757-43a2-badd-250821db50ac"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          6db87f63-6586-494d-9491-5e67cc5c1679, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"3ce1ce4d-f398-407c-8412-70be1f456679","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3ce1ce4d-f398-407c-8412-70be1f456679","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"7ff3d108-3757-43a2-badd-250821db50ac","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/7ff3d108-3757-43a2-badd-250821db50ac","nummer":"0000000004","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"8fdb5430-90af-471b-8b83-22c0ab5fd42c","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/8fdb5430-90af-471b-8b83-22c0ab5fd42c"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:35.101158Z","afgehandeldOp":null}]}},{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"d0c2b921-dabb-4b7b-9550-fda949b1964a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a"}],"leiddeTotInterneTaken":[{"uuid":"b504a8b7-1319-4f20-bdf7-4f6651d943e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b504a8b7-1319-4f20-bdf7-4f6651d943e9"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          6db87f63-6586-494d-9491-5e67cc5c1679, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"d0c2b921-dabb-4b7b-9550-fda949b1964a","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/d0c2b921-dabb-4b7b-9550-fda949b1964a","wasPartij":{"uuid":"6db87f63-6586-494d-9491-5e67cc5c1679","url":"http://localhost:8338/klantinteracties/api/v1/partijen/6db87f63-6586-494d-9491-5e67cc5c1679"},"hadKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"b504a8b7-1319-4f20-bdf7-4f6651d943e9","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b504a8b7-1319-4f20-bdf7-4f6651d943e9","nummer":"0000000003","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"d835be57-d185-4e38-9f51-083d011e1a6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/d835be57-d185-4e38-9f51-083d011e1a6b"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:35.059532Z","afgehandeldOp":null}]}},{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877","gingOverOnderwerpobjecten":[{"uuid":"db991daa-b002-4501-a705-7423d87efbb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"466767d3-0958-4028-ae5d-7b113c839a1d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/466767d3-0958-4028-ae5d-7b113c839a1d"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"db991daa-b002-4501-a705-7423d87efbb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3","klantcontact":{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877"},"wasKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"466767d3-0958-4028-ae5d-7b113c839a1d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/466767d3-0958-4028-ae5d-7b113c839a1d","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"51104a2b-4ebb-49ab-a041-da93cc388f29","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29"},{"uuid":"aef9983d-af04-4268-8526-38d0fd2e81a5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/aef9983d-af04-4268-8526-38d0fd2e81a5"},{"uuid":"466767d3-0958-4028-ae5d-7b113c839a1d","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/466767d3-0958-4028-ae5d-7b113c839a1d"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"aef9983d-af04-4268-8526-38d0fd2e81a5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/aef9983d-af04-4268-8526-38d0fd2e81a5"}],"leiddeTotInterneTaken":[{"uuid":"758c2a66-cdad-42f9-ad58-0c5b5a655c1c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/758c2a66-cdad-42f9-ad58-0c5b5a655c1c"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          73cfef09-edfa-4274-99ce-4709bddb8d4b, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"aef9983d-af04-4268-8526-38d0fd2e81a5","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/aef9983d-af04-4268-8526-38d0fd2e81a5","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"758c2a66-cdad-42f9-ad58-0c5b5a655c1c","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/758c2a66-cdad-42f9-ad58-0c5b5a655c1c","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"ff9d874f-bb12-43c5-b1ea-e9806445fce0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/ff9d874f-bb12-43c5-b1ea-e9806445fce0"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:34.980110Z","afgehandeldOp":null}]}},{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"51104a2b-4ebb-49ab-a041-da93cc388f29","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29"}],"leiddeTotInterneTaken":[{"uuid":"b8cbada8-5203-4e72-9d9e-7a0de13f3efe","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b8cbada8-5203-4e72-9d9e-7a0de13f3efe"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          73cfef09-edfa-4274-99ce-4709bddb8d4b, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"51104a2b-4ebb-49ab-a041-da93cc388f29","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/51104a2b-4ebb-49ab-a041-da93cc388f29","wasPartij":{"uuid":"73cfef09-edfa-4274-99ce-4709bddb8d4b","url":"http://localhost:8338/klantinteracties/api/v1/partijen/73cfef09-edfa-4274-99ce-4709bddb8d4b"},"hadKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"b8cbada8-5203-4e72-9d9e-7a0de13f3efe","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/b8cbada8-5203-4e72-9d9e-7a0de13f3efe","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"toegewezenAanActor":{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"},"toegewezenAanActoren":[{"uuid":"c978f943-497e-4255-b39f-8840ea11457c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/c978f943-497e-4255-b39f-8840ea11457c"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:34.937252Z","afgehandeldOp":null}]}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '19891'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3
+    response:
+      body:
+        string: '{"uuid":"db991daa-b002-4501-a705-7423d87efbb3","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/db991daa-b002-4501-a705-7423d87efbb3","klantcontact":{"uuid":"3a66fc19-172d-459d-84de-5e92e9d9a877","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a66fc19-172d-459d-84de-5e92e9d9a877"},"wasKlantcontact":{"uuid":"844ba7a6-8d4c-49e1-a173-f5d1d606ffd5","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/844ba7a6-8d4c-49e1-a173-f5d1d606ffd5"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"466fdd1f-09b5-498c-96e5-0a3eaf6762da","url":"http://localhost:8338/klantinteracties/api/v1/actoren/466fdd1f-09b5-498c-96e5-0a3eaf6762da","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/466fdd1f-09b5-498c-96e5-0a3eaf6762da
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by fae5fa2e-63e8-4b6d-af21-4acd55480085,
+        part 0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          fae5fa2e-63e8-4b6d-af21-4acd55480085, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "fae5fa2e-63e8-4b6d-af21-4acd55480085"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"0eff5472-6562-4d98-b1a7-89796d568fbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"5624d26b-0429-4aa8-8d7a-df18d23b0121","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5624d26b-0429-4aa8-8d7a-df18d23b0121","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.184073Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/5624d26b-0429-4aa8-8d7a-df18d23b0121
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by fae5fa2e-63e8-4b6d-af21-4acd55480085,
+        part 1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          fae5fa2e-63e8-4b6d-af21-4acd55480085, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "fae5fa2e-63e8-4b6d-af21-4acd55480085"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "57c497b7-0454-4aca-aa97-66736deaf332"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"5562e482-7417-48b3-a289-f718ce84f57f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5562e482-7417-48b3-a289-f718ce84f57f","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/5562e482-7417-48b3-a289-f718ce84f57f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "57c497b7-0454-4aca-aa97-66736deaf332"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"2a1d462f-0919-4f3a-adb7-2f455df00e32","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2a1d462f-0919-4f3a-adb7-2f455df00e32","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.228189Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/2a1d462f-0919-4f3a-adb7-2f455df00e32
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b
+    response:
+      body:
+        string:
+          '{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"0eff5472-6562-4d98-b1a7-89796d568fbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe"}],"leiddeTotInterneTaken":[{"uuid":"5624d26b-0429-4aa8-8d7a-df18d23b0121","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5624d26b-0429-4aa8-8d7a-df18d23b0121"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          fae5fa2e-63e8-4b6d-af21-4acd55480085, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '846'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"inhoud": "The answer is 42", "onderwerp": "Life and stuff", "taal":
+        "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '185'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '497'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"rol": "klant", "hadKlantcontact": {"uuid":
+        "2d3b01d4-d404-43fc-a687-8ebdf2b23192"}, "initiator": true, "wasPartij":
+        {"uuid": "fae5fa2e-63e8-4b6d-af21-4acd55480085"}, "organisatienaam":
+        "Open Inwoner Platform"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '211'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"8f7aa0af-30f2-491a-94ee-9954695c909c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8f7aa0af-30f2-491a-94ee-9954695c909c","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/8f7aa0af-30f2-491a-94ee-9954695c909c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "2d3b01d4-d404-43fc-a687-8ebdf2b23192"},
+        "wasKlantcontact": {"uuid": "3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '135'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"7e3c3662-0696-4e0b-806a-71ef060e4875","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875","klantcontact":{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192"},"wasKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 51a04bd9-9f10-48fa-a67e-db09ede017c5,
+        part 0", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          51a04bd9-9f10-48fa-a67e-db09ede017c5, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "51a04bd9-9f10-48fa-a67e-db09ede017c5"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"703a32d4-9db7-4c94-97ea-860f2d549442","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"5781e531-0d53-4a7e-bcf6-90f31b5437c2","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5781e531-0d53-4a7e-bcf6-90f31b5437c2","nummer":"0000000003","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.312753Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/5781e531-0d53-4a7e-bcf6-90f31b5437c2
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by 51a04bd9-9f10-48fa-a67e-db09ede017c5,
+        part 1", "onderwerp": "Life and stuff", "taal": "nld", "kanaal":
+        "oip_mijn_vragen", "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '233'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          51a04bd9-9f10-48fa-a67e-db09ede017c5, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '545'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "51a04bd9-9f10-48fa-a67e-db09ede017c5"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "4a4235fb-79c6-416e-b1c1-144f4b664951"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/be7a21f5-37ee-40d5-bf79-f82d32bd7e7c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "4a4235fb-79c6-416e-b1c1-144f4b664951"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"96c10b43-362a-4ea1-aace-97740a8a9963","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/96c10b43-362a-4ea1-aace-97740a8a9963","nummer":"0000000004","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.347338Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/96c10b43-362a-4ea1-aace-97740a8a9963
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0
+    response:
+      body:
+        string:
+          '{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"703a32d4-9db7-4c94-97ea-860f2d549442","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442"}],"leiddeTotInterneTaken":[{"uuid":"5781e531-0d53-4a7e-bcf6-90f31b5437c2","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5781e531-0d53-4a7e-bcf6-90f31b5437c2"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          51a04bd9-9f10-48fa-a67e-db09ede017c5, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '846'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"inhoud": "The answer is 42", "onderwerp": "Life and stuff", "taal":
+        "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '185'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '497'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"rol": "klant", "hadKlantcontact": {"uuid":
+        "70736eb8-0393-4582-9489-f43b03c91ec0"}, "initiator": true, "wasPartij":
+        {"uuid": "51a04bd9-9f10-48fa-a67e-db09ede017c5"}, "organisatienaam":
+        "Open Inwoner Platform"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '211'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"3c783b39-ea6b-4976-a990-088836b136ad","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3c783b39-ea6b-4976-a990-088836b136ad","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/3c783b39-ea6b-4976-a990-088836b136ad
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "70736eb8-0393-4582-9489-f43b03c91ec0"},
+        "wasKlantcontact": {"uuid": "eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '135'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"bbbb903e-c451-4356-ae1c-617c843fc427","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/bbbb903e-c451-4356-ae1c-617c843fc427","klantcontact":{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0"},"wasKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/bbbb903e-c451-4356-ae1c-617c843fc427
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
+    response:
+      body:
+        string:
+          '{"count":6,"next":null,"previous":null,"results":[{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0","gingOverOnderwerpobjecten":[{"uuid":"bbbb903e-c451-4356-ae1c-617c843fc427","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/bbbb903e-c451-4356-ae1c-617c843fc427"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"3c783b39-ea6b-4976-a990-088836b136ad","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3c783b39-ea6b-4976-a990-088836b136ad"}],"leiddeTotInterneTaken":[],"nummer":"0000000006","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"bbbb903e-c451-4356-ae1c-617c843fc427","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/bbbb903e-c451-4356-ae1c-617c843fc427","klantcontact":{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0"},"wasKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"3c783b39-ea6b-4976-a990-088836b136ad","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3c783b39-ea6b-4976-a990-088836b136ad","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"70736eb8-0393-4582-9489-f43b03c91ec0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/70736eb8-0393-4582-9489-f43b03c91ec0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5","nummer":"0000000002","interneNotitie":"","betrokkenen":[{"uuid":"703a32d4-9db7-4c94-97ea-860f2d549442","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442"},{"uuid":"be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/be7a21f5-37ee-40d5-bf79-f82d32bd7e7c"},{"uuid":"3c783b39-ea6b-4976-a990-088836b136ad","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/3c783b39-ea6b-4976-a990-088836b136ad"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/be7a21f5-37ee-40d5-bf79-f82d32bd7e7c"}],"leiddeTotInterneTaken":[{"uuid":"96c10b43-362a-4ea1-aace-97740a8a9963","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/96c10b43-362a-4ea1-aace-97740a8a9963"}],"nummer":"0000000005","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          51a04bd9-9f10-48fa-a67e-db09ede017c5, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/be7a21f5-37ee-40d5-bf79-f82d32bd7e7c","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"96c10b43-362a-4ea1-aace-97740a8a9963","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/96c10b43-362a-4ea1-aace-97740a8a9963","nummer":"0000000004","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"4a4235fb-79c6-416e-b1c1-144f4b664951","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4a4235fb-79c6-416e-b1c1-144f4b664951"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.347338Z","afgehandeldOp":null}]}},{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"703a32d4-9db7-4c94-97ea-860f2d549442","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442"}],"leiddeTotInterneTaken":[{"uuid":"5781e531-0d53-4a7e-bcf6-90f31b5437c2","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5781e531-0d53-4a7e-bcf6-90f31b5437c2"}],"nummer":"0000000004","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          51a04bd9-9f10-48fa-a67e-db09ede017c5, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"703a32d4-9db7-4c94-97ea-860f2d549442","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/703a32d4-9db7-4c94-97ea-860f2d549442","wasPartij":{"uuid":"51a04bd9-9f10-48fa-a67e-db09ede017c5","url":"http://localhost:8338/klantinteracties/api/v1/partijen/51a04bd9-9f10-48fa-a67e-db09ede017c5"},"hadKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"5781e531-0d53-4a7e-bcf6-90f31b5437c2","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5781e531-0d53-4a7e-bcf6-90f31b5437c2","nummer":"0000000003","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/eb2ddfdc-c70a-4f45-9bcf-f80d93891ac0"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.312753Z","afgehandeldOp":null}]}},{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192","gingOverOnderwerpobjecten":[{"uuid":"7e3c3662-0696-4e0b-806a-71ef060e4875","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"8f7aa0af-30f2-491a-94ee-9954695c909c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8f7aa0af-30f2-491a-94ee-9954695c909c"}],"leiddeTotInterneTaken":[],"nummer":"0000000003","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"The answer is
+          42","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[{"uuid":"7e3c3662-0696-4e0b-806a-71ef060e4875","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875","klantcontact":{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192"},"wasKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}],"hadBetrokkenen":[{"uuid":"8f7aa0af-30f2-491a-94ee-9954695c909c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8f7aa0af-30f2-491a-94ee-9954695c909c","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"0eff5472-6562-4d98-b1a7-89796d568fbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe"},{"uuid":"5562e482-7417-48b3-a289-f718ce84f57f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5562e482-7417-48b3-a289-f718ce84f57f"},{"uuid":"8f7aa0af-30f2-491a-94ee-9954695c909c","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/8f7aa0af-30f2-491a-94ee-9954695c909c"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}}}],"leiddeTotInterneTaken":[]}},{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"5562e482-7417-48b3-a289-f718ce84f57f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5562e482-7417-48b3-a289-f718ce84f57f"}],"leiddeTotInterneTaken":[{"uuid":"2a1d462f-0919-4f3a-adb7-2f455df00e32","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2a1d462f-0919-4f3a-adb7-2f455df00e32"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          fae5fa2e-63e8-4b6d-af21-4acd55480085, part
+          1","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"5562e482-7417-48b3-a289-f718ce84f57f","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/5562e482-7417-48b3-a289-f718ce84f57f","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"2a1d462f-0919-4f3a-adb7-2f455df00e32","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/2a1d462f-0919-4f3a-adb7-2f455df00e32","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"57c497b7-0454-4aca-aa97-66736deaf332","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/57c497b7-0454-4aca-aa97-66736deaf332"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.228189Z","afgehandeldOp":null}]}},{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"0eff5472-6562-4d98-b1a7-89796d568fbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe"}],"leiddeTotInterneTaken":[{"uuid":"5624d26b-0429-4aa8-8d7a-df18d23b0121","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5624d26b-0429-4aa8-8d7a-df18d23b0121"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Life
+          and stuff","inhoud":"A question asked by
+          fae5fa2e-63e8-4b6d-af21-4acd55480085, part
+          0","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"0eff5472-6562-4d98-b1a7-89796d568fbe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/0eff5472-6562-4d98-b1a7-89796d568fbe","wasPartij":{"uuid":"fae5fa2e-63e8-4b6d-af21-4acd55480085","url":"http://localhost:8338/klantinteracties/api/v1/partijen/fae5fa2e-63e8-4b6d-af21-4acd55480085"},"hadKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"5624d26b-0429-4aa8-8d7a-df18d23b0121","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/5624d26b-0429-4aa8-8d7a-df18d23b0121","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"toegewezenAanActor":{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"},"toegewezenAanActoren":[{"uuid":"9a64a3bd-53ae-476c-933f-5c4f4fa64e00","url":"http://localhost:8338/klantinteracties/api/v1/actoren/9a64a3bd-53ae-476c-933f-5c4f4fa64e00"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:30.184073Z","afgehandeldOp":null}]}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '19891'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875
+    response:
+      body:
+        string: '{"uuid":"7e3c3662-0696-4e0b-806a-71ef060e4875","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/7e3c3662-0696-4e0b-806a-71ef060e4875","klantcontact":{"uuid":"2d3b01d4-d404-43fc-a687-8ebdf2b23192","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/2d3b01d4-d404-43fc-a687-8ebdf2b23192"},"wasKlantcontact":{"uuid":"3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3bee9bdd-a4ff-4ce8-b3d3-2400c3192c6b"},"onderwerpobjectidentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '605'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_list_questions_for_zaak.yaml
@@ -1,0 +1,1656 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"fc9b9034-0561-46e1-955e-299c531e6435","url":"http://localhost:8338/klantinteracties/api/v1/actoren/fc9b9034-0561-46e1-955e-299c531e6435","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/fc9b9034-0561-46e1-955e-299c531e6435
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"4d267521-12d5-4702-abcb-f0038d462761","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d267521-12d5-4702-abcb-f0038d462761","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/4d267521-12d5-4702-abcb-f0038d462761
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"f38664e7-69b6-4ea0-882a-301b5b251e4c","url":"http://localhost:8338/klantinteracties/api/v1/partijen/f38664e7-69b6-4ea0-882a-301b5b251e4c","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/f38664e7-69b6-4ea0-882a-301b5b251e4c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"a98918be-4f32-478c-ad4d-8d46442775ab","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Monique", "achternaam": "Sullivan",
+        "voorletters": "", "voorvoegselAchternaam": ""}},
+        "partijIdentificatoren": [{"partijIdentificator": {"codeObjecttype":
+        "natuurlijk_persoon", "codeSoortObjectId": "bsn", "objectId":
+        "123456782", "codeRegister": "brp"}}]}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '533'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"2f8a758e-d47a-4662-bd41-c2203b78bdf9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/2f8a758e-d47a-4662-bd41-c2203b78bdf9","identificeerdePartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Monique","voorvoegselAchternaam":"","achternaam":"Sullivan"},"volledigeNaam":"Monique
+          Sullivan"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1549'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "dd469cdb-cf63-413a-bb8a-32e1ac71aa64"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","wasPartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"hadKlantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "a98918be-4f32-478c-ad4d-8d46442775ab"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"a35bf517-6845-4724-aba5-b7a67536472b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a35bf517-6845-4724-aba5-b7a67536472b","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},"toegewezenAanActor":{"uuid":"a98918be-4f32-478c-ad4d-8d46442775ab","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab"},"toegewezenAanActoren":[{"uuid":"a98918be-4f32-478c-ad4d-8d46442775ab","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:53.879569Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/a35bf517-6845-4724-aba5-b7a67536472b
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"f1f71839-7fbd-477b-a607-e483c1e85315","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f1f71839-7fbd-477b-a607-e483c1e85315","klantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f1f71839-7fbd-477b-a607-e483c1e85315
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "4d267521-12d5-4702-abcb-f0038d462761"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "881e1036-4098-4129-853a-cbec43737c53"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"9e7288e2-d254-4611-be0e-fed52d76ca42","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e7288e2-d254-4611-be0e-fed52d76ca42","wasPartij":{"uuid":"4d267521-12d5-4702-abcb-f0038d462761","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d267521-12d5-4702-abcb-f0038d462761"},"hadKlantcontact":{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e7288e2-d254-4611-be0e-fed52d76ca42
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "881e1036-4098-4129-853a-cbec43737c53"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "a98918be-4f32-478c-ad4d-8d46442775ab"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"9df215e7-b037-43ef-8ce7-29a5d2cd148e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/9df215e7-b037-43ef-8ce7-29a5d2cd148e","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53"},"toegewezenAanActor":{"uuid":"a98918be-4f32-478c-ad4d-8d46442775ab","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab"},"toegewezenAanActoren":[{"uuid":"a98918be-4f32-478c-ad4d-8d46442775ab","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a98918be-4f32-478c-ad4d-8d46442775ab"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:43:53.930583Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/9df215e7-b037-43ef-8ce7-29a5d2cd148e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "881e1036-4098-4129-853a-cbec43737c53"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"f3df95ea-9416-4cb2-8bae-196391098b71","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f3df95ea-9416-4cb2-8bae-196391098b71","klantcontact":{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f3df95ea-9416-4cb2-8bae-196391098b71
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=aa0f58a0-1234-4567-abcd-ef0123456789&expand=hadBetrokkenen
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53","gingOverOnderwerpobjecten":[{"uuid":"f3df95ea-9416-4cb2-8bae-196391098b71","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f3df95ea-9416-4cb2-8bae-196391098b71"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"9e7288e2-d254-4611-be0e-fed52d76ca42","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e7288e2-d254-4611-be0e-fed52d76ca42"}],"leiddeTotInterneTaken":[{"uuid":"9df215e7-b037-43ef-8ce7-29a5d2cd148e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/9df215e7-b037-43ef-8ce7-29a5d2cd148e"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"9e7288e2-d254-4611-be0e-fed52d76ca42","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/9e7288e2-d254-4611-be0e-fed52d76ca42","wasPartij":{"uuid":"4d267521-12d5-4702-abcb-f0038d462761","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4d267521-12d5-4702-abcb-f0038d462761"},"hadKlantcontact":{"uuid":"881e1036-4098-4129-853a-cbec43737c53","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/881e1036-4098-4129-853a-cbec43737c53"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true}]}},{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","gingOverOnderwerpobjecten":[{"uuid":"f1f71839-7fbd-477b-a607-e483c1e85315","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f1f71839-7fbd-477b-a607-e483c1e85315"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3"}],"leiddeTotInterneTaken":[{"uuid":"a35bf517-6845-4724-aba5-b7a67536472b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a35bf517-6845-4724-aba5-b7a67536472b"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","wasPartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"hadKlantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}]}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '4203'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"2f8a758e-d47a-4662-bd41-c2203b78bdf9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/2f8a758e-d47a-4662-bd41-c2203b78bdf9","identificeerdePartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Monique","voorvoegselAchternaam":"","achternaam":"Sullivan"},"volledigeNaam":"Monique
+          Sullivan"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1764'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    response:
+      body:
+        string:
+          '{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"2f8a758e-d47a-4662-bd41-c2203b78bdf9","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/2f8a758e-d47a-4662-bd41-c2203b78bdf9","identificeerdePartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Monique","voorvoegselAchternaam":"","achternaam":"Sullivan"},"volledigeNaam":"Monique
+          Sullivan"},"_expand":{"betrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","wasPartij":{"uuid":"dd469cdb-cf63-413a-bb8a-32e1ac71aa64","url":"http://localhost:8338/klantinteracties/api/v1/partijen/dd469cdb-cf63-413a-bb8a-32e1ac71aa64"},"hadKlantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/3a1d038d-9577-498f-a1e2-ecdd74dc3e4b","gingOverOnderwerpobjecten":[{"uuid":"f1f71839-7fbd-477b-a607-e483c1e85315","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/f1f71839-7fbd-477b-a607-e483c1e85315"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a4e93f8d-e8bd-493d-9ebb-d6dfc0549de3"}],"leiddeTotInterneTaken":[{"uuid":"a35bf517-6845-4724-aba5-b7a67536472b","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/a35bf517-6845-4724-aba5-b7a67536472b"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}}}],"digitaleAdressen":[]}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '3824'
+        Content-Security-Policy:
+          - "worker-src 'self' blob:; frame-ancestors 'none'; object-src 'none';
+            font-src 'self' fonts.gstatic.com; img-src 'self' data:
+            cdn.redoc.ly; style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+            script-src 'self' 'unsafe-inline'; base-uri 'self'; form-action
+            'self'; frame-src 'self'; default-src 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"15f31ae8-8882-4430-88d2-5457a680ea0c","url":"http://localhost:8338/klantinteracties/api/v1/actoren/15f31ae8-8882-4430-88d2-5457a680ea0c","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/15f31ae8-8882-4430-88d2-5457a680ea0c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"ae33c2c6-aa82-41c4-b296-4db2d6818d9f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ae33c2c6-aa82-41c4-b296-4db2d6818d9f","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/ae33c2c6-aa82-41c4-b296-4db2d6818d9f
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"0292efc2-73c8-44fd-a1a4-cdf1c14fcad0","url":"http://localhost:8338/klantinteracties/api/v1/partijen/0292efc2-73c8-44fd-a1a4-cdf1c14fcad0","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/0292efc2-73c8-44fd-a1a4-cdf1c14fcad0
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"622f129a-d2c4-4bed-a811-097949f536c1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voornaam": "Kristen", "achternaam": "Rios",
+        "voorletters": "", "voorvoegselAchternaam": ""}},
+        "partijIdentificatoren": [{"partijIdentificator": {"codeObjecttype":
+        "natuurlijk_persoon", "codeSoortObjectId": "bsn", "objectId":
+        "123456782", "codeRegister": "brp"}}]}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '529'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","nummer":"0000000003","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"60414998-c75a-4bca-bb4a-d2ffff5d03d4","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/60414998-c75a-4bca-bb4a-d2ffff5d03d4","identificeerdePartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Kristen","voorvoegselAchternaam":"","achternaam":"Rios"},"volledigeNaam":"Kristen
+          Rios"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1541'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "4dcfc60b-d266-43e9-be87-c44c8210319d"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166","wasPartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"hadKlantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "4dcfc60b-d266-43e9-be87-c44c8210319d"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "622f129a-d2c4-4bed-a811-097949f536c1"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"520e2ef5-ad33-4467-a529-af85fe1efff1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/520e2ef5-ad33-4467-a529-af85fe1efff1","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d"},"toegewezenAanActor":{"uuid":"622f129a-d2c4-4bed-a811-097949f536c1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1"},"toegewezenAanActoren":[{"uuid":"622f129a-d2c4-4bed-a811-097949f536c1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:48.549261Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/520e2ef5-ad33-4467-a529-af85fe1efff1
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "4dcfc60b-d266-43e9-be87-c44c8210319d"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"4527305a-b52d-4672-9115-395663b20dde","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/4527305a-b52d-4672-9115-395663b20dde","klantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/4527305a-b52d-4672-9115-395663b20dde
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question asked by Morice", "onderwerp": "Vraag voor zaak:
+        Coffee zaak", "taal": "nld", "kanaal": "oip_mijn_vragen",
+        "vertrouwelijk": false, "plaatsgevondenOp":
+        "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '209'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '521'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "ae33c2c6-aa82-41c4-b296-4db2d6818d9f"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"4d77f3c0-64df-44ed-b3e0-1d10181e6e0e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4d77f3c0-64df-44ed-b3e0-1d10181e6e0e","wasPartij":{"uuid":"ae33c2c6-aa82-41c4-b296-4db2d6818d9f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ae33c2c6-aa82-41c4-b296-4db2d6818d9f"},"hadKlantcontact":{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/4d77f3c0-64df-44ed-b3e0-1d10181e6e0e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "622f129a-d2c4-4bed-a811-097949f536c1"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"81554b1d-a766-4d04-ab90-20dbf369516e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/81554b1d-a766-4d04-ab90-20dbf369516e","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"},"toegewezenAanActor":{"uuid":"622f129a-d2c4-4bed-a811-097949f536c1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1"},"toegewezenAanActoren":[{"uuid":"622f129a-d2c4-4bed-a811-097949f536c1","url":"http://localhost:8338/klantinteracties/api/v1/actoren/622f129a-d2c4-4bed-a811-097949f536c1"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:49:48.598553Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/81554b1d-a766-4d04-ab90-20dbf369516e
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"klantcontact": {"uuid": "23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"},
+        "wasKlantcontact": null, "onderwerpobjectidentificator": {"objectId":
+        "aa0f58a0-1234-4567-abcd-ef0123456789", "codeObjecttype": "zgw-Zaak",
+        "codeRegister": "openzaak", "codeSoortObjectId": "uuid"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '264'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten
+    response:
+      body:
+        string: '{"uuid":"c55b498d-132f-4c66-a813-ebfaf2ddbd9c","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/c55b498d-132f-4c66-a813-ebfaf2ddbd9c","klantcontact":{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"aa0f58a0-1234-4567-abcd-ef0123456789","codeObjecttype":"zgw-Zaak","codeRegister":"openzaak","codeSoortObjectId":"uuid"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/c55b498d-132f-4c66-a813-ebfaf2ddbd9c
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?onderwerpobject__onderwerpobjectidentificatorObjectId=aa0f58a0-1234-4567-abcd-ef0123456789&expand=hadBetrokkenen
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","gingOverOnderwerpobjecten":[{"uuid":"c55b498d-132f-4c66-a813-ebfaf2ddbd9c","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/c55b498d-132f-4c66-a813-ebfaf2ddbd9c"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"4d77f3c0-64df-44ed-b3e0-1d10181e6e0e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4d77f3c0-64df-44ed-b3e0-1d10181e6e0e"}],"leiddeTotInterneTaken":[{"uuid":"81554b1d-a766-4d04-ab90-20dbf369516e","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/81554b1d-a766-4d04-ab90-20dbf369516e"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"4d77f3c0-64df-44ed-b3e0-1d10181e6e0e","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/4d77f3c0-64df-44ed-b3e0-1d10181e6e0e","wasPartij":{"uuid":"ae33c2c6-aa82-41c4-b296-4db2d6818d9f","url":"http://localhost:8338/klantinteracties/api/v1/partijen/ae33c2c6-aa82-41c4-b296-4db2d6818d9f"},"hadKlantcontact":{"uuid":"23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/23df6c6f-bf90-4b5f-bdd3-9e7ef9cf2732"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true}]}},{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d","gingOverOnderwerpobjecten":[{"uuid":"4527305a-b52d-4672-9115-395663b20dde","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/4527305a-b52d-4672-9115-395663b20dde"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166"}],"leiddeTotInterneTaken":[{"uuid":"520e2ef5-ad33-4467-a529-af85fe1efff1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/520e2ef5-ad33-4467-a529-af85fe1efff1"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"hadBetrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166","wasPartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"hadKlantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}]}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '4203'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782&soortPartij=persoon
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"60414998-c75a-4bca-bb4a-d2ffff5d03d4","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/60414998-c75a-4bca-bb4a-d2ffff5d03d4","identificeerdePartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Kristen","voorvoegselAchternaam":"","achternaam":"Rios"},"volledigeNaam":"Kristen
+          Rios"},"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1756'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9?expand=digitaleAdressen%2Cbetrokkenen%2Cbetrokkenen.hadKlantcontact
+    response:
+      body:
+        string:
+          '{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","nummer":"0000000003","interneNotitie":"","betrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"60414998-c75a-4bca-bb4a-d2ffff5d03d4","url":"http://localhost:8338/klantinteracties/api/v1/partij-identificatoren/60414998-c75a-4bca-bb4a-d2ffff5d03d4","identificeerdePartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Kristen","voorvoegselAchternaam":"","achternaam":"Rios"},"volledigeNaam":"Kristen
+          Rios"},"_expand":{"betrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166","wasPartij":{"uuid":"86d7060a-0a14-4fa8-a94f-4bf213d6d0c9","url":"http://localhost:8338/klantinteracties/api/v1/partijen/86d7060a-0a14-4fa8-a94f-4bf213d6d0c9"},"hadKlantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"hadKlantcontact":{"uuid":"4dcfc60b-d266-43e9-be87-c44c8210319d","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/4dcfc60b-d266-43e9-be87-c44c8210319d","gingOverOnderwerpobjecten":[{"uuid":"4527305a-b52d-4672-9115-395663b20dde","url":"http://localhost:8338/klantinteracties/api/v1/onderwerpobjecten/4527305a-b52d-4672-9115-395663b20dde"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"620a3d02-c679-4bde-8838-d17baa62c166","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/620a3d02-c679-4bde-8838-d17baa62c166"}],"leiddeTotInterneTaken":[{"uuid":"520e2ef5-ad33-4467-a529-af85fe1efff1","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/520e2ef5-ad33-4467-a529-af85fe1efff1"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Vraag
+          voor zaak: Coffee zaak","inhoud":"A question asked by
+          Morice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}}}],"digitaleAdressen":[]}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+        Content-Length:
+          - '3816'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_questions_for_partij_ignores_anonymous_questions.yaml
+++ b/src/open_inwoner/openklant/tests/cassettes/QuestionAnswerTestCase.test_questions_for_partij_ignores_anonymous_questions.yaml
@@ -1,0 +1,741 @@
+interactions:
+  - request:
+      body:
+        '{"naam": "Afdeling Klantenservice", "soortActor":
+        "organisatorische_eenheid", "indicatieActief": true}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"5e9dc131-c09d-4ebc-94d5-f5558a403073","url":"http://localhost:8338/klantinteracties/api/v1/actoren/5e9dc131-c09d-4ebc-94d5-f5558a403073","naam":"Afdeling
+          Klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/5e9dc131-c09d-4ebc-94d5-f5558a403073
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Alice",
+        "voorvoegselAchternaam": "", "achternaam": "McAlice"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"4b7bb201-999c-4190-b86a-059a638311d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4b7bb201-999c-4190-b86a-059a638311d3","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1021'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/4b7bb201-999c-4190-b86a-059a638311d3
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"digitaleAdressen": null, "voorkeursDigitaalAdres": null,
+        "rekeningnummers": null, "voorkeursRekeningnummer": null,
+        "indicatieGeheimhouding": false, "indicatieActief": true,
+        "voorkeurstaal": "nld", "soortPartij": "persoon", "partijIdentificatie":
+        {"contactnaam": {"voorletters": "", "voornaam": "Bob",
+        "voorvoegselAchternaam": "", "achternaam": "McBob"}}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '356'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/partijen
+    response:
+      body:
+        string:
+          '{"uuid":"7faa5c62-5f72-43fe-b4ec-cb1081624554","url":"http://localhost:8338/klantinteracties/api/v1/partijen/7faa5c62-5f72-43fe-b4ec-cb1081624554","nummer":"0000000002","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Bob","voorvoegselAchternaam":"","achternaam":"McBob"},"volledigeNaam":"Bob
+          McBob"}}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1013'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/partijen/7faa5c62-5f72-43fe-b4ec-cb1081624554
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"naam": "Afdeling klantenservice", "indicatieActief": true,
+        "soortActor": "organisatorische_eenheid"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '102'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/actoren
+    response:
+      body:
+        string:
+          '{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4","naam":"Afdeling
+          klantenservice","soortActor":"organisatorische_eenheid","indicatieActief":true,"actoridentificator":{"objectId":"","codeObjecttype":"","codeRegister":"","codeSoortObjectId":""},"actorIdentificatie":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '366'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "A question from Alice", "onderwerp": "Alice''s question",
+        "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '192'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+          question","inhoud":"A question from
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '504'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": {"uuid": "4b7bb201-999c-4190-b86a-059a638311d3"}, "rol":
+        "klant", "hadKlantcontact": {"uuid":
+        "c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '232'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"a1caa2b1-e47e-4308-8034-45a962805dfe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a1caa2b1-e47e-4308-8034-45a962805dfe","wasPartij":{"uuid":"4b7bb201-999c-4190-b86a-059a638311d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4b7bb201-999c-4190-b86a-059a638311d3"},"hadKlantcontact":{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '1065'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/a1caa2b1-e47e-4308-8034-45a962805dfe
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "a446990e-26de-49b7-9a91-02c65c4afcc4"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"c419a06f-a1f0-453a-8142-d93fe34721cb","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c419a06f-a1f0-453a-8142-d93fe34721cb","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"},"toegewezenAanActor":{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"},"toegewezenAanActoren":[{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:50:07.701023Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/c419a06f-a1f0-453a-8142-d93fe34721cb
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"inhoud": "An anonymous question", "onderwerp": "Anonymous inquiry",
+        "taal": "nld", "kanaal": "oip_mijn_vragen", "vertrouwelijk": false,
+        "plaatsgevondenOp": "2024-10-02T14:00:25.587564+00:00"}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '193'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten
+    response:
+      body:
+        string:
+          '{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[],"leiddeTotInterneTaken":[],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"An anonymous
+          question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z"}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '505'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"wasPartij": null, "rol": "klant", "hadKlantcontact": {"uuid":
+        "22fa1106-4cf5-4777-b213-8cd443366312"}, "organisatienaam": "Open
+        Inwoner Platform", "initiator": true, "contactnaam": {"voornaam":
+        "Anonymous", "achternaam": "User"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '231'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/betrokkenen
+    response:
+      body:
+        string:
+          '{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2","wasPartij":null,"hadKlantcontact":{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+          User","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '949'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=1f56a696-51f7-4a13-9aad-1437b08704e2
+    response:
+      body:
+        string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '52'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "anon@example.com", "soortDigitaalAdres": "email",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "1f56a696-51f7-4a13-9aad-1437b08704e2"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '224'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"6f9f51cc-70d9-42b8-9a56-192184491c25","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/6f9f51cc-70d9-42b8-9a56-192184491c25","verstrektDoorBetrokkene":{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '509'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/6f9f51cc-70d9-42b8-9a56-192184491c25
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen?verstrektDoorBetrokkene__uuid=1f56a696-51f7-4a13-9aad-1437b08704e2
+    response:
+      body:
+        string:
+          '{"count":1,"next":null,"previous":null,"results":[{"uuid":"6f9f51cc-70d9-42b8-9a56-192184491c25","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/6f9f51cc-70d9-42b8-9a56-192184491c25","verstrektDoorBetrokkene":{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2"},"verstrektDoorPartij":null,"adres":"anon@example.com","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null,"_expand":{}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '574'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"adres": "0612345678", "soortDigitaalAdres": "telefoonnummer",
+        "isStandaardAdres": false, "omschrijving": "OIP profiel",
+        "verstrektDoorBetrokkene": {"uuid":
+        "1f56a696-51f7-4a13-9aad-1437b08704e2"}, "verstrektDoorPartij": null}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '227'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/digitaleadressen
+    response:
+      body:
+        string:
+          '{"uuid":"ff4449f1-aa97-477a-99bc-848d23389cfe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ff4449f1-aa97-477a-99bc-848d23389cfe","verstrektDoorBetrokkene":{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2"},"verstrektDoorPartij":null,"adres":"0612345678","soortDigitaalAdres":"telefoonnummer","isStandaardAdres":false,"omschrijving":"OIP
+          profiel","referentie":"","verificatieDatum":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '512'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ff4449f1-aa97-477a-99bc-848d23389cfe
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body:
+        '{"aanleidinggevendKlantcontact": {"uuid":
+        "22fa1106-4cf5-4777-b213-8cd443366312"}, "toelichting": "Beantwoorden
+        vraag", "gevraagdeHandeling": "Vraag beantwoorden in aanleiding gevend
+        klant contact", "status": "te_verwerken", "toegewezenAanActor": {"uuid":
+        "a446990e-26de-49b7-9a91-02c65c4afcc4"}}'
+      headers:
+        Authorization:
+          - Token test-api-token
+        Content-Length:
+          - '296'
+        Content-Type:
+          - application/json
+      method: POST
+      uri: http://localhost:8338/klantinteracties/api/v1/internetaken
+    response:
+      body:
+        string:
+          '{"uuid":"77a773d5-b3f4-40e1-95dc-64f8d760ce14","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/77a773d5-b3f4-40e1-95dc-64f8d760ce14","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312"},"toegewezenAanActor":{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"},"toegewezenAanActoren":[{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:50:07.772420Z","afgehandeldOp":null}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '900'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Location:
+          - http://localhost:8338/klantinteracties/api/v1/internetaken/77a773d5-b3f4-40e1-95dc-64f8d760ce14
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Authorization:
+          - Token test-api-token
+      method: GET
+      uri: http://localhost:8338/klantinteracties/api/v1/klantcontacten?expand=leiddeTotInterneTaken%2CgingOverOnderwerpobjecten%2ChadBetrokkenen%2ChadBetrokkenen.wasPartij&kanaal=oip_mijn_vragen
+    response:
+      body:
+        string:
+          '{"count":2,"next":null,"previous":null,"results":[{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2"}],"leiddeTotInterneTaken":[{"uuid":"77a773d5-b3f4-40e1-95dc-64f8d760ce14","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/77a773d5-b3f4-40e1-95dc-64f8d760ce14"}],"nummer":"0000000002","kanaal":"oip_mijn_vragen","onderwerp":"Anonymous
+          inquiry","inhoud":"An anonymous
+          question","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"1f56a696-51f7-4a13-9aad-1437b08704e2","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/1f56a696-51f7-4a13-9aad-1437b08704e2","wasPartij":null,"hadKlantcontact":{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312"},"digitaleAdressen":[{"uuid":"6f9f51cc-70d9-42b8-9a56-192184491c25","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/6f9f51cc-70d9-42b8-9a56-192184491c25"},{"uuid":"ff4449f1-aa97-477a-99bc-848d23389cfe","url":"http://localhost:8338/klantinteracties/api/v1/digitaleadressen/ff4449f1-aa97-477a-99bc-848d23389cfe"}],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"Anonymous","voorvoegselAchternaam":"","achternaam":"User"},"volledigeNaam":"Anonymous
+          User","rol":"klant","organisatienaam":"Open Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":null}}],"leiddeTotInterneTaken":[{"uuid":"77a773d5-b3f4-40e1-95dc-64f8d760ce14","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/77a773d5-b3f4-40e1-95dc-64f8d760ce14","nummer":"0000000002","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"22fa1106-4cf5-4777-b213-8cd443366312","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/22fa1106-4cf5-4777-b213-8cd443366312"},"toegewezenAanActor":{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"},"toegewezenAanActoren":[{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:50:07.772420Z","afgehandeldOp":null}]}},{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","gingOverOnderwerpobjecten":[],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"a1caa2b1-e47e-4308-8034-45a962805dfe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a1caa2b1-e47e-4308-8034-45a962805dfe"}],"leiddeTotInterneTaken":[{"uuid":"c419a06f-a1f0-453a-8142-d93fe34721cb","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c419a06f-a1f0-453a-8142-d93fe34721cb"}],"nummer":"0000000001","kanaal":"oip_mijn_vragen","onderwerp":"Alice''s
+          question","inhoud":"A question from
+          Alice","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":false,"plaatsgevondenOp":"2024-10-02T14:00:25.587564Z","_expand":{"gingOverOnderwerpobjecten":[],"hadBetrokkenen":[{"uuid":"a1caa2b1-e47e-4308-8034-45a962805dfe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a1caa2b1-e47e-4308-8034-45a962805dfe","wasPartij":{"uuid":"4b7bb201-999c-4190-b86a-059a638311d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4b7bb201-999c-4190-b86a-059a638311d3"},"hadKlantcontact":{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"Open
+          Inwoner
+          Platform","initiator":true,"_expand":{"wasPartij":{"uuid":"4b7bb201-999c-4190-b86a-059a638311d3","url":"http://localhost:8338/klantinteracties/api/v1/partijen/4b7bb201-999c-4190-b86a-059a638311d3","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"a1caa2b1-e47e-4308-8034-45a962805dfe","url":"http://localhost:8338/klantinteracties/api/v1/betrokkenen/a1caa2b1-e47e-4308-8034-45a962805dfe"}],"categorieRelaties":[],"digitaleAdressen":[],"voorkeursDigitaalAdres":null,"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[],"soortPartij":"persoon","indicatieGeheimhouding":false,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"","voornaam":"Alice","voorvoegselAchternaam":"","achternaam":"McAlice"},"volledigeNaam":"Alice
+          McAlice"}}}}],"leiddeTotInterneTaken":[{"uuid":"c419a06f-a1f0-453a-8142-d93fe34721cb","url":"http://localhost:8338/klantinteracties/api/v1/internetaken/c419a06f-a1f0-453a-8142-d93fe34721cb","nummer":"0000000001","gevraagdeHandeling":"Vraag
+          beantwoorden in aanleiding gevend klant
+          contact","aanleidinggevendKlantcontact":{"uuid":"c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3","url":"http://localhost:8338/klantinteracties/api/v1/klantcontacten/c542e78f-cc3e-4b0b-8b7f-b6ca21adadb3"},"toegewezenAanActor":{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"},"toegewezenAanActoren":[{"uuid":"a446990e-26de-49b7-9a91-02c65c4afcc4","url":"http://localhost:8338/klantinteracties/api/v1/actoren/a446990e-26de-49b7-9a91-02c65c4afcc4"}],"toelichting":"Beantwoorden
+          vraag","status":"te_verwerken","toegewezenOp":"2026-07-06T12:50:07.701023Z","afgehandeldOp":null}]}}]}'
+      headers:
+        API-version:
+          - 0.6.0
+        Allow:
+          - GET, POST, HEAD, OPTIONS
+        Content-Length:
+          - '7194'
+        Content-Security-Policy:
+          - "style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src
+            'self' data: cdn.redoc.ly; worker-src 'self' blob:; frame-ancestors
+            'none'; frame-src 'self'; object-src 'none'; form-action 'self';
+            script-src 'self' 'unsafe-inline'; font-src 'self'
+            fonts.gstatic.com; default-src 'self'; base-uri 'self'"
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Referrer-Policy:
+          - same-origin
+        Vary:
+          - origin
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/src/open_inwoner/openklant/tests/helpers.py
+++ b/src/open_inwoner/openklant/tests/helpers.py
@@ -1,0 +1,220 @@
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from django.test import TestCase as DjangoTestCase
+
+import requests
+import structlog
+from openklant_client import OpenKlantClient
+from typing_extensions import TypedDict
+from vcr.record_mode import RecordMode
+from vcr.unittest import VCRMixin
+
+from open_inwoner.conf.utils import config
+
+logger = structlog.stdlib.get_logger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+class OpenKlantServiceManager:
+    _in_server_context: bool = False
+    _django_service_name: str = "openklant-web"
+    _api_root: str = "http://localhost:8338"
+    _api_path: str = "/klantinteracties/api/v1"
+    # Must match the `secret` used by OpenKlant2ConfigFactory's ServiceFactory,
+    # since that's the token the client under test actually sends.
+    _api_token: str = "test-api-token"
+    _docker_compose_project_name: str = "openklant2-api-test"
+    _docker_compose_path: Path = _REPO_ROOT / "docker" / "docker-compose.openklant.yml"
+
+    def _docker_compose(self, *args: str, check: bool = True, input: str | None = None):
+        input_data = {"text": True, "input": input} if input else {}
+        try:
+            return subprocess.run(
+                args=[
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(self._docker_compose_path),
+                    "-p",
+                    self._docker_compose_project_name,
+                    *args,
+                ],
+                check=check,
+                capture_output=True,
+                **input_data,
+            )
+        except subprocess.CalledProcessError as exc:
+            logger.exception(
+                "Unable to execute command",
+                stderr=str(exc.stderr),
+                stdout=str(exc.stdout),
+            )
+            raise
+
+    def _manage_py(self, *args: str, input: str | None = None):
+        self._docker_compose(
+            "run",
+            "--rm",
+            self._django_service_name,
+            "python",
+            "src/manage.py",
+            *args,
+            input=input,
+        )
+
+    def _service_teardown(self):
+        self._docker_compose("kill", check=False)
+        self._docker_compose("down", "-v")
+        self._docker_compose("rm", "-f")
+
+    def _service_init(self):
+        self._docker_compose("up", "-d")
+        self._wait_for_response()
+        self._manage_py("migrate")
+
+    def reset_db_state(self):
+        self._manage_py("flush", "--no-input")
+        self._load_fixture_from_json_string(self._generate_token_fixture())
+
+    def _load_fixture_from_json_string(self, fixture: str):
+        self._manage_py("loaddata", "--format", "json", "-", input=fixture)
+
+    def _generate_token_fixture(self) -> str:
+        return json.dumps(
+            [
+                {
+                    "model": "token.tokenauth",
+                    "pk": 1,
+                    "fields": {
+                        "identifier": "test-token",
+                        "token": self._api_token,
+                        "contact_person": "Boaty McBoatface",
+                        "email": "boaty@mcboatface.com",
+                        "organization": "",
+                        "last_modified": "2024-08-22T07:43:21.837Z",
+                        "created": "2024-08-22T07:43:21.837Z",
+                        "application": "",
+                        "administration": "",
+                    },
+                },
+                {
+                    "model": "accounts.user",
+                    "pk": 1,
+                    "fields": {
+                        # password is "secret"
+                        "password": "pbkdf2_sha256$600000$11HRNvD3J8QPTCkp0avgKX$gY/NX5+Ap8jAmD86HxEneVHwzi9+g45NhTBMkB3vJuo=",
+                        "last_login": "2025-01-28T10:30:23.474Z",
+                        "is_superuser": True,
+                        "username": "admin",
+                        "first_name": "",
+                        "last_name": "",
+                        "email": "admin@oip.nl",
+                        "is_staff": True,
+                        "is_active": True,
+                        "date_joined": "2025-01-28T10:29:59.843Z",
+                        "groups": [],
+                        "user_permissions": [],
+                    },
+                },
+            ]
+        )
+
+    def _wait_for_response(self, interval: float = 0.5, max_wait: float = 60):
+        start_time = time.time()
+        while True:
+            try:
+                requests.get(self._api_root)
+                return
+            except requests.RequestException:
+                logger.debug("Exception while checking for liveness", exc_info=True)
+                elapsed = time.time() - start_time
+                if elapsed > max_wait:
+                    raise RuntimeError(
+                        f"Maximum wait for service to be healthy exceeded: {elapsed} > {max_wait}"
+                    ) from None
+                time.sleep(interval)
+
+    def setUp(self):
+        if self._in_server_context:
+            raise RuntimeError(
+                "You cannot have multiple server contexts active at the same time"
+            )
+        self._in_server_context = True
+        self._service_teardown()
+        self._service_init()
+
+    def tearDown(self):
+        self._service_teardown()
+        self._in_server_context = False
+
+    def client_factory(self) -> OpenKlantClient:
+        return OpenKlantClient(
+            base_url=f"{self._api_root}{self._api_path}",
+            token=self._api_token,
+        )
+
+
+class LiveOpenKlantTestMixin:
+    _service: OpenKlantServiceManager
+
+    @classmethod
+    def should_bypass_live_server(cls) -> bool:
+        raise NotImplementedError
+
+    @property
+    def openklant_client(self) -> OpenKlantClient:
+        return self._service.client_factory()
+
+    def reset_db(self):
+        if not self.should_bypass_live_server():
+            self._service.reset_db_state()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._service = OpenKlantServiceManager()
+        if not cls.should_bypass_live_server():
+            cls._service.setUp()
+
+    @classmethod
+    def tearDownClass(cls):
+        if not cls.should_bypass_live_server():
+            cls._service.tearDown()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.reset_db()
+
+
+class OpenKlant2ServiceTestConfig(TypedDict):
+    use_live_service: bool
+    vcr_record_mode: RecordMode
+
+
+class Openklant2ServiceTestCase(VCRMixin, LiveOpenKlantTestMixin, DjangoTestCase):
+    vcr_record_mode: RecordMode = RecordMode.NONE
+
+    @classmethod
+    def get_config(cls) -> OpenKlant2ServiceTestConfig:
+        record_openklant_cassettes = config("RECORD_OPENKLANT_CASSETTES", default=False)
+        return {
+            "use_live_service": record_openklant_cassettes,
+            "vcr_record_mode": (
+                RecordMode.ALL if record_openklant_cassettes else cls.vcr_record_mode
+            ),
+        }
+
+    @classmethod
+    def should_bypass_live_server(cls) -> bool:
+        return not cls.get_config()["use_live_service"]
+
+    def _get_vcr(self, **kwargs):
+        vcr = super()._get_vcr(**kwargs)
+        vcr.record_mode = self.get_config()["vcr_record_mode"]
+        vcr.match_on = ["method", "scheme", "host", "port", "path", "query"]
+        return vcr

--- a/src/open_inwoner/openklant/tests/test_openklant_vcr.py
+++ b/src/open_inwoner/openklant/tests/test_openklant_vcr.py
@@ -1,0 +1,661 @@
+import datetime
+
+from django.test import tag
+
+import freezegun
+from timeline_logger.models import TimelineLog
+
+from open_inwoner.accounts.tests.factories import (
+    DigidUserFactory,
+    UserFactory,
+    eHerkenningUserFactory,
+    eHerkenningVestigingUserFactory,
+)
+from open_inwoner.openklant.services import OpenKlant2Question, OpenKlant2Service
+from open_inwoner.openklant.tests.factories import OpenKlant2ConfigFactory
+from open_inwoner.openklant.tests.helpers import Openklant2ServiceTestCase
+from open_inwoner.openklant.tests.validators import PartijValidator
+
+# Zaak used in cassettes for create_question_for_zaak / list_questions_for_zaak.
+# UUID is extracted from this URL and stored as onderwerpobjectidentificator objectId.
+_MOCK_ZAAK_URL = (
+    "http://localhost:8338/zaken/api/v1/zaken/aa0f58a0-1234-4567-abcd-ef0123456789"
+)
+_MOCK_ZAAK_UUID = "aa0f58a0-1234-4567-abcd-ef0123456789"
+_MOCK_ZAAK_IDENTIFICATIE = "Coffee zaak"
+
+
+@tag("openklant2")
+class PartijGetOrCreateTestCase(Openklant2ServiceTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.openklant2_config = OpenKlant2ConfigFactory()
+        self.service = OpenKlant2Service(config=self.openklant2_config)
+        self.digid_user = DigidUserFactory(
+            first_name="John", last_name="Doe", bsn="521311408"
+        )
+        self.kvk_only_user = eHerkenningUserFactory(kvk="12345678")
+        self.vestiging_user = eHerkenningVestigingUserFactory(
+            kvk=self.kvk_only_user.kvk, vestiging="123456789123"
+        )
+
+    def test_get_or_create_persoon(self):
+        # Empty state
+        self.assertEqual(self.service.client.partij.list()["count"], 0)
+        self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
+
+        # First call creates
+        persoon, created = self.service.get_or_create_partij_for_user(self.digid_user)
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "natuurlijk_persoon",
+                    "codeSoortObjectId": "bsn",
+                    "objectId": "521311408",
+                    "codeRegister": "brp",
+                }
+            ],
+        )
+
+        # Second call gets
+        persoon, created = self.service.get_or_create_partij_for_user(self.digid_user)
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "natuurlijk_persoon",
+                    "codeSoortObjectId": "bsn",
+                    "objectId": "521311408",
+                    "codeRegister": "brp",
+                }
+            ],
+        )
+
+    def test_get_or_create_organisatie_without_vestiging(self):
+        # Empty state
+        self.assertEqual(self.service.client.partij.list()["count"], 0)
+        self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
+
+        # First call creates
+        persoon, created = self.service.get_or_create_partij_for_user(
+            self.kvk_only_user
+        )
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "niet_natuurlijk_persoon",
+                    "codeSoortObjectId": "kvk_nummer",
+                    "objectId": "12345678",
+                    "codeRegister": "hr",
+                },
+            ],
+        )
+
+        # Second call gets
+        persoon, created = self.service.get_or_create_partij_for_user(
+            self.kvk_only_user
+        )
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "niet_natuurlijk_persoon",
+                    "codeSoortObjectId": "kvk_nummer",
+                    "objectId": "12345678",
+                    "codeRegister": "hr",
+                }
+            ],
+        )
+
+    def test_get_or_create_organisatie_with_vestiging(self):
+        # Empty state
+        self.assertEqual(self.service.client.partij.list()["count"], 0)
+        self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
+
+        # First call creates
+        persoon, created = self.service.get_or_create_partij_for_user(
+            self.vestiging_user,
+        )
+
+        self.assertTrue(
+            created, "persoon was retrieved (GET), expected create via POST"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "vestiging",
+                    "codeSoortObjectId": "vestigingsnummer",
+                    "objectId": "123456789123",
+                    "codeRegister": "hr",
+                },
+                {
+                    "codeObjecttype": "niet_natuurlijk_persoon",
+                    "codeSoortObjectId": "kvk_nummer",
+                    "objectId": "12345678",
+                    "codeRegister": "hr",
+                },
+            ],
+        )
+
+        # Second call gets
+        persoon, created = self.service.get_or_create_partij_for_user(
+            self.vestiging_user
+        )
+
+        self.assertFalse(
+            created, "persoon was was created (POST), expected retrieve via GET"
+        )
+
+        PartijValidator.validate_python(persoon)
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            [
+                row["partijIdentificator"]
+                for row in self.service.client.partij_identificator.list()["results"]
+            ],
+            [
+                {
+                    "codeObjecttype": "vestiging",
+                    "codeSoortObjectId": "vestigingsnummer",
+                    "objectId": "123456789123",
+                    "codeRegister": "hr",
+                },
+                {
+                    "codeObjecttype": "niet_natuurlijk_persoon",
+                    "codeSoortObjectId": "kvk_nummer",
+                    "objectId": "12345678",
+                    "codeRegister": "hr",
+                },
+            ],
+        )
+
+    def test_get_or_create_partij_for_user_without_bsn_kvk(self):
+        """Test that users without BSN/KVK get a persoon created without identificatoren"""
+        # Create user without BSN/KVK
+        user_without_ids = UserFactory(
+            first_name="Jane", last_name="Anonymous", bsn="", kvk=""
+        )
+
+        # Empty state
+        self.assertEqual(self.service.client.partij.list()["count"], 0)
+        self.assertEqual(self.service.client.partij_identificator.list()["count"], 0)
+
+        # First call creates persoon without identificatoren
+        partij, created = self.service.get_or_create_partij_for_user(user_without_ids)
+
+        self.assertTrue(created, "partij was retrieved (GET), expected create via POST")
+        self.assertIsNotNone(partij, "partij should always be created")
+
+        # Validate partij structure
+        PartijValidator.validate_python(partij)
+        self.assertEqual(partij["soortPartij"], "persoon")
+        self.assertEqual(
+            partij["partijIdentificatie"]["contactnaam"]["voornaam"], "Jane"
+        )
+        self.assertEqual(
+            partij["partijIdentificatie"]["contactnaam"]["achternaam"], "Anonymous"
+        )
+
+        # Check that partij was created but NO identificatoren
+        self.assertEqual(self.service.client.partij.list()["count"], 1)
+        self.assertEqual(
+            self.service.client.partij_identificator.list()["count"],
+            0,
+            "No identificatoren should be created when user has no BSN/KVK",
+        )
+
+        # Second call should retrieve the same partij (though without identificatoren,
+        # it will create a new one since find_persoon_for_bsn won't find it)
+        partij2, created2 = self.service.get_or_create_partij_for_user(user_without_ids)
+
+        # Since there's no BSN to search by, a new partij is created each time
+        self.assertTrue(created2, "Without BSN/KVK, a new partij is created each call")
+        self.assertEqual(self.service.client.partij.list()["count"], 2)
+
+
+QUESTION_DATE = datetime.datetime(
+    2024, 10, 2, 14, 0, 25, 587564, tzinfo=datetime.timezone.utc
+)
+
+
+@tag("openklant2")
+@freezegun.freeze_time(QUESTION_DATE)
+class QuestionAnswerTestCase(Openklant2ServiceTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.designated_actor = self.openklant_client.actor.create(
+            data={
+                "naam": "Afdeling Klantenservice",
+                "soortActor": "organisatorische_eenheid",
+                "indicatieActief": True,
+            }
+        )
+        self.een_persoon = self.openklant_client.partij.create_persoon(
+            data={
+                "digitaleAdressen": None,
+                "voorkeursDigitaalAdres": None,
+                "rekeningnummers": None,
+                "voorkeursRekeningnummer": None,
+                "indicatieGeheimhouding": False,
+                "indicatieActief": True,
+                "voorkeurstaal": "nld",
+                "soortPartij": "persoon",
+                "partijIdentificatie": {
+                    "contactnaam": {
+                        "voorletters": "",
+                        "voornaam": "Alice",
+                        "voorvoegselAchternaam": "",
+                        "achternaam": "McAlice",
+                    }
+                },
+            }
+        )
+        self.een_ander_persoon = self.openklant_client.partij.create_persoon(
+            data={
+                "digitaleAdressen": None,
+                "voorkeursDigitaalAdres": None,
+                "rekeningnummers": None,
+                "voorkeursRekeningnummer": None,
+                "indicatieGeheimhouding": False,
+                "indicatieActief": True,
+                "voorkeurstaal": "nld",
+                "soortPartij": "persoon",
+                "partijIdentificatie": {
+                    "contactnaam": {
+                        "voorletters": "",
+                        "voornaam": "Bob",
+                        "voorvoegselAchternaam": "",
+                        "achternaam": "McBob",
+                    }
+                },
+            }
+        )
+
+        self.designated_actor = self.openklant_client.actor.create(
+            data={
+                "naam": "Afdeling klantenservice",
+                "indicatieActief": True,
+                "soortActor": "organisatorische_eenheid",
+            }
+        )
+
+        self.openklant2_config = OpenKlant2ConfigFactory(
+            mijn_vragen_actor=self.designated_actor["uuid"]
+        )
+        self.service = OpenKlant2Service(config=self.openklant2_config)
+        self.user = DigidUserFactory()
+
+    def test_designated_actor_is_required_to_create_question(self):
+        self.openklant2_config.mijn_vragen_actor = None
+
+        with self.assertRaises(RuntimeError):
+            self.service.create_question_for_partij(
+                self.een_persoon["uuid"],
+                question="A question asked by Alice",
+                subject="Important questions",
+            )
+
+    def test_create_question_raises_on_missing_question(self):
+        for question in ("", " ", "   ", "\n", "   \n"):
+            with self.subTest("{q=} is not a valid question"):
+                with self.assertRaises(ValueError):
+                    self.service.create_question_for_partij(
+                        self.een_persoon["uuid"],
+                        question=question,
+                        subject="Important questions",
+                    )
+
+    def test_create_question(self):
+        question = self.service.create_question_for_partij(
+            self.een_persoon["uuid"],
+            question="A question asked by Alice",
+            subject="Important questions",
+        )
+
+        # 1 question => 1 klantcontact, 1 betrokkene, 1 taak
+        (klantcontact,) = self.service.client.klant_contact.list_iter()
+        (betrokkene,) = self.service.client.betrokkene.list_iter()
+        (taak,) = self.service.client.interne_taak.list_iter()
+
+        self.assertEqual(
+            klantcontact["kanaal"], self.openklant2_config.mijn_vragen_kanaal
+        )
+        self.assertEqual(betrokkene["hadKlantcontact"]["uuid"], klantcontact["uuid"])
+        self.assertEqual(betrokkene["wasPartij"]["uuid"], self.een_persoon["uuid"])
+        self.assertEqual(
+            taak["aanleidinggevendKlantcontact"]["uuid"], klantcontact["uuid"]
+        )
+
+        self.assertEqual(
+            question,
+            OpenKlant2Question(
+                url=klantcontact["url"],
+                answer=None,
+                nummer=klantcontact["nummer"],
+                question_kcm_uuid=klantcontact["uuid"],
+                question="A question asked by Alice",
+                onderwerp="Important questions",
+                kanaal=self.openklant2_config.mijn_vragen_kanaal,
+                taal="nld",
+                plaatsgevonden_op=QUESTION_DATE,
+            ),
+        )
+
+    def test_get_questions(self):
+        for persoon in (self.een_persoon, self.een_ander_persoon):
+            raw_questions = [
+                self.service.create_question_for_partij(
+                    persoon["uuid"],
+                    question=f"A question asked by {persoon['uuid']}, part {i}",
+                    subject="Life and stuff",
+                )
+                for i in range(2)
+            ]
+
+            for rq in raw_questions[:1]:
+                self.service.create_answer(
+                    persoon["uuid"], rq.question_kcm_uuid, "The answer is 42"
+                )
+
+        questions = self.service.questions_for_partij(self.een_persoon["uuid"])
+
+        self.assertEqual(
+            len(questions), 2, msg="Only the user's questions should be returned"
+        )
+
+        self.assertFalse(
+            all(
+                self.een_ander_persoon["uuid"] in question.question
+                for question in questions
+            )
+        )
+        self.assertTrue(
+            all(self.een_persoon["uuid"] in question.question for question in questions)
+        )
+
+    def test_create_question_for_zaak(self):
+        class MockZaak:
+            identificatie = _MOCK_ZAAK_IDENTIFICATIE
+            url = _MOCK_ZAAK_URL
+
+        zaak = MockZaak()
+        question = self.service.create_question_for_zaak(
+            self.een_persoon["uuid"],
+            question="A question asked by Morice",
+            zaak=zaak,
+        )
+
+        # check onderwerp_object created
+        onderwerp_objecten = self.service.client.onderwerp_object.list()
+        self.assertEqual(len(onderwerp_objecten["results"]), 1)
+
+        onderwerp_object = onderwerp_objecten["results"][0]
+        self.assertEqual(
+            onderwerp_object["klantcontact"]["uuid"], question.question_kcm_uuid
+        )
+
+        # check logs
+        log_entries = TimelineLog.objects.all()
+
+        self.assertEqual(log_entries.count(), 2)
+        self.assertEqual(
+            log_entries[0].extra_data["message"],
+            f"registered question {question.question_kcm_uuid} for partij {self.een_persoon['uuid']} via OpenKlant",
+        )
+        self.assertEqual(
+            log_entries[1].extra_data["message"],
+            f"Created onderwerp_object {onderwerp_object['uuid']} for zaak `{zaak.identificatie}`",
+        )
+
+    def test_list_questions_for_zaak(self):
+        class MockZaak:
+            identificatie = _MOCK_ZAAK_IDENTIFICATIE
+            url = _MOCK_ZAAK_URL
+
+        persoon, _ = self.service.get_or_create_partij_for_user(user=self.user)
+        zaak = MockZaak()
+        question_initiated_by_user = self.service.create_question_for_zaak(
+            persoon["uuid"],
+            question="A question asked by Morice",
+            zaak=zaak,
+        )
+        question_initiated_by_another_partij = self.service.create_question_for_zaak(
+            self.een_persoon["uuid"],
+            question="A question asked by Morice",
+            zaak=zaak,
+        )
+
+        questions = self.service.list_questions_for_zaak(zaak, self.user)
+        question_urls = {q["api_source_url"] for q in questions}
+        self.assertEqual(
+            question_urls,
+            {question_initiated_by_user.url},
+            msg="Questions initiated by the user should be returned",
+        )
+        self.assertNotEqual(
+            question_urls,
+            {question_initiated_by_another_partij.url},
+            msg="Questions initiated by others users should not be returned",
+        )
+
+    def test_create_question_with_betrokkene(self):
+        question = self.service.create_question_with_betrokkene(
+            question="A question from an anonymous user",
+            subject="Anonymous inquiry",
+            first_name="Hieronymous",
+            last_name="Anonymous",
+            email="hieronymous.anonymous@example.com",
+            phonenumber="0612345678",
+        )
+
+        # 1 question => 1 klantcontact, 1 betrokkene, 1 taak
+        (klantcontact,) = self.service.client.klant_contact.list_iter()
+        (betrokkene,) = self.service.client.betrokkene.list_iter()
+        (taak,) = self.service.client.interne_taak.list_iter()
+
+        # Check klantcontact
+        self.assertEqual(
+            klantcontact["kanaal"], self.openklant2_config.mijn_vragen_kanaal
+        )
+        self.assertEqual(klantcontact["inhoud"], "A question from an anonymous user")
+        self.assertEqual(klantcontact["onderwerp"], "Anonymous inquiry")
+
+        # Check betrokkene - should be linked to klantcontact but NOT to a partij
+        self.assertEqual(betrokkene["hadKlantcontact"]["uuid"], klantcontact["uuid"])
+        self.assertIsNone(betrokkene["wasPartij"])
+        self.assertEqual(betrokkene["contactnaam"]["voornaam"], "Hieronymous")
+        self.assertEqual(betrokkene["contactnaam"]["achternaam"], "Anonymous")
+        self.assertTrue(betrokkene["initiator"])
+        self.assertEqual(betrokkene["rol"], "klant")
+
+        # Check taak
+        self.assertEqual(
+            taak["aanleidinggevendKlantcontact"]["uuid"], klantcontact["uuid"]
+        )
+
+        # Check digital addresses were created for the betrokkene
+        digitale_adressen = self.service.retrieve_digitale_addressen_for_betrokkene(
+            betrokkene["uuid"]
+        )
+        self.assertEqual(len(digitale_adressen), 2)
+
+        email_addresses = [
+            addr for addr in digitale_adressen if addr["soortDigitaalAdres"] == "email"
+        ]
+        phone_addresses = [
+            addr
+            for addr in digitale_adressen
+            if addr["soortDigitaalAdres"] == "telefoonnummer"
+        ]
+
+        self.assertEqual(len(email_addresses), 1)
+        self.assertEqual(
+            email_addresses[0]["adres"], "hieronymous.anonymous@example.com"
+        )
+        self.assertEqual(
+            email_addresses[0]["verstrektDoorBetrokkene"]["uuid"], betrokkene["uuid"]
+        )
+        self.assertIsNone(email_addresses[0]["verstrektDoorPartij"])
+
+        self.assertEqual(len(phone_addresses), 1)
+        self.assertEqual(phone_addresses[0]["adres"], "0612345678")
+        self.assertEqual(
+            phone_addresses[0]["verstrektDoorBetrokkene"]["uuid"], betrokkene["uuid"]
+        )
+        self.assertIsNone(phone_addresses[0]["verstrektDoorPartij"])
+
+        # Check the returned question object
+        self.assertEqual(
+            question,
+            OpenKlant2Question(
+                url=klantcontact["url"],
+                answer=None,
+                nummer=klantcontact["nummer"],
+                question_kcm_uuid=klantcontact["uuid"],
+                question="A question from an anonymous user",
+                onderwerp="Anonymous inquiry",
+                kanaal=self.openklant2_config.mijn_vragen_kanaal,
+                taal="nld",
+                plaatsgevonden_op=QUESTION_DATE,
+            ),
+        )
+
+    def test_create_question_with_betrokkene_without_contact_info(self):
+        self.service.create_question_with_betrokkene(
+            question="A question without contact details",
+            subject="Minimal inquiry",
+            first_name="Jane",
+            last_name="Minimal",
+            email="",
+            phonenumber="",
+        )
+
+        # Check that betrokkene was created
+        (betrokkene,) = self.service.client.betrokkene.list_iter()
+        self.assertEqual(betrokkene["contactnaam"]["voornaam"], "Jane")
+        self.assertEqual(betrokkene["contactnaam"]["achternaam"], "Minimal")
+
+        # Check that no digital addresses were created
+        digitale_adressen = self.service.retrieve_digitale_addressen_for_betrokkene(
+            betrokkene["uuid"]
+        )
+        self.assertEqual(len(digitale_adressen), 0)
+
+    def test_create_question_with_betrokkene_partial_contact_info(self):
+        self.service.create_question_with_betrokkene(
+            question="A question with only email",
+            subject="Email only inquiry",
+            first_name="Bob",
+            last_name="EmailOnly",
+            email="bob.email@example.com",
+            phonenumber="",
+        )
+
+        (betrokkene,) = self.service.client.betrokkene.list_iter()
+
+        # Check that only email address was created
+        digitale_adressen = self.service.retrieve_digitale_addressen_for_betrokkene(
+            betrokkene["uuid"]
+        )
+        self.assertEqual(len(digitale_adressen), 1)
+        self.assertEqual(digitale_adressen[0]["soortDigitaalAdres"], "email")
+        self.assertEqual(digitale_adressen[0]["adres"], "bob.email@example.com")
+
+    def test_create_question_with_betrokkene_raises_on_missing_question(self):
+        for question in ("", " ", "   ", "\n", "   \n"):
+            with self.subTest(f"{question=} is not a valid question"):
+                with self.assertRaises(ValueError):
+                    self.service.create_question_with_betrokkene(
+                        question=question,
+                        subject="Test subject",
+                        first_name="Test",
+                        last_name="User",
+                        email="test@example.com",
+                        phonenumber="0612345678",
+                    )
+
+    def test_questions_for_partij_ignores_anonymous_questions(self):
+        # Create a question for a partij
+        partij_question = self.service.create_question_for_partij(
+            self.een_persoon["uuid"],
+            question="A question from Alice",
+            subject="Alice's question",
+        )
+
+        # Create an anonymous question (betrokkene without wasPartij)
+        anonymous_question = self.service.create_question_with_betrokkene(
+            question="An anonymous question",
+            subject="Anonymous inquiry",
+            first_name="Anonymous",
+            last_name="User",
+            email="anon@example.com",
+            phonenumber="0612345678",
+        )
+
+        # Get questions for the partij - should only return partij's question, not anonymous
+        questions = self.service.questions_for_partij(self.een_persoon["uuid"])
+
+        self.assertEqual(
+            len(questions), 1, msg="Only the partij's question should be returned"
+        )
+        self.assertEqual(
+            questions[0].question_kcm_uuid,
+            partij_question.question_kcm_uuid,
+            msg="The returned question should be the partij's question",
+        )
+        self.assertNotEqual(
+            questions[0].question_kcm_uuid,
+            anonymous_question.question_kcm_uuid,
+            msg="Anonymous questions should be filtered out",
+        )

--- a/src/open_inwoner/openzaak/services.py
+++ b/src/open_inwoner/openzaak/services.py
@@ -823,6 +823,60 @@ class ZGWService:
 
         return zaak, api_group
 
+    def get_zaak_by_uuid(self, uuid: str) -> ZaakWithApiGroup | None:
+        config = OpenZaakConfig.get_solo()
+        api_groups = list(ZGWApiGroupConfig.objects.select_related("zrc_service"))
+
+        def fetch(api_group: ZGWApiGroupConfig) -> ZaakWithApiGroup:
+            zaak = self._zaken_client_factory(api_group, config).fetch_single_zaak(uuid)
+            return ZaakWithApiGroup(
+                zaak=zaak, api_group=api_group, type_aanvraag=TypeAanvraag.ZAAK
+            )
+
+        results: list[ZaakWithApiGroup] = []
+
+        with parallel(max_workers=self._max_workers) as executor:
+            future_to_group: dict[concurrent.futures.Future, ZGWApiGroupConfig] = {
+                executor.submit(fetch, group): group for group in api_groups
+            }
+            try:
+                for future in concurrent.futures.as_completed(
+                    future_to_group, timeout=config.case_list_fetch_timeout
+                ):
+                    api_group = future_to_group[future]
+                    try:
+                        results.append(future.result())
+                    except ZgwAPIError as exc:
+                        if exc.status_code == 404:
+                            continue
+                        logger.warning(
+                            "error fetching zaak by uuid",
+                            uuid=uuid,
+                            api_group=api_group.pk,
+                            status_code=exc.status_code,
+                            exc_info=True,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "unexpected error fetching zaak by uuid",
+                            uuid=uuid,
+                            api_group=api_group.pk,
+                            exc_info=True,
+                        )
+            except concurrent.futures.TimeoutError:
+                logger.warning(
+                    "timed out fetching zaak by uuid", uuid=uuid, exc_info=True
+                )
+
+        if len(results) > 1:
+            logger.warning(
+                "zaak found in multiple API groups",
+                uuid=uuid,
+                api_groups=[r.api_group.pk for r in results],
+            )
+
+        return results[0] if results else None
+
     def fetch_zaak_by_url(
         self, zaak_url: str, api_group: ZGWApiGroupConfig
     ) -> Zaak | None:

--- a/src/open_inwoner/openzaak/tests/test_case_detail.py
+++ b/src/open_inwoner/openzaak/tests/test_case_detail.py
@@ -3253,10 +3253,10 @@ class TestCaseDetailView(
             "klantcontact": klantcontact,
             "wasKlantcontact": None,
             "onderwerpobjectidentificator": {
-                "objectId": self.zaak["identificatie"],
-                "codeObjecttype": "string",
-                "codeRegister": "string",
-                "codeSoortObjectId": "identificatie",
+                "objectId": self.zaak["uuid"],
+                "codeObjecttype": "zgw-Zaak",
+                "codeRegister": "openzaak",
+                "codeSoortObjectId": "uuid",
             },
         }
         OnderwerpObjectValidator.validate_python(onderwerp_object)

--- a/src/open_inwoner/openzaak/tests/test_services.py
+++ b/src/open_inwoner/openzaak/tests/test_services.py
@@ -1,11 +1,16 @@
 import threading
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
+import requests_mock as requests_mock_module
+
 from open_inwoner.accounts.user_identification import BSNIdentification
-from open_inwoner.openzaak.services import ZGWService
+from open_inwoner.openzaak.constants import TypeAanvraag
+from open_inwoner.openzaak.services import ZaakWithApiGroup, ZGWService
 from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
+from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
+from open_inwoner.openzaak.tests.shared import ANOTHER_ZAKEN_ROOT, ZAKEN_ROOT
 from open_inwoner.utils.test import ClearCachesMixin
 
 _USER_IDENTIFICATION = BSNIdentification(bsn="900222086")
@@ -128,4 +133,119 @@ class TimeoutHandlingTests(ClearCachesMixin, TestCase):
         self.assertEqual(result, [])
         self.assertTrue(
             any("Timeout while fetching formulieren" in msg for msg in cm.output)
+        )
+
+
+_ZAAK_UUID = "d8bbdeb7-770f-4ca9-b1ea-77b4730bf67d"
+
+
+@requests_mock_module.Mocker()
+class GetZaakByUuidTests(ClearCachesMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.api_group_1 = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ZAKEN_ROOT, form_service=None
+        )
+        self.api_group_2 = ZGWApiGroupConfigFactory(
+            zrc_service__api_root=ANOTHER_ZAKEN_ROOT, form_service=None
+        )
+        self.service = ZGWService()
+        self.zaak_data = generate_oas_component_cached(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}",
+            identificatie="ZAAK-2022-0000000024",
+            omschrijving="Test zaak",
+            startdatum="2022-01-02",
+            einddatum=None,
+        )
+
+    def test_returns_zaak_when_found_in_one_group(self, m):
+        m.get(f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}", json=self.zaak_data)
+        m.get(f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=404)
+
+        result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ZaakWithApiGroup)
+        self.assertEqual(result.api_group, self.api_group_1)
+        self.assertEqual(result.type_aanvraag, TypeAanvraag.ZAAK)
+
+    def test_returns_none_when_all_groups_return_404(self, m):
+        m.get(f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=404)
+        m.get(f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=404)
+
+        with self.assertNoLogs("open_inwoner.openzaak.services", level="WARNING"):
+            result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+
+        self.assertIsNone(result)
+
+    def test_logs_warning_for_non_404_client_error(self, m):
+        m.get(f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=403)
+        m.get(f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=404)
+
+        with self.assertLogs("open_inwoner.openzaak.services", level="WARNING") as cm:
+            result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+
+        self.assertIsNone(result)
+        self.assertTrue(any("error fetching zaak by uuid" in msg for msg in cm.output))
+
+    def test_logs_warning_for_server_error(self, m):
+        m.get(f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=500)
+        m.get(f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}", status_code=404)
+
+        with self.assertLogs("open_inwoner.openzaak.services", level="WARNING") as cm:
+            result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+
+        self.assertIsNone(result)
+        self.assertTrue(any("error fetching zaak by uuid" in msg for msg in cm.output))
+
+    def test_logs_warning_and_returns_first_when_found_in_multiple_groups(self, m):
+        zaak_data_2 = {
+            **self.zaak_data,
+            "url": f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}",
+        }
+        m.get(f"{ZAKEN_ROOT}zaken/{_ZAAK_UUID}", json=self.zaak_data)
+        m.get(f"{ANOTHER_ZAKEN_ROOT}zaken/{_ZAAK_UUID}", json=zaak_data_2)
+
+        with self.assertLogs("open_inwoner.openzaak.services", level="WARNING") as cm:
+            result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ZaakWithApiGroup)
+        self.assertTrue(
+            any("zaak found in multiple API groups" in msg for msg in cm.output)
+        )
+
+    def test_logs_warning_on_timeout(self, m):
+        release = threading.Event()
+        timer = threading.Timer(0.05, release.set)
+
+        mock_client = Mock()
+        mock_client.fetch_single_zaak.side_effect = lambda *a, **kw: release.wait(
+            timeout=5
+        )
+
+        with (
+            patch.object(
+                self.service, "_zaken_client_factory", return_value=mock_client
+            ),
+            patch(
+                "open_inwoner.openzaak.services.OpenZaakConfig.get_solo",
+                return_value=Mock(case_list_fetch_timeout=0.001),
+            ),
+        ):
+            timer.start()
+            try:
+                with self.assertLogs(
+                    "open_inwoner.openzaak.services", level="WARNING"
+                ) as cm:
+                    result = self.service.get_zaak_by_uuid(_ZAAK_UUID)
+            finally:
+                release.set()
+                timer.cancel()
+
+        self.assertIsNone(result)
+        self.assertTrue(
+            any("timed out fetching zaak by uuid" in msg for msg in cm.output)
         )

--- a/src/open_inwoner/utils/api.py
+++ b/src/open_inwoner/utils/api.py
@@ -11,7 +11,9 @@ Object = dict[str, Any]
 
 
 class APIError(Exception):
-    pass
+    def __init__(self, message: str = "", status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class BaseAPIClient(APIClient):
@@ -43,8 +45,12 @@ class BaseAPIClient(APIClient):
             response.raise_for_status()
         except requests.HTTPError as exc:
             if response.status_code >= 500:
-                raise self.server_error_type(str(exc)) from exc
-            raise self.client_error_type(str(exc)) from exc
+                raise self.server_error_type(
+                    str(exc), status_code=response.status_code
+                ) from exc
+            raise self.client_error_type(
+                str(exc), status_code=response.status_code
+            ) from exc
 
     def parse_json(self, response) -> dict:
         try:


### PR DESCRIPTION
## Summary

Stored the zaak UUID (extracted from its URL) as `onderwerpobjectidentificator.objectId` instead of the human-readable `identificatie`, and set `codeObjecttype` / `codeSoortObjectId` to match (`zgw-Zaak` / `uuid`).

 Added `ZGWService.get_zaak_by_uuid()` to resolve a zaak across all configured API groups by UUID. Use it in retrieve_question instead of `search_zaken()`, which filtered by `identificatie` and would no longer match. Update `list_questions_for_zaak()` to filter the OpenKlant API by UUID as well.

Restored VCR cassettes for OpenKlant API integration tests which were removed during a recent refactor.

Closes #2663 
