### PR TITLE
[#2684] Stop raising CommandError on partial zgw_import_data failures

### DIFF
--- a/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
+++ b/src/open_inwoner/openzaak/management/commands/zgw_import_data.py
@@ -1,8 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from open_inwoner.openzaak.models import ZGWApiGroupConfig
 from open_inwoner.openzaak.zgw_imports import (
-    ExclusionReason,
     ZGWCatalogusImporter,
 )
 
@@ -22,18 +21,9 @@ class Command(BaseCommand):
             for api_group in ZGWApiGroupConfig.objects.all()
         ]
 
-        results = []
+        outputs: list[str] = []
         for importer in importers:
             result = importer.import_all()
-            results.append(result)
+            outputs.append(result.pretty_print())
 
-        self.stdout.write("\n".join(result.pretty_print() for result in results))
-
-        has_errors = any(
-            excluded.reason
-            in (ExclusionReason.API_ERROR, ExclusionReason.DATABASE_ERROR)
-            for result in results
-            for excluded in result.all_excluded()
-        )
-        if has_errors:
-            raise CommandError("Import completed with errors")
+        self.stdout.write("\n".join(outputs))

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports.py
@@ -21,11 +21,7 @@ from open_inwoner.openzaak.tests.factories import (
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import ANOTHER_CATALOGI_ROOT, CATALOGI_ROOT
 from open_inwoner.openzaak.zgw_imports import (
-    ExcludedObject,
     ExclusionReason,
-    FullImportResult,
-    ImportResult,
-    ZaakTypeRelatedImportResult,
     ZGWCatalogusImporter,
 )
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
@@ -2991,56 +2987,3 @@ class ZGWImportTest(ClearCachesMixin, TestCase):
                 f"ZaakType {zt.identificatie} from API group 2 should not be affected "
                 f"by API group 1's import",
             )
-
-
-class FullImportResultAllExcludedTest(TestCase):
-    def _make_excluded(
-        self, object_type="StatusType", reason=ExclusionReason.API_ERROR
-    ):
-        return ExcludedObject(
-            object_type=object_type, url="https://example.com", reason=reason
-        )
-
-    def test_all_excluded_empty_when_no_exclusions(self):
-        api_group = ZGWApiGroupConfigFactory()
-        result = FullImportResult(api_group=api_group)
-        self.assertEqual(result.all_excluded(), [])
-
-    def test_all_excluded_collects_from_catalogi_and_zaaktypen(self):
-        api_group = ZGWApiGroupConfigFactory()
-        exc_catalogus = self._make_excluded("Catalogus")
-        exc_zaaktype = self._make_excluded("ZaakType")
-        result = FullImportResult(
-            api_group=api_group,
-            catalogi=ImportResult(excluded=[exc_catalogus]),
-            zaaktypen=ImportResult(excluded=[exc_zaaktype]),
-        )
-        self.assertEqual(result.all_excluded(), [exc_catalogus, exc_zaaktype])
-
-    def test_all_excluded_collects_from_per_zaaktype_results(self):
-        api_group = ZGWApiGroupConfigFactory()
-        exc_statustype = self._make_excluded("StatusType")
-        exc_resultaattype = self._make_excluded("ResultaatType")
-        exc_iot = self._make_excluded("InformatieObjectType")
-        result = FullImportResult(
-            api_group=api_group,
-            statustypen=[ZaakTypeRelatedImportResult(excluded=[exc_statustype])],
-            resultaattypen=[ZaakTypeRelatedImportResult(excluded=[exc_resultaattype])],
-            informatieobjecttypen=[ZaakTypeRelatedImportResult(excluded=[exc_iot])],
-        )
-        self.assertCountEqual(
-            result.all_excluded(), [exc_statustype, exc_resultaattype, exc_iot]
-        )
-
-    def test_all_excluded_returns_flat_list_across_multiple_zaaktypen(self):
-        api_group = ZGWApiGroupConfigFactory()
-        exc_a = self._make_excluded("StatusType")
-        exc_b = self._make_excluded("StatusType")
-        result = FullImportResult(
-            api_group=api_group,
-            statustypen=[
-                ZaakTypeRelatedImportResult(excluded=[exc_a]),
-                ZaakTypeRelatedImportResult(excluded=[exc_b]),
-            ],
-        )
-        self.assertEqual(result.all_excluded(), [exc_a, exc_b])

