### PR TITLE
fix: [#2662] keep legacy per-provider OIDC callback URLs as redirect_uri

### DIFF
--- a/src/open_inwoner/accounts/digid_urls.py
+++ b/src/open_inwoner/accounts/digid_urls.py
@@ -9,7 +9,10 @@ app_name = "digid_oidc"
 
 
 urlpatterns = [
-    # XXX: generic callback view, this can move to a single URL.
+    # Deprecated: legacy callback URL, kept because customers have whitelisted it in
+    # their IdP configuration (see LegacyCallbackURLMixin in oidc_plugins.plugins).
+    # Remove in favour of the generic /oidc/callback/ endpoint once IdP whitelists
+    # have been updated everywhere.
     path("callback/", OIDCCallbackView.as_view(), name="callback"),
     path("authenticate/", digid_init, name="init"),
     path("logout/", digid_logout, name="logout"),

--- a/src/open_inwoner/accounts/eherkenning_urls.py
+++ b/src/open_inwoner/accounts/eherkenning_urls.py
@@ -9,7 +9,10 @@ app_name = "eherkenning_oidc"
 
 
 urlpatterns = [
-    # XXX: generic callback view, this can move to a single URL.
+    # Deprecated: legacy callback URL, kept because customers have whitelisted it in
+    # their IdP configuration (see LegacyCallbackURLMixin in oidc_plugins.plugins).
+    # Remove in favour of the generic /oidc/callback/ endpoint once IdP whitelists
+    # have been updated everywhere.
     path("callback/", OIDCCallbackView.as_view(), name="callback"),
     path("authenticate/", eherkenning_init, name="init"),
     path("logout/", eherkenning_logout, name="logout"),

--- a/src/open_inwoner/accounts/eidas_urls.py
+++ b/src/open_inwoner/accounts/eidas_urls.py
@@ -9,6 +9,10 @@ app_name = "eidas_oidc"
 
 
 urlpatterns = [
+    # Deprecated: legacy callback URL, kept because customers have whitelisted it in
+    # their IdP configuration (see LegacyCallbackURLMixin in oidc_plugins.plugins).
+    # Remove in favour of the generic /oidc/callback/ endpoint once IdP whitelists
+    # have been updated everywhere.
     path("callback/", OIDCCallbackView.as_view(), name="callback"),
     path("authenticate/", eidas_init, name="init"),
     path("logout/", eidas_logout, name="logout"),

--- a/src/open_inwoner/accounts/oidc_plugins/plugins.py
+++ b/src/open_inwoner/accounts/oidc_plugins/plugins.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponseBase
 
 from digid_eherkenning.oidc.schemas import (
@@ -30,14 +31,21 @@ class LegacyCallbackURLMixin:
        ``redirect_uri`` because customers have whitelisted them in their identity
        provider configuration, and switching would break logins until every IdP
        whitelist is updated. Once all environments also whitelist
-       ``/oidc/callback/``, remove this mixin and the legacy callback routes in the
-       ``*_urls`` modules.
+       ``/oidc/callback/``, remove this mixin, the ``OIDC_USE_LEGACY_ENDPOINTS``
+       setting and the legacy callback routes in the ``*_urls`` modules.
+
+    Controlled by the deprecated ``OIDC_USE_LEGACY_ENDPOINTS`` setting (default
+    ``True``), so the legacy behaviour can be turned off per environment once its
+    IdP whitelist has been updated, ahead of the eventual removal.
     """
 
     legacy_callback_url_name: str
 
     def get_setting(self, attr: str, *args) -> Any:
-        if attr == "OIDC_AUTHENTICATION_CALLBACK_URL":
+        if (
+            attr == "OIDC_AUTHENTICATION_CALLBACK_URL"
+            and settings.OIDC_USE_LEGACY_ENDPOINTS
+        ):
             return self.legacy_callback_url_name
         return super().get_setting(attr, *args)
 

--- a/src/open_inwoner/accounts/oidc_plugins/plugins.py
+++ b/src/open_inwoner/accounts/oidc_plugins/plugins.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.http import HttpRequest, HttpResponseBase
 
 from digid_eherkenning.oidc.schemas import (
@@ -18,8 +20,32 @@ from .constants import OIDC_DIGID_IDENTIFIER, OIDC_EH_IDENTIFIER, OIDC_EIDAS_IDE
 from .schema import EIDAS_OPTIONS_SCHEMA
 
 
+class LegacyCallbackURLMixin:
+    """
+    Advertise the legacy per-provider callback URL as ``redirect_uri`` to the IdP.
+
+    .. deprecated:: The per-provider callback URLs (``/digid-oidc/callback/`` etc.)
+       predate the plugin architecture, which routes all callbacks through the single
+       generic ``/oidc/callback/`` endpoint. They are kept as the advertised
+       ``redirect_uri`` because customers have whitelisted them in their identity
+       provider configuration, and switching would break logins until every IdP
+       whitelist is updated. Once all environments also whitelist
+       ``/oidc/callback/``, remove this mixin and the legacy callback routes in the
+       ``*_urls`` modules.
+    """
+
+    legacy_callback_url_name: str
+
+    def get_setting(self, attr: str, *args) -> Any:
+        if attr == "OIDC_AUTHENTICATION_CALLBACK_URL":
+            return self.legacy_callback_url_name
+        return super().get_setting(attr, *args)
+
+
 @register(OIDC_DIGID_IDENTIFIER)
-class DigiDOIDCPlugin(AbstractUserOIDCPlugin):
+class DigiDOIDCPlugin(LegacyCallbackURLMixin, AbstractUserOIDCPlugin):
+    legacy_callback_url_name = "digid_oidc:callback"
+
     def get_schema(self) -> JSONObject:
         return DIGID_OPTIONS_SCHEMA
 
@@ -31,7 +57,9 @@ class DigiDOIDCPlugin(AbstractUserOIDCPlugin):
 
 
 @register(OIDC_EH_IDENTIFIER)
-class eHerkenningOIDCPlugin(AbstractUserOIDCPlugin):
+class eHerkenningOIDCPlugin(LegacyCallbackURLMixin, AbstractUserOIDCPlugin):
+    legacy_callback_url_name = "eherkenning_oidc:callback"
+
     def get_schema(self) -> JSONObject:
         return EHERKENNING_OPTIONS_SCHEMA
 
@@ -43,7 +71,9 @@ class eHerkenningOIDCPlugin(AbstractUserOIDCPlugin):
 
 
 @register(OIDC_EIDAS_IDENTIFIER)
-class EIDASOIDCPlugin(AbstractUserOIDCPlugin):
+class EIDASOIDCPlugin(LegacyCallbackURLMixin, AbstractUserOIDCPlugin):
+    legacy_callback_url_name = "eidas_oidc:callback"
+
     def get_schema(self) -> JSONObject:
         return EIDAS_OPTIONS_SCHEMA
 

--- a/src/open_inwoner/accounts/tests/test_oidc_login_e2e.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_login_e2e.py
@@ -198,6 +198,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
         link_selector: str,
         username: str,
         password: str,
+        callback_path: str,
         activate_zakelijk: bool = False,
     ):
         """Log in by visiting the login page and clicking the flow's link.
@@ -205,9 +206,20 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
         This exercises the login-page rendering + link wiring, not just the init
         view. A fresh browser context per call keeps Keycloak's SSO session from
         carrying over between flows.
+
+        ``callback_path`` is the URL path Keycloak must redirect the browser back
+        to. For the citizen flows this is the legacy per-provider callback URL:
+        that is the redirect_uri customers have whitelisted in their IdP
+        configuration, and it must not silently change (see
+        LegacyCallbackURLMixin in oidc_plugins.plugins).
         """
         context = self.get_context()
         page = context.new_page()
+
+        # Record the browser's requests so we can assert which callback URL the
+        # IdP redirected to.
+        request_urls: list[str] = []
+        page.on("request", lambda request: request_urls.append(request.url))
 
         page.goto(self.live_reverse("login"))
         if activate_zakelijk:
@@ -223,6 +235,13 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
 
         # Back on our live server (callback + post-login redirect).
         page.wait_for_url(lambda url: url.startswith(self.live_server_url))
+
+        callback_prefix = f"{self.live_server_url}{callback_path}"
+        self.assertTrue(
+            any(url.startswith(callback_prefix) for url in request_urls),
+            f"expected Keycloak to redirect the browser to {callback_prefix}, "
+            f"but no request hit it",
+        )
         return page
 
     def _assert_active_session(self, context, user: User) -> None:
@@ -246,7 +265,10 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
     def test_digid_login(self):
         """DigiD (BSN) via `testuser` -> bsn 111222333, logged in."""
         page = self._login(
-            link_selector=".link--digid", username="testuser", password="testuser"
+            link_selector=".link--digid",
+            username="testuser",
+            password="testuser",
+            callback_path="/digid-oidc/callback/",
         )
 
         user = User.objects.get(login_type=LoginTypeChoices.digid)
@@ -259,6 +281,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             link_selector=".link--eherkenning",
             username="eherkenning-vestiging",
             password="eherkenning-vestiging",
+            callback_path="/eherkenning-oidc/callback/",
             activate_zakelijk=True,
         )
 
@@ -277,6 +300,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             link_selector=".link--eherkenning",
             username="eherkenning-rechtspersoon",
             password="eherkenning-rechtspersoon",
+            callback_path="/eherkenning-oidc/callback/",
             activate_zakelijk=True,
         )
 
@@ -297,6 +321,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             link_selector=".link--eidas",
             username="eidas-person-pseudo",
             password="eidas-person-pseudo",
+            callback_path="/eidas-oidc/callback/",
         )
 
         user = User.objects.get(login_type=LoginTypeChoices.eidas_person_pseudo_id)
@@ -306,7 +331,12 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
     def test_admin_oidc_login(self):
         """Admin SSO via `admin` -> staff + superuser (Registreerders), logged in."""
         page = self._login(
-            link_selector=".link--oidc", username="admin", password="admin"
+            link_selector=".link--oidc",
+            username="admin",
+            password="admin",
+            # The admin flow always used the generic callback endpoint; only the
+            # citizen flows have legacy per-provider callback URLs.
+            callback_path="/oidc/callback/",
         )
 
         # Fetch by oidc_id (the sub): create_homepage() also makes a staff user,
@@ -331,7 +361,10 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
         existing = DigidUserFactory(bsn="111222333")
 
         self._login(
-            link_selector=".link--digid", username="testuser", password="testuser"
+            link_selector=".link--digid",
+            username="testuser",
+            password="testuser",
+            callback_path="/digid-oidc/callback/",
         )
 
         self._assert_reused(existing.pk, bsn="111222333")
@@ -345,6 +378,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             link_selector=".link--eherkenning",
             username="eherkenning-vestiging",
             password="eherkenning-vestiging",
+            callback_path="/eherkenning-oidc/callback/",
             activate_zakelijk=True,
         )
 
@@ -360,6 +394,7 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             link_selector=".link--eidas",
             username="eidas-person-pseudo",
             password="eidas-person-pseudo",
+            callback_path="/eidas-oidc/callback/",
         )
 
         self._assert_reused(existing.pk, eidas_pseudo_id="4B75A0EA107B3D36")
@@ -369,7 +404,12 @@ class OIDCLoginFlowsE2ETest(PlaywrightSyncLiveServerTestCase):
             oidc_id=KEYCLOAK_ADMIN_SUB, login_type=LoginTypeChoices.oidc
         )
 
-        self._login(link_selector=".link--oidc", username="admin", password="admin")
+        self._login(
+            link_selector=".link--oidc",
+            username="admin",
+            password="admin",
+            callback_path="/oidc/callback/",
+        )
 
         self._assert_reused(existing.pk, oidc_id=KEYCLOAK_ADMIN_SUB)
         self.assertTrue(User.objects.get(pk=existing.pk).is_superuser)

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -71,6 +71,12 @@ def perform_oidc_login(
 
     callback_url = reverse(f"{login_type}_oidc:callback")
 
+    # The advertised redirect_uri must be the legacy per-provider callback URL
+    # (see LegacyCallbackURLMixin), and the simulated IdP redirect below must
+    # target that same URL to stay faithful to the real flow.
+    advertised_redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+    assert advertised_redirect_uri == f"http://testserver{callback_url}"
+
     with requests_mock.Mocker() as m:
         callback_url = (
             furl(f"http://testserver{callback_url}")
@@ -493,6 +499,23 @@ class DigiDOIDCFlowTests(OIDCMixin, WebTest):
     @property
     def regular_users(self):
         return User.objects.exclude(pk__in=self._infra_user_pks)
+
+    def test_init_advertises_legacy_callback_url(self):
+        """
+        The redirect_uri sent to the IdP must remain the legacy per-provider
+        callback URL: customers have whitelisted these URLs in their IdP
+        configuration (see LegacyCallbackURLMixin).
+        """
+        OIDCClientFactory(
+            with_digid=True,
+            oidc_provider__oidc_op_authorization_endpoint="http://idp.local/auth",
+        )
+
+        init_response = self.app.get(reverse("digid_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/digid-oidc/callback/")
 
     @patch("open_inwoner.accounts.signals._update_user_from_brp")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
@@ -1062,6 +1085,23 @@ class eHerkenningOIDCFlowTests(OIDCMixin, WebTest):
     def regular_users(self):
         """Users created by tests, excluding CMS infrastructure users."""
         return User.objects.exclude(pk__in=self._infra_user_pks)
+
+    def test_init_advertises_legacy_callback_url(self):
+        """
+        The redirect_uri sent to the IdP must remain the legacy per-provider
+        callback URL: customers have whitelisted these URLs in their IdP
+        configuration (see LegacyCallbackURLMixin).
+        """
+        OIDCClientFactory(
+            with_eherkenning=True,
+            oidc_provider__oidc_op_authorization_endpoint="http://idp.local/auth",
+        )
+
+        init_response = self.app.get(reverse("eherkenning_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/eherkenning-oidc/callback/")
 
     @skip(
         "[#2662] This guarded a ValueError that the old mozilla-django-oidc-db "
@@ -2191,6 +2231,18 @@ class EIDASOIDCFlowTests(OIDCMixin, WebTest):
                 }
             },
         )
+
+    def test_init_advertises_legacy_callback_url(self):
+        """
+        The redirect_uri sent to the IdP must remain the legacy per-provider
+        callback URL: customers have whitelisted these URLs in their IdP
+        configuration (see LegacyCallbackURLMixin).
+        """
+        init_response = self.app.get(reverse("eidas_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/eidas-oidc/callback/")
 
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")

--- a/src/open_inwoner/accounts/tests/test_oidc_views.py
+++ b/src/open_inwoner/accounts/tests/test_oidc_views.py
@@ -517,6 +517,23 @@ class DigiDOIDCFlowTests(OIDCMixin, WebTest):
         redirect_uri = furl(init_response.url).query.params["redirect_uri"]
         self.assertEqual(redirect_uri, "http://testserver/digid-oidc/callback/")
 
+    @override_settings(OIDC_USE_LEGACY_ENDPOINTS=False)
+    def test_init_advertises_generic_callback_url_when_legacy_endpoints_disabled(self):
+        """
+        Setting the deprecated ``OIDC_USE_LEGACY_ENDPOINTS`` to False must restore
+        the generic /oidc/callback/ endpoint as the advertised redirect_uri.
+        """
+        OIDCClientFactory(
+            with_digid=True,
+            oidc_provider__oidc_op_authorization_endpoint="http://idp.local/auth",
+        )
+
+        init_response = self.app.get(reverse("digid_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/oidc/callback/")
+
     @patch("open_inwoner.accounts.signals._update_user_from_brp")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")
@@ -1102,6 +1119,23 @@ class eHerkenningOIDCFlowTests(OIDCMixin, WebTest):
         self.assertEqual(init_response.status_code, 302)
         redirect_uri = furl(init_response.url).query.params["redirect_uri"]
         self.assertEqual(redirect_uri, "http://testserver/eherkenning-oidc/callback/")
+
+    @override_settings(OIDC_USE_LEGACY_ENDPOINTS=False)
+    def test_init_advertises_generic_callback_url_when_legacy_endpoints_disabled(self):
+        """
+        Setting the deprecated ``OIDC_USE_LEGACY_ENDPOINTS`` to False must restore
+        the generic /oidc/callback/ endpoint as the advertised redirect_uri.
+        """
+        OIDCClientFactory(
+            with_eherkenning=True,
+            oidc_provider__oidc_op_authorization_endpoint="http://idp.local/auth",
+        )
+
+        init_response = self.app.get(reverse("eherkenning_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/oidc/callback/")
 
     @skip(
         "[#2662] This guarded a ValueError that the old mozilla-django-oidc-db "
@@ -2243,6 +2277,18 @@ class EIDASOIDCFlowTests(OIDCMixin, WebTest):
         self.assertEqual(init_response.status_code, 302)
         redirect_uri = furl(init_response.url).query.params["redirect_uri"]
         self.assertEqual(redirect_uri, "http://testserver/eidas-oidc/callback/")
+
+    @override_settings(OIDC_USE_LEGACY_ENDPOINTS=False)
+    def test_init_advertises_generic_callback_url_when_legacy_endpoints_disabled(self):
+        """
+        Setting the deprecated ``OIDC_USE_LEGACY_ENDPOINTS`` to False must restore
+        the generic /oidc/callback/ endpoint as the advertised redirect_uri.
+        """
+        init_response = self.app.get(reverse("eidas_oidc:init"))
+
+        self.assertEqual(init_response.status_code, 302)
+        redirect_uri = furl(init_response.url).query.params["redirect_uri"]
+        self.assertEqual(redirect_uri, "http://testserver/oidc/callback/")
 
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.get_userinfo")
     @patch("mozilla_django_oidc_db.backends.OIDCAuthenticationBackend.store_tokens")

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -1620,6 +1620,23 @@ OIDC_AUTHENTICATION_CALLBACK_URL = "oidc_authentication_callback"
 # ID token is required to enable OIDC logout
 OIDC_STORE_ID_TOKEN = True
 
+OIDC_USE_LEGACY_ENDPOINTS = config(
+    "OIDC_USE_LEGACY_ENDPOINTS",
+    default=True,
+    documentation=DocumentationParams(
+        help_text=(
+            "Deprecated: advertise the legacy per-provider OIDC callback URLs "
+            "(e.g. /digid-oidc/callback/) as the redirect_uri sent to the IdP, "
+            "instead of the generic /oidc/callback/ endpoint. Kept for backwards "
+            "compatibility with identity providers that whitelist the legacy "
+            "URLs. Set to False once every IdP whitelist has been updated to "
+            "allow the generic callback endpoint; this setting will be removed "
+            "in a future release."
+        ),
+        group="Security",
+    ),
+)
+
 # Amount of elapsed time before redirecting the user back to the IdP for re-authentication
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = config(
     "OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS",


### PR DESCRIPTION
The mozilla-django-oidc-db 2.0.1 upgrade dropped our per-config oidc_authentication_callback_url properties, so every flow started advertising the generic /oidc/callback/ endpoint as redirect_uri. Customer IdPs whitelist the legacy per-provider callback URLs (/digid-oidc/callback/ etc.), so rolling out the upgrade would break logins until every IdP configuration is updated.

Restore the legacy URLs via a plugin-level get_setting override. The init view, the authentication backend and the SessionRefresh middleware all resolve OIDC_AUTHENTICATION_CALLBACK_URL through the plugin, and the generic callback view dispatches on the OIDC state rather than the URL path, so the old endpoints keep working end-to-end. The admin flow is unaffected: it always used the generic endpoint.

Guard the contract in tests: the OIDC view tests now assert the advertised redirect_uri, and the Keycloak e2e tests assert the browser is redirected back through the expected callback path (the dev realm uses wildcard redirect URIs, so Keycloak itself does not enforce this).

Closes #2712 
