### PR TITLE
Release 2.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+2.4.1 (2026-07-22)
+==================
+
+Voor een volledig overzicht van alle commits, zie :release:`v2.4.1`.
+
+Bugfixes
+--------
+
+* ``maykin-common`` bijgewerkt naar ``0.20.1``; dit verhelpt 500-fouten
+  bij healthchecks op Kubernetes.
+
 2.4.0 (2026-07-20)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Open Inwoner
 ==================
 
 
-:Version: 2.4.0
+:Version: 2.4.1
 :Demo: https://openinwoner.nl
 :Source: https://github.com/maykinmedia/open-inwoner
 :Documentation: https://docs.openinwoner.nl

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,8 +7,8 @@ publiccodeYmlVersion: '0.2'
 name: Open Inwoner Platform
 url: 'http://github.com/maykinmedia/open-inwoner.git'
 softwareType: standalone
-softwareVersion: 2.4.0
-releaseDate: '2026-07-20'
+softwareVersion: 2.4.1
+releaseDate: '2026-07-22'
 logo: 'https://github.com/maykinmedia/open-inwoner/blob/develop/docs/logo.png'
 platforms:
   - web

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-inwoner"
-version = "2.4.0"
+version = "2.4.1"
 requires-python = "~= 3.13"
 
 [tool.uv.pip]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -449,7 +449,7 @@ markupsafe==3.0.3
     # via jinja2
 maykin-2fa==1.0.2
     # via -r requirements/base.in
-maykin-common[cli, docs, health-checks, otel]==0.19.0
+maykin-common[cli, docs, health-checks, otel]==0.20.1
     # via -r requirements/base.in
 maykin-django-prosemirror[images]==0.8.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -784,7 +784,7 @@ maykin-2fa==1.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-common[cli, docs, health-checks, otel]==0.19.0
+maykin-common[cli, docs, health-checks, otel]==0.20.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -871,7 +871,7 @@ maykin-2fa==1.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-common[cli, docs, health-checks, otel]==0.19.0
+maykin-common[cli, docs, health-checks, otel]==0.20.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/open_inwoner/conf/base.py
+++ b/src/open_inwoner/conf/base.py
@@ -1194,7 +1194,7 @@ SENTRY_DSN = config(
         group="Monitoring",
     ),
 )
-RELEASE = "v2.4.0"  # get_current_version()
+RELEASE = "v2.4.1"  # get_current_version()
 
 PRIVATE_MEDIA_ROOT = os.path.join(BASE_DIR, "private_media")
 FILER_ROOT = os.path.join(BASE_DIR, "media", "filer")

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.13, <4"
 
 [[package]]
 name = "open-inwoner"
-version = "2.4.0"
+version = "2.4.1"
 source = { virtual = "." }


### PR DESCRIPTION
Patch release. Upgrades `maykin-common` to `0.20.1` to fix 500 errors for healthchecks when running on kubernetes.

Closes #2724 