### PR TITLE
[#2745] prevent broken navigation for formulier cards on homepage

### DIFF
--- a/src/open_inwoner/cms/tests/test_homepage_playwright.py
+++ b/src/open_inwoner/cms/tests/test_homepage_playwright.py
@@ -1,0 +1,300 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings, tag
+from django.urls import reverse
+
+from cms.api import add_plugin
+from cms.models import PageContent, Placeholder
+from playwright.sync_api import expect
+
+from open_inwoner.accounts.tests.factories import DigidUserFactory
+from open_inwoner.cms.plugins.cms_plugins import CMSZakenPlugin
+from open_inwoner.cms.tests import cms_tools
+from open_inwoner.configurations.models import SiteConfiguration
+from open_inwoner.openzaak.constants import TypeAanvraag
+from open_inwoner.openzaak.models import OpenZaakConfig
+from open_inwoner.openzaak.services import FormulierenResult, ZakenResult
+from open_inwoner.openzaak.tests.factories import ZGWApiGroupConfigFactory
+from open_inwoner.utils.test import ClearCachesMixin
+from open_inwoner.utils.tests.playwright import PlaywrightSyncLiveServerTestCase
+
+
+@tag("e2e")
+@override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
+class HomepagePlaywrightTests(ClearCachesMixin, PlaywrightSyncLiveServerTestCase):
+    """
+    Browser-level tests for plugins rendered on the homepage."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.user = DigidUserFactory(bsn="900222086")
+        self.user_login_state = self.get_user_bsn_login_state(self.user)
+
+        self.homepage = cms_tools.create_homepage()
+
+        # avoid the cookie banner overlapping/intercepting clicks on cards
+        config = SiteConfiguration.get_solo()
+        config.cookie_info_text = ""
+        config.save()
+
+    def _add_plugin_to_homepage(self, plugin_class, **plugin_data):
+        """
+        Add `plugin_class` to the homepage's `content` placeholder and
+        (re)publish the page so it's visible to the live server.
+        """
+        page_content = PageContent._original_manager.get(
+            page=self.homepage, language="nl"
+        )
+        placeholder = Placeholder.objects.get_for_obj(page_content).get(slot="content")
+        add_plugin(
+            placeholder=placeholder,
+            plugin_type=plugin_class,
+            language="nl",
+            **plugin_data,
+        )
+        cms_tools.publish_page(self.homepage, "nl")
+
+    def _mock_formulier_submission(
+        self, *, vervolg_link, identification="SUBMISSION-001", naam="Test formulier"
+    ):
+        """
+        Build a formulier submission mock as returned by `ZGWService.get_formulieren`.
+        """
+        api_group = ZGWApiGroupConfigFactory()
+
+        mock_submission = MagicMock()
+        mock_submission.process_data.return_value = {
+            "uuid": "submission-uuid-1",
+            "identification": identification,
+            "naam": naam,
+            "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.FORMULIER.value,
+            "vervolg_link": vervolg_link,
+        }
+        return mock_submission
+
+    def _mock_zaak(self, *, zaak_uuid, identification, naam):
+        """
+        Build a resolved zaak mock, as returned by `ZGWService.get_visible_zaken`
+        and passed straight through the (patched) `fully_resolve_zaken`.
+
+        Returns the mock together with its `ZGWApiGroupConfig`, so callers
+        can build the expected detail URL from that concrete instance
+        instead of reading it back off the mock.
+        """
+        api_group = ZGWApiGroupConfigFactory()
+
+        mock_zaak = MagicMock()
+        mock_zaak.process_data.return_value = {
+            "uuid": zaak_uuid,
+            "identification": identification,
+            "naam": naam,
+            "api_group": api_group,
+            "type_aanvraag": TypeAanvraag.ZAAK.value,
+        }
+        return mock_zaak, api_group
+
+    def _patch_zgw_service(self, *, formulieren, zaken=()):
+        """
+        Patch the `ZGWService` calls made by the zaken plugin's HTMX content
+        view, so it returns `formulieren` and `zaken` without making any
+        real ZGW API calls (`zaken` is passed through as-is, since
+        `fully_resolve_zaken` is patched to a no-op).
+        """
+        return (
+            patch(
+                "open_inwoner.cms.plugins.views.ZGWService.get_formulieren",
+                return_value=FormulierenResult(formulieren=formulieren),
+            ),
+            patch(
+                "open_inwoner.cms.plugins.views.ZGWService.get_visible_zaken",
+                return_value=ZakenResult(zaken=list(zaken), skipped=[]),
+            ),
+            patch(
+                "open_inwoner.cms.plugins.views.ZGWService.fully_resolve_zaken",
+                side_effect=lambda zaken: ZakenResult(zaken=zaken, skipped=[]),
+            ),
+        )
+
+    # regression test for #2745
+    def test_mijn_zaken_formulier_without_vervolg_link_renders_as_non_interactive_card(
+        self,
+    ):
+        mock_submission = self._mock_formulier_submission(vervolg_link=None)
+        self._add_plugin_to_homepage(CMSZakenPlugin, title="Mijn Zaken", num_zaken=4)
+
+        patchers = self._patch_zgw_service(formulieren=[mock_submission])
+        with patchers[0], patchers[1], patchers[2]:
+            context = self.get_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_url("/"))
+
+            card = page.locator("oip-home-plugin-card").first
+            rendered_card = card.locator(".oip-home-plugin-card")
+            expect(rendered_card).to_be_visible()
+            expect(card.locator("a.oip-home-plugin-card")).to_have_count(0)
+
+            url_before_click = page.url
+            rendered_card.click()
+
+            # a non-interactive card should never cause navigation
+            expect(page).to_have_url(url_before_click)
+
+    def test_mijn_zaken_formulier_with_vervolg_link_renders_as_link_to_vervolg_link(
+        self,
+    ):
+        mock_submission = self._mock_formulier_submission(
+            vervolg_link="https://example.com/formulier/123"
+        )
+        self._add_plugin_to_homepage(CMSZakenPlugin, title="Mijn Zaken", num_zaken=4)
+
+        patchers = self._patch_zgw_service(formulieren=[mock_submission])
+        with patchers[0], patchers[1], patchers[2]:
+            context = self.get_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_url("/"))
+
+            link = page.locator("oip-home-plugin-card a.oip-home-plugin-card").first
+            expect(link).to_have_attribute("href", "https://example.com/formulier/123")
+
+    def test_mijn_zaken_shows_each_formulier_and_zaak_with_own_title_label_and_link(
+        self,
+    ):
+        formulier = self._mock_formulier_submission(
+            identification="FORM-2025-001",
+            naam="Kwijtschelding aanvraag",
+            vervolg_link="https://example.com/formulier/456",
+        )
+        zaak_1, zaak_1_api_group = self._mock_zaak(
+            zaak_uuid="zaak-uuid-1",
+            identification="ZAAK-2025-042",
+            naam="Vergunning aanvraag",
+        )
+        zaak_2, zaak_2_api_group = self._mock_zaak(
+            zaak_uuid="zaak-uuid-2",
+            identification="ZAAK-2025-043",
+            naam="Melding openbare ruimte",
+        )
+        self._add_plugin_to_homepage(CMSZakenPlugin, title="Mijn Zaken", num_zaken=4)
+
+        patchers = self._patch_zgw_service(
+            formulieren=[formulier], zaken=[zaak_1, zaak_2]
+        )
+        with patchers[0], patchers[1], patchers[2]:
+            context = self.get_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_url("/"))
+
+            expect(page.locator("oip-home-plugin-card")).to_have_count(3)
+
+            # the formulier has no case number, only a title and a real link
+            formulier_card = page.locator(
+                'oip-home-plugin-card[identificatie="FORM-2025-001"]'
+            )
+            expect(
+                formulier_card.get_by_text("Kwijtschelding aanvraag")
+            ).to_be_visible()
+            expect(formulier_card.locator("a.oip-home-plugin-card")).to_have_attribute(
+                "href", "https://example.com/formulier/456"
+            )
+
+            zaak_label = OpenZaakConfig.get_solo().zaak_identificatie_label
+            for zaak_uuid, api_group, identification, naam in [
+                (
+                    "zaak-uuid-1",
+                    zaak_1_api_group,
+                    "ZAAK-2025-042",
+                    "Vergunning aanvraag",
+                ),
+                (
+                    "zaak-uuid-2",
+                    zaak_2_api_group,
+                    "ZAAK-2025-043",
+                    "Melding openbare ruimte",
+                ),
+            ]:
+                card = page.locator(
+                    f'oip-home-plugin-card[identificatie="{identification}"]'
+                )
+                expect(card.get_by_text(naam)).to_be_visible()
+                expect(
+                    card.get_by_text(f"{zaak_label} {identification}")
+                ).to_be_visible()
+
+                expected_url = reverse(
+                    "cases:case_detail",
+                    kwargs={
+                        "object_id": zaak_uuid,
+                        "api_group_id": str(api_group.id),
+                    },
+                )
+                expect(card.locator("a.oip-home-plugin-card")).to_have_attribute(
+                    "href", expected_url
+                )
+
+    # -- Bfcache reload (BfcacheReloader) --------------------------------
+    #
+    # Real browser back/forward-cache restoration is too unreliable to force
+    # deterministically in headless automation, so instead of navigating
+    # away and back, these dispatch the same synthetic `pageshow` event a
+    # real bfcache restore would - directly against the production bundle
+    # running in a real browser, exercising the actual `BfcacheReloader`
+    # wired up in `components/index.js`. What they don't cover is whether
+    # Chromium actually chooses to bfcache this page; that's a browser
+    # platform behaviour outside this code's control.
+
+    def test_bfcache_restore_with_pending_load_element_triggers_reload(self):
+        mock_submission = self._mock_formulier_submission(vervolg_link=None)
+        self._add_plugin_to_homepage(CMSZakenPlugin, title="Mijn Zaken", num_zaken=4)
+
+        patchers = self._patch_zgw_service(formulieren=[mock_submission])
+        with patchers[0], patchers[1], patchers[2]:
+            context = self.get_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_url("/"))
+            page.wait_for_load_state("networkidle")
+
+            # simulate a page that was frozen into bfcache before its
+            # `hx-trigger="load"` request finished
+            page.evaluate(
+                """
+                () => {
+                  const stray = document.createElement('div');
+                  stray.setAttribute('hx-trigger', 'load');
+                  document.body.appendChild(stray);
+                }
+                """
+            )
+            page.evaluate("() => { window.__test_marker = true; }")
+
+            with page.expect_navigation():
+                page.evaluate(
+                    "() => window.dispatchEvent("
+                    "new PageTransitionEvent('pageshow', { persisted: true }))"
+                )
+
+            # a real navigation wipes the JS context, so the marker is gone
+            self.assertIsNone(page.evaluate("() => window.__test_marker"))
+
+    def test_bfcache_restore_without_pending_load_element_does_not_reload(self):
+        mock_submission = self._mock_formulier_submission(vervolg_link=None)
+        self._add_plugin_to_homepage(CMSZakenPlugin, title="Mijn Zaken", num_zaken=4)
+
+        patchers = self._patch_zgw_service(formulieren=[mock_submission])
+        with patchers[0], patchers[1], patchers[2]:
+            context = self.get_context(storage_state=self.user_login_state)
+            page = context.new_page()
+            page.goto(self.live_url("/"))
+            # zaken content has already loaded and swapped away the spinner,
+            # so there's no pending `hx-trigger="load"` element left
+            page.wait_for_load_state("networkidle")
+
+            page.evaluate("() => { window.__test_marker = true; }")
+            page.evaluate(
+                "() => window.dispatchEvent("
+                "new PageTransitionEvent('pageshow', { persisted: true }))"
+            )
+            page.wait_for_timeout(200)  # give a reload a moment, if one were coming
+
+            self.assertTrue(page.evaluate("() => window.__test_marker"))

--- a/src/open_inwoner/js/components/bfcache-reload/index.spec.ts
+++ b/src/open_inwoner/js/components/bfcache-reload/index.spec.ts
@@ -1,0 +1,61 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+import { BfcacheReloader } from './index';
+
+function dispatchPageShow(persisted: boolean): void {
+  const event = new Event('pageshow') as PageTransitionEvent;
+  Object.defineProperty(event, 'persisted', { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe('BfcacheReloader', () => {
+  let reloadSpy: Mock<() => void>;
+
+  // Constructed once: the reloader registers a `pageshow` listener on
+  // `window` for the lifetime of the page, so we route it through an
+  // indirection that always calls the *current* test's spy instead of
+  // creating (and leaking) a new listener per test.
+  beforeAll(() => {
+    new BfcacheReloader(() => reloadSpy());
+  });
+
+  beforeEach(() => {
+    reloadSpy = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('reloads when the page is restored from bfcache with a pending hx-trigger="load" element', () => {
+    document.body.innerHTML = '<div hx-trigger="load"></div>';
+
+    dispatchPageShow(true);
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does not reload when the page is restored from bfcache without pending load-triggered elements', () => {
+    document.body.innerHTML = '<div>Already loaded content</div>';
+
+    dispatchPageShow(true);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not reload on a regular (non-persisted) pageshow', () => {
+    document.body.innerHTML = '<div hx-trigger="load"></div>';
+
+    dispatchPageShow(false);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/open_inwoner/js/components/bfcache-reload/index.ts
+++ b/src/open_inwoner/js/components/bfcache-reload/index.ts
@@ -1,0 +1,32 @@
+/**
+ * HTMX elements using `hx-trigger="load"` (e.g. the homepage's "Mijn Zaken"
+ * plugin) fire their request on the browser's `load` event. That event does
+ * not fire again when a page is restored from the back/forward cache
+ * (bfcache) via browser back/forward navigation - only `pageshow` does, with
+ * `event.persisted` set to `true`.
+ *
+ * If the page was cached before its `hx-trigger="load"` request finished
+ * (e.g. the user navigated away right after the initial page load), the
+ * restored page is stuck showing the loading spinner forever, since HTMX
+ * never gets a chance to retry.
+ *
+ * This does not disable bfcache restores in general - a `[hx-trigger="load"]`
+ * element is swapped away by HTMX once its request resolves, so on a normal
+ * restore (request already finished before the page was cached) the selector
+ * below finds nothing and the cached page is shown instantly, as usual. Only
+ * when that element is still present - meaning the page was frozen mid-load -
+ * do we force a full reload, trading the instant restore for a fresh `load`
+ * event that lets the stuck request run again from scratch.
+ */
+export class BfcacheReloader {
+  constructor(private reload: () => void = () => window.location.reload()) {
+    window.addEventListener('pageshow', this.handlePageShow.bind(this));
+  }
+
+  private handlePageShow(event: PageTransitionEvent): void {
+    if (!event.persisted) return;
+    if (document.querySelector('[hx-trigger="load"]')) {
+      this.reload();
+    }
+  }
+}

--- a/src/open_inwoner/js/components/index.js
+++ b/src/open_inwoner/js/components/index.js
@@ -19,6 +19,7 @@ import { CreateGumshoe } from './anchor-menu/anchor-menu';
 import './autocomplete-search';
 import './autocomplete';
 import './autosumbit';
+import { BfcacheReloader } from './bfcache-reload';
 import './cases';
 import './spinner';
 import { DisableContactFormButton } from './form/DisableContactFormButton';
@@ -114,6 +115,8 @@ function wrapComponentsOf(targetElement) {
 }
 
 htmx.onLoad(wrapComponentsOf);
+
+new BfcacheReloader();
 
 if (typeof htmx.on !== 'function') {
   console.error('HTMX not properly initialized at start!');

--- a/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.spec.tsx
+++ b/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.spec.tsx
@@ -32,4 +32,18 @@ describe('HomePluginCardItem', () => {
     render(<HomePluginCard title="TEST" detailUrl="/" identificatie="101" />);
     expect(screen.getByText('TEST')).toBeInTheDocument();
   });
+
+  it('renders as a link when a detailUrl is provided', () => {
+    render(
+      <HomePluginCard title="TEST" detailUrl="/some-url" identificatie="101" />
+    );
+    const link = screen.getByText('TEST').closest('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/some-url');
+  });
+
+  it('renders as a non-interactive card when detailUrl is empty (e.g. a formulier without a vervolg_link)', () => {
+    render(<HomePluginCard title="TEST" detailUrl="" identificatie="101" />);
+    expect(screen.getByText('TEST').closest('a')).not.toBeInTheDocument();
+  });
 });

--- a/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.tsx
+++ b/src/open_inwoner/react/components/HomePluginCard/HomePluginCard.tsx
@@ -18,34 +18,46 @@ const HomePluginCard: AC<HomepageCardTypes> = ({
   const Heading = String(renderAsHeading) !== 'false' ? 'h3' : 'p';
   const addressLineFirst = title && date && address;
   const id = 'card-' + kebabCase(identificatie);
-  return (
-    <a href={detailUrl} class="oip-home-plugin-card" aria-labelledby={id}>
-      <div class="oip-home-plugin-card__content">
-        <div class="oip-home-plugin-card__body">
-          <Heading
-            id={!addressLineFirst ? id : undefined}
-            class={clsx({
-              ['utrecht-heading-2']: !addressLineFirst,
-              ['nl-paragraph']: addressLineFirst,
-            })}
-          >
-            {addressLineFirst ? (
-              <>
-                {date && <span>{date}</span>}
-                {address && <span>{address}</span>}
-              </>
-            ) : (
-              title
-            )}
-          </Heading>
-          <Paragraph id={addressLineFirst ? id : undefined}>
-            {addressLineFirst ? title : description}
-          </Paragraph>
-        </div>
-
-        <MaterialIcon name="arrow_forward" />
+  // Some cases (e.g. a formulier without a `vervolg_link`) have no
+  // destination to link to. Rendering an empty `href` would make the
+  // browser navigate to the current page, which is worse than not being
+  // clickable at all, so we render a non-interactive card instead.
+  const Container = detailUrl ? 'a' : 'div';
+  const content = (
+    <div class="oip-home-plugin-card__content">
+      <div class="oip-home-plugin-card__body">
+        <Heading
+          id={!addressLineFirst ? id : undefined}
+          class={clsx({
+            ['utrecht-heading-2']: !addressLineFirst,
+            ['nl-paragraph']: addressLineFirst,
+          })}
+        >
+          {addressLineFirst ? (
+            <>
+              {date && <span>{date}</span>}
+              {address && <span>{address}</span>}
+            </>
+          ) : (
+            title
+          )}
+        </Heading>
+        <Paragraph id={addressLineFirst ? id : undefined}>
+          {addressLineFirst ? title : description}
+        </Paragraph>
       </div>
-    </a>
+
+      {detailUrl && <MaterialIcon name="arrow_forward" />}
+    </div>
+  );
+  return (
+    <Container
+      {...(detailUrl ? { href: detailUrl } : {})}
+      class="oip-home-plugin-card"
+      aria-labelledby={id}
+    >
+      {content}
+    </Container>
   );
 };
 


### PR DESCRIPTION
https://github.com/maykinmedia/open-inwoner/pull/2512 changed `src/open_inwoner/cms/plugins/views.py:123-135` so that for a formulier-type zaak, the card's URL comes from `vervolg_link` (the continuation link from Open Formulieren) instead of an internal `cases:case_detail` URL that never resolves for forms. But it added no fallback for when vervolg_link is empty - this is a legitimate, expected state on the Open Formulieren side (e.g. certain submission statuses don't return one), not an edge case.

Fixes #2745 :

- **Formulier cards with no link**: empty `href` reloaded the homepage; now renders as a non-clickable card.
- **Back-button stuck spinner**: `bfcache` restore doesn't re-fire `hx-trigger="load"`; now forces a reload if the request never finished.