### PR TITLE
[#2711] Update admin manual for OIDC update 

### DIFF
--- a/docs/beheerhandleiding/10_inlog_koppelingen.rst
+++ b/docs/beheerhandleiding/10_inlog_koppelingen.rst
@@ -79,7 +79,7 @@ Dit is de configuratie voor de koppeling van het Open Inwoner platform met eHerk
 
 .. note::
 
-   Wanneer de OpenID Connect-koppeling voor eHerkenning is ingeschakeld (zie sectie 10.6),
+   Wanneer de OpenID Connect-koppeling voor eHerkenning is ingeschakeld (zie sectie 10.5),
    vervangt deze de SAML-koppeling op de loginpagina. Beide kunnen niet tegelijkertijd
    actief zijn.
 
@@ -127,116 +127,288 @@ tot één bestand:
    certificaat bij te werken (potlood icoon) of een nieuw certificaat toe te voegen
    (via het plus icoon).
 
-10.5. OpenID Connect configuratie voor DigiD
-============================================
+10.5. OpenID Connect configuratie (DigiD, eHerkenning en eIDAS)
+===============================================================
 
-Open Inwoner ondersteunt DigiD-login voor burgers via het OpenID Connect protocol (OIDC).
-Dit is een alternatief voor de SAML-gebaseerde DigiD-koppeling. OIDC staat standaard
-uitgeschakeld en vereist technische configuratie voordat het in gebruik genomen kan worden.
+Open Inwoner ondersteunt inloggen voor burgers (DigiD, eIDAS) en bedrijven
+(eHerkenning, eIDAS) via het OpenID Connect protocol (OIDC), doorgaans via een
+identity broker zoals Signicat of Keycloak. Dit is een alternatief voor de
+SAML-gebaseerde DigiD- en eHerkenning-koppelingen. OIDC staat standaard
+uitgeschakeld en vereist technische configuratie voordat het in gebruik genomen
+kan worden.
 
-**Let op! Enkel de technisch beheerder dient de OpenID Connect Configuratie te wijzigen.**
-
-.. image:: images/image77.png
-   :width: 620px
-   :height: 333px
-
-*Activatie*
-
-**Inschakelen**
-Schakelt DigiD-login via OIDC in of uit. Staat standaard uitgeschakeld.
+**Let op! Enkel de technisch beheerder dient de OpenID Connect configuratie te wijzigen.**
 
 .. note::
 
-   Wanneer ingeschakeld, vervangt de OIDC-koppeling de SAML-gebaseerde DigiD-koppeling
-   op de loginpagina. Beide kunnen niet tegelijkertijd actief zijn.
+   De aparte beheerpagina's *OpenID Connect configuratie voor DigiD*,
+   *OpenID Connect configuratie voor eHerkenning* en *OpenID Connect
+   configuratie voor eIDAS* (evenals de aparte OpenID Connect-configuratie
+   voor beheerders) zijn vervangen door twee generieke beheerschermen:
+   **OIDC-Providers** en **OIDC-clients**. Bestaande configuratie wordt bij
+   een upgrade automatisch overgezet.
 
-*Algemene instellingen*
+De configuratie bestaat uit twee delen:
 
-**OpenID Connect client ID**
-Het client-ID verstrekt door de OIDC-provider (identity broker).
+1. Een **OIDC provider** bevat de verbindingsgegevens van de OpenID Connect
+   provider (de identity broker), zoals de verschillende endpoints. Meerdere
+   clients kunnen naar dezelfde provider verwijzen: gebruikt u één broker voor
+   zowel DigiD als eHerkenning, dan hoeft u de endpoints maar één keer in te
+   richten.
+2. Een **OIDC client** per loginmethode bevat het client-ID, het secret, de
+   scopes en de methode-specifieke instellingen (claims,
+   betrouwbaarheidsniveaus).
 
-**OpenID Connect secret**
-Het bijbehorende client-secret van de OIDC-provider.
+10.5.1. OIDC-Providers
+----------------------
 
-**OpenID Connect scopes**
-De scopes die worden aangevraagd bij de identity provider. Standaard: ``openid``, ``bsn``.
-
-**Ondertekeningsalgoritme**
-Algoritme waarmee de provider ID-tokens ondertekent. Standaard ``HS256``; gebruik ``RS256`` bij een asymmetrisch sleutelpaar.
-
-**Ondertekeningssleutel**
-Openbare sleutel van de provider in PEM- of DER-formaat. Alleen vereist bij RSA-algoritmen zoals ``RS256``.
-
-*Attributen uit claims*
-
-**BSN claim**
-Naam van de claim die het BSN van de gebruiker bevat. Standaard: ``bsn``.
-
-**LoA claim**
-Naam van de claim met het betrouwbaarheidsniveau (Level of Assurance). Laat leeg als de provider geen LoA levert; de standaardwaarde hieronder wordt dan gebruikt.
-
-**Standaard LoA**
-Het betrouwbaarheidsniveau dat wordt toegepast als de identity provider geen LoA-claim
-meestuurt in het token. Het betrouwbaarheidsniveau bepaalt welke acties een ingelogde
-gebruiker mag uitvoeren - een hoger niveau vereist een sterkere vorm van authenticatie.
-
-**LoA-mapping**
-Vertaaltabel voor LoA-claimwaarden van de provider naar Nederlandse standaardniveaus. Gebruik dit als de provider eigen waarden hanteert.
-
-*Eindpunten*
-
-**Discovery endpoint**
-URL van het discovery-endpoint van de provider. Het pad ``.well-known/openid-configuration``
-wordt automatisch toegevoegd. Als dit is ingevuld, kunnen de overige eindpunten worden
-weggelaten - ze worden automatisch afgeleid bij het opslaan van de configuratie.
+Navigeer in de beheeromgeving naar **Inlog koppelingen** > **OIDC-Providers**
+en maak een provider aan (of open een bestaande).
 
 .. note::
 
-   Als er geen discovery-endpoint beschikbaar is, kunnen de onderstaande velden handmatig
-   worden ingevuld.
+   Bij een upgrade vanaf een eerdere versie zijn de providers automatisch
+   aangemaakt op basis van de oude configuratie, met namen als
+   ``oidc-digid-provider`` en ``oidc-eherkenning-provider``. Verwijzen deze
+   naar dezelfde broker, dan kunt u ze desgewenst samenvoegen tot één provider.
 
-**JSON Web Key Set endpoint**
+**Identificatie**
+Unieke (technische) naam van de provider, bijvoorbeeld ``signicat-broker``.
+
+**Discovery-endpoint**
+URL van het discovery-endpoint van de provider, eindigend op een ``/``. Het pad
+``.well-known/openid-configuration`` wordt automatisch toegevoegd. Als dit is
+ingevuld, kunnen de overige eindpunten worden weggelaten - ze worden automatisch
+afgeleid bij het opslaan van de configuratie.
+
+.. note::
+
+   Als er geen discovery-endpoint beschikbaar is, kunnen de onderstaande velden
+   handmatig worden ingevuld.
+
+**JSON Web Key Set-endpoint**
 URL van het JWKS-endpoint. Verplicht bij gebruik van het ``RS256``-algoritme.
 
-**Authorization endpoint**
+**Autorisatie-endpoint**
 URL van het autorisatie-endpoint van de provider.
 
-**Token endpoint**
+**Token-endpoint**
 URL van het token-endpoint van de provider.
 
-**Gebruik Basic auth voor token endpoint**
-Indien ingeschakeld worden client-ID en secret via HTTP Basic auth meegestuurd bij het
-ophalen van het access token. Standaard worden ze in de request body geplaatst.
-
-**User endpoint**
+**Gebruikers-endpoint**
 URL van het userinfo-endpoint van de provider.
 
-**Logout endpoint**
+**Uitlog-endpoint**
 URL van het logout-endpoint van de provider. Optioneel.
 
-*Keycloak-specifieke instellingen*
+**Gebruik 'Basic auth' voor het token-endpoint**
+Indien ingeschakeld worden client-ID en secret via HTTP Basic auth meegestuurd
+bij het ophalen van het access token. Standaard worden ze in de request body
+geplaatst.
 
-**Keycloak Identity Provider hint**
-Alleen van toepassing bij Keycloak: geeft aan welke identity provider gebruikt moet worden,
-zodat het Keycloak-loginscherm wordt overgeslagen. Laat leeg bij andere providers.
-
-*Geavanceerde instellingen*
-
-.. _digid-oidc-userinfo-bron:
-
-**Gebruikersinformatie claims afkomstig van**
-Bepaalt vanwaar de gebruikersclaims worden opgehaald: het *Userinfo endpoint* (standaard)
-of het *ID-token*. Kies *Userinfo endpoint* wanneer de identity provider de claims niet
-in het ID-token zelf meelevert.
-
-**Nonce verificatie**
+**Gebruik nonce**
 Schakelt nonce-verificatie in of uit (standaard ingeschakeld).
 
 **Nonce-grootte** / **State-grootte**
 Lengte van de willekeurige nonce- en state-strings (standaard: 32 tekens).
 
-Signicat (eID Hub, nieuwe stijl)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+10.5.2. OIDC-clients
+--------------------
+
+Navigeer in de beheeromgeving naar **Inlog koppelingen** > **OIDC-clients**.
+Voor elke ondersteunde loginmethode bestaat er automatisch precies één client;
+clients kunnen niet worden toegevoegd of verwijderd, alleen gewijzigd:
+
+- ``oidc-digid`` - DigiD-login voor burgers
+- ``oidc-eherkenning`` - eHerkenning-login voor bedrijven
+- ``oidc-eidas`` - eIDAS-login voor Europese burgers en bedrijven
+- ``admin-oidc`` - OpenID Connect-login voor (hoofd)beheerders en medewerkers
+  (zie ook hoofdstuk 12.1.9)
+
+Elke client heeft een eigen redirect-URI (callback-URL) die bij de identity
+provider bekend moet zijn. Vervang in onderstaande voorbeelden de basis-URL
+(``https://mijn.gemeente.nl``, het adres waarop uw Open Inwoner-omgeving
+bereikbaar is) door die van uw eigen omgeving:
+
+- ``oidc-digid`` - ``https://mijn.gemeente.nl/digid-oidc/callback/``
+- ``oidc-eherkenning`` - ``https://mijn.gemeente.nl/eherkenning-oidc/callback/``
+- ``oidc-eidas`` - ``https://mijn.gemeente.nl/eidas-oidc/callback/``
+- ``admin-oidc`` - ``https://mijn.gemeente.nl/oidc/callback/``
+
+.. note::
+
+   De legacy per-provider callback-URL's hierboven voor ``oidc-digid``,
+   ``oidc-eherkenning`` en ``oidc-eidas`` worden gebruikt zolang de
+   (vervallen) omgevingsvariabele ``OIDC_USE_LEGACY_ENDPOINTS`` op zijn
+   standaardwaarde ``True`` staat. Is de whitelist bij uw identity broker
+   al bijgewerkt met de generieke callback-URL
+   (``https://mijn.gemeente.nl/oidc/callback/``, dezelfde die ``admin-oidc``
+   al gebruikt), zet deze variabele dan op ``False``: alle vier de clients
+   gebruiken dan dezelfde generieke callback-URL. Deze instelling en de
+   legacy callback-URL's worden in een toekomstige release verwijderd.
+
+Open de client die u wilt configureren:
+
+*Activering*
+
+**Ingeschakeld**
+Schakelt de loginmethode via OIDC in of uit. Staat standaard uitgeschakeld.
+
+.. note::
+
+   Wanneer ingeschakeld, vervangt de OIDC-koppeling de SAML-gebaseerde
+   DigiD- of eHerkenning-koppeling op de loginpagina. Beide kunnen niet
+   tegelijkertijd actief zijn.
+
+*OIDC-Provider*
+
+**OIDC-Provider**
+Selecteer hier de provider die u in sectie 10.5.1 heeft ingericht.
+
+**Controleer beschikbaarheid OIDC-provider**
+Indien ingeschakeld wordt vóór het doorsturen van de gebruiker gecontroleerd of
+de provider bereikbaar is. Staat standaard uitgeschakeld.
+
+*Instellingen voor Relying Party*
+
+**Client-ID**
+Het client-ID verstrekt door de OIDC-provider (identity broker).
+
+**Secret**
+Het bijbehorende client-secret van de OIDC-provider.
+
+**Scopes**
+De scopes die worden aangevraagd bij de identity provider. Standaard:
+``openid``, ``email``, ``profile``. Pas dit aan volgens de instructies van uw
+broker, bijvoorbeeld ``openid`` en ``bsn`` voor DigiD of ``openid`` en ``kvk``
+voor eHerkenning.
+
+**OpenID ondertekenalgoritme**
+Algoritme waarmee de provider ID-tokens ondertekent. Gebruik ``RS256`` bij een
+asymmetrisch sleutelpaar.
+
+**Onderteken-sleutel**
+Openbare sleutel van de provider in PEM- of DER-formaat. Alleen vereist bij
+RSA-algoritmen zoals ``RS256`` als er geen JWKS-endpoint beschikbaar is.
+
+*Eigen instellingen*
+
+**Opties**
+Methode-specifieke instellingen, zoals de claims en betrouwbaarheidsniveaus.
+De beschikbare velden verschillen per client, zie sectie 10.5.3.
+
+*Geavanceerde instellingen*
+
+.. _digid-oidc-userinfo-bron:
+
+**Gebruikersinformatie ophalen uit**
+Bepaalt vanwaar de gebruikersclaims worden opgehaald: het *Userinfo endpoint*
+(standaard) of het *ID-token*. Kies *Userinfo endpoint* wanneer de identity
+provider de claims niet in het ID-token zelf meelevert.
+
+**Keycloak Identity Provider hint**
+Alleen van toepassing bij Keycloak: geeft aan welke identity provider gebruikt
+moet worden, zodat het Keycloak-loginscherm wordt overgeslagen. Laat leeg bij
+andere providers.
+
+10.5.3. Opties per loginmethode
+-------------------------------
+
+In het veld **Opties** van elke OIDC client worden claim-*paden* ingesteld: een
+pad bestaat uit één of meer stappen, zodat ook geneste claims bereikbaar zijn.
+Het pad ``kvk`` > ``kvkNummer`` verwijst bijvoorbeeld naar de claim
+``kvkNummer`` binnen de claim ``kvk``. Meestal volstaat een pad van één stap.
+
+Alle clients hebben de volgende **Betrouwbaarheidsniveau (LoA)-instellingen**
+(Level of Assurance):
+
+**Claimnaam**
+Pad van de claim met het betrouwbaarheidsniveau. Laat leeg als de provider geen
+LoA levert; de standaardwaarde hieronder wordt dan gebruikt.
+
+**Standaardwaarde**
+Het betrouwbaarheidsniveau dat wordt toegepast als de identity provider geen
+LoA-claim meestuurt in het token. Het betrouwbaarheidsniveau bepaalt welke
+acties een ingelogde gebruiker mag uitvoeren - een hoger niveau vereist een
+sterkere vorm van authenticatie.
+
+**LoA-vertalingen**
+Vertaaltabel voor LoA-claimwaarden van de provider naar de standaardniveaus.
+Gebruik dit als de provider eigen waarden hanteert. Bijvoorbeeld:
+
+* Klik op "Add item"
+* Kies "Tekstuele waarde" in de **From** dropdown en voer de waarde van de
+  provider in, bijvoorbeeld ``10``
+* Selecteer het bijbehorende niveau (bijvoorbeeld "DigiD Basis") in de **To**
+  dropdown
+* Herhaal voor de overige waarden en niveaus
+
+DigiD (``oidc-digid``)
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Identificatieinstellingen** > **BSN-claim**
+Pad van de claim die het BSN van de ingelogde gebruiker bevat.
+Standaard: ``bsn``.
+
+eHerkenning (``oidc-eherkenning``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Onder **Identificatieinstellingen**:
+
+**Claimnaam identificatietype**
+Pad van de claim die aangeeft hoe de bedrijfsidentifier geïnterpreteerd moet
+worden. Verwachte waarden: ``urn:etoegang:1.9:EntityConcernedID:KvKnr``
+(KVK-nummer) of ``urn:etoegang:1.9:EntityConcernedID:RSIN``.
+Standaard: ``namequalifier``.
+
+**Claimnaam juridisch verantwoordelijke**
+Pad van de claim met het KVK-nummer of RSIN van het ingelogde bedrijf.
+Standaard: ``urn:etoegang:core:LegalSubjectID``.
+
+**Claimnaam handelende persoon**
+Pad van de claim met de (pseudonieme) identifier van de gebruiker die namens
+het bedrijf handelt. Standaard: ``urn:etoegang:core:ActingSubjectID``.
+
+**Claimnaam vestigingsnummer**
+Pad van de claim met het vestigingsnummer, indien van toepassing.
+Standaard: ``urn:etoegang:1.9:ServiceRestriction:Vestigingsnr``.
+
+eIDAS (``oidc-eidas``)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Via eIDAS kunnen zowel Europese burgers als bedrijven inloggen; beide varianten
+worden met dezelfde client geconfigureerd. De eIDAS-specifieke velden worden
+(vooralsnog) in het Engels getoond. Onder **Identificatieinstellingen**:
+
+**Legal subject pseudo identifier claim path**
+Pad van de claim met de pseudonieme identifier van de ingelogde gebruiker.
+Verplicht voor alle eIDAS-logins.
+Standaard: ``urn:etoegang:1.12:EntityConcernedID:PseudoID``.
+
+**Legal subject bsn identifier claim path**
+Pad van de claim met het BSN van de ingelogde gebruiker, indien deze een BSN
+aan de eIDAS-identiteit heeft gekoppeld.
+Standaard: ``urn:etoegang:1.12:EntityConcernedID:BSN``.
+
+**Legal subject first name claim path** / **Legal subject family name claim path**
+Paden van de claims met de voor- en achternaam van de ingelogde gebruiker.
+Standaard: ``urn:etoegang:1.9:attribute:FirstName`` respectievelijk
+``urn:etoegang:1.9:attribute:FamilyName``.
+
+**Legal subject date of birth claim path**
+Pad van de claim met de geboortedatum van de ingelogde gebruiker.
+Standaard: ``urn:etoegang:1.9:attribute:DateOfBirth``.
+
+**Legal entity identifier claim path**
+Pad van de claim met de identifier van de rechtspersoon, bij bedrijfslogins.
+Standaard: ``urn:etoegang:1.11:EntityConcernedID:eIDASLegalIdentifier``.
+
+**Company name claim path**
+Pad van de claim met de bedrijfsnaam, bij bedrijfslogins.
+Standaard: ``urn:etoegang:1.11:attribute-represented:CompanyName``.
+
+10.5.4. Signicat (eID Hub, nieuwe stijl)
+----------------------------------------
 
 `Signicat <https://www.signicat.com/>`_ is een veelgebruikte identity broker voor
 DigiD en eHerkenning via OIDC. Onderstaande instellingen zijn de aanbevolen configuratie
@@ -254,11 +426,23 @@ voor gebruik met Open Inwoner. Deze instructies gaan uit van de **eID and Wallet
 
 - Tabblad **URIs**:
 
-  - **Redirect URIs** - voeg de volgende drie toe (pas de basis-URL aan):
+  - **Redirect URIs** - voeg de volgende vier toe (pas de basis-URL aan):
 
     - ``https://open-inwoner-test.maykin.nl/digid-oidc/callback/``
     - ``https://open-inwoner-test.maykin.nl/eherkenning-oidc/callback/``
     - ``https://open-inwoner-test.maykin.nl/eidas-oidc/callback/``
+    - ``https://open-inwoner-test.maykin.nl/oidc/callback/``
+
+    .. note::
+
+       De laatste (generieke) callback-URL wordt voor de burger- en
+       bedrijfslogins alleen gebruikt wanneer ``OIDC_USE_LEGACY_ENDPOINTS``
+       op ``False`` staat (zie sectie 10.5.2); met de standaardwaarde
+       ``True`` blijven de drie bovenstaande legacy-URL's in gebruik. Door
+       de generieke URL nu alvast bij de broker te whitelisten, kan die
+       omgevingsvariabele later worden omgezet zonder wijziging bij de
+       broker, vooruitlopend op het uiteindelijk verdwijnen van de
+       legacy-URL's.
 
   - **Post logout Redirect URIs**:
 
@@ -297,132 +481,21 @@ voor gebruik met Open Inwoner. Deze instructies gaan uit van de **eID and Wallet
 
          Omdat Signicat met deze instelling de claims niet in het ID-token meelevert,
          moet in Open Inwoner onder *Geavanceerde instellingen* de optie
-         **Gebruikersinformatie claims afkomstig van** worden ingesteld op
-         *Userinfo endpoint*. Dit veld is te vinden in de DigiD- en
-         eHerkenning OIDC-configuratiepagina's in de beheeromgeving.
+         **Gebruikersinformatie ophalen uit** worden ingesteld op
+         *Userinfo endpoint*. Dit veld is te vinden op de betreffende
+         **OIDC-client** pagina's in de beheeromgeving (zie sectie 10.5.2).
 
     - **User Info Response Type**: ``JSON``
     - **Content encryption algorithm**: ``A128CBC-HS256``
     - **Allowed CORS Origins**: leeg laten
     - **Requires Secret**: aanvinken; alle overige checkboxes uitvinken
 
-10.5.1. Geschiedenis
+10.5.5. Geschiedenis
 --------------------
 
-Wanneer er wijzigingen aan de OpenID Connect configuratie hebben plaatsgevonden, kunnen deze worden nagetrokken in de geschiedenis rechts bovenin beeld.
+Wanneer er wijzigingen aan een OIDC client of OIDC provider hebben plaatsgevonden, kunnen deze worden nagetrokken in de geschiedenis rechts bovenin beeld.
 
-10.6. OpenID Connect configuratie voor eHerkenning
-==================================================
-
-Open Inwoner ondersteunt eHerkenning-login voor ondernemers via het OpenID Connect protocol
-(OIDC). Dit is een alternatief voor de SAML-gebaseerde eHerkenning-koppeling. OIDC staat
-standaard uitgeschakeld en vereist technische configuratie voordat het in gebruik genomen
-kan worden.
-
-**Let op! Enkel de technisch beheerder dient de OpenID Connect Configuratie te wijzigen.**
-
-*Activatie*
-
-**Inschakelen**
-Schakelt eHerkenning-login via OIDC in of uit. Staat standaard uitgeschakeld.
-
-.. note::
-
-   Wanneer ingeschakeld, vervangt de OIDC-koppeling de SAML-gebaseerde
-   eHerkenning-koppeling op de loginpagina. Beide kunnen niet tegelijkertijd actief zijn.
-
-*Algemene instellingen*
-
-**OpenID Connect client ID**
-Het client-ID verstrekt door de OIDC-provider (identity broker).
-
-**OpenID Connect secret**
-Het bijbehorende client-secret van de OIDC-provider.
-
-**OpenID Connect scopes**
-De scopes die worden aangevraagd bij de identity provider. Standaard: ``openid``, ``kvk``.
-
-**Ondertekeningsalgoritme**
-Algoritme waarmee de provider ID-tokens ondertekent. Standaard ``HS256``; gebruik ``RS256`` bij een asymmetrisch sleutelpaar.
-
-**Ondertekeningssleutel**
-Openbare sleutel van de provider in PEM- of DER-formaat. Alleen vereist bij RSA-algoritmen zoals ``RS256``.
-
-*Attributen uit claims*
-
-**Identifier type claim**
-Naam van de claim die aangeeft hoe de bedrijfsidentifier geïnterpreteerd moet worden.
-Verwachte waarden: ``urn:etoegang:1.9:EntityConcernedID:KvKnr`` (KVK-nummer) of
-``urn:etoegang:1.9:EntityConcernedID:RSIN``. Standaard: ``namequalifier``.
-
-**Bedrijfsidentifier claim**
-Naam van de claim met het KVK-nummer of RSIN van het ingelogde bedrijf.
-Standaard: ``urn:etoegang:core:LegalSubjectID``.
-
-**Vestigingsnummer claim**
-Naam van de claim met het vestigingsnummer, indien van toepassing.
-Standaard: ``urn:etoegang:1.9:ServiceRestriction:Vestigingsnr``.
-
-**Vertegenwoordiger claim**
-Naam van de claim met de (pseudonieme) identifier van de gebruiker die namens het
-bedrijf handelt. Standaard: ``urn:etoegang:core:ActingSubjectID``.
-
-**LoA claim**
-Naam van de claim met het betrouwbaarheidsniveau (Level of Assurance). Laat leeg als de provider geen LoA levert; de standaardwaarde hieronder wordt dan gebruikt.
-
-**Standaard LoA**
-Het betrouwbaarheidsniveau dat wordt toegepast als de identity provider geen LoA-claim meestuurt in het token. Het betrouwbaarheidsniveau bepaalt welke acties een ingelogde gebruiker mag uitvoeren - een hoger niveau vereist een sterkere vorm van authenticatie.
-
-**LoA-mapping**
-Vertaaltabel voor LoA-claimwaarden van de provider naar Nederlandse standaardniveaus. Gebruik dit als de provider eigen waarden hanteert.
-
-*Eindpunten*
-
-**Discovery endpoint**
-URL van het discovery-endpoint van de provider. Het pad ``.well-known/openid-configuration``
-wordt automatisch toegevoegd. Als dit is ingevuld, kunnen de overige eindpunten worden
-weggelaten - ze worden automatisch afgeleid bij het opslaan van de configuratie. Als er
-geen discovery-endpoint beschikbaar is, kunnen de onderstaande velden handmatig worden
-ingevuld.
-
-**JSON Web Key Set endpoint**
-URL van het JWKS-endpoint. Verplicht bij gebruik van het ``RS256``-algoritme.
-
-**Authorization endpoint**
-URL van het autorisatie-endpoint van de provider.
-
-**Token endpoint**
-URL van het token-endpoint van de provider.
-
-**Gebruik Basic auth voor token endpoint**
-Indien ingeschakeld worden client-ID en secret via HTTP Basic auth meegestuurd bij het
-ophalen van het access token. Standaard worden ze in de request body geplaatst.
-
-**User endpoint**
-URL van het userinfo-endpoint van de provider.
-
-**Logout endpoint**
-URL van het logout-endpoint van de provider. Optioneel.
-
-*Keycloak-specifieke instellingen*
-
-**Keycloak Identity Provider hint**
-Alleen van toepassing bij Keycloak: geeft aan welke identity provider gebruikt moet worden,
-zodat het Keycloak-loginscherm wordt overgeslagen. Laat leeg bij andere providers.
-
-*Geavanceerde instellingen*
-
-**Gebruikersinformatie claims afkomstig van**
-Bepaalt vanwaar de gebruikersclaims worden opgehaald: het *Userinfo endpoint* (standaard)
-of het *ID-token*. Zie sectie 10.5 voor een toelichting.
-
-**Nonce verificatie**
-Schakelt nonce-verificatie in of uit (standaard ingeschakeld).
-
-**Nonce-grootte** / **State-grootte**
-Lengte van de willekeurige nonce- en state-strings (standaard: 32 tekens).
-
-10.7. OpenID Connect sessie management
+10.6. OpenID Connect sessie management
 =======================================
 
 Bij gebruik van OpenID Connect (OIDC) voor DigiD en eHerkenning is het belangrijk om
@@ -430,8 +503,8 @@ rekening te houden met sessie-management. Open Inwoner vernieuwt periodiek de
 authenticatiesessie om te controleren of de gebruiker nog steeds ingelogd is bij de
 Identity Provider (IdP).
 
-10.7.1. Automatische sessievernieuwing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+10.6.1. Automatische sessievernieuwing
+--------------------------------------
 
 De omgevingsvariabele ``OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS`` bepaalt hoe vaak
 de sessie wordt ververst. De standaardwaarde is **15 minuten**. Na deze periode wordt de

--- a/docs/beheerhandleiding/12_configuratie.rst
+++ b/docs/beheerhandleiding/12_configuratie.rst
@@ -345,7 +345,7 @@ Hier vult u de e-mailadressen van beheerders die dagelijks een samenvatting dien
 12.1.9. OpenID Connect
 ----------------------
 
-Dit is een alternatieve login methode die naast DigiD kan worden ingesteld (zie 10.2). In de algemene configuratie kunt u de login button voor OpenID Connect configureren. Alle andere zaken rond de OpenID Connect configuratie vindt u onder inlog koppelingen (hoofdstuk 10.5 en 10.6).
+Dit is een alternatieve login methode die naast DigiD kan worden ingesteld (zie 10.2). In de algemene configuratie kunt u de login button voor OpenID Connect configureren. Alle andere zaken rond de OpenID Connect configuratie vindt u onder inlog koppelingen (hoofdstuk 10.5); voor deze loginmethode gebruikt u de OIDC client ``admin-oidc``.
 
 **OpenID Connect logo**
 Hier kunt u het logo uploaden van de OpenID connect methode die u wilt gebruiken. Door een logo te uploaden maakt u het voor de gebruiker duidelijker welke login methode er wordt geboden.
@@ -362,7 +362,7 @@ Hier kunt u selecteren welk soort gebruiker er de mogelijkheid moet krijgen om v
 ----------------------
 
 **eHerkenning authenticatie ingeschakeld**
-Hier kunt u aanvinken of u gebruikers de mogelijkheid wilt bieden in te loggen met eHerkenning. Standaard wordt er gebruik gemaakt van de SAML integratie (bij een rechtstreekse aansluiting op een eHerkenning Makelaar). Een OpenID Connect koppeling met eHerkenning kunt u configureren onder inlog koppelingen (zie hoofdstuk 10.6).
+Hier kunt u aanvinken of u gebruikers de mogelijkheid wilt bieden in te loggen met eHerkenning. Standaard wordt er gebruik gemaakt van de SAML integratie (bij een rechtstreekse aansluiting op een eHerkenning Makelaar). Een OpenID Connect koppeling met eHerkenning kunt u configureren onder inlog koppelingen (zie hoofdstuk 10.5).
 
 12.1.11. Analytics
 ------------------


### PR DESCRIPTION
Update admin manual for the generic OIDC provider/client config

The per-flow OpenID Connect admin pages (DigiD, eHerkenning, eIDAS and admin login) were replaced by the generic OIDC-Providers and OIDC-clients screens in the mozilla-django-oidc-db 2.0.1 upgrade. Rewrite section 10.5 of the admin manual around the new provider/client model and fix the section references in chapter 12.

Also document the redirect-URI per OIDC client (including the admin flow's generic /oidc/callback/) and advise whitelisting the generic callback URL at the broker ahead of the future migration away from the legacy per-provider callback URLs.
