### PR TITLE
[#2676] Show public container id in Mijn Afval container heading

### DIFF
--- a/src/open_inwoner/mijn_afval/api_models.py
+++ b/src/open_inwoner/mijn_afval/api_models.py
@@ -24,6 +24,7 @@ class Periode(PydanticModel):
 
 class AfvalContainer(PydanticModel):
     id: str
+    public_container_id: str
     afval_type: str
     is_verzamelcontainer: bool
     heeft_sleutel: bool

--- a/src/open_inwoner/mijn_afval/tests/test_client.py
+++ b/src/open_inwoner/mijn_afval/tests/test_client.py
@@ -22,6 +22,7 @@ class OpenAfvalClientTest(TestCase):
             "containers": [
                 {
                     "id": "container-1",
+                    "publicContainerId": "PUB-001",
                     "afvalType": "restafval",
                     "isVerzamelcontainer": True,
                     "heeftSleutel": True,

--- a/src/open_inwoner/mijn_afval/tests/test_views.py
+++ b/src/open_inwoner/mijn_afval/tests/test_views.py
@@ -25,6 +25,7 @@ class ExtractFilterOptionsTest(TestCase):
             containers=[
                 AfvalContainer(
                     id="container-1",
+                    public_container_id="PUB-001",
                     afval_type="gft",
                     is_verzamelcontainer=False,
                     heeft_sleutel=True,

--- a/src/open_inwoner/mijn_afval/views.py
+++ b/src/open_inwoner/mijn_afval/views.py
@@ -260,7 +260,7 @@ def _format_container_for_table(
         ledigingen: List of formatted lediging objects
         totaal_gewicht: Total weight of the container
         totaal_kosten: Total cost of all ledigingen for this container
-        identifier: Container identifier
+        identifier: Public container identifier shown in the heading
         type_label: Localized container type label (e.g., "Groente, Fruit en Tuin afval (GFT)")
 
     Returns:
@@ -404,7 +404,7 @@ def _format_afval_profiel(profiel: AfvalProfiel) -> list[_ContainerLocationData]
                 ledigingen_data,
                 totaal_gewicht,
                 totaal_kosten,
-                container.id,
+                container.public_container_id,
                 _get_container_type_label(afval_type),
             )
 


### PR DESCRIPTION
The container table caption used the internal API id, which is an opaque identifier not meant for end users. Add publicContainerId to the AfvalContainer model and use it in the heading instead.

Closes #2676 