### PR TITLE
fix: [#2765] drop unserializable object_type from notification collec…

### DIFF
--- a/src/open_inwoner/accounts/notifications/actions/notify.py
+++ b/src/open_inwoner/accounts/notifications/actions/notify.py
@@ -38,7 +38,6 @@ def collect_notifications_about_expiring_actions() -> list[dict]:
                     end_date=today,
                 ).values_list("id", flat=True)
             ),
-            object_type=Action,
         )
         for receiver in receivers
     ]

--- a/src/open_inwoner/accounts/notifications/messages/notify.py
+++ b/src/open_inwoner/accounts/notifications/messages/notify.py
@@ -36,7 +36,6 @@ def collect_notifications_about_messages() -> list[dict]:
                     sent=False,
                 ).values_list("id", flat=True)
             ),
-            object_type=Message,
         )
         for receiver in receivers
     ]

--- a/src/open_inwoner/accounts/notifications/plans/notify.py
+++ b/src/open_inwoner/accounts/notifications/plans/notify.py
@@ -52,7 +52,6 @@ def collect_notifications_about_expiring_plans() -> list[dict]:
                 .filter(Q(created_by=receiver) | Q(plan_contacts=receiver))
                 .values_list("id", flat=True),
             ),
-            object_type=Plan,
         )
         for receiver in receivers
     ]

--- a/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
+++ b/src/open_inwoner/accounts/tests/test_notify_expiring_actions.py
@@ -4,7 +4,12 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from kombu.utils.json import dumps as celery_dumps
+
 from open_inwoner.accounts.choices import StatusChoices
+from open_inwoner.accounts.notifications.actions.notify import (
+    collect_notifications_about_expiring_actions,
+)
 from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.accounts.tests.factories import ActionFactory, UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
@@ -13,6 +18,14 @@ from open_inwoner.configurations.models import SiteConfiguration
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ExpiringActionsNotificationTest(TestCase):
+    def test_collected_notifications_are_json_serializable(self):
+        # regression test for #2765
+        ActionFactory(end_date=date.today())
+
+        notifications = collect_notifications_about_expiring_actions()
+
+        celery_dumps(notifications)
+
     def test_send_emails_about_expiring_actions(self):
         harry = UserFactory()
         sally = UserFactory()

--- a/src/open_inwoner/accounts/tests/test_notify_expiring_plans.py
+++ b/src/open_inwoner/accounts/tests/test_notify_expiring_plans.py
@@ -5,6 +5,11 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from kombu.utils.json import dumps as celery_dumps
+
+from open_inwoner.accounts.notifications.plans.notify import (
+    collect_notifications_about_expiring_plans,
+)
 from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.accounts.tests.factories import UserFactory
 from open_inwoner.configurations.models import SiteConfiguration
@@ -15,6 +20,15 @@ from open_inwoner.plans.tests.factories import PlanFactory
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ExpiringPlansNotificationTest(TestCase):
+    def test_collected_notifications_are_json_serializable(self):
+        # regression test for #2765
+        harry = UserFactory(first_name="Harry")
+        PlanFactory(end_date=date.today(), created_by=harry, title="Harry's plan")
+
+        notifications = collect_notifications_about_expiring_plans()
+
+        celery_dumps(notifications)
+
     def test_send_emails_about_expiring_plans(self):
         harry = UserFactory(first_name="Harry")
         sally = UserFactory(first_name="Sally")

--- a/src/open_inwoner/accounts/tests/test_notify_messages.py
+++ b/src/open_inwoner/accounts/tests/test_notify_messages.py
@@ -2,6 +2,11 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from kombu.utils.json import dumps as celery_dumps
+
+from open_inwoner.accounts.notifications.messages.notify import (
+    collect_notifications_about_messages,
+)
 from open_inwoner.accounts.tasks import schedule_user_notifications
 from open_inwoner.configurations.models import SiteConfiguration
 
@@ -11,6 +16,16 @@ from .factories import MessageFactory, UserFactory
 @override_settings(ROOT_URLCONF="open_inwoner.cms.tests.urls")
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class MessagesNotificationTest(TestCase):
+    def test_collected_notifications_are_json_serializable(self):
+        # regression test for #2765
+        user = UserFactory.create()
+        sender = UserFactory.create()
+        MessageFactory.create(receiver=user, sender=sender)
+
+        notifications = collect_notifications_about_messages()
+
+        celery_dumps(notifications)
+
     def test_send_emails_about_messages(self):
         jack = UserFactory.create(first_name="Jack")
         jill = UserFactory.create(first_name="Jill")


### PR DESCRIPTION
…tors

The task parameters for the various notification collectors (in the context of the plans/actions) included a non-serializable argument, which broke in production but was not visible in tests. This went undetected because the ALWAYS_EAGER flag did not serialize the task parameters and the feature is not in active use.

Closes: #2765
