### PR TITLE
[#2728] Sanitize hrefs in prosemirror-rendered content

### DIFF
--- a/src/open_inwoner/api/pdc/serializers.py
+++ b/src/open_inwoner/api/pdc/serializers.py
@@ -9,6 +9,7 @@ from open_inwoner.pdc.models.product import (
     ProductFile,
     ProductLocation,
 )
+from open_inwoner.utils.html import sanitize_html
 
 
 class FilerImageSerializer(serializers.ModelSerializer):
@@ -68,7 +69,7 @@ class Questionserializer(serializers.ModelSerializer):
     def get_answer(self, obj):
         if obj.answer:
             try:
-                return obj.answer.html
+                return sanitize_html(obj.answer.html)
             except Exception:
                 return None
         return None
@@ -87,7 +88,7 @@ class SmallCategorySerializer(serializers.HyperlinkedModelSerializer):
     def get_description(self, obj):
         if obj.description:
             try:
-                return obj.description.html
+                return sanitize_html(obj.description.html)
             except Exception:
                 return None
         return None
@@ -119,7 +120,7 @@ class CategoryWithChildSerializer(serializers.ModelSerializer):
     def get_description(self, obj):
         if obj.description:
             try:
-                return obj.description.html
+                return sanitize_html(obj.description.html)
             except Exception:
                 return None
         return None
@@ -213,7 +214,7 @@ class ProductSerializer(serializers.ModelSerializer):
     def get_content(self, obj):
         if obj.content:
             try:
-                return obj.content.html
+                return sanitize_html(obj.content.html)
             except Exception:
                 return None
         return None

--- a/src/open_inwoner/utils/html.py
+++ b/src/open_inwoner/utils/html.py
@@ -4,6 +4,35 @@ from django.utils.translation import gettext as _
 import markdown
 from bs4 import BeautifulSoup
 
+ALLOWED_URL_SCHEMES = ("http://", "https://", "mailto:", "tel:")
+
+
+def is_safe_url(url: str) -> bool:
+    """Return True if url is relative/fragment or uses an allowed scheme.
+
+    Blocks javascript:, data:, vbscript: and other script-executing schemes
+    that can be entered as a link target in the prosemirror rich text editor.
+    """
+    if not url:
+        return False
+    url = url.strip()
+    if url.startswith(("/", "#", "?")):
+        return True
+    return url.lower().startswith(ALLOWED_URL_SCHEMES)
+
+
+def sanitize_html(html: str) -> str:
+    """Strip unsafe anchor hrefs (e.g. javascript:) from a prosemirror HTML string."""
+    if not html:
+        return html
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup.find_all("a"):
+        href = element.attrs.get("href")
+        if href is not None and not is_safe_url(href):
+            del element.attrs["href"]
+    return str(soup)
+
+
 CLASS_ADDERS = [
     ("h1", "utrecht-heading-1"),
     ("h2", "utrecht-heading-2"),
@@ -47,6 +76,7 @@ def get_rendered_content(content) -> str:
             # treat as empty content
             return ""
 
+    html = sanitize_html(html)
     soup = BeautifulSoup(html, "html.parser")
 
     for tag, class_name in CLASS_ADDERS:
@@ -96,6 +126,7 @@ def get_product_rendered_content(product):
         # ProsemirrorModelField - use .html property
         html = product.content.html
 
+    html = sanitize_html(html)
     soup = BeautifulSoup(html, "html.parser")
 
     for tag, class_name in CLASS_ADDERS:

--- a/src/open_inwoner/utils/tests/test_html.py
+++ b/src/open_inwoner/utils/tests/test_html.py
@@ -1,0 +1,76 @@
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from open_inwoner.pdc.tests.factories import QuestionFactory
+from open_inwoner.utils.html import get_rendered_content, is_safe_url, sanitize_html
+
+
+class IsSafeUrlTest(SimpleTestCase):
+    def test_allows_http_and_https(self):
+        self.assertTrue(is_safe_url("http://example.com"))
+        self.assertTrue(is_safe_url("https://example.com"))
+
+    def test_allows_mailto_and_tel(self):
+        self.assertTrue(is_safe_url("mailto:info@example.com"))
+        self.assertTrue(is_safe_url("tel:+31612345678"))
+
+    def test_allows_relative_and_fragment_links(self):
+        self.assertTrue(is_safe_url("/some/path"))
+        self.assertTrue(is_safe_url("#anchor"))
+        self.assertTrue(is_safe_url("?query=1"))
+
+    def test_blocks_javascript_scheme(self):
+        self.assertFalse(is_safe_url("javascript:alert(document.cookie)"))
+        self.assertFalse(is_safe_url("JaVaScRiPt:alert(1)"))
+
+    def test_blocks_data_and_vbscript_schemes(self):
+        self.assertFalse(is_safe_url("data:text/html;base64,PHNjcmlwdD4="))
+        self.assertFalse(is_safe_url("vbscript:msgbox(1)"))
+
+    def test_blocks_empty_url(self):
+        self.assertFalse(is_safe_url(""))
+
+
+class SanitizeHtmlTest(SimpleTestCase):
+    def test_strips_javascript_href(self):
+        html = '<p><a href="javascript:alert(1)">click</a></p>'
+
+        result = sanitize_html(html)
+
+        self.assertNotIn("javascript:", result)
+        self.assertIn("click", result)
+
+    def test_keeps_safe_href(self):
+        html = '<p><a href="https://example.com">click</a></p>'
+
+        result = sanitize_html(html)
+
+        self.assertIn('href="https://example.com"', result)
+
+    def test_handles_empty_input(self):
+        self.assertEqual(sanitize_html(""), "")
+        self.assertEqual(sanitize_html(None), None)
+
+
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class GetRenderedContentLinkSanitizationTest(TestCase):
+    def test_faq_answer_with_javascript_link_is_sanitized(self):
+        question = QuestionFactory.create()
+        question.answer.html = (
+            '<p><a href="javascript:alert(document.cookie)">click me</a></p>'
+        )
+        question.save()
+
+        rendered = get_rendered_content(question.answer)
+
+        self.assertNotIn("javascript:", rendered)
+        self.assertIn("click me", rendered)
+
+    def test_faq_answer_with_safe_link_is_preserved(self):
+        question = QuestionFactory.create()
+        question.answer.html = '<p><a href="https://example.com">click me</a></p>'
+        question.save()
+
+        rendered = get_rendered_content(question.answer)
+
+        self.assertIn('href="https://example.com"', rendered)
+        self.assertIn("click me", rendered)


### PR DESCRIPTION
Prosemirror rich text fields (e.g. FAQ answers, category descriptions, product content) allow the LINK mark with no restriction on href scheme. Nothing in the editor, form validation, or render pipeline rejected schemes like javascript: or data:, so a stored answer could execute arbitrary JS in a citizen's session when they clicked the link on the public FAQ page (stored XSS).

Add an href allow-list (http(s), mailto, tel, relative/fragment) and apply it in get_rendered_content()/get_product_rendered_content(), plus the PDC API serializers that returned raw .html untouched.

This is a render-side backstop in open_inwoner; the root cause in `maykin-django-prosemirror` (unvalidated href on the link mark) is tracked separately for a fix upstream (https://github.com/maykinmedia/django-prosemirror/pull/56).

Closes #2728 