### PR TITLE
fix: [#2719] chart gft bar color match is based on lower text

### DIFF
--- a/src/open_inwoner/react/components/Chart/Chart.stories.tsx
+++ b/src/open_inwoner/react/components/Chart/Chart.stories.tsx
@@ -110,6 +110,15 @@ export const Interactive: Story = {
     period: 'month',
   },
 };
+export const UnknownContainerType: Story = {
+  name: 'With unknown container type',
+  args: {
+    data: data.map((x) => ({
+      ...x,
+      containers: [{ ...x.containers[0], type: 'Glas' }, ...x.containers],
+    })),
+  },
+};
 
 // ============================================
 // Web Component

--- a/src/open_inwoner/react/components/Chart/config.ts
+++ b/src/open_inwoner/react/components/Chart/config.ts
@@ -31,6 +31,9 @@ export const CHART_STYLES = {
     restafval: getComputedStyle(document.documentElement).getPropertyValue(
       '--color-rest'
     ),
+    fallback: getComputedStyle(document.documentElement).getPropertyValue(
+      '--color-fallback-bar'
+    ),
   },
   padding: {
     chart: {

--- a/src/open_inwoner/react/components/Chart/types.ts
+++ b/src/open_inwoner/react/components/Chart/types.ts
@@ -7,7 +7,7 @@ export interface AfvalLediging {
 
 export interface AfvalContainer {
   identifier: string;
-  type: 'Restafval' | 'GFT';
+  type: string;
   totaal_gewicht: string;
   ledigingen: AfvalLediging[];
 }
@@ -29,7 +29,7 @@ export interface ChartDataPoint {
 }
 
 export interface ContainerSeries {
-  type: 'GFT' | 'Restafval';
+  type: string;
   address: string;
   containerIndex: number;
   points: ChartDataPoint[];

--- a/src/open_inwoner/react/components/Chart/useChart.ts
+++ b/src/open_inwoner/react/components/Chart/useChart.ts
@@ -221,15 +221,26 @@ export class BarChartBuilder {
     return base;
   }
 
-  private getColor(type: 'GFT' | 'Restafval', containerIndex: number): string {
-    const baseColor =
-      type === 'GFT' ? CHART_STYLES.colors.gft : CHART_STYLES.colors.restafval;
+  private isColorDefined(
+    type: string
+  ): type is keyof typeof CHART_STYLES.colors {
+    return Object.keys(CHART_STYLES.colors).includes(type);
+  }
+
+  private getColor(type: string, containerIndex: number): string {
+    let color = CHART_STYLES.colors.fallback;
+    const loweredType = type.toLowerCase();
+    if (this.isColorDefined(loweredType))
+      color = CHART_STYLES.colors[loweredType];
+    else
+      console.debug(
+        `Chart color for ${type} is not defined so we are falling back to a neutral color ${color}`
+      );
+
     const opacity = Math.max(0.4, 1 - containerIndex * 0.15);
-    return (
-      baseColor +
-      Math.round(opacity * 255)
-        .toString(16)
-        .padStart(2, '0')
-    );
+    const alpha = Math.round(opacity * 255)
+      .toString(16)
+      .padStart(2, '0');
+    return color + alpha;
   }
 }

--- a/src/open_inwoner/scss/views/App.scss
+++ b/src/open_inwoner/scss/views/App.scss
@@ -47,6 +47,7 @@
   // For reference: https://afvaleducatie.nl/images/bibliotheek/Richtlijnen_voor_gebruik_pictogrammen_afvalscheiding.pdf
   --color-rest: #646469;
   --color-gft: #41873e;
+  --color-fallback-bar: #b8b8b8;
 
   --color-primary-h: 138;
   --color-primary-s: 58%;


### PR DESCRIPTION
## Summary

chart gft bar color match is based on lower text

## Issue References

- Github Issue: #2719 