--- a/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
+++ b/src/open_inwoner/openzaak/tests/test_zgw_imports_command.py
@@ -2,7 +2,6 @@ from io import StringIO
 from unittest import mock
 
 from django.core.management import call_command
-from django.core.management.base import CommandError
 from django.test import TestCase
 
 import requests_mock
@@ -19,12 +18,6 @@ from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
 from open_inwoner.openzaak.tests.helpers import generate_oas_component_cached
 from open_inwoner.openzaak.tests.shared import ANOTHER_CATALOGI_ROOT, CATALOGI_ROOT
 from open_inwoner.openzaak.tests.test_zgw_imports import CatalogMockData
-from open_inwoner.openzaak.zgw_imports import (
-    ExcludedObject,
-    ExclusionReason,
-    FullImportResult,
-    ImportResult,
-)
 from open_inwoner.utils.test import ClearCachesMixin, paginated_response
 
 
@@ -478,54 +471,3 @@ class ZGWImportCommandWithoutConfigTest(TestCase):
         )
         # Verify the importer was never instantiated
         mock_importer.assert_not_called()
-
-
-class ZGWImportCommandErrorHandlingTest(TestCase):
-    def _make_result_with_exclusion(self, reason):
-        api_group = ZGWApiGroupConfigFactory()
-        return FullImportResult(
-            api_group=api_group,
-            zaaktypen=ImportResult(
-                excluded=[
-                    ExcludedObject(
-                        object_type="ZaakType",
-                        url="https://ztc.example.com/zaaktypen/1",
-                        reason=reason,
-                    )
-                ]
-            ),
-        )
-
-    @mock.patch(
-        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
-    )
-    def test_command_raises_on_api_error(self, mock_importer_cls):
-        result = self._make_result_with_exclusion(ExclusionReason.API_ERROR)
-        mock_importer_cls.return_value.import_all.return_value = result
-        # ZGWApiGroupConfig.objects.all() must return something for importers to be built
-        ZGWApiGroupConfigFactory()
-
-        with self.assertRaises(CommandError):
-            call_command("zgw_import_data", stdout=StringIO())
-
-    @mock.patch(
-        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
-    )
-    def test_command_raises_on_database_error(self, mock_importer_cls):
-        result = self._make_result_with_exclusion(ExclusionReason.DATABASE_ERROR)
-        mock_importer_cls.return_value.import_all.return_value = result
-        ZGWApiGroupConfigFactory()
-
-        with self.assertRaises(CommandError):
-            call_command("zgw_import_data", stdout=StringIO())
-
-    @mock.patch(
-        "open_inwoner.openzaak.management.commands.zgw_import_data.ZGWCatalogusImporter"
-    )
-    def test_command_does_not_raise_for_filtered_internal(self, mock_importer_cls):
-        result = self._make_result_with_exclusion(ExclusionReason.FILTERED_INTERNAL)
-        mock_importer_cls.return_value.import_all.return_value = result
-        ZGWApiGroupConfigFactory()
-
-        # Should not raise
-        call_command("zgw_import_data", stdout=StringIO())

--- a/src/open_inwoner/openzaak/zgw_imports.py
+++ b/src/open_inwoner/openzaak/zgw_imports.py
@@ -119,18 +119,6 @@ class FullImportResult:
         field(default_factory=list)
     )
 
-    def all_excluded(self) -> list[ExcludedObject]:
-        excluded = []
-        excluded.extend(self.catalogi.excluded)
-        excluded.extend(self.zaaktypen.excluded)
-        for obj in self.informatieobjecttypen:
-            excluded.extend(obj.excluded)
-        for obj in self.statustypen:
-            excluded.extend(obj.excluded)
-        for obj in self.resultaattypen:
-            excluded.extend(obj.excluded)
-        return excluded
-
     def pretty_print(self) -> str:
         """
         Generate a human-readable summary of the import results.


### PR DESCRIPTION
Reverts the error-raising behavior added in 7a0dd6019: partial API/DB failures during zgw_import_data no longer abort the command with a CommandError. Also removes the now-unused FullImportResult.all_excluded() helper and its tests, which existed only to support that check.

Closes #2684 