### PR TITLE
[#2770] Improve formatting of case list retry notification

### DIFF
--- a/src/open_inwoner/components/templates/components/Notification/Notification.html
+++ b/src/open_inwoner/components/templates/components/Notification/Notification.html
@@ -16,7 +16,6 @@
          {% endif %} tabindex="-1">
         {% if title %}<h2 class="utrecht-heading-2">{{ title }}</h2>{% endif %}
         {% if notification %}<nl-paragraph>{{ notification }}</nl-paragraph>{% endif %}
-        {% if action %}{% button href=action text=action_text %}{% endif %}
         {% if contents %}
             {{ contents }}
         {% else %}
@@ -26,6 +25,7 @@
                 <nl-paragraph>{{ message }}</nl-paragraph>
             {% endif %}
         {% endif %}
+        {% if action %}{% button href=action text=action_text %}{% endif %}
     </div>
 
     {% if closable %}

--- a/src/open_inwoner/scss/components/Notification/_Notification.scss
+++ b/src/open_inwoner/scss/components/Notification/_Notification.scss
@@ -111,5 +111,12 @@
     & * {
       margin: 0;
     }
+
+    // `& * { margin: 0 }` above cancels the usual heading/paragraph + .button
+    // spacing (see Button.scss), so the notification's action button needs
+    // its own margin to not sit flush against the message text above it.
+    .button {
+      margin-block-start: var(--spacing-large);
+    }
   }
 }

--- a/src/open_inwoner/templates/pages/cases/list_inner.html
+++ b/src/open_inwoner/templates/pages/cases/list_inner.html
@@ -16,7 +16,10 @@
              hx-trigger="load delay:{{ auto_retry_delay }}s"
              hx-target="#cases-content"></div>
     {% else %}
-        {% notification type="warning" title=_("Niet alle zaken konden worden opgehaald") message=_("Een deel van uw zaken kon niet worden opgehaald. Probeer het opnieuw of kom later terug.") action=manual_retry_url action_text=_("Opnieuw proberen") closable=True %}
+        {# Wrapped so htmx:load fires on this div (not the notification itself), letting wrapComponentsOf's querySelectorAll find the notification as a descendant and wire up its close button. #}
+        <div class="cases__notification">
+            {% notification type="warning" title=_("Niet alle zaken konden worden opgehaald") message=_("Een deel van uw zaken kon niet worden opgehaald. Probeer het opnieuw of kom later terug.") action=manual_retry_url action_text=_("Opnieuw proberen") closable=True %}
+        </div>
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Closes #2770

---

Now looks like this:

<img width="860" height="360" alt="image" src="https://github.com/user-attachments/assets/bb505465-9d02-49e3-97c9-ada7af51a198" />
