### PR TITLE
[#2669] Use short weekday format for Mijn Afval pickup dates

### DIFF
--- a/src/open_inwoner/mijn_afval/views.py
+++ b/src/open_inwoner/mijn_afval/views.py
@@ -388,7 +388,7 @@ def _format_afval_profiel(profiel: AfvalProfiel) -> list[_ContainerLocationData]
                     lediging_data: _LedigingData = {
                         "tijdstip_datum": lediging.geleegd_op.strftime("%d-%m-%Y"),
                         "tijdstip_tijd": lediging.geleegd_op.strftime("%H:%M"),
-                        "tijdstip_dag": date_format(lediging.geleegd_op, "l"),
+                        "tijdstip_dag": date_format(lediging.geleegd_op, "D"),
                         "gewicht": _format_number(lediging.gewicht),
                         "kosten": _format_number(lediging.kosten, decimal_places=2),
                     }


### PR DESCRIPTION
Switch the weekday label from Django's full-name format (l) to the localized short format (D), so pickup dates show as e.g. Mon instead of Monday, consistent with the requested display format.

Closes #2669 
