### PR TITLE
[#2691] Hide global preferred address from profile page

### DIFF
--- a/src/open_inwoner/accounts/forms.py
+++ b/src/open_inwoner/accounts/forms.py
@@ -152,7 +152,6 @@ class BaseUserForm(forms.ModelForm):
         fields = (
             "image",
             "cropping",
-            "preferred_address",
         )
 
     def __init__(self, user, *args, **kwargs):
@@ -164,14 +163,6 @@ class BaseUserForm(forms.ModelForm):
 
         if "first_name" in self.fields:
             self.fields["first_name"].validators.append(CharFieldValidator())
-
-        self.fields["preferred_address"].required = False
-        self.fields["preferred_address"].empty_label = _("Geen voorkeur")
-        self.fields["preferred_address"].queryset = (
-            self.instance.digital_addresses.all()
-            if self.instance.pk
-            else DigitalAddress.objects.none()
-        )
 
 
 class UserForm(ErrorMessageMixin, BaseUserForm):
@@ -193,7 +184,6 @@ class UserForm(ErrorMessageMixin, BaseUserForm):
             "city",
             "image",
             "cropping",
-            "preferred_address",
         )
 
 

--- a/src/open_inwoner/templates/pages/profile/_digital_addresses.html
+++ b/src/open_inwoner/templates/pages/profile/_digital_addresses.html
@@ -15,9 +15,3 @@
         {% endfor %}
     </div>
 </div>
-<div class="tabled__row tabled__row--blank">
-    <div class="tabled__item tabled__key">{% trans "Voorkeur digitaal adres" %}</div>
-    <div class="tabled__item tabled__value">
-        {% if user.preferred_address %}{{ user.preferred_address }}{% else %}{% trans "Niet ingesteld" %}{% endif %}
-    </div>
-</div>

--- a/src/open_inwoner/templates/pages/profile/edit.html
+++ b/src/open_inwoner/templates/pages/profile/edit.html
@@ -29,11 +29,9 @@
                         {% if user.is_eherkenning_user %}
                             {% addition_input email_formset %}
                             {% addition_input phone_formset %}
-                            {% input form.preferred_address %}
                         {% elif user.is_bsn_user_with_brp %}
                             {% addition_input email_formset %}
                             {% addition_input phone_formset %}
-                            {% input form.preferred_address %}
                             {% if user.contact_type == "begeleider" %}
                                 {% input form.image no_help=True %}
                                 {% image_crop form.cropping %}
@@ -44,7 +42,6 @@
                             {% input form.last_name %}
                             {% addition_input email_formset %}
                             {% addition_input phone_formset %}
-                            {% input form.preferred_address %}
                             {% input form.street %}
                             {% input form.housenumber %}
                             {% input form.postcode %}


### PR DESCRIPTION
The global preferred address selector ('Voorkeur digitaal adres') is removed from the profile view and edit forms until its intended use is clarified. The field, model validation, and openklant sync logic remain unchanged.

Closes #2691 
